### PR TITLE
Add missing TraceLoggingRegister calls

### DIFF
--- a/src/host/exe/exemain.cpp
+++ b/src/host/exe/exemain.cpp
@@ -222,6 +222,7 @@ int CALLBACK wWinMain(
     _In_ PWSTR /*pwszCmdLine*/,
     _In_ int /*nCmdShow*/)
 {
+    TraceLoggingRegister(g_hConhostV2EventTraceProvider);
     wil::SetResultLoggingCallback(&Tracing::TraceFailure);
     Microsoft::Console::Interactivity::ServiceLocator::LocateGlobals().hInstance = hInstance;
 

--- a/src/host/telemetry.cpp
+++ b/src/host/telemetry.cpp
@@ -4,12 +4,6 @@
 #include "precomp.h"
 #include "telemetry.hpp"
 
-TRACELOGGING_DEFINE_PROVIDER(g_hConhostV2EventTraceProvider,
-                             "Microsoft.Windows.Console.Host",
-                             // {fe1ff234-1f09-50a8-d38d-c44fab43e818}
-                             (0xfe1ff234, 0x1f09, 0x50a8, 0xd3, 0x8d, 0xc4, 0x4f, 0xab, 0x43, 0xe8, 0x18),
-                             TraceLoggingOptionMicrosoftTelemetry());
-
 // This code remains to serve as template if we ever need telemetry for conhost again.
 // The git history for this file may prove useful.
 #if 0

--- a/src/host/tracing.cpp
+++ b/src/host/tracing.cpp
@@ -12,13 +12,6 @@ TRACELOGGING_DEFINE_PROVIDER(g_hConhostV2EventTraceProvider,
                              (0xfe1ff234, 0x1f09, 0x50a8, 0xd3, 0x8d, 0xc4, 0x4f, 0xab, 0x43, 0xe8, 0x18),
                              TraceLoggingOptionMicrosoftTelemetry());
 
-static const auto cleanup = []() {
-    TraceLoggingRegister(g_hConhostV2EventTraceProvider);
-    return wil::scope_exit([]() {
-        TraceLoggingUnregister(g_hConhostV2EventTraceProvider);
-    });
-}();
-
 using namespace Microsoft::Console::Types;
 
 // NOTE: See `til.h` for which keyword flags are reserved

--- a/src/host/tracing.cpp
+++ b/src/host/tracing.cpp
@@ -6,6 +6,19 @@
 #include "../types/UiaTextRangeBase.hpp"
 #include "../types/ScreenInfoUiaProviderBase.h"
 
+TRACELOGGING_DEFINE_PROVIDER(g_hConhostV2EventTraceProvider,
+                             "Microsoft.Windows.Console.Host",
+                             // {fe1ff234-1f09-50a8-d38d-c44fab43e818}
+                             (0xfe1ff234, 0x1f09, 0x50a8, 0xd3, 0x8d, 0xc4, 0x4f, 0xab, 0x43, 0xe8, 0x18),
+                             TraceLoggingOptionMicrosoftTelemetry());
+
+static const auto cleanup = []() {
+    TraceLoggingRegister(g_hConhostV2EventTraceProvider);
+    return wil::scope_exit([]() {
+        TraceLoggingUnregister(g_hConhostV2EventTraceProvider);
+    });
+}();
+
 using namespace Microsoft::Console::Types;
 
 // NOTE: See `til.h` for which keyword flags are reserved

--- a/src/terminal/parser/tracing.cpp
+++ b/src/terminal/parser/tracing.cpp
@@ -7,6 +7,7 @@
 using namespace Microsoft::Console::VirtualTerminal;
 
 #pragma warning(push)
+#pragma warning(disable : 26426) // Global initializer calls a non-constexpr function '...' (i.22).)
 #pragma warning(disable : 26447) // The function is declared 'noexcept' but calls function '_tlgWrapBinary<wchar_t>()' which may throw exceptions
 #pragma warning(disable : 26477) // Use 'nullptr' rather than 0 or NULL
 

--- a/src/terminal/parser/tracing.cpp
+++ b/src/terminal/parser/tracing.cpp
@@ -15,6 +15,13 @@ TRACELOGGING_DEFINE_PROVIDER(g_hConsoleVirtTermParserEventTraceProvider,
                              // {c9ba2a84-d3ca-5e19-2bd6-776a0910cb9d}
                              (0xc9ba2a84, 0xd3ca, 0x5e19, 0x2b, 0xd6, 0x77, 0x6a, 0x09, 0x10, 0xcb, 0x9d));
 
+static const auto cleanup = []() {
+    TraceLoggingRegister(g_hConsoleVirtTermParserEventTraceProvider);
+    return wil::scope_exit([]() {
+        TraceLoggingUnregister(g_hConsoleVirtTermParserEventTraceProvider);
+    });
+}();
+
 void ParserTracing::TraceStateChange(_In_z_ const wchar_t* name) const noexcept
 {
     TraceLoggingWrite(g_hConsoleVirtTermParserEventTraceProvider,

--- a/src/terminal/parser/tracing.cpp
+++ b/src/terminal/parser/tracing.cpp
@@ -15,9 +15,9 @@ TRACELOGGING_DEFINE_PROVIDER(g_hConsoleVirtTermParserEventTraceProvider,
                              // {c9ba2a84-d3ca-5e19-2bd6-776a0910cb9d}
                              (0xc9ba2a84, 0xd3ca, 0x5e19, 0x2b, 0xd6, 0x77, 0x6a, 0x09, 0x10, 0xcb, 0x9d));
 
-static const auto cleanup = []() {
+static const auto cleanup = []() noexcept {
     TraceLoggingRegister(g_hConsoleVirtTermParserEventTraceProvider);
-    return wil::scope_exit([]() {
+    return wil::scope_exit([]() noexcept {
         TraceLoggingUnregister(g_hConsoleVirtTermParserEventTraceProvider);
     });
 }();


### PR DESCRIPTION
17cc109 and e9de646 both made the same mistake: When cleaning up our
telemetry code they also removed the calls to `TraceLoggingRegister`
which also broke regular tracing. Windows Defender in particular uses
the "CookedRead" event to monitor for malicious shell commands.

This doesn't fix it the "right way", because destructors of statics
aren't executed when DLLs are unloaded. But I felt like that this is
fine because we have way more statics than that in conhost land,
all of which have the same kind of issue.