### PR TITLE
Add bold, italic, and underline for copyFormatting

### DIFF
--- a/src/buffer/out/TextAttribute.cpp
+++ b/src/buffer/out/TextAttribute.cpp
@@ -288,6 +288,11 @@ bool TextAttribute::IsItalic() const noexcept
     return WI_IsFlagSet(_attrs, CharacterAttributes::Italics);
 }
 
+bool TextAttribute::IsBold() const noexcept
+{
+    return WI_IsFlagSet(_attrs, CharacterAttributes::Bold);
+}
+
 bool TextAttribute::IsBlinking() const noexcept
 {
     return WI_IsFlagSet(_attrs, CharacterAttributes::Blinking);

--- a/src/buffer/out/TextAttribute.hpp
+++ b/src/buffer/out/TextAttribute.hpp
@@ -108,6 +108,7 @@ public:
     bool IsFaint() const noexcept;
     bool IsItalic() const noexcept;
     bool IsBlinking() const noexcept;
+    bool IsBold() const noexcept;
     bool IsInvisible() const noexcept;
     bool IsCrossedOut() const noexcept;
     bool IsUnderlined() const noexcept;

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -2146,6 +2146,7 @@ std::string TextBuffer::GenHTML(const TextAndColor& rows,
                     htmlBuilder << ";";
                     htmlBuilder << "font-style:";
                     htmlBuilder << textProps.IsItalic();
+                    htmlBuilder << ";";
                     htmlBuilder << "\">";
                 }
 

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -2015,7 +2015,8 @@ std::wstring TextBuffer::GetPlainText(const til::point& start, const til::point&
 std::string TextBuffer::GenHTML(const TextAndColor& rows,
                                 const int fontHeightPoints,
                                 const std::wstring_view fontFaceName,
-                                const COLORREF backgroundColor)
+                                const COLORREF backgroundColor,
+                                const TextAttribute& textProps)
 {
     try
     {
@@ -2137,6 +2138,14 @@ std::string TextBuffer::GenHTML(const TextAndColor& rows,
                     htmlBuilder << "background-color:";
                     htmlBuilder << Utils::ColorToHexString(bkColor.value());
                     htmlBuilder << ";";
+                    htmlBuilder << "text-decoration:";
+                    htmlBuilder << textProps.IsUnderlined();
+                    htmlBuilder << ";";
+                    htmlBuilder << "font-weight:";
+                    htmlBuilder << textProps.IsBold();
+                    htmlBuilder << ";";
+                    htmlBuilder << "font-style:";
+                    htmlBuilder << textProps.IsItalic();
                     htmlBuilder << "\">";
                 }
 

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -2015,8 +2015,7 @@ std::wstring TextBuffer::GetPlainText(const til::point& start, const til::point&
 std::string TextBuffer::GenHTML(const TextAndColor& rows,
                                 const int fontHeightPoints,
                                 const std::wstring_view fontFaceName,
-                                const COLORREF backgroundColor,
-                                const TextAttribute& textProps)
+                                const COLORREF backgroundColor)
 {
     try
     {
@@ -2064,6 +2063,7 @@ std::string TextBuffer::GenHTML(const TextAndColor& rows,
         auto hasWrittenAnyText = false;
         std::optional<COLORREF> fgColor = std::nullopt;
         std::optional<COLORREF> bkColor = std::nullopt;
+        TextAttribute textProps;
         for (size_t row = 0; row < rows.text.size(); row++)
         {
             size_t startOffset = 0;

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -249,7 +249,8 @@ public:
     static std::string GenHTML(const TextAndColor& rows,
                                const int fontHeightPoints,
                                const std::wstring_view fontFaceName,
-                               const COLORREF backgroundColor);
+                               const COLORREF backgroundColor,
+                               const TextAttribute& textProps);
 
     static std::string GenRTF(const TextAndColor& rows,
                               const int fontHeightPoints,

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -249,8 +249,7 @@ public:
     static std::string GenHTML(const TextAndColor& rows,
                                const int fontHeightPoints,
                                const std::wstring_view fontFaceName,
-                               const COLORREF backgroundColor,
-                               const TextAttribute& textProps);
+                               const COLORREF backgroundColor);
 
     static std::string GenRTF(const TextAndColor& rows,
                               const int fontHeightPoints,

--- a/src/inc/conattrs.hpp
+++ b/src/inc/conattrs.hpp
@@ -14,6 +14,7 @@ enum class CharacterAttributes : uint16_t
     Normal = 0x00,
     Intense = 0x01,
     Italics = 0x02,
+    Bold = 0x03,
     Blinking = 0x04,
     Invisible = 0x08,
     CrossedOut = 0x10,


### PR DESCRIPTION
## Summary of the Pull Request
copyFormatting was broken when pasting into Word.

## References and Relevant Issues
#16191

## Detailed Description of the Pull Request / Additional comments
Fixes formatting issues with text.

## Validation Steps Performed
1. Open Vim
2. Use #16191 for an example.
3. Formats correctly.

## PR Checklist
- [x] Closes #16191 
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
