### PR TITLE
Increase VtInputThread buffer size

### DIFF
--- a/src/host/VtInputThread.cpp
+++ b/src/host/VtInputThread.cpp
@@ -69,7 +69,7 @@ DWORD WINAPI VtInputThread::StaticVtInputThreadProc(_In_ LPVOID lpParameter)
 // - true if you should continue reading
 bool VtInputThread::DoReadInput()
 {
-    char buffer[256];
+    char buffer[4096];
     DWORD dwRead = 0;
     const auto ok = ReadFile(_hFile.get(), buffer, ARRAYSIZE(buffer), &dwRead, nullptr);
 
@@ -89,6 +89,12 @@ bool VtInputThread::DoReadInput()
         return false;
     }
 
+    // If we hit a parsing error, eat it. It's bad utf-8, we can't do anything with it.
+    if (FAILED_LOG(til::u8u16({ buffer, gsl::narrow_cast<size_t>(dwRead) }, _wstr, _u8State)))
+    {
+        return true;
+    }
+
     try
     {
         // Make sure to call the GLOBAL Lock/Unlock, not the gci's lock/unlock.
@@ -99,12 +105,7 @@ bool VtInputThread::DoReadInput()
         LockConsole();
         const auto unlock = wil::scope_exit([&] { UnlockConsole(); });
 
-        std::wstring wstr;
-        // If we hit a parsing error, eat it. It's bad utf-8, we can't do anything with it.
-        if (SUCCEEDED_LOG(til::u8u16({ buffer, gsl::narrow_cast<size_t>(dwRead) }, wstr, _u8State)))
-        {
-            _pInputStateMachine->ProcessString(wstr);
-        }
+        _pInputStateMachine->ProcessString(_wstr);
     }
     CATCH_LOG();
 

--- a/src/host/VtInputThread.hpp
+++ b/src/host/VtInputThread.hpp
@@ -39,5 +39,6 @@ namespace Microsoft::Console
 
         std::unique_ptr<Microsoft::Console::VirtualTerminal::StateMachine> _pInputStateMachine;
         til::u8state _u8State;
+        std::wstring _wstr;
     };
 }


### PR DESCRIPTION
This makes 3 improvements:
* 16x larger input buffer size improves behavior when pasting
  clipboard contents while the win32-input-mode is enabled,
  as each input character is roughly 15-20x longer after encoding.
* Translate UTF8 to UTF16 outside of the console lock.
* Preserve the UTF16 buffer between reads for less mallocs.