### PR TITLE
Enable alternate scroll mode by default

### DIFF
--- a/src/terminal/input/mouseInput.cpp
+++ b/src/terminal/input/mouseInput.cpp
@@ -334,11 +334,6 @@ TerminalInput::OutputType TerminalInput::HandleMouse(const til::point position, 
         _mouseInputState.accumulatedDelta = 0;
     }
 
-    if (ShouldSendAlternateScroll(button, delta))
-    {
-        return _makeAlternateScrollOutput(delta);
-    }
-
     if (IsTrackingMouseInput())
     {
         // isHover is only true for WM_MOUSEMOVE events
@@ -390,6 +385,11 @@ TerminalInput::OutputType TerminalInput::HandleMouse(const til::point position, 
                 return _GenerateDefaultSequence(position, realButton, isHover, modifierKeyState, delta);
             }
         }
+    }
+
+    if (ShouldSendAlternateScroll(button, delta))
+    {
+        return _makeAlternateScrollOutput(delta);
     }
 
     return {};

--- a/src/terminal/input/terminalInput.cpp
+++ b/src/terminal/input/terminalInput.cpp
@@ -259,7 +259,7 @@ bool TerminalInput::GetInputMode(const Mode mode) const noexcept
 
 void TerminalInput::ResetInputModes() noexcept
 {
-    _inputMode = { Mode::Ansi, Mode::AutoRepeat };
+    _inputMode = { Mode::Ansi, Mode::AutoRepeat, Mode::AlternateScroll };
     _mouseInputState.lastPos = { -1, -1 };
     _mouseInputState.lastButton = 0;
 }

--- a/src/terminal/input/terminalInput.hpp
+++ b/src/terminal/input/terminalInput.hpp
@@ -70,7 +70,7 @@ namespace Microsoft::Console::VirtualTerminal
 
         std::optional<WORD> _lastVirtualKeyCode;
 
-        til::enumset<Mode> _inputMode{ Mode::Ansi, Mode::AutoRepeat };
+        til::enumset<Mode> _inputMode{ Mode::Ansi, Mode::AutoRepeat, Mode::AlternateScroll };
         bool _forceDisableWin32InputMode{ false };
 
         [[nodiscard]] OutputType _makeCharOutput(wchar_t ch);


### PR DESCRIPTION
## Summary of the Pull Request

This PR enables alternate scroll mode by default, and also fixes the
precedence so if there is any other mouse tracking mode enabled, that
will take priority.

## Validation Steps Performed

I've manually tested by viewing a file with `less`, and confirmed that
it can now scroll using the mouse wheel by default. Also tested mouse
mouse in vim and confirmed that still works.

## PR Checklist
- [x] Closes #13187
- [ ] Tests added/passed
