### PR TITLE
add single quotes to WSL drag and drop

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2940,13 +2940,15 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                                 }
                             }
                         }
+                        fullPath.insert(0, L"\'");
+                        fullPath += L"\'";
                     }
 
                     const auto containsSpaces = std::find(fullPath.begin(),
                                                           fullPath.end(),
                                                           L' ') != fullPath.end();
 
-                    if (containsSpaces)
+                    if (containsSpaces && !_interactivity.ManglePathsForWsl())
                     {
                         fullPath.insert(0, L"\"");
                         fullPath += L"\"";

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2908,7 +2908,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                     // However, it's likely that the control layer may need to
                     // know about the source anyways in the future, to support
                     // GH#3158
-                    if (_interactivity.ManglePathsForWsl())
+                    const auto isWSL = _interactivity.ManglePathsForWsl();
+
+                    if (isWSL)
                     {
                         std::replace(fullPath.begin(), fullPath.end(), L'\\', L'/');
 
@@ -2940,21 +2942,21 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                                 }
                             }
                         }
-                        fullPath.insert(0, L"\'");
-                        fullPath += L"\'";
                     }
 
-                    const auto containsSpaces = std::find(fullPath.begin(),
-                                                          fullPath.end(),
-                                                          L' ') != fullPath.end();
+                    const auto quotesNeeded = isWSL || fullPath.find(L' ') != std::wstring::npos;
+                    const auto quotesChar = isWSL ? L'\'' : L'"';
 
-                    if (containsSpaces && !_interactivity.ManglePathsForWsl())
+                    // Append fullPath and also wrap it in quotes if needed
+                    if (quotesNeeded)
                     {
-                        fullPath.insert(0, L"\"");
-                        fullPath += L"\"";
+                        allPathsString.push_back(quotesChar);
                     }
-
-                    allPathsString += fullPath;
+                    allPathsString.append(fullPath);
+                    if (quotesNeeded)
+                    {
+                        allPathsString.push_back(quotesChar);
+                    }
                 }
 
                 _pasteTextWithBroadcast(winrt::hstring{ allPathsString });


### PR DESCRIPTION
Wrap single quotes to drag and dropped paths in WSL

## References and Relevant Issues
#15646  , #8109 

## Detailed Description of the Pull Request / Additional comments
First time contributor, from what I understand from reading #15646 and #8109 , issue is asking for single quotes added to a drag and dropped path always, regardless of whitespace and special characters, in WSL.

## Validation Steps Performed
Tested drag and drop changes in WSL and non WSL sources.

Closes #15646 