### PR TITLE
Change DisclaimerStyle to be non-italic

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
+++ b/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
@@ -115,7 +115,6 @@
     <!--  Used for disclaimers  -->
     <Style x:Key="DisclaimerStyle"
            TargetType="TextBlock">
-        <Setter Property="FontStyle" Value="Italic" />
         <Setter Property="TextWrapping" Value="WrapWholeWords" />
         <Setter Property="MaxWidth" Value="1000" />
     </Style>


### PR DESCRIPTION
## Summary of the Pull Request
This changes the appearance of the disclaimer text that is used on some of the settings pages. The italic text style is replaced with a neutral style that fits better with the rest of the UI.

Before:
![before](https://github.com/microsoft/terminal/assets/15180557/1f8902b9-e425-4ba1-8c59-539d7a6a40ce)

After:
![after](https://github.com/microsoft/terminal/assets/15180557/db420ebb-18cc-4af0-af67-56f657bb526f)

## References and Relevant Issues
Addresses #16264.

## Detailed Description of the Pull Request / Additional comments
I also tried out these alternative styles but overall preferred the default TextBlock style (BodyTextBlockStyle).

BaseTextBlockStyle:
![image](https://github.com/microsoft/terminal/assets/15180557/de329f64-1490-45d1-8789-9735590d059a)

CaptionTextBlockStyle:
![image](https://github.com/microsoft/terminal/assets/15180557/693a0cf5-a3e8-471c-8447-1a11befb37af)

SecondaryTextBlockStyle:
![image](https://github.com/microsoft/terminal/assets/15180557/8197e6d2-f1bd-4853-9750-57efa7e2d449)


## Validation Steps Performed
Manually verified the appearance of the new text style on all pages where it is used, in light and dark mode.

## PR Checklist
- [x] Closes #16264
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
