### PR TITLE
Fix the hyperlink detection when there are leading wide glyph in the row

### DIFF
--- a/src/buffer/out/Row.cpp
+++ b/src/buffer/out/Row.cpp
@@ -97,7 +97,7 @@ til::CoordType CharToColumnMapper::GetLeadingColumnAt(ptrdiff_t offset) noexcept
     offset = clamp(offset, 0, _lastCharOffset);
 
     auto col = _currentColumn;
-    const auto currentOffset = _charOffsets[col];
+    const auto currentOffset = _charOffsets[col] & CharOffsetsMask;
 
     // Goal: Move the _currentColumn cursor to a cell which contains the given target offset.
     // Depending on where the target offset is we have to either search forward or backward.


### PR DESCRIPTION
## Summary of the Pull Request

URL detection was broken again in #15858. When the regex matched, we calculate the column(cell) by its offset, we use forward or backward iteration of the column to find the correct column that displays the glyphs of `_chars[offset]`.

https://github.com/microsoft/terminal/blob/abf5d9423a23b13e9af4c19ca35858f9aaf0a63f/src/buffer/out/Row.cpp#L95-L104

However, when calculating the `currentOffset` we forget that MSB of `_charOffsets[col]` could be `1`, or col is pointing to another glyph in preceding column.

https://github.com/microsoft/terminal/blob/abf5d9423a23b13e9af4c19ca35858f9aaf0a63f/src/buffer/out/Row.hpp#L223-L226