### PR TITLE
Fix selection expansion for Double-Width and Double-Height rows

### DIFF
--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -1298,7 +1298,8 @@ void TextBuffer::TriggerNewTextNotification(const std::wstring_view newText)
 // - the delimiter class for the given char
 DelimiterClass TextBuffer::_GetDelimiterClassAt(const til::point pos, const std::wstring_view wordDelimiters) const
 {
-    return GetRowByOffset(pos.y).DelimiterClassAt(pos.x, wordDelimiters);
+    const auto realPos = ScreenToBufferPosition(pos);
+    return GetRowByOffset(realPos.y).DelimiterClassAt(realPos.x, wordDelimiters);
 }
 
 // Method Description:


### PR DESCRIPTION
Closes #16782

### Validation Steps Performed
- Double-clicking on a Double-Width row selects the word (identified by delimiters) under the cursor.
- Tripple-clicking on a Double-Width row selects the whole line under the cursor.
- The same works for Double-Height rows also.
- The same works for Single-Width rows also.