### PR TITLE
Fix an apparent x86 miscompilation on MSVC 19.38

### DIFF
--- a/src/inc/til/bitmap.h
+++ b/src/inc/til/bitmap.h
@@ -23,7 +23,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
             using pointer = const til::rect*;
             using reference = const til::rect&;
 
-            _bitmap_const_iterator(const dynamic_bitset<unsigned long long, Allocator>& values, til::rect rc, ptrdiff_t pos) :
+            _bitmap_const_iterator(const dynamic_bitset<size_t, Allocator>& values, til::rect rc, ptrdiff_t pos) :
                 _values(values),
                 _rc(rc),
                 _pos(pos),
@@ -77,7 +77,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
             }
 
         private:
-            const dynamic_bitset<unsigned long long, Allocator>& _values;
+            const dynamic_bitset<size_t, Allocator>& _values;
             const til::rect _rc;
             size_t _pos;
             size_t _nextPos;
@@ -133,7 +133,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
             }
         };
 
-        template<typename Allocator = std::allocator<unsigned long long>>
+        template<typename Allocator = std::allocator<size_t>>
         class bitmap
         {
         public:
@@ -172,7 +172,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
                 _alloc{ allocator },
                 _sz(sz),
                 _rc(sz),
-                _bits(_sz.area(), fill ? std::numeric_limits<unsigned long long>::max() : 0, _alloc),
+                _bits(_sz.area(), fill ? std::numeric_limits<size_t>::max() : 0, _alloc),
                 _runs{ _alloc }
             {
             }
@@ -538,7 +538,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
             allocator_type _alloc;
             til::size _sz;
             til::rect _rc;
-            dynamic_bitset<unsigned long long, allocator_type> _bits;
+            dynamic_bitset<size_t, allocator_type> _bits;
 
             mutable std::optional<std::vector<til::rect, run_allocator_type>> _runs;
 
@@ -553,7 +553,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
 
     namespace pmr
     {
-        using bitmap = ::til::details::bitmap<std::pmr::polymorphic_allocator<unsigned long long>>;
+        using bitmap = ::til::details::bitmap<std::pmr::polymorphic_allocator<size_t>>;
     }
 }
 

--- a/src/inc/til/bitmap.h
+++ b/src/inc/til/bitmap.h
@@ -172,7 +172,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
                 _alloc{ allocator },
                 _sz(sz),
                 _rc(sz),
-                _bits(_sz.area(), fill ? std::numeric_limits<size_t>::max() : 0, _alloc),
+                _bits(_sz.area(), fill ? std::numeric_limits<unsigned long long>::max() : 0, _alloc),
                 _runs{ _alloc }
             {
             }


### PR DESCRIPTION
There's an apparent miscompilation of `dynamic_bitset` on x86 with
MSVC 19.38, where the following code:
```cpp
dynamic_bitset<uint64_t> bits(80 * 24, 0);
bits.set(0, 3 * 80, true);
```

is expected to set the first 3.75 blocks to 1 which should produce
the following blocks:
```
0xffffffffffffffff
0xffffffffffffffff
0xffffffffffffffff
0x0000ffffffffffff
```

but it actually produces:
```
0xffffffffffffffff
0x00000000ffffffff
0xffffffffffffffff
0x0000ffffffffffff
```

The weird thing here is that this only happens if `til::bitmap`
uses a `dynamic_bitset<uint64_t>`. As soon as it uses `<uint32_t>`
any other instantiation of `<uint64_t>` is magically fixed.

Conclusion: Use `size_t` until we know what's going on.
Last known good CL version: 14.37.32822
Current broken CL version: 14.38.33130

## Validation Steps Performed

The following test completes successfully again:
```cpp
til::bitmap map{ { 80, 24 } };
map.translate({ 0, 3 }, true);
VERIFY_ARE_EQUAL(3u, map.runs().size());
```