### PR TITLE
Fix rectangular clipboard copying initiated from the app menu

### DIFF
--- a/src/interactivity/win32/Clipboard.cpp
+++ b/src/interactivity/win32/Clipboard.cpp
@@ -248,7 +248,7 @@ void Clipboard::StoreSelectionToClipboard(const bool copyFormatting)
                                      trimTrailingWhitespace,
                                      selectionRects,
                                      GetAttributeColors,
-                                     selection.IsKeyboardMarkSelection());
+                                     !selection.IsLineSelection());
 
     CopyTextToSystemClipboard(text, copyFormatting);
 }


### PR DESCRIPTION
cd6b083 had 2 issues:
* Improper testing with Ctrl+M instead of Edit > Mark.
* Wrong SelectionState function being used. When the selection is
  initiated without keyboard or mouse, `IsKeyboardMarkSelection`
  returns false. The proper function to use is `IsLineSelection`.

Closes #15153

## Validation Steps Performed
* Run Far
* Start selection via Edit>Mark
* Hold Alt while dragging to make a rectangular selection
* Right click
* Clipboard contains a rectangular copy ✅