### PR TITLE
Fix chunked soft fonts not working

### DIFF
--- a/src/host/VtIo.cpp
+++ b/src/host/VtIo.cpp
@@ -468,10 +468,6 @@ void VtIo::SendCloseEvent()
 void VtIo::CorkRenderer(bool corked) const noexcept
 {
     _pVtRenderEngine->Cork(corked);
-    if (!corked)
-    {
-        LOG_IF_FAILED(ServiceLocator::LocateGlobals().pRender->PaintFrame());
-    }
 }
 
 #ifdef UNIT_TESTING

--- a/src/renderer/vt/state.cpp
+++ b/src/renderer/vt/state.cpp
@@ -167,6 +167,7 @@ void VtEngine::_flushImpl() noexcept
 void VtEngine::Cork(bool corked) noexcept
 {
     _corked = corked;
+    _Flush();
 }
 
 // Method Description:


### PR DESCRIPTION
This changeset fixes an issue caused by #15991 where "chunked" escape
sequences would get corrupted. The fix is to simply not flush eagerly
anymore. I tried my best to keep the input lag reduction from #15991,
but unfortunately this isn't possible for console APIs.

Closes #16079

## Validation Steps Performed
* `type ascii.com` produces soft font ASCII characters ✅