### PR TITLE
General improvements in preparation for #16598

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -183,6 +183,7 @@ chh
 chshdng
 CHT
 Cic
+CLASSSTRING
 CLE
 cleartype
 CLICKACTIVE

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -124,8 +124,7 @@ namespace winrt::TerminalApp::implementation
         return appLogic->GetSettings();
     }
 
-    AppLogic::AppLogic() :
-        _reloadState{ std::chrono::milliseconds(100), []() { ApplicationState::SharedInstance().Reload(); } }
+    AppLogic::AppLogic()
     {
         // For your own sanity, it's better to do setup outside the ctor.
         // If you do any setup in the ctor that ends up throwing an exception,
@@ -326,10 +325,6 @@ namespace winrt::TerminalApp::implementation
                 if (modifiedBasename == settingsBasename)
                 {
                     _reloadSettings->Run();
-                }
-                else if (ApplicationState::SharedInstance().IsStatePath(modifiedBasename))
-                {
-                    _reloadState();
                 }
             });
     }

--- a/src/cascadia/TerminalApp/AppLogic.h
+++ b/src/cascadia/TerminalApp/AppLogic.h
@@ -91,7 +91,6 @@ namespace winrt::TerminalApp::implementation
         ::TerminalApp::AppCommandlineArgs _settingsAppArgs;
 
         std::shared_ptr<ThrottledFuncTrailing<>> _reloadSettings;
-        til::throttled_func_trailing<> _reloadState;
 
         std::vector<Microsoft::Terminal::Settings::Model::SettingsLoadWarnings> _warnings{};
 

--- a/src/cascadia/TerminalApp/DebugTapConnection.cpp
+++ b/src/cascadia/TerminalApp/DebugTapConnection.cpp
@@ -50,6 +50,7 @@ namespace winrt::Microsoft::TerminalApp::implementation
         void TerminalOutput(const winrt::event_token& token) noexcept { _wrappedConnection.TerminalOutput(token); };
         winrt::event_token StateChanged(const TypedEventHandler<ITerminalConnection, IInspectable>& handler) { return _wrappedConnection.StateChanged(handler); };
         void StateChanged(const winrt::event_token& token) noexcept { _wrappedConnection.StateChanged(token); };
+        winrt::guid SessionId() const noexcept { return {}; }
         ConnectionState State() const noexcept { return _wrappedConnection.State(); }
 
     private:
@@ -96,6 +97,15 @@ namespace winrt::Microsoft::TerminalApp::implementation
         _outputRevoker.revoke();
         _stateChangedRevoker.revoke();
         _wrappedConnection = nullptr;
+    }
+
+    guid DebugTapConnection::SessionId() const noexcept
+    {
+        if (const auto c = _wrappedConnection.get())
+        {
+            return c.SessionId();
+        }
+        return {};
     }
 
     ConnectionState DebugTapConnection::State() const noexcept

--- a/src/cascadia/TerminalApp/DebugTapConnection.h
+++ b/src/cascadia/TerminalApp/DebugTapConnection.h
@@ -19,6 +19,8 @@ namespace winrt::Microsoft::TerminalApp::implementation
         void WriteInput(const hstring& data);
         void Resize(uint32_t rows, uint32_t columns);
         void Close();
+
+        winrt::guid SessionId() const noexcept;
         winrt::Microsoft::Terminal::TerminalConnection::ConnectionState State() const noexcept;
 
         void SetInputTap(const Microsoft::Terminal::TerminalConnection::ITerminalConnection& inputTap);

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1210,7 +1210,7 @@ namespace winrt::TerminalApp::implementation
         TerminalConnection::ITerminalConnection connection{ nullptr };
 
         auto connectionType = profile.ConnectionType();
-        winrt::guid sessionGuid{};
+        Windows::Foundation::Collections::ValueSet valueSet;
 
         if (connectionType == TerminalConnection::AzureConnection::ConnectionType() &&
             TerminalConnection::AzureConnection::IsAzureConnectionAvailable())
@@ -1226,23 +1226,16 @@ namespace winrt::TerminalApp::implementation
                 connection = TerminalConnection::ConptyConnection{};
             }
 
-            auto valueSet = TerminalConnection::ConptyConnection::CreateSettings(azBridgePath.native(),
-                                                                                 L".",
-                                                                                 L"Azure",
-                                                                                 false,
-                                                                                 L"",
-                                                                                 nullptr,
-                                                                                 settings.InitialRows(),
-                                                                                 settings.InitialCols(),
-                                                                                 winrt::guid(),
-                                                                                 profile.Guid());
-
-            if constexpr (Feature_VtPassthroughMode::IsEnabled())
-            {
-                valueSet.Insert(L"passthroughMode", Windows::Foundation::PropertyValue::CreateBoolean(settings.VtPassthrough()));
-            }
-
-            connection.Initialize(valueSet);
+            valueSet = TerminalConnection::ConptyConnection::CreateSettings(azBridgePath.native(),
+                                                                            L".",
+                                                                            L"Azure",
+                                                                            false,
+                                                                            L"",
+                                                                            nullptr,
+                                                                            settings.InitialRows(),
+                                                                            settings.InitialCols(),
+                                                                            winrt::guid(),
+                                                                            profile.Guid());
         }
 
         else
@@ -1267,30 +1260,30 @@ namespace winrt::TerminalApp::implementation
             // process until later, on another thread, after we've already
             // restored the CWD to its original value.
             auto newWorkingDirectory{ _evaluatePathForCwd(settings.StartingDirectory()) };
-            auto conhostConn = TerminalConnection::ConptyConnection();
-            auto valueSet = TerminalConnection::ConptyConnection::CreateSettings(settings.Commandline(),
-                                                                                 newWorkingDirectory,
-                                                                                 settings.StartingTitle(),
-                                                                                 settings.ReloadEnvironmentVariables(),
-                                                                                 _WindowProperties.VirtualEnvVars(),
-                                                                                 environment,
-                                                                                 settings.InitialRows(),
-                                                                                 settings.InitialCols(),
-                                                                                 winrt::guid(),
-                                                                                 profile.Guid());
-
-            valueSet.Insert(L"passthroughMode", Windows::Foundation::PropertyValue::CreateBoolean(settings.VtPassthrough()));
+            connection = TerminalConnection::ConptyConnection{};
+            valueSet = TerminalConnection::ConptyConnection::CreateSettings(settings.Commandline(),
+                                                                            newWorkingDirectory,
+                                                                            settings.StartingTitle(),
+                                                                            settings.ReloadEnvironmentVariables(),
+                                                                            _WindowProperties.VirtualEnvVars(),
+                                                                            environment,
+                                                                            settings.InitialRows(),
+                                                                            settings.InitialCols(),
+                                                                            winrt::guid(),
+                                                                            profile.Guid());
 
             if (inheritCursor)
             {
                 valueSet.Insert(L"inheritCursor", Windows::Foundation::PropertyValue::CreateBoolean(true));
             }
-
-            conhostConn.Initialize(valueSet);
-
-            sessionGuid = conhostConn.Guid();
-            connection = conhostConn;
         }
+
+        if constexpr (Feature_VtPassthroughMode::IsEnabled())
+        {
+            valueSet.Insert(L"passthroughMode", Windows::Foundation::PropertyValue::CreateBoolean(settings.VtPassthrough()));
+        }
+
+        connection.Initialize(valueSet);
 
         TraceLoggingWrite(
             g_hTerminalAppProvider,
@@ -1298,7 +1291,7 @@ namespace winrt::TerminalApp::implementation
             TraceLoggingDescription("Event emitted upon the creation of a connection"),
             TraceLoggingGuid(connectionType, "ConnectionTypeGuid", "The type of the connection"),
             TraceLoggingGuid(profile.Guid(), "ProfileGuid", "The profile's GUID"),
-            TraceLoggingGuid(sessionGuid, "SessionGuid", "The WT_SESSION's GUID"),
+            TraceLoggingGuid(connection.SessionId(), "SessionGuid", "The WT_SESSION's GUID"),
             TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
             TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
 

--- a/src/cascadia/TerminalConnection/AzureConnection.cpp
+++ b/src/cascadia/TerminalConnection/AzureConnection.cpp
@@ -77,8 +77,14 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
     {
         if (settings)
         {
-            _initialRows = gsl::narrow<til::CoordType>(winrt::unbox_value_or<uint32_t>(settings.TryLookup(L"initialRows").try_as<Windows::Foundation::IPropertyValue>(), _initialRows));
-            _initialCols = gsl::narrow<til::CoordType>(winrt::unbox_value_or<uint32_t>(settings.TryLookup(L"initialCols").try_as<Windows::Foundation::IPropertyValue>(), _initialCols));
+            _initialRows = unbox_prop_or<uint32_t>(settings, L"initialRows", _initialRows);
+            _initialCols = unbox_prop_or<uint32_t>(settings, L"initialCols", _initialCols);
+            _sessionId = unbox_prop_or<guid>(settings, L"sessionId", _sessionId);
+        }
+
+        if (_sessionId == guid{})
+        {
+            _sessionId = Utils::CreateGuid();
         }
     }
 

--- a/src/cascadia/TerminalConnection/AzureConnection.h
+++ b/src/cascadia/TerminalConnection/AzureConnection.h
@@ -8,12 +8,12 @@
 #include <mutex>
 #include <condition_variable>
 
-#include "ConnectionStateHolder.h"
+#include "BaseTerminalConnection.h"
 #include "AzureClient.h"
 
 namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 {
-    struct AzureConnection : AzureConnectionT<AzureConnection>, ConnectionStateHolder<AzureConnection>
+    struct AzureConnection : AzureConnectionT<AzureConnection>, BaseTerminalConnection<AzureConnection>
     {
         static winrt::guid ConnectionType() noexcept;
         static bool IsAzureConnectionAvailable() noexcept;

--- a/src/cascadia/TerminalConnection/BaseTerminalConnection.h
+++ b/src/cascadia/TerminalConnection/BaseTerminalConnection.h
@@ -4,13 +4,28 @@
 namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 {
     template<typename T>
-    struct ConnectionStateHolder
+    struct BaseTerminalConnection
     {
     public:
-        ConnectionState State() const noexcept { return _connectionState; }
+        winrt::guid SessionId() const noexcept
+        {
+            return _sessionId;
+        }
+
+        ConnectionState State() const noexcept
+        {
+            return _connectionState;
+        }
+
         TYPED_EVENT(StateChanged, ITerminalConnection, winrt::Windows::Foundation::IInspectable);
 
     protected:
+        template<typename U>
+        U unbox_prop_or(const Windows::Foundation::Collections::ValueSet& blob, std::wstring_view key, U defaultValue)
+        {
+            return winrt::unbox_value_or<U>(blob.TryLookup(key).try_as<Windows::Foundation::IPropertyValue>(), defaultValue);
+        }
+
 #pragma warning(push)
 #pragma warning(disable : 26447) // Analyzer is still upset about noexcepts throwing even with function level try.
         // Method Description:
@@ -85,6 +100,8 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         {
             return _isStateOneOf(ConnectionState::Connected);
         }
+
+        winrt::guid _sessionId{};
 
     private:
         std::atomic<ConnectionState> _connectionState{ ConnectionState::NotConnected };

--- a/src/cascadia/TerminalConnection/ConptyConnection.h
+++ b/src/cascadia/TerminalConnection/ConptyConnection.h
@@ -4,14 +4,14 @@
 #pragma once
 
 #include "ConptyConnection.g.h"
-#include "ConnectionStateHolder.h"
+#include "BaseTerminalConnection.h"
 
 #include "ITerminalHandoff.h"
 #include <til/env.h>
 
 namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 {
-    struct ConptyConnection : ConptyConnectionT<ConptyConnection>, ConnectionStateHolder<ConptyConnection>
+    struct ConptyConnection : ConptyConnectionT<ConptyConnection>, BaseTerminalConnection<ConptyConnection>
     {
         ConptyConnection(const HANDLE hSig,
                          const HANDLE hIn,
@@ -36,7 +36,6 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 
         void ReparentWindow(const uint64_t newParent);
 
-        winrt::guid Guid() const noexcept;
         winrt::hstring Commandline() const;
         winrt::hstring StartingTitle() const;
         WORD ShowWindow() const noexcept;
@@ -77,7 +76,6 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         hstring _startingTitle{};
         bool _initialVisibility{ true };
         Windows::Foundation::Collections::ValueSet _environment{ nullptr };
-        guid _guid{}; // A unique session identifier for connected client
         hstring _clientName{}; // The name of the process hosted by this ConPTY connection (as of launch).
 
         bool _receivedFirstByte{ false };

--- a/src/cascadia/TerminalConnection/ConptyConnection.idl
+++ b/src/cascadia/TerminalConnection/ConptyConnection.idl
@@ -10,7 +10,6 @@ namespace Microsoft.Terminal.TerminalConnection
     [default_interface] runtimeclass ConptyConnection : ITerminalConnection
     {
         ConptyConnection();
-        Guid Guid { get; };
         String Commandline { get; };
         String StartingTitle { get; };
         UInt16 ShowWindow { get; };

--- a/src/cascadia/TerminalConnection/EchoConnection.h
+++ b/src/cascadia/TerminalConnection/EchoConnection.h
@@ -18,6 +18,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 
         void Initialize(const Windows::Foundation::Collections::ValueSet& /*settings*/) const noexcept {};
 
+        winrt::guid SessionId() const noexcept { return {}; }
         ConnectionState State() const noexcept { return ConnectionState::Connected; }
 
         WINRT_CALLBACK(TerminalOutput, TerminalOutputHandler);

--- a/src/cascadia/TerminalConnection/ITerminalConnection.idl
+++ b/src/cascadia/TerminalConnection/ITerminalConnection.idl
@@ -25,8 +25,9 @@ namespace Microsoft.Terminal.TerminalConnection
         void Close();
 
         event TerminalOutputHandler TerminalOutput;
-
         event Windows.Foundation.TypedEventHandler<ITerminalConnection, Object> StateChanged;
+
+        Guid SessionId { get; };
         ConnectionState State { get; };
     };
 }

--- a/src/cascadia/TerminalConnection/TerminalConnection.vcxproj
+++ b/src/cascadia/TerminalConnection/TerminalConnection.vcxproj
@@ -17,6 +17,7 @@
   <Import Project="$(OpenConsoleDir)src\cppwinrt.build.pre.props" />
   <ItemGroup>
     <ClInclude Include="AzureClientID.h" />
+    <ClInclude Include="BaseTerminalConnection.h" />
     <ClInclude Include="ConnectionInformation.h">
       <DependentUpon>ConnectionInformation.idl</DependentUpon>
     </ClInclude>

--- a/src/cascadia/TerminalConnection/TerminalConnection.vcxproj.filters
+++ b/src/cascadia/TerminalConnection/TerminalConnection.vcxproj.filters
@@ -26,6 +26,7 @@
     <ClInclude Include="AzureConnection.h" />
     <ClInclude Include="AzureClientID.h" />
     <ClInclude Include="CTerminalHandoff.h" />
+    <ClInclude Include="BaseTerminalConnection.h" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="ITerminalConnection.idl" />
@@ -35,10 +36,8 @@
     <Midl Include="ConnectionInformation.idl" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <Natvis Include="$(SolutionDir)tools\ConsoleTypes.natvis" />
+    <Natvis Include="$(MSBuildThisFileDirectory)..\..\natvis\wil.natvis" />
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="Resources\en-US\Resources.resw" />

--- a/src/cascadia/TerminalSettingsEditor/PreviewConnection.h
+++ b/src/cascadia/TerminalSettingsEditor/PreviewConnection.h
@@ -29,6 +29,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         void DisplayPowerlineGlyphs(bool d) noexcept;
 
+        winrt::guid SessionId() const noexcept { return {}; }
         winrt::Microsoft::Terminal::TerminalConnection::ConnectionState State() const noexcept { return winrt::Microsoft::Terminal::TerminalConnection::ConnectionState::Connected; }
 
         WINRT_CALLBACK(TerminalOutput, winrt::Microsoft::Terminal::TerminalConnection::TerminalOutputHandler);

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
@@ -117,7 +117,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     private:
         Model::Profile _profile;
-        winrt::guid _originalProfileGuid;
+        winrt::guid _originalProfileGuid{};
         winrt::hstring _lastBgImagePath;
         winrt::hstring _lastStartingDirectoryPath;
         Editor::AppearanceViewModel _defaultAppearanceViewModel;

--- a/src/cascadia/TerminalSettingsModel/ApplicationState.h
+++ b/src/cascadia/TerminalSettingsModel/ApplicationState.h
@@ -63,14 +63,11 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         ~ApplicationState();
 
         // Methods
-        void Reload() const noexcept;
+        void Flush();
         void Reset() noexcept;
 
         void FromJson(const Json::Value& root, FileSource parseSource) const noexcept;
         Json::Value ToJson(FileSource parseSource) const noexcept;
-
-        // General getters/setters
-        bool IsStatePath(const winrt::hstring& filename);
 
         // State getters/setters
 #define MTSM_APPLICATION_STATE_GEN(source, type, name, key, ...) \

--- a/src/cascadia/TerminalSettingsModel/ApplicationState.idl
+++ b/src/cascadia/TerminalSettingsModel/ApplicationState.idl
@@ -28,10 +28,8 @@ namespace Microsoft.Terminal.Settings.Model
     [default_interface] runtimeclass ApplicationState {
         static ApplicationState SharedInstance();
 
-        void Reload();
+        void Flush();
         void Reset();
-
-        Boolean IsStatePath(String filename);
 
         String SettingsHash;
         Windows.Foundation.Collections.IVector<WindowLayout> PersistedWindowLayouts;

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -410,7 +410,7 @@ bool SettingsLoader::FixupUserSettings()
 {
     struct CommandlinePatch
     {
-        winrt::guid guid;
+        winrt::guid guid{};
         std::wstring_view before;
         std::wstring_view after;
     };

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.h
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.h
@@ -83,7 +83,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         static constexpr bool debugFeaturesDefault{ true };
 #endif
 
-        winrt::guid _defaultProfile;
+        winrt::guid _defaultProfile{};
         bool _legacyReloadEnvironmentVariables{ true };
         winrt::com_ptr<implementation::ActionMap> _actionMap{ winrt::make_self<implementation::ActionMap>() };
 

--- a/src/cascadia/UnitTests_Control/MockConnection.h
+++ b/src/cascadia/UnitTests_Control/MockConnection.h
@@ -23,6 +23,7 @@ namespace ControlUnitTests
         void Resize(uint32_t /*rows*/, uint32_t /*columns*/) noexcept {}
         void Close() noexcept {}
 
+        winrt::guid SessionId() const noexcept { return {}; }
         winrt::Microsoft::Terminal::TerminalConnection::ConnectionState State() const noexcept { return winrt::Microsoft::Terminal::TerminalConnection::ConnectionState::Connected; }
 
         WINRT_CALLBACK(TerminalOutput, winrt::Microsoft::Terminal::TerminalConnection::TerminalOutputHandler);

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -142,6 +142,9 @@ void WindowEmperor::WaitForWindows()
         TranslateMessage(&message);
         DispatchMessage(&message);
     }
+
+    _finalizeSessionPersistence();
+    TerminateProcess(GetCurrentProcess(), 0);
 }
 
 void WindowEmperor::_createNewWindowThread(const Remoting::WindowRequestedArgs& args)
@@ -597,6 +600,14 @@ winrt::fire_and_forget WindowEmperor::_close()
     // quit will go to the emperor's message pump.
     co_await wil::resume_foreground(_dispatcher);
     PostQuitMessage(0);
+}
+
+void WindowEmperor::_finalizeSessionPersistence() const
+{
+    const auto state = ApplicationState::SharedInstance();
+
+    // Ensure to write the state.json before we TerminateProcess()
+    state.Flush();
 }
 
 #pragma endregion

--- a/src/cascadia/WindowsTerminal/WindowEmperor.h
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.h
@@ -79,6 +79,7 @@ private:
     winrt::fire_and_forget _setupGlobalHotkeys();
 
     winrt::fire_and_forget _close();
+    void _finalizeSessionPersistence() const;
 
     void _createNotificationIcon();
     void _destroyNotificationIcon();

--- a/src/types/inc/utils.hpp
+++ b/src/types/inc/utils.hpp
@@ -39,8 +39,10 @@ namespace Microsoft::Console::Utils
                                              static_cast<long>(SHRT_MAX)));
     }
 
-    std::wstring GuidToString(const GUID guid);
+    std::wstring GuidToString(const GUID& guid);
+    std::wstring GuidToPlainString(const GUID& guid);
     GUID GuidFromString(_Null_terminated_ const wchar_t* str);
+    GUID GuidFromPlainString(_Null_terminated_ const wchar_t* str);
     GUID CreateGuid();
 
     std::string ColorToHexString(const til::color color);

--- a/src/types/ut_types/UtilsTests.cpp
+++ b/src/types/ut_types/UtilsTests.cpp
@@ -66,15 +66,23 @@ void UtilsTests::TestClampToShortMax()
 
 void UtilsTests::TestGuidToString()
 {
-    constexpr GUID constantGuid{
+    static constexpr GUID constantGuid{
         0x01020304, 0x0506, 0x0708, { 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10 }
     };
-    constexpr std::wstring_view constantGuidString{ L"{01020304-0506-0708-090a-0b0c0d0e0f10}" };
 
-    auto generatedGuid{ GuidToString(constantGuid) };
+    {
+        const auto str = GuidToString(constantGuid);
+        const auto guid = GuidFromString(str.c_str());
+        VERIFY_ARE_EQUAL(L"{01020304-0506-0708-090a-0b0c0d0e0f10}", str);
+        VERIFY_ARE_EQUAL(constantGuid, guid);
+    }
 
-    VERIFY_ARE_EQUAL(constantGuidString.size(), generatedGuid.size());
-    VERIFY_ARE_EQUAL(constantGuidString, generatedGuid);
+    {
+        const auto str = GuidToPlainString(constantGuid);
+        const auto guid = GuidFromPlainString(str.c_str());
+        VERIFY_ARE_EQUAL(L"01020304-0506-0708-090a-0b0c0d0e0f10", str);
+        VERIFY_ARE_EQUAL(constantGuid, guid);
+    }
 }
 
 void UtilsTests::TestSplitString()


### PR DESCRIPTION
This contains all the parts of #16598 that aren't specific to session
restore, but are required for the code in #16598:
* Adds new GUID<>String functions that remove the `{}` brackets.
* Adds `SessionId` to the `ITerminalConnection` interface.
* Flush the `ApplicationState` before we terminate the process.
* Not monitoring `state.json` for changes is important as it prevents
  disturbing the session state while session persistence is ongoing.
  That's because when `ApplicationState` flushes to disk, the FS
  monitor will be triggered and reload the `ApplicationState` again.