### PR TITLE
Fix for search selections highlight going backward when the selection wraps to next line

### DIFF
--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -83,7 +83,7 @@ std::vector<til::inclusive_rect> Terminal::_GetSearchSelectionRects(Microsoft::C
         for (auto selection = lowerIt; selection != upperIt; ++selection)
         {
             const auto start = til::point{ selection->left, selection->top };
-            const auto end = til::point{ selection->right, selection->top };
+            const auto end = til::point{ selection->right, selection->bottom };
             const auto adj = _activeBuffer().GetTextRects(start, end, _blockSelection, false);
             for (auto a : adj)
             {


### PR DESCRIPTION
Hi,  I realized I had a bug in my pull request for search selections where when the highlight is wrapped it causes the selection to select back to start of the current line instead of wrapping to the next line.

PR where I introduced this bug.
https://github.com/microsoft/terminal/pull/16227

## Summary of the Pull Request
![SearchSelection_Backward](https://github.com/microsoft/terminal/assets/811029/035eeb84-d77a-4e16-b416-81b86f89d3eb)

## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
