### PR TITLE
Add support for actions in fragments

### DIFF
--- a/src/cascadia/LocalTests_SettingsModel/SerializationTests.cpp
+++ b/src/cascadia/LocalTests_SettingsModel/SerializationTests.cpp
@@ -75,7 +75,6 @@ namespace SettingsModelLocalTests
         // we do any sort of roundtrip testing.
         static Json::Value removeSchema(Json::Value json)
         {
-            // DebugBreak();
             if (json.isMember("$schema"))
             {
                 json.removeMember("$schema");

--- a/src/cascadia/LocalTests_SettingsModel/SerializationTests.cpp
+++ b/src/cascadia/LocalTests_SettingsModel/SerializationTests.cpp
@@ -68,6 +68,20 @@ namespace SettingsModelLocalTests
             // written alphabetically.
             VERIFY_ARE_EQUAL(toString(json), toString(result));
         }
+
+        // Helper to remove the `$schema` property from a json object. We
+        // populate that based off the local path to the settings file. Of
+        // course, that's entirely unpredictable in tests. So cut it out before
+        // we do any sort of roundtrip testing.
+        static Json::Value removeSchema(Json::Value json)
+        {
+            // DebugBreak();
+            if (json.isMember("$schema"))
+            {
+                json.removeMember("$schema");
+            }
+            return json;
+        }
     };
 
     void SerializationTests::GlobalSettings()
@@ -262,15 +276,6 @@ namespace SettingsModelLocalTests
                                                 { "command": { "action": "adjustFontSize", "delta": 1.0 }, "keys": "ctrl+c" },
                                                 { "command": { "action": "adjustFontSize", "delta": 1.0 }, "keys": "ctrl+d" }
                                             ])" };
-        // GH#13323 - these can be fragile. In the past, the order these get
-        // re-serialized as has been not entirely stable. We don't really care
-        // about the order they get re-serialized in, but the tests aren't
-        // clever enough to compare the structure, only the literal string
-        // itself. Feel free to change as needed.
-        static constexpr std::string_view actionsString4B{ R"([
-                                                { "command": { "action": "findMatch", "direction": "prev" }, "keys": "ctrl+shift+r" },
-                                                { "command": { "action": "adjustFontSize", "delta": 1.0 }, "keys": "ctrl+d" }
-                                            ])" };
 
         // command with name and icon and multiple key chords
         static constexpr std::string_view actionsString5{ R"([
@@ -384,7 +389,6 @@ namespace SettingsModelLocalTests
 
         Log::Comment(L"complex commands with key chords");
         RoundtripTest<implementation::ActionMap>(actionsString4A);
-        RoundtripTest<implementation::ActionMap>(actionsString4B);
 
         Log::Comment(L"command with name and icon and multiple key chords");
         RoundtripTest<implementation::ActionMap>(actionsString5);
@@ -483,7 +487,8 @@ namespace SettingsModelLocalTests
         const auto settings{ winrt::make_self<implementation::CascadiaSettings>(settingsString) };
 
         const auto result{ settings->ToJson() };
-        VERIFY_ARE_EQUAL(toString(VerifyParseSucceeded(settingsString)), toString(result));
+        VERIFY_ARE_EQUAL(toString(removeSchema(VerifyParseSucceeded(settingsString))),
+                         toString(removeSchema(result)));
     }
 
     void SerializationTests::LegacyFontSettings()

--- a/src/cascadia/TerminalSettingsModel/ActionMap.h
+++ b/src/cascadia/TerminalSettingsModel/ActionMap.h
@@ -67,7 +67,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         // JSON
         static com_ptr<ActionMap> FromJson(const Json::Value& json);
-        std::vector<SettingsLoadWarnings> LayerJson(const Json::Value& json);
+        std::vector<SettingsLoadWarnings> LayerJson(const Json::Value& json, const bool withKeybindings = true);
         Json::Value ToJson() const;
 
         // modification

--- a/src/cascadia/TerminalSettingsModel/ActionMapSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionMapSerialization.cpp
@@ -35,7 +35,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     // - json: an array of Json::Value's to deserialize into our ActionMap.
     // Return value:
     // - a list of warnings encountered while deserializing the json
-    std::vector<SettingsLoadWarnings> ActionMap::LayerJson(const Json::Value& json)
+    std::vector<SettingsLoadWarnings> ActionMap::LayerJson(const Json::Value& json, const bool withKeybindings)
     {
         // It's possible that the user provided keybindings have some warnings in
         // them - problems that we should alert the user to, but we can recover
@@ -50,7 +50,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                 continue;
             }
 
-            AddAction(*Command::FromJson(cmdJson, warnings));
+            AddAction(*Command::FromJson(cmdJson, warnings, withKeybindings));
         }
 
         return warnings;

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -649,14 +649,16 @@ void SettingsLoader::_parseFragment(const winrt::hstring& source, const std::str
             CATCH_LOG()
         }
 
-        // const Json::Value& actions = _getJSONValue(json.root, ActionsKey);
-        // Json::Value tmp = {};
-
-        // Construct a temp Json::Value that contains the actions from the fragment.
+        // Construct a temp Json::Value that contains ONLY the actions from the
+        // fragment. This will allow fragments to add actions, but not
+        // necessarily set other global properties.
         Json::Value tmp = {};
         tmp[ActionsKey.data()] = json.root[ActionsKey.data()];
-
+        // Now parse that tmep json object, as if it were a global settings blob.
         settings.globals->LayerJson(tmp);
+
+        // TODO!
+        // settings.globals->RemoveAllKeybindings();
     }
 
     {
@@ -698,10 +700,9 @@ void SettingsLoader::_parseFragment(const winrt::hstring& source, const std::str
         }
     }
 
-    // for (const auto& kv : settings.globals->ColorSchemes())
-    // {
-    //     userSettings.globals->AddColorScheme(kv.Value());
-    // }
+    // Add the parsed fragment globals as a parent of the user's settings.
+    // Later, in FinalizeInheritance, this will result in the action map from
+    // the fragments being applied before the user's own settings.
     userSettings.globals->AddLeastImportantParent(settings.globals);
 }
 
@@ -991,13 +992,13 @@ void CascadiaSettings::_researchOnLoad()
         // system (legacy): 4
         // light (legacy): 5
         // dark (legacy): 6
-        const auto themeChoice = themeInUse == L"system" ? 0 :
-                                                           themeInUse == L"light" ? 1 :
-                                                                                    themeInUse == L"dark" ? 2 :
-                                                                                                            themeInUse == L"legacyDark" ? 4 :
-                                                                                                                                          themeInUse == L"legacyLight" ? 5 :
-                                                                                                                                                                         themeInUse == L"legacySystem" ? 6 :
-                                                                                                                                                                                                         3;
+        const auto themeChoice = themeInUse == L"system"       ? 0 :
+                                 themeInUse == L"light"        ? 1 :
+                                 themeInUse == L"dark"         ? 2 :
+                                 themeInUse == L"legacyDark"   ? 4 :
+                                 themeInUse == L"legacyLight"  ? 5 :
+                                 themeInUse == L"legacySystem" ? 6 :
+                                                                 3;
 
         TraceLoggingWrite(
             g_hSettingsModelProvider,

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -47,6 +47,7 @@ static constexpr std::string_view DefaultSettingsKey{ "defaults" };
 static constexpr std::string_view ProfilesListKey{ "list" };
 static constexpr std::string_view SchemesKey{ "schemes" };
 static constexpr std::string_view ThemesKey{ "themes" };
+static constexpr std::string_view ActionsKey{ "actions" };
 
 constexpr std::wstring_view systemThemeName{ L"system" };
 constexpr std::wstring_view darkThemeName{ L"dark" };
@@ -629,7 +630,7 @@ void SettingsLoader::_parse(const OriginTag origin, const winrt::hstring& source
 // schemes and profiles. Additionally this function supports profiles which specify an "updates" key.
 void SettingsLoader::_parseFragment(const winrt::hstring& source, const std::string_view& content, ParsedSettings& settings)
 {
-    const auto json = _parseJson(content);
+    auto json = _parseJson(content);
 
     settings.clear();
 
@@ -647,6 +648,15 @@ void SettingsLoader::_parseFragment(const winrt::hstring& source, const std::str
             }
             CATCH_LOG()
         }
+
+        // const Json::Value& actions = _getJSONValue(json.root, ActionsKey);
+        // Json::Value tmp = {};
+
+        // Construct a temp Json::Value that contains the actions from the fragment.
+        Json::Value tmp = {};
+        tmp[ActionsKey.data()] = json.root[ActionsKey.data()];
+
+        settings.globals->LayerJson(tmp);
     }
 
     {
@@ -688,10 +698,11 @@ void SettingsLoader::_parseFragment(const winrt::hstring& source, const std::str
         }
     }
 
-    for (const auto& kv : settings.globals->ColorSchemes())
-    {
-        userSettings.globals->AddColorScheme(kv.Value());
-    }
+    // for (const auto& kv : settings.globals->ColorSchemes())
+    // {
+    //     userSettings.globals->AddColorScheme(kv.Value());
+    // }
+    userSettings.globals->AddLeastImportantParent(settings.globals);
 }
 
 SettingsLoader::JsonSettings SettingsLoader::_parseJson(const std::string_view& content)
@@ -980,13 +991,13 @@ void CascadiaSettings::_researchOnLoad()
         // system (legacy): 4
         // light (legacy): 5
         // dark (legacy): 6
-        const auto themeChoice = themeInUse == L"system"       ? 0 :
-                                 themeInUse == L"light"        ? 1 :
-                                 themeInUse == L"dark"         ? 2 :
-                                 themeInUse == L"legacyDark"   ? 4 :
-                                 themeInUse == L"legacyLight"  ? 5 :
-                                 themeInUse == L"legacySystem" ? 6 :
-                                                                 3;
+        const auto themeChoice = themeInUse == L"system" ? 0 :
+                                                           themeInUse == L"light" ? 1 :
+                                                                                    themeInUse == L"dark" ? 2 :
+                                                                                                            themeInUse == L"legacyDark" ? 4 :
+                                                                                                                                          themeInUse == L"legacyLight" ? 5 :
+                                                                                                                                                                         themeInUse == L"legacySystem" ? 6 :
+                                                                                                                                                                                                         3;
 
         TraceLoggingWrite(
             g_hSettingsModelProvider,

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -47,7 +47,6 @@ static constexpr std::string_view DefaultSettingsKey{ "defaults" };
 static constexpr std::string_view ProfilesListKey{ "list" };
 static constexpr std::string_view SchemesKey{ "schemes" };
 static constexpr std::string_view ThemesKey{ "themes" };
-static constexpr std::string_view ActionsKey{ "actions" };
 
 constexpr std::wstring_view systemThemeName{ L"system" };
 constexpr std::wstring_view darkThemeName{ L"dark" };
@@ -649,17 +648,10 @@ void SettingsLoader::_parseFragment(const winrt::hstring& source, const std::str
             CATCH_LOG()
         }
 
-        // Construct a temp Json::Value that contains ONLY the actions from the
-        // fragment. This will allow fragments to add actions, but not
-        // necessarily set other global properties.
-        Json::Value tmp = {};
-        tmp[ActionsKey.data()] = json.root[ActionsKey.data()];
-
-        // Now parse that tmep json object, as if it were a global settings
-        // blob. Manually opt-out of keybinding parsing - fragments shouldn't be
-        // allowed to bind actions to keys directly. We may want to revisit
-        // circa GH#2205
-        settings.globals->LayerJson(tmp, false);
+        // Parse out actions from the fragment. Manually opt-out of keybinding
+        // parsing - fragments shouldn't be allowed to bind actions to keys
+        // directly. We may want to revisit circa GH#2205
+        settings.globals->LayerActionsFrom(json.root, false);
     }
 
     {

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -654,11 +654,12 @@ void SettingsLoader::_parseFragment(const winrt::hstring& source, const std::str
         // necessarily set other global properties.
         Json::Value tmp = {};
         tmp[ActionsKey.data()] = json.root[ActionsKey.data()];
-        // Now parse that tmep json object, as if it were a global settings blob.
-        settings.globals->LayerJson(tmp);
 
-        // TODO!
-        // settings.globals->RemoveAllKeybindings();
+        // Now parse that tmep json object, as if it were a global settings
+        // blob. Manually opt-out of keybinding parsing - fragments shouldn't be
+        // allowed to bind actions to keys directly. We may want to revisit
+        // circa GH#2205
+        settings.globals->LayerJson(tmp, false);
     }
 
     {

--- a/src/cascadia/TerminalSettingsModel/Command.cpp
+++ b/src/cascadia/TerminalSettingsModel/Command.cpp
@@ -258,7 +258,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     // Return Value:
     // - the newly constructed Command object.
     winrt::com_ptr<Command> Command::FromJson(const Json::Value& json,
-                                              std::vector<SettingsLoadWarnings>& warnings)
+                                              std::vector<SettingsLoadWarnings>& warnings,
+                                              const bool parseKeys)
     {
         auto result = winrt::make_self<Command>();
 
@@ -313,20 +314,23 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                 result->_ActionAndArgs = make<implementation::ActionAndArgs>();
             }
 
-            // GH#4239 - If the user provided more than one key
-            // chord to a "keys" array, warn the user here.
-            // TODO: GH#1334 - remove this check.
-            const auto keysJson{ json[JsonKey(KeysKey)] };
-            if (keysJson.isArray() && keysJson.size() > 1)
+            if (parseKeys)
             {
-                warnings.push_back(SettingsLoadWarnings::TooManyKeysForChord);
-            }
-            else
-            {
-                Control::KeyChord keys{ nullptr };
-                if (JsonUtils::GetValueForKey(json, KeysKey, keys))
+                // GH#4239 - If the user provided more than one key
+                // chord to a "keys" array, warn the user here.
+                // TODO: GH#1334 - remove this check.
+                const auto keysJson{ json[JsonKey(KeysKey)] };
+                if (keysJson.isArray() && keysJson.size() > 1)
                 {
-                    result->RegisterKey(keys);
+                    warnings.push_back(SettingsLoadWarnings::TooManyKeysForChord);
+                }
+                else
+                {
+                    Control::KeyChord keys{ nullptr };
+                    if (JsonUtils::GetValueForKey(json, KeysKey, keys))
+                    {
+                        result->RegisterKey(keys);
+                    }
                 }
             }
         }

--- a/src/cascadia/TerminalSettingsModel/Command.h
+++ b/src/cascadia/TerminalSettingsModel/Command.h
@@ -39,7 +39,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         com_ptr<Command> Copy() const;
 
         static winrt::com_ptr<Command> FromJson(const Json::Value& json,
-                                                std::vector<SettingsLoadWarnings>& warnings);
+                                                std::vector<SettingsLoadWarnings>& warnings,
+                                                const bool parseKeys = true);
 
         static void ExpandCommands(Windows::Foundation::Collections::IMap<winrt::hstring, Model::Command>& commands,
                                    Windows::Foundation::Collections::IVectorView<Model::Profile> profiles,

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
@@ -129,7 +129,7 @@ winrt::com_ptr<GlobalAppSettings> GlobalAppSettings::FromJson(const Json::Value&
     return result;
 }
 
-void GlobalAppSettings::LayerJson(const Json::Value& json)
+void GlobalAppSettings::LayerJson(const Json::Value& json, const bool withKeybindings)
 {
     JsonUtils::GetValueForKey(json, DefaultProfileKey, _UnparsedDefaultProfile);
     // GH#8076 - when adding enum values to this key, we also changed it from
@@ -147,7 +147,7 @@ void GlobalAppSettings::LayerJson(const Json::Value& json)
     {
         if (auto bindings{ json[JsonKey(jsonKey)] })
         {
-            auto warnings = _actionMap->LayerJson(bindings);
+            auto warnings = _actionMap->LayerJson(bindings, withKeybindings);
 
             // It's possible that the user provided keybindings have some warnings
             // in them - problems that we should alert the user to, but we can

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
@@ -129,7 +129,7 @@ winrt::com_ptr<GlobalAppSettings> GlobalAppSettings::FromJson(const Json::Value&
     return result;
 }
 
-void GlobalAppSettings::LayerJson(const Json::Value& json, const bool withKeybindings)
+void GlobalAppSettings::LayerJson(const Json::Value& json)
 {
     JsonUtils::GetValueForKey(json, DefaultProfileKey, _UnparsedDefaultProfile);
     // GH#8076 - when adding enum values to this key, we also changed it from
@@ -142,6 +142,13 @@ void GlobalAppSettings::LayerJson(const Json::Value& json, const bool withKeybin
     MTSM_GLOBAL_SETTINGS(GLOBAL_SETTINGS_LAYER_JSON)
 #undef GLOBAL_SETTINGS_LAYER_JSON
 
+    LayerActionsFrom(json, true);
+
+    JsonUtils::GetValueForKey(json, LegacyReloadEnvironmentVariablesKey, _legacyReloadEnvironmentVariables);
+}
+
+void GlobalAppSettings::LayerActionsFrom(const Json::Value& json, const bool withKeybindings)
+{
     static constexpr std::array bindingsKeys{ LegacyKeybindingsKey, ActionsKey };
     for (const auto& jsonKey : bindingsKeys)
     {
@@ -158,8 +165,6 @@ void GlobalAppSettings::LayerJson(const Json::Value& json, const bool withKeybin
             _keybindingsWarnings.insert(_keybindingsWarnings.end(), warnings.begin(), warnings.end());
         }
     }
-
-    JsonUtils::GetValueForKey(json, LegacyReloadEnvironmentVariablesKey, _legacyReloadEnvironmentVariables);
 }
 
 // Method Description:

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.h
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.h
@@ -48,7 +48,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         Model::ActionMap ActionMap() const noexcept;
 
         static com_ptr<GlobalAppSettings> FromJson(const Json::Value& json);
-        void LayerJson(const Json::Value& json);
+        void LayerJson(const Json::Value& json, const bool withKeybindings = true);
 
         Json::Value ToJson() const;
 

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.h
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.h
@@ -48,7 +48,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         Model::ActionMap ActionMap() const noexcept;
 
         static com_ptr<GlobalAppSettings> FromJson(const Json::Value& json);
-        void LayerJson(const Json::Value& json, const bool withKeybindings = true);
+        void LayerJson(const Json::Value& json);
+        void LayerActionsFrom(const Json::Value& json, const bool withKeybindings = true);
 
         Json::Value ToJson() const;
 


### PR DESCRIPTION
Surprisingly easier than I thought this would be. ActionMap already supports layering (from defaults.json), so this basically re-uses a lot of that for fun and profit. 

The trickiest bits:
* In `SettingsLoader::_parseFragment`, I'm constructing a fake, empty JSON object, and taking _only_ the actions out from the fragment, and stuffing them into this temp json. Then, I parse that as a globals object, and set _that_ as the parent to the user settings file. That results in _only_ the actions from the fragment being parsed before the user's actions. 
* In that same method, I'm also explicitly preventing the ActionMap (et al.) from parsing `keys` from these actions. We don't want fragments to be able to say "ctrl+f is clear buffer" or something like that. This required a bit of annoying plumbing. 


Closes #16063 
Tests added.
Docs need to be updated. 
