### PR TITLE
Add support for XTerm's NumLock mode

### DIFF
--- a/src/terminal/adapter/DispatchTypes.hpp
+++ b/src/terminal/adapter/DispatchTypes.hpp
@@ -542,6 +542,7 @@ namespace Microsoft::Console::VirtualTerminal::DispatchTypes
         UTF8_EXTENDED_MODE = DECPrivateMode(1005),
         SGR_EXTENDED_MODE = DECPrivateMode(1006),
         ALTERNATE_SCROLL = DECPrivateMode(1007),
+        XTERM_NumLockMode = DECPrivateMode(1035),
         ASB_AlternateScreenBuffer = DECPrivateMode(1049),
         XTERM_BracketedPasteMode = DECPrivateMode(2004),
         W32IM_Win32InputMode = DECPrivateMode(9001),

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1938,6 +1938,9 @@ bool AdaptDispatch::_ModeParamsHelper(const DispatchTypes::ModeParams param, con
     case DispatchTypes::ModeParams::ALTERNATE_SCROLL:
         _terminalInput.SetInputMode(TerminalInput::Mode::AlternateScroll, enable);
         return !_PassThroughInputModes();
+    case DispatchTypes::ModeParams::XTERM_NumLockMode:
+        _terminalInput.SetInputMode(TerminalInput::Mode::NumLock, enable);
+        return true;
     case DispatchTypes::ModeParams::ASB_AlternateScreenBuffer:
         _SetAlternateScreenBufferMode(enable);
         return true;
@@ -2075,6 +2078,9 @@ bool AdaptDispatch::RequestMode(const DispatchTypes::ModeParams param)
         break;
     case DispatchTypes::ModeParams::ALTERNATE_SCROLL:
         enabled = _terminalInput.GetInputMode(TerminalInput::Mode::AlternateScroll);
+        break;
+    case DispatchTypes::ModeParams::XTERM_NumLockMode:
+        enabled = _terminalInput.GetInputMode(TerminalInput::Mode::NumLock);
         break;
     case DispatchTypes::ModeParams::ASB_AlternateScreenBuffer:
         enabled = _usingAltBuffer;

--- a/src/terminal/input/terminalInput.hpp
+++ b/src/terminal/input/terminalInput.hpp
@@ -32,6 +32,7 @@ namespace Microsoft::Console::VirtualTerminal
             Keypad,
             CursorKey,
             BackarrowKey,
+            NumLock,
             Win32,
 
             Utf8MouseEncoding,
@@ -77,7 +78,7 @@ namespace Microsoft::Console::VirtualTerminal
         std::wstring _focusInSequence;
         std::wstring _focusOutSequence;
 
-        til::enumset<Mode> _inputMode{ Mode::Ansi, Mode::AutoRepeat, Mode::AlternateScroll };
+        til::enumset<Mode> _inputMode{ Mode::Ansi, Mode::AutoRepeat, Mode::NumLock, Mode::AlternateScroll };
         bool _forceDisableWin32InputMode{ false };
 
         // In the future, if we add support for "8-bit" input mode, these prefixes


### PR DESCRIPTION
## Summary of the Pull Request

NumLock mode provides a way to alter the behavior of the numeric keypad,
switching between the standard DEC interpretation of `DECKPAM`, and a
kind of Linux-compatible mode, where `DECKPAM` only applies if `NumLock`
is off. Even then it only applies to the non-digit keys, since the digit
keys are interpreted as cursor keys when `NumLock` is off.

## References and Relevant Issues

#16506, #16511, #16654, #16675

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
