### PR TITLE
build: remove symbols' dependency on the Package phase

### DIFF
--- a/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
@@ -247,7 +247,7 @@ extends:
 
       - stage: Publish
         displayName: Publish
-        dependsOn: [Build, Package]
+        dependsOn: [Build]
         jobs:
           - template: ./build/pipelines/templates-v2/job-publish-symbols.yml@self
             parameters:


### PR DESCRIPTION
Due to things outside our control, sometimes the Package phase fails when VPack publication is enabled. Because of this, symbols won't be published. We still want these builds to be considered "golden" and we are still shipping them, so we *must* publish symbols.