### PR TITLE
schema: add experimental.repositionCursorWithMouse

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2782,6 +2782,11 @@
           "description": "When set to true, marks added to the buffer via the addMark action will appear on the scrollbar.",
           "type": "boolean"
         },
+        "experimental.repositionCursorWithMouse": {
+          "default": false,
+          "description": "When set to true, you can move the text cursor by clicking with the mouse on the current commandline. This is an experimental feature - there are lots of edge cases where this will not work as expected.",
+          "type": "boolean"
+        },
         "experimental.pixelShaderPath": {
           "description": "Use to set a path to a pixel shader to use with the Terminal. Overrides `experimental.retroTerminalEffect`. This is an experimental feature, and its continued existence is not guaranteed.",
           "type": "string"


### PR DESCRIPTION
## Summary of the Pull Request
Add experimental.repositionCursorWithMouse to profiles.schema.json.  So when editing settings.json with vscode, it autocompletes and don't complain.

## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments

Not really relevant, but how I found out this was missing: It was `experimental.moveCursorWithMouse` early in the feature implementation PR. I was in my personal list to check out the feature, finally I tried to test it today, couldn't make it work cause I was trying with `moveCursorWithMouse`. VScode also wasn't much help as `experimental.` autocomplete didn't contain this value. After looking over the PR thoroughly and the relevant docs PR I realized my mistake.

## Validation Steps Performed

I set **$schema** to my patched one's url and vscode no longer complains about `experimental.repositionCursorWithMouse`. Autocompletes and also shows description on hover.

## PR Checklist
- [ ] Closes #xxx **N/A**
- [ ] Tests added/passed **N/A**
- [ ] Documentation updated **N/A**
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [x] Schema updated (if necessary)
