### PR TITLE
AtlasEngine: Improve dotted, dashed and curly underlines

### DIFF
--- a/src/renderer/atlas/BackendD3D.cpp
+++ b/src/renderer/atlas/BackendD3D.cpp
@@ -310,29 +310,18 @@ void BackendD3D::_updateFontDependents(const RenderingPayload& p)
     // baseline of curlyline is at the middle of singly underline. When there's
     // limited space to draw a curlyline, we apply a limit on the peak height.
     {
-        // initialize curlyline peak height to a desired value. Clamp it to at
-        // least 1.
-        constexpr auto curlyLinePeakHeightEm = 0.075f;
-        _curlyLinePeakHeight = std::max(1.0f, std::roundf(curlyLinePeakHeightEm * font.fontSize));
+        const auto cellHeight = static_cast<f32>(font.cellSize.y);
+        const auto strokeWidth = static_cast<f32>(font.thinLineWidth);
 
-        // calc the limit we need to apply
-        const auto strokeHalfWidth = std::floor(font.underline.height / 2.0f);
-        const auto underlineMidY = font.underline.position + strokeHalfWidth;
-        const auto maxDrawableCurlyLinePeakHeight = font.cellSize.y - underlineMidY - font.underline.height;
+        // This gives it the same position and height as our double-underline. There's no particular reason for that, apart from
+        // it being simple to implement and robust against more peculiar fonts with unusually large/small descenders, etc.
+        // We still need to ensure though that it doesn't clip out of the cellHeight at the bottom.
+        const auto height = std::max(3.0f, static_cast<f32>(font.doubleUnderline[1].position + font.doubleUnderline[1].height - font.doubleUnderline[0].position));
+        const auto top = std::min(static_cast<f32>(font.doubleUnderline[0].position), floorf(cellHeight - height - strokeWidth));
 
-        // if the limit is <= 0 (no height at all), stick with the desired height.
-        // This is how we force a curlyline even when there's no space, though it
-        // might be clipped at the bottom.
-        if (maxDrawableCurlyLinePeakHeight > 0.0f)
-        {
-            _curlyLinePeakHeight = std::min(_curlyLinePeakHeight, maxDrawableCurlyLinePeakHeight);
-        }
-
-        const auto curlyUnderlinePos = underlineMidY - _curlyLinePeakHeight - font.underline.height;
-        const auto curlyUnderlineWidth = 2.0f * (_curlyLinePeakHeight + font.underline.height);
-        const auto curlyUnderlinePosU16 = gsl::narrow_cast<u16>(lrintf(curlyUnderlinePos));
-        const auto curlyUnderlineWidthU16 = gsl::narrow_cast<u16>(lrintf(curlyUnderlineWidth));
-        _curlyUnderline = { curlyUnderlinePosU16, curlyUnderlineWidthU16 };
+        _curlyLineHalfHeight = height * 0.5f;
+        _curlyUnderline.position = gsl::narrow_cast<u16>(lrintf(top));
+        _curlyUnderline.height = gsl::narrow_cast<u16>(lrintf(height));
     }
 
     DWrite_GetRenderParams(p.dwriteFactory.get(), &_gamma, &_cleartypeEnhancedContrast, &_grayscaleEnhancedContrast, _textRenderingParams.put());
@@ -573,9 +562,8 @@ void BackendD3D::_recreateConstBuffer(const RenderingPayload& p) const
         DWrite_GetGammaRatios(_gamma, data.gammaRatios);
         data.enhancedContrast = p.s->font->antialiasingMode == AntialiasingMode::ClearType ? _cleartypeEnhancedContrast : _grayscaleEnhancedContrast;
         data.underlineWidth = p.s->font->underline.height;
-        data.curlyLineWaveFreq = 2.0f * 3.14f / p.s->font->cellSize.x;
-        data.curlyLinePeakHeight = _curlyLinePeakHeight;
-        data.curlyLineCellOffset = p.s->font->underline.position + p.s->font->underline.height / 2.0f;
+        data.thinLineWidth = p.s->font->thinLineWidth;
+        data.curlyLineHalfHeight = _curlyLineHalfHeight;
         p.deviceContext->UpdateSubresource(_psConstantBuffer.get(), 0, nullptr, &data, 0, 0);
     }
 }
@@ -1209,10 +1197,11 @@ void BackendD3D::_initializeFontFaceEntry(AtlasFontFaceEntryInner& fontFaceEntry
     }
 
     ALLOW_UNINITIALIZED_BEGIN
-    std::array<u32, 0x100> codepoints;
-    std::array<u16, 0x100> indices;
+    std::array<u32, 0xA0> codepoints;
+    std::array<u16, 0xA0> indices;
     ALLOW_UNINITIALIZED_END
 
+    // U+2500 .. U+259F
     for (u32 i = 0; i < codepoints.size(); ++i)
     {
         codepoints[i] = 0x2500 + i;
@@ -1220,9 +1209,9 @@ void BackendD3D::_initializeFontFaceEntry(AtlasFontFaceEntryInner& fontFaceEntry
 
     THROW_IF_FAILED(fontFaceEntry.fontFace->GetGlyphIndicesW(codepoints.data(), codepoints.size(), indices.data()));
 
-    for (u32 i = 0; i < indices.size(); ++i)
+    for (const auto idx : indices)
     {
-        if (const auto idx = indices[i])
+        if (idx)
         {
             fontFaceEntry.boxGlyphs.insert(idx);
         }

--- a/src/renderer/atlas/BackendD3D.cpp
+++ b/src/renderer/atlas/BackendD3D.cpp
@@ -1197,11 +1197,10 @@ void BackendD3D::_initializeFontFaceEntry(AtlasFontFaceEntryInner& fontFaceEntry
     }
 
     ALLOW_UNINITIALIZED_BEGIN
-    std::array<u32, 0xA0> codepoints;
-    std::array<u16, 0xA0> indices;
+    std::array<u32, 0x100> codepoints;
+    std::array<u16, 0x100> indices;
     ALLOW_UNINITIALIZED_END
 
-    // U+2500 .. U+259F
     for (u32 i = 0; i < codepoints.size(); ++i)
     {
         codepoints[i] = 0x2500 + i;
@@ -1209,9 +1208,9 @@ void BackendD3D::_initializeFontFaceEntry(AtlasFontFaceEntryInner& fontFaceEntry
 
     THROW_IF_FAILED(fontFaceEntry.fontFace->GetGlyphIndicesW(codepoints.data(), codepoints.size(), indices.data()));
 
-    for (const auto idx : indices)
+    for (u32 i = 0; i < indices.size(); ++i)
     {
-        if (idx)
+        if (const auto idx = indices[i])
         {
             fontFaceEntry.boxGlyphs.insert(idx);
         }

--- a/src/renderer/atlas/BackendD3D.h
+++ b/src/renderer/atlas/BackendD3D.h
@@ -42,9 +42,8 @@ namespace Microsoft::Console::Render::Atlas
             alignas(sizeof(f32x4)) f32 gammaRatios[4]{};
             alignas(sizeof(f32)) f32 enhancedContrast = 0;
             alignas(sizeof(f32)) f32 underlineWidth = 0;
-            alignas(sizeof(f32)) f32 curlyLinePeakHeight = 0;
-            alignas(sizeof(f32)) f32 curlyLineWaveFreq = 0;
-            alignas(sizeof(f32)) f32 curlyLineCellOffset = 0;
+            alignas(sizeof(f32)) f32 thinLineWidth = 0;
+            alignas(sizeof(f32)) f32 curlyLineHalfHeight = 0;
 #pragma warning(suppress : 4324) // 'PSConstBuffer': structure was padded due to alignment specifier
         };
 
@@ -291,7 +290,7 @@ namespace Microsoft::Console::Render::Atlas
         // The bounding rect of _cursorRects in pixels.
         til::rect _cursorPosition;
 
-        f32 _curlyLinePeakHeight = 0.0f;
+        f32 _curlyLineHalfHeight = 0.0f;
         FontDecorationPosition _curlyUnderline;
 
         bool _requiresContinuousRedraw = false;


### PR DESCRIPTION
This changeset makes 3 improvements:
* Dotted lines now use a 2:1 ratio between gaps and dots (from 1:1).
  This makes the dots a lot easier to spot at small font sizes.
* Dashed lines use a 1:2 ratio and a cells-size independent stride.
  By being cell-size independent it works more consistently with a
  wider variety of fonts with weird cell aspect ratios.
* Curly lines are now cell-size independent as well and have a
  height that equals the double-underline size.
  This ensures that the curve isn't cut off anymore and just like
  with dashed lines, that it works under weird aspect ratios.

Closes #16712

## Validation Steps Performed
This was tested using RenderingTests using Cascadia Mono, Consolas,
Courier New, Lucida Console and MS Gothic.