### PR TITLE
Fix font preview for conhost

### DIFF
--- a/src/propsheet/misc.cpp
+++ b/src/propsheet/misc.cpp
@@ -398,10 +398,6 @@ CreateBoldFont:
     /*
      * Store the font info
      */
-    if (FontInfo[nFont].hFont != nullptr)
-    {
-        DeleteObject(FontInfo[nFont].hFont);
-    }
     FontInfo[nFont].hFont = hFont;
     FontInfo[nFont].Family = tmFamily;
     FontInfo[nFont].Size = SizeActual;


### PR DESCRIPTION
After exiting the main loop in this function the invariant
`nFont <= NumberOfFonts` still holds true. Additionally,
preceding this removed code is this (paraphrased):
```cpp
if (nFont < NumberOfFonts) {
    RtlMoveMemory(...);
}
```
It ensures that the given slot `nFont` is always unoccupied by moving
it and all following items upwards if needed. As such, the call to
`DeleteObject` is always incorrect, as the slot is always "empty",
but may contain a copy of the previous occupant due to the `memmove`.

This regressed in 154ac2b.

Closes #16297

## Validation Steps Performed
* All fonts have a unique look in the preview panel ✅