### PR TITLE
Another theoretical fix for a crash

### DIFF
--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -979,7 +979,8 @@ winrt::Windows::Foundation::IAsyncOperation<winrt::hstring> AppHost::_GetWindowL
     co_await wil::resume_foreground(_windowLogic.GetRoot().Dispatcher());
 
     const auto strongThis = weakThis.lock();
-    if (!strongThis)
+    // GH #16235: If we don't have a window logic, we're already refrigerating, and won't have our _window either.
+    if (!strongThis || _windowLogic == nullptr)
     {
         co_return layoutJson;
     }
@@ -1267,7 +1268,8 @@ winrt::fire_and_forget AppHost::_QuitRequested(const winrt::Windows::Foundation:
     co_await wil::resume_foreground(_windowLogic.GetRoot().Dispatcher());
 
     const auto strongThis = weakThis.lock();
-    if (!strongThis)
+    // GH #16235: If we don't have a window logic, we're already refrigerating, and won't have our _window either.
+    if (!strongThis || _windowLogic == nullptr)
     {
         co_return;
     }
@@ -1431,7 +1433,7 @@ winrt::fire_and_forget AppHost::_WindowInitializedHandler(const winrt::Windows::
 
     // If we're gone on the other side of this co_await, well, that's fine. Just bail.
     const auto strongThis = weakThis.lock();
-    if (!strongThis)
+    if (!strongThis || _window == nullptr)
     {
         co_return;
     }


### PR DESCRIPTION
For history: 

> This is MSFT:46763065 internally. Dumps show this repros on 1.19 too. 
> 
> This was previously #16061 which had a theoretical fix in #16065. Looks like you're on Terminal Stable v1.18.2822.0, and https://github.com/microsoft/terminal/releases/tag/v1.18.2822.0 is supposed to have had that fix in it. Dang. 

> well this is embarrassing ... I never actually checked if we _still had a `_window`_. We're alive, yay! But we're still in the middle of refrigerating. So, there's no HWND anymore 

Attempt to fix this by actually ensuring there's a `_window` in `AppHost::_WindowInitializedHandler`

Closes #16235