### PR TITLE
test: Add an LLM-powered bot to detect dupes

### DIFF
--- a/.github/workflows/similarIssues.yml
+++ b/.github/workflows/similarIssues.yml
@@ -1,0 +1,32 @@
+name: GitGudSimilarIssues comments
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  getsimilarissues:
+    runs-on: ubuntu-latest
+    outputs:
+      message: ${{ steps.getbody.outputs.message }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: getbody
+        uses: craigloewen-msft/GitGudSimilarIssues@main
+        with:
+          issuetitle: ${{ github.event.issue.title }}
+          repo: ${{ github.repository }}
+          similaritytolerance: "0.8"
+  add-comment:
+    needs: getsimilarissues
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add comment
+        run: gh issue comment "$NUMBER" --repo "$REPO" --body "$BODY"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          BODY: ${{ needs.getsimilarissues.outputs.message }}

--- a/.github/workflows/similarIssues.yml
+++ b/.github/workflows/similarIssues.yml
@@ -10,7 +10,6 @@ jobs:
     outputs:
       message: ${{ steps.getbody.outputs.message }}
     steps:
-      - uses: actions/checkout@v2
       - id: getbody
         uses: craigloewen-msft/GitGudSimilarIssues@main
         with:


### PR DESCRIPTION
Just like in https://github.com/microsoft/WSL/pull/10745

We're working with the WSL team to figure out if we can use a LLM to help us triage. This _should_ just comment on issues, if it finds something similar on the backlog. 

@craigloewen-msft as an FYI. If this explodes or doesn't work, well, we'll figure it out soon enough 😝 