### PR TITLE
releng: add --first-parent to the scripts that use git log

### DIFF
--- a/tools/Get-OSSConhostLog.ps1
+++ b/tools/Get-OSSConhostLog.ps1
@@ -43,7 +43,7 @@ Function Get-Git2GitIgnoresAsExcludes() {
 
 $Excludes = Get-Git2GitIgnoresAsExcludes
 Write-Verbose "IGNORING: $Excludes"
-$Entries = & git log $RevisionRange "--pretty=format:%an%x1C%ae%x1C%s" -- $Excludes |
+$Entries = & git log $RevisionRange --first-parent "--pretty=format:%an%x1C%ae%x1C%s" -- $Excludes |
     ConvertFrom-CSV -Delimiter "`u{001C}" -Header Author,Email,Subject
 
 Write-Verbose ("{0} unfiltered log entries" -f $Entries.Count)

--- a/tools/ReleaseEngineering/New-TerminalStackedChangelog.ps1
+++ b/tools/ReleaseEngineering/New-TerminalStackedChangelog.ps1
@@ -62,7 +62,7 @@ ForEach ($RevisionRange in $RevisionRanges) {
     #   - %ae: author email
     #   - %x1C: another FS
     #   - %s: subject, the title of the commit
-    $NewEntries = & git log $RevisionRange "--pretty=format:%an%x1C%ae%x1C%s" |
+    $NewEntries = & git log $RevisionRange --first-parent "--pretty=format:%an%x1C%ae%x1C%s" |
         ConvertFrom-CSV -Delimiter "`u{001C}" -Header Author,Email,Subject
 
     $Entries += $NewEntries | % { [PSCustomObject]@{

--- a/tools/ReleaseEngineering/ServicingPipeline.ps1
+++ b/tools/ReleaseEngineering/ServicingPipeline.ps1
@@ -89,7 +89,7 @@ $Cards = Get-GithubProjectCard -ColumnId $ToPickColumn.id
 
 & git fetch --all 2>&1 | Out-Null
 
-$Entries = @(& git log $SourceBranch --grep "(#\($($Cards.Number -Join "\|")\))" "--pretty=format:%H%x1C%s"  |
+$Entries = @(& git log $SourceBranch --first-parent --grep "(#\($($Cards.Number -Join "\|")\))" "--pretty=format:%H%x1C%s"  |
     ConvertFrom-CSV -Delimiter "`u{001C}" -Header CommitID,Subject)
 
 [Array]::Reverse($Entries)


### PR DESCRIPTION
It makes the output less cluttered and more correct (for example: ServicingPipeline no longer tries to service two copies of each commit if there's a merge in the history...)