### PR TITLE
Fix a coroutine AV crash

### DIFF
--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -933,9 +933,13 @@ namespace winrt::TerminalApp::implementation
         ControlEventTokens events{};
 
         events.titleToken = control.TitleChanged([dispatcher, weakThis](auto&&, auto&&) -> winrt::fire_and_forget {
+            // The lambda lives in the `std::function`-style container owned by `control`. That is, when the
+            // `control` gets destroyed the lambda struct also gets destroyed. In other words, we need to
+            // copy `weakThis` onto the stack, because that's the only thing that gets captured in coroutines.
+            // See: https://devblogs.microsoft.com/oldnewthing/20211103-00/?p=105870
+            const auto weakThisCopy = weakThis;
             co_await wil::resume_foreground(dispatcher);
-            // Check if Tab's lifetime has expired
-            if (auto tab{ weakThis.get() })
+            if (auto tab{ weakThisCopy.get() })
             {
                 // The title of the control changed, but not necessarily the title of the tab.
                 // Set the tab's text to the active panes' text.
@@ -944,8 +948,9 @@ namespace winrt::TerminalApp::implementation
         });
 
         events.colorToken = control.TabColorChanged([dispatcher, weakThis](auto&&, auto&&) -> winrt::fire_and_forget {
+            const auto weakThisCopy = weakThis;
             co_await wil::resume_foreground(dispatcher);
-            if (auto tab{ weakThis.get() })
+            if (auto tab{ weakThisCopy.get() })
             {
                 // The control's tabColor changed, but it is not necessarily the
                 // active control in this tab. We'll just recalculate the
@@ -955,33 +960,36 @@ namespace winrt::TerminalApp::implementation
         });
 
         events.taskbarToken = control.SetTaskbarProgress([dispatcher, weakThis](auto&&, auto&&) -> winrt::fire_and_forget {
+            const auto weakThisCopy = weakThis;
             co_await wil::resume_foreground(dispatcher);
-            // Check if Tab's lifetime has expired
-            if (auto tab{ weakThis.get() })
+            if (auto tab{ weakThisCopy.get() })
             {
                 tab->_UpdateProgressState();
             }
         });
 
         events.stateToken = control.ConnectionStateChanged([dispatcher, weakThis](auto&&, auto&&) -> winrt::fire_and_forget {
+            const auto weakThisCopy = weakThis;
             co_await wil::resume_foreground(dispatcher);
-            if (auto tab{ weakThis.get() })
+            if (auto tab{ weakThisCopy.get() })
             {
                 tab->_UpdateConnectionClosedState();
             }
         });
 
         events.readOnlyToken = control.ReadOnlyChanged([dispatcher, weakThis](auto&&, auto&&) -> winrt::fire_and_forget {
+            const auto weakThisCopy = weakThis;
             co_await wil::resume_foreground(dispatcher);
-            if (auto tab{ weakThis.get() })
+            if (auto tab{ weakThisCopy.get() })
             {
                 tab->_RecalculateAndApplyReadOnly();
             }
         });
 
         events.focusToken = control.FocusFollowMouseRequested([dispatcher, weakThis](auto sender, auto) -> winrt::fire_and_forget {
+            const auto weakThisCopy = weakThis;
             co_await wil::resume_foreground(dispatcher);
-            if (const auto tab{ weakThis.get() })
+            if (const auto tab{ weakThisCopy.get() })
             {
                 if (tab->_focused())
                 {


### PR DESCRIPTION
tl;dr: A coroutine lambda does not hold onto captured variables.
This causes an AV crash when closing tabs. I randomly noticed this
in a Debug build as the memory contents got replaced with 0xCD.
In a Release build this bug is probably fairly subtle and not common.