### PR TITLE
Don't explicitly disable the terminal StartupTask in our manifest

### DIFF
--- a/src/cascadia/CascadiaPackage/Package-Can.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Can.appxmanifest
@@ -81,7 +81,6 @@
         <uap5:Extension Category="windows.startupTask">
           <uap5:StartupTask
             TaskId="StartTerminalOnLoginTask"
-            Enabled="false"
             DisplayName="ms-resource:AppNameCan" />
         </uap5:Extension>
         <uap3:Extension Category="windows.appExtension">

--- a/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
@@ -75,7 +75,6 @@
         <uap5:Extension Category="windows.startupTask">
           <uap5:StartupTask
             TaskId="StartTerminalOnLoginTask"
-            Enabled="false"
             DisplayName="ms-resource:AppNameDev" />
         </uap5:Extension>
         <uap3:Extension Category="windows.appExtensionHost">

--- a/src/cascadia/CascadiaPackage/Package.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package.appxmanifest
@@ -169,7 +169,6 @@
         <uap5:Extension Category="windows.startupTask">
           <uap5:StartupTask
             TaskId="StartTerminalOnLoginTask"
-            Enabled="false"
             DisplayName="ms-resource:AppName" />
         </uap5:Extension>
         <uap3:Extension Category="windows.appExtension">


### PR DESCRIPTION
## Summary of the Pull Request
Removed  `Enabled="false"` so that Windows Terminal can launch automatically after enter desktop and App start up setting should be on for Windows Terminal.

## References and Relevant Issues
Issue [#12564 ](https://github.com/microsoft/terminal/issues/12564)

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

## PR Checklist
- [x] Closes #12564
