### PR TITLE
Fix scroll-forward-disable setting

### DIFF
--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -95,7 +95,7 @@ til::rect ConhostInternalGetSet::GetViewport() const
 void ConhostInternalGetSet::SetViewportPosition(const til::point position)
 {
     auto& info = _io.GetActiveOutputBuffer();
-    THROW_IF_FAILED(info.SetViewportOrigin(true, position, false));
+    THROW_IF_FAILED(info.SetViewportOrigin(true, position, true));
     // SetViewportOrigin() only updates the virtual bottom (the bottom coordinate of the area
     // in the text buffer a VT client writes its output into) when it's moving downwards.
     // But this function is meant to truly move the viewport no matter what. Otherwise `tput reset` breaks.


### PR DESCRIPTION
The final parameter, `updateBottom`, controls not just whether the
`_virtualBottom` is updated, but also whether the position is clamped
to be within the existing `_virtualBottom`. Setting this to `false`
thus broke scroll-forward as the `_virtualBottom` was now a constant.

## Validation Steps Performed
* Disable scroll-foward
* Press and hold Ctrl+C
* It scrolls past the viewport bottom ✅