### PR TITLE
Fix scrolling with SetConsoleWindowInfo

### DIFF
--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -217,7 +217,7 @@ void Renderer::TriggerSystemRedraw(const til::rect* const prcDirtyClient)
 // - <none>
 void Renderer::TriggerRedraw(const Viewport& region)
 {
-    auto view = _viewport;
+    auto view = _pData->GetViewport();
     auto srUpdateRegion = region.ToExclusive();
 
     // If the dirty region has double width lines, we need to double the size of


### PR DESCRIPTION
81b7e54 caused a regression in `SetConsoleWindowInfo` and any other
function that used the `WriteToScreen` helper. This is because it
assumes that it can place the viewport anywhere randomly and it was
written at a time where `TriggerScroll` didn't exist yet (there was
no need for that (also not today, but that's being worked on)). 

Caching the viewport meant that `WriteToScreen`'s call to
`TriggerRedraw` would pick up the viewport from the last rendered
frame, which would cause the intersection of both to be potentially
empty and nothing to be drawn on the screen.

This commit reverts 81b7e54 as I found that it has no or negligible
impact on performance at this point, likely due to the overall
vastly better performance of conhost nowadays.

Closes #15932

## Validation Steps Performed
* Scroll the viewport by entire pages worth of content using
  `SetConsoleWindowInfo` - see #15932
* The screen and scrollbars update immediately ✅