### PR TITLE
Add experimental tags to Terminal Chat labels

### DIFF
--- a/src/cascadia/QueryExtension/Resources/en-US/Resources.resw
+++ b/src/cascadia/QueryExtension/Resources/en-US/Resources.resw
@@ -142,7 +142,7 @@
     <comment>Part of the placeholder text in the user's message box to let them know that the AI is aware of their current shell.</comment>
   </data>
   <data name="IntroText.Text" xml:space="preserve">
-    <value>Welcome to Terminal Chat</value>
+    <value>Welcome to Terminal Chat (experimental)</value>
     <comment>Header text of the AI chat box control.</comment>
   </data>
   <data name="ClearMessagesButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -737,7 +737,7 @@
     <value>Command Palette</value>
   </data>
   <data name="AIChatMenuItem" xml:space="preserve">
-    <value>Terminal Chat</value>
+    <value>Terminal Chat (experimental)</value>
   </data>
   <data name="NotificationIconFocusTerminal" xml:space="preserve">
     <value>Focus Terminal</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -635,7 +635,7 @@
     <comment>Header for the "appearance" menu item. This navigates to a page that lets you see and modify settings related to the app's appearance.</comment>
   </data>
   <data name="Nav_AISettings.Content" xml:space="preserve">
-    <value>Terminal Chat</value>
+    <value>Terminal Chat (experimental)</value>
     <comment>Header for the "Terminal Chat Settings" menu item. This navigates to a page that lets you see and modify settings related to AI services.</comment>
   </data>
   <data name="Nav_ColorSchemes.Content" xml:space="preserve">


### PR DESCRIPTION
## Summary of the Pull Request
Add the `experimental` tag to various locations where we refer to Terminal Chat

## Validation Steps Performed
Settings UI navigation view:
![image](https://github.com/microsoft/terminal/assets/26824113/493ef1b3-ae1f-4eaa-9b03-dd5511f83f61)

Terminal Chat UI itself:
![image](https://github.com/microsoft/terminal/assets/26824113/d3bfb3c6-4d1a-4586-80a8-8827f86399fd)

Dropdown:
![image](https://github.com/microsoft/terminal/assets/26824113/13673b58-6c86-41fe-a5e7-be6863cbf064)

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
