### PR TITLE
Update similarIssues.yml to have a lower tolerance

### DIFF
--- a/.github/workflows/similarIssues.yml
+++ b/.github/workflows/similarIssues.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           issuetitle: ${{ github.event.issue.title }}
           repo: ${{ github.repository }}
-          similaritytolerance: "0.8"
+          similaritytolerance: "0.75"
   add-comment:
     needs: getSimilarIssues
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary of the Pull Request
The tolerance value for a similar issue was changed from 0.8 to 0.75.

## References and Relevant Issues
This is because I changed the backend service for this to use pinecone instead of Azure AI search (see here https://github.com/craigloewen-msft/GitGudIssues/commit/f72fa59e23c0b7501b613daea95371cb13831d42 ) and the metric changed as a result of that. They are slightly lower than they were before, so this should offset that.

## Detailed Description of the Pull Request / Additional comments
Small PR so only one change of a value.

## Validation Steps Performed
Validated with the same calls to the Azure AI search and then to the new database to determine that minusing 0.05 would be sufficient.

## PR Checklist
- [X] No closed relevant issues
- [X] No specific Terminal tests
- [X] No need for documentation updates
- [X] No need for schema updates
