### PR TITLE
Update paths to use linking within repo instead of github URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ The point of doing all this work in public is to ensure that we are holding ours
 
 The team triages new issues several times a week. During triage, the team uses labels to categorize, manage, and drive the project workflow.
 
-We employ [a bot engine](https://github.com/microsoft/terminal/blob/main/doc/bot.md) to help us automate common processes within our workflow.
+We employ [a bot engine](./doc/bot.md) to help us automate common processes within our workflow.
 
 We drive the bot by tagging issues with specific labels which cause the bot engine to close issues, merge branches, etc. This bot engine helps us keep the repo clean by automating the process of notifying appropriate parties if/when information/follow-up is needed, and closing stale issues/PRs after reminders have remained unanswered for several days.
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This repository contains the source code for:
 * [Windows Terminal Preview](https://aka.ms/terminal-preview)
 * The Windows console host (`conhost.exe`)
 * Components shared between the two projects
-* [ColorTool](https://github.com/microsoft/terminal/tree/main/src/tools/ColorTool)
-* [Sample projects](https://github.com/microsoft/terminal/tree/main/samples)
+* [ColorTool](./src/tools/ColorTool)
+* [Sample projects](./samples)
   that show how to consume the Windows Console APIs
 
 Related repositories include:
@@ -286,7 +286,7 @@ enhance Windows Terminal\!
 
 ***BEFORE you start work on a feature/fix***, please read & follow our
 [Contributor's
-Guide](https://github.com/microsoft/terminal/blob/main/CONTRIBUTING.md) to
+Guide](./CONTRIBUTING.md) to
 help avoid any wasted or duplicate effort.
 
 ## Communicating with the Team
@@ -387,10 +387,10 @@ Please review these brief docs below about our coding practices.
 This is a work in progress as we learn what we'll need to provide people in
 order to be effective contributors to our project.
 
-* [Coding Style](https://github.com/microsoft/terminal/blob/main/doc/STYLE.md)
-* [Code Organization](https://github.com/microsoft/terminal/blob/main/doc/ORGANIZATION.md)
-* [Exceptions in our legacy codebase](https://github.com/microsoft/terminal/blob/main/doc/EXCEPTIONS.md)
-* [Helpful smart pointers and macros for interfacing with Windows in WIL](https://github.com/microsoft/terminal/blob/main/doc/WIL.md)
+* [Coding Style](./doc/STYLE.md)
+* [Code Organization](./doc/ORGANIZATION.md)
+* [Exceptions in our legacy codebase](./doc/EXCEPTIONS.md)
+* [Helpful smart pointers and macros for interfacing with Windows in WIL](./doc/WIL.md)
 
 ---
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -14,4 +14,4 @@ Support for Windows Terminal is limited to the resources listed above.
 [gh-bug]: https://github.com/microsoft/terminal/issues/new?assignees=&labels=Issue-Bug&template=bug_report.md&title=
 [gh-feature]: https://github.com/microsoft/terminal/issues/new?assignees=&labels=Issue-Feature&template=Feature_Request.md&title=
 [docs]: https://docs.microsoft.com/windows/terminal
-[contributor]: https://github.com/microsoft/terminal/blob/main/CONTRIBUTING.md
+[contributor]: ./CONTRIBUTING.md

--- a/doc/roadmap-2022.md
+++ b/doc/roadmap-2022.md
@@ -115,7 +115,7 @@ Incoming issues/asks/etc. are triaged several times a week, labeled appropriatel
 [Up Next]: https://github.com/microsoft/terminal/milestone/37
 [Backlog]: https://github.com/microsoft/terminal/milestone/45
 
-[Terminal v2 Roadmap]: https://github.com/microsoft/terminal/tree/main/doc/terminal-v2-roadmap.md
+[Terminal v2 Roadmap]: ./terminal-v2-roadmap.md
 
 [Windows Terminal Preview 1.2 Release]: https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-2-release/
 [Windows Terminal Preview 1.3 Release]: https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-3-release/
@@ -131,4 +131,4 @@ Incoming issues/asks/etc. are triaged several times a week, labeled appropriatel
 [Windows Terminal Preview 1.13 Release]: https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-13-release/
 [Windows Terminal Preview 1.14 Release]: https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-14-release/
 
-[Terminal 2023 Roadmap]: https://github.com/microsoft/terminal/tree/main/doc/roadmap-2023.md
+[Terminal 2023 Roadmap]: ./roadmap-2023.md

--- a/doc/roadmap-2023.md
+++ b/doc/roadmap-2023.md
@@ -54,9 +54,9 @@ _informative, not normative_
 For a more fluid take on what each of the team's personal goals are, head on over to [Core team North Stars]. This has a list of more long-term goals that each team member is working towards, but not things that are necessarily committed work.
 
 
-[^1]: A conclusive list of these features can be found at https://github.com/microsoft/terminal/blob/main/src/features.xml. Note that this is a raw XML doc used to light up specific parts of the codebase, and not something authored for human consumption.
+[^1]: A conclusive list of these features can be found at [../src/features.xml](../src/features.xml). Note that this is a raw XML doc used to light up specific parts of the codebase, and not something authored for human consumption.
 
-[2022 Roadmap]: https://github.com/microsoft/terminal/tree/main/doc/roadmap-2022.md
+[2022 Roadmap]: ./roadmap-2022.md
 
 [Terminal 1.17]: https://github.com/microsoft/terminal/releases/tag/v1.17.1023
 [Terminal 1.18]: https://github.com/microsoft/terminal/releases/tag/v1.18.1462.0

--- a/doc/specs/#1571 - New Tab Menu Customization/#1571 - New Tab Menu Customization.md
+++ b/doc/specs/#1571 - New Tab Menu Customization/#1571 - New Tab Menu Customization.md
@@ -435,7 +435,7 @@ ultimately deemed it to be out of scope for the initial spec review.
 
 <!-- Footnotes -->
 [#2046]: https://github.com/microsoft/terminal/issues/2046
-[Command Palette, Addendum 1]: https://github.com/microsoft/terminal/blob/main/doc/specs/%232046%20-%20Unified%20keybindings%20and%20commands%2C%20and%20synthesized%20action%20names.md
+[Command Palette, Addendum 1]: ../%232046%20-%20Unified%20keybindings%20and%20commands%2C%20and%20synthesized%20action%20names.md
 
 [#3337]: https://github.com/microsoft/terminal/issues/3337
 [#6899]: https://github.com/microsoft/terminal/issues/6899

--- a/doc/specs/#1595 - Suggestions UI/Suggestions-UI.md
+++ b/doc/specs/#1595 - Suggestions UI/Suggestions-UI.md
@@ -734,7 +734,7 @@ shape of extensions will be is very much still to be determined.
 [#14939]: https://github.com/microsoft/terminal/issues/7285
 
 [#keep]: https://github.com/zadjii/keep
-[VsCode Tasks]: https://github.com/microsoft/terminal/blob/main/.vscode/tasks.json
+[VsCode Tasks]: ../../../../.vscode/tasks.json
 
 <!-- Note: This is its own spec in progress, but for the time being #12862 will do -->
 [Tasks]: https://github.com/microsoft/terminal/issues/12862

--- a/doc/specs/#1595 - Suggestions UI/Suggestions-UI.md
+++ b/doc/specs/#1595 - Suggestions UI/Suggestions-UI.md
@@ -734,7 +734,7 @@ shape of extensions will be is very much still to be determined.
 [#14939]: https://github.com/microsoft/terminal/issues/7285
 
 [#keep]: https://github.com/zadjii/keep
-[VsCode Tasks]: ../../../../.vscode/tasks.json
+[VsCode Tasks]: ../../../.vscode/tasks.json
 
 <!-- Note: This is its own spec in progress, but for the time being #12862 will do -->
 [Tasks]: https://github.com/microsoft/terminal/issues/12862

--- a/doc/specs/#2046 - Unified keybindings and commands, and synthesized action names.md
+++ b/doc/specs/#2046 - Unified keybindings and commands, and synthesized action names.md
@@ -605,4 +605,4 @@ as well as 3 schemes: "Scheme 1", "Scheme 2", and "Scheme 3".
 
 
 <!-- Footnotes -->
-[Command Palette Spec]: https://github.com/microsoft/terminal/blob/main/doc/specs/%232046%20-%20Command%20Palette.md
+[Command Palette Spec]: ./%232046%20-%20Command%20Palette.md

--- a/doc/specs/#5000 - Process Model 2.0/#1032 - Elevation Quality of Life Improvements.md
+++ b/doc/specs/#5000 - Process Model 2.0/#1032 - Elevation Quality of Life Improvements.md
@@ -612,8 +612,8 @@ You could have a profile that layers on an existing profile, with elevated-speci
 [#8514]: https://github.com/microsoft/terminal/issues/8514
 [#10276]: https://github.com/microsoft/terminal/issues/10276
 
-[Process Model 2.0 Spec]: https://github.com/microsoft/terminal/blob/main/doc/specs/%235000%20-%20Process%20Model%202.0.md
-[Configuration object for profiles]: https://github.com/microsoft/terminal/blob/main/doc/specs/Configuration%20object%20for%20profiles.md
-[Session Management Spec]: https://github.com/microsoft/terminal/blob/main/doc/specs/%234472%20-%20Windows%20Terminal%20Session%20Management.md
+[Process Model 2.0 Spec]: ../%235000%20-%20Process%20Model%202.0.md
+[Configuration object for profiles]: ../%233062%20-%20Appearance configuration object for profiles.md
+[Session Management Spec]: ./%234472%20-%20Windows%20Terminal%20Session%20Management.md
 [The Old New Thing: How can I launch an unelevated process from my elevated process, redux]: https://devblogs.microsoft.com/oldnewthing/20190425-00/?p=102443
 [Workspace Trust]: https://code.visualstudio.com/docs/editor/workspace-trust

--- a/doc/specs/#5000 - Process Model 2.0/#4472 - Windows Terminal Session Management.md
+++ b/doc/specs/#5000 - Process Model 2.0/#4472 - Windows Terminal Session Management.md
@@ -559,4 +559,4 @@ runtime.
 [Tab Tear-out in the community toolkit]: https://github.com/windows-toolkit/Sample-TabView-TearOff
 [Quake mode scenarios]: https://github.com/microsoft/terminal/issues/653#issuecomment-661370107
 [`ISwapChainPanelNative2::SetSwapChainHandle`]: https://docs.microsoft.com/en-us/windows/win32/api/windows.ui.xaml.media.dxinterop/nf-windows-ui-xaml-media-dxinterop-iswapchainpanelnative2-setswapchainhandle
-[Process Model 2.0 Spec]: https://github.com/microsoft/terminal/blob/main/doc/specs/%235000%20-%20Process%20Model%202.0/%235000%20-%20Process%20Model%202.0.md
+[Process Model 2.0 Spec]: ./doc/specs/%235000%20-%20Process%20Model%202.0/%235000%20-%20Process%20Model%202.0.md

--- a/doc/specs/#653 - Quake Mode/#653 - Quake Mode.md
+++ b/doc/specs/#653 - Quake Mode/#653 - Quake Mode.md
@@ -730,7 +730,7 @@ user to differentiate between the two behaviors.
 [#5727]: https://github.com/microsoft/terminal/issues/5727
 [#9992]: https://github.com/microsoft/terminal/issues/9992
 
-[Process Model 2.0 Spec]: https://github.com/microsoft/terminal/blob/main/doc/specs/%235000%20-%20Process%20Model%202.0/%235000%20-%20Process%20Model%202.0.md
+[Process Model 2.0 Spec]: ../%235000%20-%20Process%20Model%202.0/%235000%20-%20Process%20Model%202.0.md
 [Quake 3 sample]: https://youtu.be/ZmR6HQbuHPA?t=27
 [`RegisterHotKey`]: https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-registerhotkey
 [`dev/migrie/f/653-QUAKE-MODE`]: https://github.com/microsoft/terminal/tree/dev/migrie/f/653-QUAKE-MODE

--- a/doc/specs/#6899 - Action IDs/#6899 - Action IDs.md
+++ b/doc/specs/#6899 - Action IDs/#6899 - Action IDs.md
@@ -215,8 +215,8 @@ actions manually.
       the tab context menu or the control context menu.
 
 <!-- Footnotes -->
-[Command Palette Spec]: https://github.com/microsoft/terminal/blob/main/doc/specs/%232046%20-%20Command%20Palette.md
-[New Tab Menu Customization Spec]: https://github.com/microsoft/terminal/blob/main/doc/specs/%231571%20-%20New%20Tab%20Menu%20Customization.md
+[Command Palette Spec]: ./doc/specs/%232046%20-%20Command%20Palette.md
+[New Tab Menu Customization Spec]: ./doc/specs/%231571%20-%20New%20Tab%20Menu%20Customization.md
 
 [#1571]: https://github.com/microsoft/terminal/issues/1571
 [#1912]: https://github.com/microsoft/terminal/issues/1912

--- a/doc/terminal-v2-roadmap.md
+++ b/doc/terminal-v2-roadmap.md
@@ -142,4 +142,4 @@ Feature Notes:
 [#4472]: https://github.com/microsoft/terminal/issues/4472
 [#8048]: https://github.com/microsoft/terminal/pull/8048
 
-[Terminal 2022 Roadmap]: https://github.com/microsoft/terminal/tree/main/doc/roadmap-2022.md
+[Terminal 2022 Roadmap]: ./roadmap-2022.md


### PR DESCRIPTION
Update paths to use relative linking instead of static GitHub link. Also fixes some dead links

Closes #16338
