### PR TITLE
Fix overlapping disclaimer text in Profiles' Defaults section

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.xaml
@@ -35,7 +35,8 @@
                    Margin="{StaticResource StandardIndentMargin}"
                    Style="{StaticResource DisclaimerStyle}"
                    Visibility="{x:Bind Profile.IsBaseLayer}" />
-        <StackPanel Style="{StaticResource SettingsStackStyle}">
+        <StackPanel Grid.Row="1"
+                    Style="{StaticResource SettingsStackStyle}">
             <!--  Suppress Application Title  -->
             <local:SettingContainer x:Uid="Profile_SuppressApplicationTitle"
                                     ClearSettingValue="{x:Bind Profile.ClearSuppressApplicationTitle}"

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.xaml
@@ -41,13 +41,14 @@
                    Margin="{StaticResource StandardIndentMargin}"
                    Style="{StaticResource DisclaimerStyle}"
                    Visibility="{x:Bind Profile.IsBaseLayer}" />
-        <StackPanel Style="{StaticResource SettingsStackStyle}">
+        <StackPanel Grid.Row="1"
+                    Style="{StaticResource SettingsStackStyle}">
             <!--  Control Preview  -->
             <Border MaxWidth="{StaticResource StandardControlMaxWidth}">
                 <Border x:Name="ControlPreview"
                         Width="400"
                         Height="180"
-                        Margin="0,0,0,12"
+                        Margin="0,12,0,12"
                         HorizontalAlignment="Left"
                         BorderBrush="{ThemeResource SystemControlForegroundBaseMediumLowBrush}"
                         BorderThickness="1" />

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
@@ -31,7 +31,8 @@
                    Margin="{StaticResource StandardIndentMargin}"
                    Style="{StaticResource DisclaimerStyle}"
                    Visibility="{x:Bind Profile.IsBaseLayer}" />
-        <StackPanel Style="{StaticResource SettingsStackStyle}">
+        <StackPanel Grid.Row="1"
+                    Style="{StaticResource SettingsStackStyle}">
 
             <!--  Name  -->
             <!--


### PR DESCRIPTION
Fix overlapping disclaimer text in Profiles' Defaults section

[While removing ScrollViewer](https://github.com/microsoft/terminal/pull/16261) from the subpages in the settings UI, the main Grid child element order was not preserved and as a result, the disclaimer text overlapped with the main content on the page.

To fix that we now apply (the lost) `Grid.Row` property on the parent StackPanel of the main content.

![Screenshot 2024-01-25 194231](https://github.com/microsoft/terminal/assets/55626797/ec31a3fc-2e39-4114-8afb-5b427149b5af)

### Validation Steps Performed
- Disclaimer text does not overlap.

### PR Checklist
- [x] Tests added/passed
