### PR TITLE
Fix being unable to delete a changed Font Axis or Font Feature

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Appearances.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.xaml
@@ -329,7 +329,7 @@
                                             HorizontalAlignment="Right"
                                             Click="DeleteAxisKeyValuePair_Click"
                                             Style="{StaticResource DeleteButtonStyle}"
-                                            Tag="{x:Bind AxisKey}">
+                                            Tag="{x:Bind AxisKey, Mode=OneWay}">
                                         <FontIcon FontSize="{StaticResource StandardIconSize}"
                                                   Glyph="&#xE74D;" />
                                     </Button>
@@ -390,7 +390,7 @@
                                             HorizontalAlignment="Right"
                                             Click="DeleteFeatureKeyValuePair_Click"
                                             Style="{StaticResource DeleteButtonStyle}"
-                                            Tag="{x:Bind FeatureKey}">
+                                            Tag="{x:Bind FeatureKey, Mode=OneWay}">
                                         <FontIcon FontSize="{StaticResource StandardIconSize}"
                                                   Glyph="&#xE74D;" />
                                     </Button>


### PR DESCRIPTION
Make sure the delete button's `Tag` updates when the selected axis/feature changes, so that the correct key value gets propagated when the delete button is clicked.

Refs #16678 #16104 

## Validation Steps Performed
1. Add a new feature/axis
2. Change the key
3. Click the delete button
4. Delete button works