### PR TITLE
Fix margins on color schemes settings page

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -36,22 +36,15 @@
         </ResourceDictionary>
     </Page.Resources>
 
-    <Grid Margin="0,0,0,8"
-          RowSpacing="8">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-        <StackPanel Grid.Row="0"
-                    MaxWidth="{StaticResource StandardControlMaxWidth}"
-                    Spacing="8">
+    <StackPanel Style="{StaticResource SettingsStackStyle}">
+        <StackPanel MaxWidth="{StaticResource StandardControlMaxWidth}"
+                    Spacing="8"
+                    Margin="4,0,0,8">
             <TextBlock x:Uid="ColorSchemesDisclaimer"
                        Style="{StaticResource DisclaimerStyle}" />
 
             <Button x:Name="AddNewButton"
-                    Margin="4,0,0,0"
-                    Click="AddNew_Click"
-                    Style="{StaticResource BrowseButtonStyle}">
+                    Click="AddNew_Click">
                 <StackPanel Orientation="Horizontal">
                     <FontIcon FontSize="{StaticResource StandardIconSize}"
                               Glyph="&#xE710;" />
@@ -62,7 +55,6 @@
         </StackPanel>
 
         <ListView x:Name="ColorSchemeListView"
-                  Grid.Row="1"
                   MaxWidth="{StaticResource StandardControlMaxWidth}"
                   IsItemClickEnabled="True"
                   ItemClick="{x:Bind ViewModel.SchemeListItemClicked}"
@@ -217,5 +209,5 @@
                 </DataTemplate>
             </ListView.ItemTemplate>
         </ListView>
-    </Grid>
+    </StackPanel>
 </Page>


### PR DESCRIPTION
## Summary of the Pull Request
This increases the left and right margins of the contents of the color schemes settings page so that they line up correctly with the page header.

## References and Relevant Issues
Addresses #16290.

## Detailed Description of the Pull Request / Additional comments
* Replaced the Grid with a StackPanel to be consistent with other settings pages

## Validation Steps Performed
Visually verified the changes.

Before:
![image](https://github.com/microsoft/terminal/assets/15180557/6e35bd43-2b5a-48b3-a833-3741bc86d4b9)

After:
![image](https://github.com/microsoft/terminal/assets/15180557/7d78ed90-5107-42fb-8dbd-bfa5ab80d66b)

## PR Checklist
- [x] Closes #16290
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
