### PR TITLE
Change the SUB control glyph to U+2426

### DIFF
--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -87,8 +87,8 @@ bool OutputStateMachineEngine::ActionExecute(const wchar_t wch)
     case AsciiChars::SUB:
         // The SUB control is used to cancel a control sequence in the same
         // way as CAN, but unlike CAN it also displays an error character,
-        // typically a reverse question mark.
-        _dispatch->Print(L'\u2E2E');
+        // typically a reverse question mark (Unicode substitute form two).
+        _dispatch->Print(L'\u2426');
         break;
     case AsciiChars::DEL:
         // The DEL control can sometimes be translated into a printable glyph


### PR DESCRIPTION
## Summary of the Pull Request

Up to now we've using `U+2E2E` (reverse question mark) to represent the
`SUB` control glyph. This PR changes the glyph to `U+2426` (substitute
form two), which is also rendered as a reverse question mark, but is
more semantically correct.

## References and Relevant Issues

The original `SUB` control rendering was implemented in PR #15075.

## Validation Steps Performed

I've manually confirmed that `printf "\x1A"` is now shown as a reverse
question mark in OpenConsole when using the Cascadia Code font. That
would not previously have worked, because `U+2E2E` is not supported by
Cascadia Code.

## PR Checklist
- [x] Closes #16558
