### PR TITLE
Disable DECKPAM mode behind velocity

### DIFF
--- a/src/features.xml
+++ b/src/features.xml
@@ -177,4 +177,14 @@
         </alwaysEnabledBrandingTokens>
     </feature>
 
+    <feature>
+        <name>Feature_KepadModeEnabled</name>
+        <description>Enables the DECKPAM, DECKPNM sequences to work as intended </description>
+        <id>16654</id>
+        <stage>AlwaysDisabled</stage>
+        <alwaysEnabledBrandingTokens>
+            <brandingToken>Dev</brandingToken>
+        </alwaysEnabledBrandingTokens>
+    </feature>
+
 </featureStaging>

--- a/src/features.xml
+++ b/src/features.xml
@@ -178,7 +178,7 @@
     </feature>
 
     <feature>
-        <name>Feature_KepadModeEnabled</name>
+        <name>Feature_KeypadModeEnabled</name>
         <description>Enables the DECKPAM, DECKPNM sequences to work as intended </description>
         <id>16654</id>
         <stage>AlwaysDisabled</stage>

--- a/src/terminal/input/terminalInput.cpp
+++ b/src/terminal/input/terminalInput.cpp
@@ -441,7 +441,7 @@ try
         // the ASCII character assigned by the keyboard layout, but when set
         // they transmit SS3 escape sequences. When used with a modifier, the
         // modifier is embedded as a parameter value (not standard).
-        if (Feature_KepadModeEnabled::IsEnabled() && _inputMode.test(Mode::Keypad))
+        if (Feature_KeypadModeEnabled::IsEnabled() && _inputMode.test(Mode::Keypad))
         {
             defineNumericKey(VK_MULTIPLY, L'j');
             defineNumericKey(VK_ADD, L'k');
@@ -493,7 +493,7 @@ try
 
         // Keypad keys also depend on Keypad mode, the same as ANSI mappings,
         // but the sequences use an ESC ? prefix instead of SS3.
-        if (Feature_KepadModeEnabled::IsEnabled() && _inputMode.test(Mode::Keypad))
+        if (Feature_KeypadModeEnabled::IsEnabled() && _inputMode.test(Mode::Keypad))
         {
             defineKeyWithUnusedModifiers(VK_MULTIPLY, L"\033?j"s);
             defineKeyWithUnusedModifiers(VK_ADD, L"\033?k"s);

--- a/src/terminal/input/terminalInput.cpp
+++ b/src/terminal/input/terminalInput.cpp
@@ -441,7 +441,7 @@ try
         // the ASCII character assigned by the keyboard layout, but when set
         // they transmit SS3 escape sequences. When used with a modifier, the
         // modifier is embedded as a parameter value (not standard).
-        if (_inputMode.test(Mode::Keypad))
+        if (_inputMode.test(Mode::Keypad) && Feature_KepadModeEnabled::IsEnabled())
         {
             defineNumericKey(VK_MULTIPLY, L'j');
             defineNumericKey(VK_ADD, L'k');
@@ -493,7 +493,7 @@ try
 
         // Keypad keys also depend on Keypad mode, the same as ANSI mappings,
         // but the sequences use an ESC ? prefix instead of SS3.
-        if (_inputMode.test(Mode::Keypad))
+        if (_inputMode.test(Mode::Keypad) && Feature_KepadModeEnabled::IsEnabled())
         {
             defineKeyWithUnusedModifiers(VK_MULTIPLY, L"\033?j"s);
             defineKeyWithUnusedModifiers(VK_ADD, L"\033?k"s);

--- a/src/terminal/input/terminalInput.cpp
+++ b/src/terminal/input/terminalInput.cpp
@@ -441,7 +441,7 @@ try
         // the ASCII character assigned by the keyboard layout, but when set
         // they transmit SS3 escape sequences. When used with a modifier, the
         // modifier is embedded as a parameter value (not standard).
-        if (_inputMode.test(Mode::Keypad) && Feature_KepadModeEnabled::IsEnabled())
+        if (Feature_KepadModeEnabled::IsEnabled() && _inputMode.test(Mode::Keypad))
         {
             defineNumericKey(VK_MULTIPLY, L'j');
             defineNumericKey(VK_ADD, L'k');
@@ -493,7 +493,7 @@ try
 
         // Keypad keys also depend on Keypad mode, the same as ANSI mappings,
         // but the sequences use an ESC ? prefix instead of SS3.
-        if (_inputMode.test(Mode::Keypad) && Feature_KepadModeEnabled::IsEnabled())
+        if (Feature_KepadModeEnabled::IsEnabled() && _inputMode.test(Mode::Keypad))
         {
             defineKeyWithUnusedModifiers(VK_MULTIPLY, L"\033?j"s);
             defineKeyWithUnusedModifiers(VK_ADD, L"\033?k"s);


### PR DESCRIPTION
DECKPAM originally tracked in #16506.
Support was added in #16511.
But turns out people didn't expect the Terminal to actually be like, compliant: #16654

This closes #16654 while we think over in #16672 how we want to solve this