### PR TITLE
Enable AtlasEngine by default

### DIFF
--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -949,25 +949,6 @@ void CascadiaSettings::_researchOnLoad()
     // Only do this if we're actually being sampled
     if (TraceLoggingProviderEnabled(g_hSettingsModelProvider, 0, MICROSOFT_KEYWORD_MEASURES))
     {
-        // GH#13936: We're interested in how many users opt out of useAtlasEngine,
-        // indicating major issues that would require us to disable it by default again.
-        {
-            size_t enabled[2]{};
-            for (const auto& profile : _activeProfiles)
-            {
-                enabled[profile.UseAtlasEngine()]++;
-            }
-
-            TraceLoggingWrite(
-                g_hSettingsModelProvider,
-                "AtlasEngine_Usage",
-                TraceLoggingDescription("Event emitted upon settings load, containing the number of profiles opted-in/out of useAtlasEngine"),
-                TraceLoggingUIntPtr(enabled[0], "UseAtlasEngineDisabled", "Number of profiles for which AtlasEngine is disabled"),
-                TraceLoggingUIntPtr(enabled[1], "UseAtlasEngineEnabled", "Number of profiles for which AtlasEngine is enabled"),
-                TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
-                TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
-        }
-
         // ----------------------------- RE: Themes ----------------------------
         const auto numThemes = GlobalSettings().Themes().Size();
         const auto themeInUse = GlobalSettings().CurrentTheme().Name();

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -90,7 +90,7 @@ Author(s):
     X(hstring, TabTitle, "tabTitle")                                                                                                                           \
     X(Model::BellStyle, BellStyle, "bellStyle", BellStyle::Audible)                                                                                            \
     X(IEnvironmentVariableMap, EnvironmentVariables, "environment", nullptr)                                                                                   \
-    X(bool, UseAtlasEngine, "useAtlasEngine", Feature_AtlasEngine::IsEnabled())                                                                                \
+    X(bool, UseAtlasEngine, "useAtlasEngine", true)                                                                                                            \
     X(bool, RightClickContextMenu, "experimental.rightClickContextMenu", false)                                                                                \
     X(Windows::Foundation::Collections::IVector<winrt::hstring>, BellSound, "bellSound", nullptr)                                                              \
     X(bool, Elevate, "elevate", false)                                                                                                                         \

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.h
@@ -148,7 +148,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         INHERITABLE_SETTING(Model::TerminalSettings, IEnvironmentVariableMap, EnvironmentVariables);
 
         INHERITABLE_SETTING(Model::TerminalSettings, Microsoft::Terminal::Control::ScrollbarState, ScrollState, Microsoft::Terminal::Control::ScrollbarState::Visible);
-        INHERITABLE_SETTING(Model::TerminalSettings, bool, UseAtlasEngine, false);
+        INHERITABLE_SETTING(Model::TerminalSettings, bool, UseAtlasEngine, true);
 
         INHERITABLE_SETTING(Model::TerminalSettings, Microsoft::Terminal::Control::TextAntialiasingMode, AntialiasingMode, Microsoft::Terminal::Control::TextAntialiasingMode::Grayscale);
 

--- a/src/cascadia/inc/ControlProperties.h
+++ b/src/cascadia/inc/ControlProperties.h
@@ -72,7 +72,7 @@
     X(winrt::Microsoft::Terminal::Control::TextAntialiasingMode, AntialiasingMode, winrt::Microsoft::Terminal::Control::TextAntialiasingMode::Grayscale) \
     X(bool, ForceFullRepaintRendering, false)                                                                                                            \
     X(bool, SoftwareRendering, false)                                                                                                                    \
-    X(bool, UseAtlasEngine, false)                                                                                                                       \
+    X(bool, UseAtlasEngine, true)                                                                                                                        \
     X(bool, UseBackgroundImageForWindow, false)                                                                                                          \
     X(bool, ShowMarks, false)                                                                                                                            \
     X(bool, RightClickContextMenu, false)

--- a/src/features.xml
+++ b/src/features.xml
@@ -77,16 +77,6 @@
     </feature>
 
     <feature>
-        <name>Feature_AtlasEngine</name>
-        <description>If enabled, AtlasEngine is used by default</description>
-        <stage>AlwaysEnabled</stage>
-        <alwaysDisabledBrandingTokens>
-            <brandingToken>Release</brandingToken>
-            <brandingToken>WindowsInbox</brandingToken>
-        </alwaysDisabledBrandingTokens>
-    </feature>
-
-    <feature>
         <name>Feature_AtlasEnginePresentFallback</name>
         <description>We don't feel super confident in our usage of the Present1 API, so this settings adds a fallback to Present on error</description>
         <stage>AlwaysDisabled</stage>


### PR DESCRIPTION
This enables AtlasEngine by default in the 1.19 release branch.
A future change will remove the alternative DxEngine entirely.