### PR TITLE
Update SUI Color Scheme colors' AutoProp.Name and ToolTip

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/ColorSchemeViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemeViewModel.cpp
@@ -178,6 +178,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         Name(TableColorNames[index]);
         Tag(winrt::box_value<uint8_t>(index));
         Color(color);
+
+        PropertyChanged({ get_weak(), &ColorTableEntry::_PropertyChangedHandler });
     }
 
     ColorTableEntry::ColorTableEntry(std::wstring_view tag, Windows::UI::Color color)
@@ -185,5 +187,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         Name(LocalizedNameForEnumName(L"ColorScheme_", tag, L"Text"));
         Tag(winrt::box_value(tag));
         Color(color);
+
+        PropertyChanged({ get_weak(), &ColorTableEntry::_PropertyChangedHandler });
     }
+
+
 }

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemeViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemeViewModel.cpp
@@ -191,4 +191,13 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         PropertyChanged({ get_weak(), &ColorTableEntry::_PropertyChangedHandler });
     }
 
+    void ColorTableEntry::_PropertyChangedHandler(const IInspectable& /*sender*/, const PropertyChangedEventArgs& args)
+    {
+        const auto propertyName{ args.PropertyName() };
+        if (propertyName == L"Color" || propertyName == L"Name")
+        {
+            _PropertyChangedHandlers(*this, PropertyChangedEventArgs{ L"AccessibleName" });
+        }
+    }
+
 }

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemeViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemeViewModel.cpp
@@ -191,5 +191,4 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         PropertyChanged({ get_weak(), &ColorTableEntry::_PropertyChangedHandler });
     }
 
-
 }

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemeViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemeViewModel.h
@@ -63,6 +63,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         ColorTableEntry(uint8_t index, Windows::UI::Color color);
         ColorTableEntry(std::wstring_view tag, Windows::UI::Color color);
 
+        hstring AccessibleName() const
+        {
+            return hstring{ fmt::format(L"{} RGB({}, {}, {})", _Name, _Color.R, _Color.G, _Color.B) };
+        }
+
         WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
         WINRT_OBSERVABLE_PROPERTY(Windows::UI::Color, Color, _PropertyChangedHandlers);
         WINRT_OBSERVABLE_PROPERTY(winrt::hstring, Name, _PropertyChangedHandlers);
@@ -70,5 +75,14 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     private:
         Windows::UI::Color _color;
+
+        void _PropertyChangedHandler(const Windows::Foundation::IInspectable& /*sender*/, const Windows::UI::Xaml::Data::PropertyChangedEventArgs& args)
+        {
+            const auto propertyName{ args.PropertyName() };
+            if (propertyName == L"Color")
+            {
+                _PropertyChangedHandlers(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"AccessibleName" });
+            }
+        }
     };
 };

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemeViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemeViewModel.h
@@ -65,7 +65,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         hstring AccessibleName() const
         {
-            return hstring{ fmt::format(L"{} RGB({}, {}, {})", _Name, _Color.R, _Color.G, _Color.B) };
+            return hstring{ fmt::format(FMT_COMPILE(L"{} RGB({}, {}, {})"), _Name, _Color.R, _Color.G, _Color.B) };
         }
 
         WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
@@ -76,13 +76,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     private:
         Windows::UI::Color _color;
 
-        void _PropertyChangedHandler(const Windows::Foundation::IInspectable& /*sender*/, const Windows::UI::Xaml::Data::PropertyChangedEventArgs& args)
-        {
-            const auto propertyName{ args.PropertyName() };
-            if (propertyName == L"Color")
-            {
-                _PropertyChangedHandlers(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"AccessibleName" });
-            }
-        }
+        void _PropertyChangedHandler(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Data::PropertyChangedEventArgs& args);
     };
 };

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemeViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemeViewModel.idl
@@ -34,5 +34,6 @@ namespace Microsoft.Terminal.Settings.Editor
         String Name { get; };
         IInspectable Tag;
         Windows.UI.Color Color;
+        String AccessibleName { get; };
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/EditColorScheme.xaml
+++ b/src/cascadia/TerminalSettingsEditor/EditColorScheme.xaml
@@ -55,10 +55,10 @@
 
             <DataTemplate x:Key="ColorTableEntryTemplate"
                           x:DataType="local:ColorTableEntry">
-                <Button AutomationProperties.Name="{x:Bind Name}"
+                <Button AutomationProperties.Name="{x:Bind AccessibleName, Mode=OneWay}"
                         Background="{x:Bind local:Converters.ColorToBrush(Color), Mode=OneWay}"
                         Style="{StaticResource ColorSchemesColorButtonStyle}"
-                        ToolTipService.ToolTip="{x:Bind Name}">
+                        ToolTipService.ToolTip="{x:Bind AccessibleName, Mode=OneWay}">
                     <Button.Flyout>
                         <Flyout>
                             <muxc:ColorPicker ColorChanged="ColorPickerChanged"


### PR DESCRIPTION
## Summary of the Pull Request

In the Settings UI's Color Scheme page (where you edit the color scheme itself), update the color chip buttons to include the RGB value in the tooltip and screen reader announcements.

Closes #15985
Closes #15983

## Validation Steps Performed
Tooltip and screen reader announcement is updated on launch and when a new value is selected.
