### PR TITLE
Avoid encoding VT via win32 input mode

### DIFF
--- a/src/host/inputBuffer.hpp
+++ b/src/host/inputBuffer.hpp
@@ -58,6 +58,7 @@ public:
     size_t Prepend(const std::span<const INPUT_RECORD>& inEvents);
     size_t Write(const INPUT_RECORD& inEvent);
     size_t Write(const std::span<const INPUT_RECORD>& inEvents);
+    void WriteDirect(const std::span<const INPUT_RECORD>& inEvents);
     void WriteFocusEvent(bool focused) noexcept;
     bool WriteMouseEvent(til::point position, unsigned int button, short keyState, short wheelDelta);
 

--- a/src/host/inputBuffer.hpp
+++ b/src/host/inputBuffer.hpp
@@ -58,7 +58,7 @@ public:
     size_t Prepend(const std::span<const INPUT_RECORD>& inEvents);
     size_t Write(const INPUT_RECORD& inEvent);
     size_t Write(const std::span<const INPUT_RECORD>& inEvents);
-    void WriteDirect(const std::span<const INPUT_RECORD>& inEvents);
+    void WriteString(const std::wstring_view& text);
     void WriteFocusEvent(bool focused) noexcept;
     bool WriteMouseEvent(til::point position, unsigned int button, short keyState, short wheelDelta);
 
@@ -97,6 +97,7 @@ private:
     void _WriteBuffer(const std::span<const INPUT_RECORD>& inRecords, _Out_ size_t& eventsWritten, _Out_ bool& setWaitEvent);
     bool _CoalesceEvent(const INPUT_RECORD& inEvent) noexcept;
     void _HandleTerminalInputCallback(const Microsoft::Console::VirtualTerminal::TerminalInput::StringType& text);
+    void _writeString(const std::wstring_view& text);
 
 #ifdef UNIT_TESTING
     friend class InputBufferTests;

--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -33,24 +33,11 @@ ConhostInternalGetSet::ConhostInternalGetSet(_In_ IIoProvider& io) :
 // - <none>
 void ConhostInternalGetSet::ReturnResponse(const std::wstring_view response)
 {
-    InputEventQueue inEvents;
-
-    // generate a paired key down and key up event for every
-    // character to be sent into the console's input buffer
-    for (const auto& wch : response)
-    {
-        // This wasn't from a real keyboard, so we're leaving key/scan codes blank.
-        auto keyEvent = SynthesizeKeyEvent(true, 1, 0, 0, wch, 0);
-        inEvents.push_back(keyEvent);
-        keyEvent.Event.KeyEvent.bKeyDown = false;
-        inEvents.push_back(keyEvent);
-    }
-
     // TODO GH#4954 During the input refactor we may want to add a "priority" input list
     // to make sure that "response" input is spooled directly into the application.
     // We switched this to an append (vs. a prepend) to fix GH#1637, a bug where two CPR
     // could collide with each other.
-    _io.GetActiveInputBuffer()->WriteDirect(inEvents);
+    _io.GetActiveInputBuffer()->WriteString(response);
 }
 
 // Routine Description:

--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -50,7 +50,7 @@ void ConhostInternalGetSet::ReturnResponse(const std::wstring_view response)
     // to make sure that "response" input is spooled directly into the application.
     // We switched this to an append (vs. a prepend) to fix GH#1637, a bug where two CPR
     // could collide with each other.
-    _io.GetActiveInputBuffer()->Write(inEvents);
+    _io.GetActiveInputBuffer()->WriteDirect(inEvents);
 }
 
 // Routine Description:


### PR DESCRIPTION
This changeset avoids re-encoding output from `AdaptDispatch`
via the win32-input-mode mechanism when VT input is enabled.
That is, an `AdaptDispatch` output like `\x1b[C` would otherwise
result in dozens of characters of input.

Related to #16343

## Validation Steps Performed
* Replace conhost with this
* Launch a Win32 application inside WSL
* ASCII keyboard inputs are represented as single `INPUT_RECORD`s ✅