### PR TITLE
Make shaded block glyphs look even betterer

### DIFF
--- a/src/renderer/atlas/Backend.h
+++ b/src/renderer/atlas/Backend.h
@@ -7,12 +7,24 @@
 
 namespace Microsoft::Console::Render::Atlas
 {
+    // Don't use this definition in the code elsewhere.
+    // It only exists to make the definitions below possible.
+#ifdef NDEBUG
+#define ATLAS_DEBUG__IS_DEBUG 0
+#else
+#define ATLAS_DEBUG__IS_DEBUG 1
+#endif
+
     // If set to 1, this will cause the entire viewport to be invalidated at all times.
     // Helpful for benchmarking our text shaping code based on DirectWrite.
 #define ATLAS_DEBUG_DISABLE_PARTIAL_INVALIDATION 0
 
     // Redraw at display refresh rate at all times. This helps with shader debugging.
 #define ATLAS_DEBUG_CONTINUOUS_REDRAW 0
+
+    // Hot reload the builtin .hlsl files whenever they change on disk.
+    // Enabled by default in debug builds.
+#define ATLAS_DEBUG_SHADER_HOT_RELOAD ATLAS_DEBUG__IS_DEBUG
 
     // Disables the use of DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT.
     // This helps with benchmarking the application as it'll run beyond display refresh rate.

--- a/src/renderer/atlas/BackendD3D.h
+++ b/src/renderer/atlas/BackendD3D.h
@@ -64,17 +64,18 @@ namespace Microsoft::Console::Render::Atlas
 
             // This block of values will be used for the TextDrawingFirst/Last range and need to stay together.
             // This is used to quickly check if an instance is related to a "text drawing primitive".
-            TextGrayscale = 1,
-            TextClearType = 2,
-            TextPassthrough = 3,
-            DottedLine = 4,
-            DashedLine = 5,
-            CurlyLine = 6,
+            TextGrayscale,
+            TextClearType,
+            TextBuiltinGlyph,
+            TextPassthrough,
+            DottedLine,
+            DashedLine,
+            CurlyLine,
             // All items starting here will be drawing as a solid RGBA color
-            SolidLine = 7,
+            SolidLine,
 
-            Cursor = 8,
-            Selection = 9,
+            Cursor,
+            Selection,
 
             TextDrawingFirst = TextGrayscale,
             TextDrawingLast = SolidLine,
@@ -305,7 +306,7 @@ namespace Microsoft::Console::Render::Atlas
         size_t _colorizeGlyphAtlasCounter = 0;
 #endif
 
-#ifndef NDEBUG
+#if ATLAS_DEBUG_SHADER_HOT_RELOAD
         std::filesystem::path _sourceDirectory;
         wil::unique_folder_change_reader_nothrow _sourceCodeWatcher;
         std::atomic<int64_t> _sourceCodeInvalidationTime{ INT64_MAX };

--- a/src/renderer/atlas/BuiltinGlyphs.cpp
+++ b/src/renderer/atlas/BuiltinGlyphs.cpp
@@ -1071,57 +1071,6 @@ static const Instruction* GetInstructions(char32_t codepoint) noexcept
     return nullptr;
 }
 
-static wil::com_ptr<ID2D1BitmapBrush> createShadedBitmapBrush(ID2D1DeviceContext* renderTarget, Shape shape)
-{
-    static constexpr u32 _ = 0;
-    static constexpr u32 w = 0xffffffff;
-    static constexpr u32 size = 4;
-    // clang-format off
-    static constexpr u32 shades[3][size * size] = {
-        {
-            w, _, _, _,
-            w, _, _, _,
-            _, _, w, _,
-            _, _, w, _,
-        },
-        {
-            w, _, w, _,
-            _, w, _, w,
-            w, _, w, _,
-            _, w, _, w,
-        },
-        {
-            _, w, w, w,
-            _, w, w, w,
-            w, w, _, w,
-            w, w, _, w,
-        },
-    };
-    // clang-format on
-
-    static constexpr D2D1_SIZE_U bitmapSize{ size, size };
-    static constexpr D2D1_BITMAP_PROPERTIES bitmapProps{
-        .pixelFormat = { DXGI_FORMAT_B8G8R8A8_UNORM, D2D1_ALPHA_MODE_PREMULTIPLIED },
-        .dpiX = 96,
-        .dpiY = 96,
-    };
-    static constexpr D2D1_BITMAP_BRUSH_PROPERTIES bitmapBrushProps{
-        .extendModeX = D2D1_EXTEND_MODE_WRAP,
-        .extendModeY = D2D1_EXTEND_MODE_WRAP,
-        .interpolationMode = D2D1_BITMAP_INTERPOLATION_MODE_NEAREST_NEIGHBOR
-    };
-
-    assert(shape < ARRAYSIZE(shades));
-
-    wil::com_ptr<ID2D1Bitmap> bitmap;
-    THROW_IF_FAILED(renderTarget->CreateBitmap(bitmapSize, &shades[shape][0], sizeof(u32) * size, &bitmapProps, bitmap.addressof()));
-
-    wil::com_ptr<ID2D1BitmapBrush> bitmapBrush;
-    THROW_IF_FAILED(renderTarget->CreateBitmapBrush(bitmap.get(), &bitmapBrushProps, nullptr, bitmapBrush.addressof()));
-
-    return bitmapBrush;
-}
-
 void BuiltinGlyphs::DrawBuiltinGlyph(ID2D1Factory* factory, ID2D1DeviceContext* renderTarget, ID2D1SolidColorBrush* brush, const D2D1_RECT_F& rect, char32_t codepoint)
 {
     renderTarget->PushAxisAlignedClip(&rect, D2D1_ANTIALIAS_MODE_ALIASED);
@@ -1188,16 +1137,47 @@ void BuiltinGlyphs::DrawBuiltinGlyph(ID2D1Factory* factory, ID2D1DeviceContext* 
         case Shape_Filled025:
         case Shape_Filled050:
         case Shape_Filled075:
-        {
-            const D2D1_RECT_F r{ begXabs, begYabs, endXabs, endYabs };
-            const auto bitmapBrush = createShadedBitmapBrush(renderTarget, shape);
-            renderTarget->FillRectangle(&r, bitmapBrush.get());
-            break;
-        }
         case Shape_Filled100:
         {
+            // This code works in tandem with SHADING_TYPE_TEXT_BUILTIN_GLYPH in our pixel shader.
+            // The pixel shader splits the viewport into a 2x2 pixel checkerboard like this:
+            //       x
+            //    +----->
+            //    | +---+---+---+---+
+            //  y | | 0 | 1 | 0 | 1 |
+            //    v +---+---+---+---+
+            //      | 1 | 2 | 1 | 2 |
+            //      +---+---+---+---+
+            //      | 0 | 1 | 0 | 1 |
+            //      +---+---+---+---+
+            //      | 1 | 2 | 1 | 2 |
+            //      +---+---+---+---+
+            //
+            // When it then loads our glyph texture it only uses the RGB component of the given index above.
+            // This means we can produce solid colors by drawing plain white glyphs here (the default color anyway)
+            // and shaded glyphs by only setting select RGB channels that we want it to show.
+            static constexpr D2D1_COLOR_F colors[] = {
+                // __
+                // _#
+                { 0, 0, 1, 1 }, // Shape_Filled025
+                // _#
+                // #_
+                { 0, 1, 0, 1 }, // Shape_Filled050
+                // ##
+                // #_
+                { 1, 1, 0, 1 }, // Shape_Filled075
+                // ##
+                // ##
+                { 1, 1, 1, 1 }, // Shape_Filled100
+            };
+
+            const auto brushColor = brush->GetColor();
+            brush->SetColor(&colors[shape]);
+
             const D2D1_RECT_F r{ begXabs, begYabs, endXabs, endYabs };
             renderTarget->FillRectangle(&r, brush);
+
+            brush->SetColor(&brushColor);
             break;
         }
         case Shape_LightLine:

--- a/src/renderer/atlas/dwrite.hlsl
+++ b/src/renderer/atlas/dwrite.hlsl
@@ -37,12 +37,12 @@ float3 DWrite_EnhanceContrast3(float3 alpha, float k)
 
 float DWrite_ApplyAlphaCorrection(float a, float f, float4 g)
 {
-    return a + a * (1 - a) * ((g.x * f + g.y) * a + (g.z * f + g.w));
+    return a + a * (1.0f - a) * ((g.x * f + g.y) * a + (g.z * f + g.w));
 }
 
 float3 DWrite_ApplyAlphaCorrection3(float3 a, float3 f, float4 g)
 {
-    return a + a * (1 - a) * ((g.x * f + g.y) * a + (g.z * f + g.w));
+    return a + a * (1.0f - a) * ((g.x * f + g.y) * a + (g.z * f + g.w));
 }
 
 // Call this function to get the same gamma corrected alpha blending effect

--- a/src/renderer/atlas/shader_common.hlsl
+++ b/src/renderer/atlas/shader_common.hlsl
@@ -1,15 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-// clang-format off
+// Depends on the background texture
 #define SHADING_TYPE_TEXT_BACKGROUND    0
+
+// Depends on the glyphAtlas texture
 #define SHADING_TYPE_TEXT_GRAYSCALE     1
 #define SHADING_TYPE_TEXT_CLEARTYPE     2
-#define SHADING_TYPE_TEXT_PASSTHROUGH   3
-#define SHADING_TYPE_DOTTED_LINE        4
-#define SHADING_TYPE_DASHED_LINE        5
-#define SHADING_TYPE_CURLY_LINE         6
-// clang-format on
+#define SHADING_TYPE_TEXT_BUILTIN_GLYPH 3
+#define SHADING_TYPE_TEXT_PASSTHROUGH   4
+
+// Independent of any textures
+#define SHADING_TYPE_DOTTED_LINE        5
+#define SHADING_TYPE_DASHED_LINE        6
+#define SHADING_TYPE_CURLY_LINE         7
+#define SHADING_TYPE_SOLID_LINE         8
+#define SHADING_TYPE_CURSOR             9
+#define SHADING_TYPE_SELECTION          10
 
 struct VSData
 {
@@ -27,7 +34,7 @@ struct PSData
     float4 position : SV_Position;
     float2 texcoord : texcoord;
     nointerpolation uint shadingType : shadingType;
-    nointerpolation uint2 renditionScale : renditionScale;
+    nointerpolation float2 renditionScale : renditionScale;
     nointerpolation float4 color : color;
 };
 

--- a/src/renderer/atlas/shader_ps.hlsl
+++ b/src/renderer/atlas/shader_ps.hlsl
@@ -67,6 +67,16 @@ Output main(PSData data) : SV_Target
         color = weights * data.color;
         break;
     }
+    case SHADING_TYPE_TEXT_BUILTIN_GLYPH:
+    {
+        const uint2 checkerboard = (uint2)(data.position.xy / (thinLineWidth * data.renditionScale)) & 1;
+        // There's no need to use the .a channel because glyphAtlas is in premultiplied alpha
+        // (= .rgb is already multiplied by .a) and we expect builtin glyphs to not use ClearType.
+        const float alpha = glyphAtlas[data.texcoord][checkerboard.x + checkerboard.y];
+        color = premultiplyColor(data.color) * alpha;
+        weights = color.aaaa;
+        break;
+    }
     case SHADING_TYPE_TEXT_PASSTHROUGH:
     {
         color = glyphAtlas[data.texcoord];


### PR DESCRIPTION
Shaded glyphs (U+2591..3, etc.) all have one problem in common:
The pixel/dot size in the glyph may not be evenly divisible by the
cell size. This either results in blurring, or in moiré-like patterns
at the edges of the cells with its neighbors, because they happen to
start with a pattern that overlaps with the end of the previous cell.

This PR solves the issue by moving the pixel/dot pattern generation
into the shader. That way the pixel/dot location can be made dependent
on the viewport-position of the actual underlying pixels, which avoids
repeating patterns between cells.

The PR contains some additional modifications, all of which either
extend or improve the existing debug facilities in AtlasEngine.
Suppressing whitespaces changes makes the diff way smaller.