### PR TITLE
Fix curlyline rendering in `AtlasEngine` and `GDIRenderer`

### DIFF
--- a/src/renderer/atlas/BackendD3D.h
+++ b/src/renderer/atlas/BackendD3D.h
@@ -291,7 +291,7 @@ namespace Microsoft::Console::Render::Atlas
         // The bounding rect of _cursorRects in pixels.
         til::rect _cursorPosition;
 
-        f32 _curlyLineDrawPeakHeight = 0;
+        f32 _curlyLinePeakHeight = 0.0f;
         FontDecorationPosition _curlyUnderline;
 
         bool _requiresContinuousRedraw = false;

--- a/src/renderer/gdi/paint.cpp
+++ b/src/renderer/gdi/paint.cpp
@@ -551,7 +551,7 @@ bool GdiEngine::FontHasWesternScript(HDC hdc)
         std::vector<POINT> points;
         points.reserve(cPoints);
 
-        const auto end = x + cCurlyLines * curlyLineWidth;
+        const auto end = x + gsl::narrow_cast<til::CoordType>(cCurlyLines * curlyLineWidth);
         auto start = x;
         while (start < end)
         {

--- a/src/renderer/gdi/paint.cpp
+++ b/src/renderer/gdi/paint.cpp
@@ -541,7 +541,7 @@ bool GdiEngine::FontHasWesternScript(HDC hdc)
         RETURN_HR_IF(E_FAIL, !LineTo(_hdcMemoryContext, x + w, y));
         return S_OK;
     };
-    const auto DrawCurlyLine = [&](const auto x, const auto y, const auto cCurlyLines) {
+    const auto DrawCurlyLine = [&](const til::CoordType x, const til::CoordType y, const size_t cCurlyLines) {
         const auto curlyLineWidth = fontWidth;
         const auto curlyLineHalfWidth = std::lround(curlyLineWidth / 2.0f);
         const auto controlPointHeight = std::lround(3.5f * _lineMetrics.curlylinePeakHeight);
@@ -551,9 +551,8 @@ bool GdiEngine::FontHasWesternScript(HDC hdc)
         std::vector<POINT> points;
         points.reserve(cPoints);
 
-        const auto end = x + gsl::narrow_cast<til::CoordType>(cCurlyLines * curlyLineWidth);
         auto start = x;
-        while (start < end)
+        for (size_t i = 0; i < cCurlyLines; i++)
         {
             points.emplace_back(start + curlyLineHalfWidth, y - controlPointHeight);
             points.emplace_back(start + curlyLineHalfWidth, y + controlPointHeight);

--- a/src/renderer/gdi/paint.cpp
+++ b/src/renderer/gdi/paint.cpp
@@ -536,9 +536,9 @@ bool GdiEngine::FontHasWesternScript(HDC hdc)
     const auto DrawLine = [=](const auto x, const auto y, const auto w, const auto h) {
         return PatBlt(_hdcMemoryContext, x, y, w, h, PATCOPY);
     };
-    const auto DrawStrokedLine = [&](const auto x, const auto y, const auto w) {
+    const auto DrawStrokedLine = [&](const til::CoordType x, const til::CoordType y, const unsigned w) {
         RETURN_HR_IF(E_FAIL, !MoveToEx(_hdcMemoryContext, x, y, nullptr));
-        RETURN_HR_IF(E_FAIL, !LineTo(_hdcMemoryContext, x + w, y));
+        RETURN_HR_IF(E_FAIL, !LineTo(_hdcMemoryContext, gsl::narrow_cast<int>(x + w), y));
         return S_OK;
     };
     const auto DrawCurlyLine = [&](const til::CoordType x, const til::CoordType y, const size_t cCurlyLines) {

--- a/src/renderer/gdi/state.cpp
+++ b/src/renderer/gdi/state.cpp
@@ -397,30 +397,24 @@ GdiEngine::~GdiEngine()
         _lineMetrics.underlineOffset2 = _lineMetrics.underlineOffset - _lineMetrics.gridlineWidth;
     }
 
-    const int strokeHalfWidth = std::lround(_lineMetrics.underlineWidth / 2.0f);
-
     // Since we use GDI pen for drawing, the underline offset should point to
     // the center of the underline.
-    _lineMetrics.underlineOffset += strokeHalfWidth;
-    _lineMetrics.underlineOffset2 += strokeHalfWidth;
-
-    // We want the underline to always be visible and remain within the cell
-    // bottom, so we clamp the offset to fit just inside.
-    _lineMetrics.underlineOffset = std::min(_lineMetrics.underlineOffset, maxUnderlineOffset);
-    _lineMetrics.underlineOffset2 = std::min(_lineMetrics.underlineOffset2, maxUnderlineOffset);
+    const auto underlineHalfWidth = gsl::narrow_cast<int>(std::floor(_lineMetrics.underlineWidth / 2.0f));
+    _lineMetrics.underlineOffset += underlineHalfWidth;
+    _lineMetrics.underlineOffset2 += underlineHalfWidth;
 
     // Curlyline uses the gap between cell bottom and singly underline position
     // as the height of the wave's peak. The baseline for curly line is at the
     // middle of singly underline. The gap could be too big, so we also apply a
     // limit on the peak height.
     {
-        const auto cellBottomGap = std::lround(Font.GetSize().height - _lineMetrics.underlineOffset - strokeHalfWidth);
+        const auto cellBottomGap = std::max(0, Font.GetSize().height - _lineMetrics.underlineOffset - _lineMetrics.underlineWidth);
 
         // get the max height for curly line peak. Max height is in `em` units.
         constexpr auto maxCurlyLinePeakHeightEm = 0.075f;
-        const auto maxCurlyLinePeakHeight = std::lround(maxCurlyLinePeakHeightEm * fontSize);
+        const auto maxCurlyLinePeakHeight = gsl::narrow_cast<int>(std::lround(maxCurlyLinePeakHeightEm * fontSize));
 
-        _lineMetrics.curlylinePeakHeight = std::clamp(cellBottomGap, 0L, maxCurlyLinePeakHeight);
+        _lineMetrics.curlylinePeakHeight = std::min(cellBottomGap, maxCurlyLinePeakHeight);
     }
 
     // Now find the size of a 0 in this current font and save it for conversions done later.

--- a/src/renderer/gdi/state.cpp
+++ b/src/renderer/gdi/state.cpp
@@ -397,7 +397,7 @@ GdiEngine::~GdiEngine()
         _lineMetrics.underlineOffset2 = _lineMetrics.underlineOffset - _lineMetrics.gridlineWidth;
     }
 
-    const int strokeHalfWidth = std::lround(_lineMetrics.underlineWidth / 2.0);
+    const int strokeHalfWidth = std::lround(_lineMetrics.underlineWidth / 2.0f);
 
     // Since we use GDI pen for drawing, the underline offset should point to
     // the center of the underline.


### PR DESCRIPTION
Fixes Curlyline being drawn as single underline in some cases

**Detailed Description**

- Curlyline is drawn at all font sizes.
- We might render a curlyline that is clipped in cases where we don't have enough space to draw a full curlyline. This is to give users a consistent view of Curlylines. Previously in those cases, it was drawn as a single underline.
- Removed minimum threshold `minCurlyLinePeakHeight` for Curlyline drawing.
- GDIRender changes:
  - Underline offset now points to the (vertical) mid position of the underline. Removes redundant `underlineMidY` calculation inside the draw call.

Closes #16288

**Validation Steps Performed**
- underlines are drawn properly in WT and Conhost

**PR Checklist**

- [x] Tests added/passed
