### PR TITLE
Remove EDP auditing completely

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -546,7 +546,6 @@ Edgium
 EDITKEYS
 EDITTEXT
 EDITUPDATE
-edputil
 Efast
 efghijklmn
 EHsc

--- a/src/host/res.rc
+++ b/src/host/res.rc
@@ -61,9 +61,6 @@ BEGIN
 
     ID_CONSOLE_FMT_WINDOWTITLE, "%s%s"
 
-/* WIP Audit destination name */
-    ID_CONSOLE_WIP_DESTINATIONNAME, "console application"
-
 /* Menu items that replace the standard ones. These don't have the accelerators */
     SC_CLOSE,       "&Close"
 

--- a/src/host/resource.h
+++ b/src/host/resource.h
@@ -28,7 +28,6 @@ Author(s):
 #define ID_CONSOLE_MSGMARKMODE           0x100C
 #define ID_CONSOLE_MSGSCROLLMODE         0x100D
 #define ID_CONSOLE_FMT_WINDOWTITLE       0x100E
-#define ID_CONSOLE_WIP_DESTINATIONNAME   0x100F
 
 // Menu Item strings
 #define ID_CONSOLE_COPY         0xFFF0

--- a/src/host/sources.inc
+++ b/src/host/sources.inc
@@ -138,7 +138,6 @@ TARGETLIBS = \
     $(ONECOREUAP_EXTERNAL_SDK_LIB_PATH)\d3d11.lib \
     $(MODERNCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\api-ms-win-mm-playsound-l1.lib \
     $(ONECORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-dwmapi-ext-l1.lib \
-    $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-edputil-policy-l1.lib \
     $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-gdi-dc-l1.lib \
     $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-gdi-dc-create-l1.lib \
     $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-gdi-draw-l1.lib \
@@ -206,7 +205,6 @@ DELAYLOAD = \
     api-ms-win-shell-dataobject-l1.dll; \
     api-ms-win-shell-namespace-l1.dll; \
     ext-ms-win-dwmapi-ext-l1.dll; \
-    ext-ms-win-edputil-policy-l1.dll; \
     ext-ms-win-usp10-l1.dll; \
     ext-ms-win-gdi-dc-l1.dll; \
     ext-ms-win-gdi-dc-create-l1.dll; \

--- a/src/inc/conint.h
+++ b/src/inc/conint.h
@@ -35,11 +35,6 @@ namespace Microsoft::Console::Internal
 
     }
 
-    namespace EdpPolicy
-    {
-        void AuditClipboard(const std::wstring_view destinationName) noexcept;
-    }
-
     namespace Theming
     {
         [[nodiscard]] HRESULT TrySetDarkMode(HWND hwnd) noexcept;

--- a/src/interactivity/win32/Clipboard.cpp
+++ b/src/interactivity/win32/Clipboard.cpp
@@ -75,8 +75,6 @@ void Clipboard::Paste()
     StringPaste(pwstr, (ULONG)GlobalSize(ClipboardDataHandle) / sizeof(WCHAR));
 
     // WIP auditing if user is enrolled
-    static auto DestinationName = _LoadString(ID_CONSOLE_WIP_DESTINATIONNAME);
-    Microsoft::Console::Internal::EdpPolicy::AuditClipboard(DestinationName);
 
     GlobalUnlock(ClipboardDataHandle);
 

--- a/src/interactivity/win32/resource.h
+++ b/src/interactivity/win32/resource.h
@@ -25,7 +25,6 @@ Author(s):
 #define ID_CONSOLE_MSGMARKMODE           0x100C
 #define ID_CONSOLE_MSGSCROLLMODE         0x100D
 #define ID_CONSOLE_FMT_WINDOWTITLE       0x100E
-#define ID_CONSOLE_WIP_DESTINATIONNAME   0x100F
 
 // Menu Item strings
 #define ID_CONSOLE_COPY         0xFFF0

--- a/src/interactivity/win32/ut_interactivity_win32/sources
+++ b/src/interactivity/win32/ut_interactivity_win32/sources
@@ -51,7 +51,6 @@ TARGETLIBS = \
     $(ONECOREUAP_EXTERNAL_SDK_LIB_PATH)\d3dcompiler.lib \
     $(MODERNCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\api-ms-win-mm-playsound-l1.lib \
     $(ONECORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-dwmapi-ext-l1.lib \
-    $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-edputil-policy-l1.lib \
     $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-gdi-dc-l1.lib \
     $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-gdi-dc-create-l1.lib \
     $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-gdi-draw-l1.lib \
@@ -116,7 +115,6 @@ DELAYLOAD = \
     api-ms-win-shell-dataobject-l1.dll; \
     api-ms-win-shell-namespace-l1.dll; \
     ext-ms-win-dwmapi-ext-l1.dll; \
-    ext-ms-win-edputil-policy-l1.dll; \
     ext-ms-win-gdi-dc-l1.dll; \
     ext-ms-win-gdi-dc-create-l1.dll; \
     ext-ms-win-gdi-draw-l1.dll; \

--- a/src/internal/stubs.cpp
+++ b/src/internal/stubs.cpp
@@ -21,10 +21,6 @@ using namespace Microsoft::Console::Internal;
     return S_OK;
 }
 
-void EdpPolicy::AuditClipboard(const std::wstring_view /*destinationName*/) noexcept
-{
-}
-
 [[nodiscard]] HRESULT Theming::TrySetDarkMode(HWND /*hwnd*/) noexcept
 {
     return S_FALSE;

--- a/src/propsheet/sources
+++ b/src/propsheet/sources
@@ -84,7 +84,6 @@ TARGETLIBS = \
     $(ONECORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\onecoreuap_internal.lib \
     $(ONECOREUAP_INTERNAL_SDK_LIB_PATH)\onecoreuapuuid.lib \
     $(ONECORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-dwmapi-ext-l1.lib \
-    $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-edputil-policy-l1.lib \
     $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-gdi-dc-l1.lib \
     $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-gdi-dc-create-l1.lib \
     $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-gdi-draw-l1.lib \
@@ -109,7 +108,6 @@ TARGETLIBS = \
 
 DELAYLOAD = \
     ext-ms-win-dwmapi-ext-l1.dll; \
-    ext-ms-win-edputil-policy-l1.dll; \
     ext-ms-win-uxtheme-themes-l1.dll; \
     ext-ms-win-shell32-shellfolders-l1.dll; \
     ext-ms-win-gdi-dc-l1.dll; \

--- a/src/terminal/adapter/ut_adapter/sources
+++ b/src/terminal/adapter/ut_adapter/sources
@@ -49,7 +49,6 @@ TARGETLIBS = \
     $(ONECOREUAP_EXTERNAL_SDK_LIB_PATH)\d3dcompiler.lib \
     $(MODERNCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\api-ms-win-mm-playsound-l1.lib \
     $(ONECORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-dwmapi-ext-l1.lib \
-    $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-edputil-policy-l1.lib \
     $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-gdi-dc-l1.lib \
     $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-gdi-dc-create-l1.lib \
     $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-gdi-draw-l1.lib \
@@ -111,7 +110,6 @@ DELAYLOAD = \
     api-ms-win-shell-dataobject-l1.dll; \
     api-ms-win-shell-namespace-l1.dll; \
     ext-ms-win-dwmapi-ext-l1.dll; \
-    ext-ms-win-edputil-policy-l1.dll; \
     ext-ms-win-usp10-l1.dll; \
     ext-ms-win-gdi-dc-l1.dll; \
     ext-ms-win-gdi-dc-create-l1.dll; \

--- a/src/terminal/parser/ut_parser/sources
+++ b/src/terminal/parser/ut_parser/sources
@@ -39,7 +39,6 @@ TARGETLIBS = \
     $(ONECOREUAP_EXTERNAL_SDK_LIB_PATH)\d3dcompiler.lib \
     $(MODERNCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\api-ms-win-mm-playsound-l1.lib \
     $(ONECORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-dwmapi-ext-l1.lib \
-    $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-edputil-policy-l1.lib \
     $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-gdi-dc-l1.lib \
     $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-gdi-dc-create-l1.lib \
     $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-gdi-draw-l1.lib \
@@ -102,7 +101,6 @@ DELAYLOAD = \
     api-ms-win-shell-dataobject-l1.dll; \
     api-ms-win-shell-namespace-l1.dll; \
     ext-ms-win-dwmapi-ext-l1.dll; \
-    ext-ms-win-edputil-policy-l1.dll; \
     ext-ms-win-gdi-dc-l1.dll; \
     ext-ms-win-gdi-dc-create-l1.dll; \
     ext-ms-win-gdi-draw-l1.dll; \


### PR DESCRIPTION
This pull request started out very differently. I was going to move all the EDP code from the internal `conint` project into the public, because EDP is [fully documented]!

Well, it doesn't have any headers in the SDK.

Or import libraries.

And it's got a deprecation notice:

> [!NOTE]
> Starting in July 2022, Microsoft is deprecating Windows Information
> Protection (WIP) and the APIs that support WIP. Microsoft will continue
> to support WIP on supported versions of Windows. New versions of Windows
> won't include new capabilities for WIP, and it won't be supported in
> future versions of Windows.

So I'm blasting it out the airlock instead.

[fully documented]: https://learn.microsoft.com/en-us/windows/win32/devnotes/windows-information-protection-api