### PR TITLE
Fix the velocity script to actually support canary

### DIFF
--- a/build/rules/GenerateFeatureFlags.proj
+++ b/build/rules/GenerateFeatureFlags.proj
@@ -30,6 +30,7 @@
     <IntermediateOutputPath>$(SolutionDir)obj\$(Configuration)\GenerateFeatureFlags\</IntermediateOutputPath>
     <OpenConsoleCommonOutDir>$(SolutionDir)bin\$(Configuration)\</OpenConsoleCommonOutDir>
 
+    <_WTBrandingName Condition="'$(WindowsTerminalBranding)'=='Canary'">Canary</_WTBrandingName>
     <_WTBrandingName Condition="'$(WindowsTerminalBranding)'=='Preview'">Preview</_WTBrandingName>
     <_WTBrandingName Condition="'$(WindowsTerminalBranding)'=='Release'">Release</_WTBrandingName>
     <_WTBrandingName Condition="'$(_WTBrandingName)'==''">Dev</_WTBrandingName>


### PR DESCRIPTION
Welp, would you look at that? We never actually supported "canary" feature settings. Canary's been defaulting to the "Dev" config since inception. 

There's a couple things that are supposed to only be on in Dev and not Canary. They clearly haven't mattered but better safe than sorry 