### PR TITLE
Fix Scratch.sln

### DIFF
--- a/scratch/ScratchIslandApp/SampleApp/MyPage.cpp
+++ b/scratch/ScratchIslandApp/SampleApp/MyPage.cpp
@@ -31,9 +31,12 @@ namespace winrt::SampleApp::implementation
         auto connectionSettings{ TerminalConnection::ConptyConnection::CreateSettings(L"cmd.exe /k echo This TermControl is hosted in-proc...",
                                                                                       winrt::hstring{},
                                                                                       L"",
+                                                                                      false,
+                                                                                      L"",
                                                                                       nullptr,
                                                                                       32,
                                                                                       80,
+                                                                                      winrt::guid(),
                                                                                       winrt::guid()) };
 
         // "Microsoft.Terminal.TerminalConnection.ConptyConnection"


### PR DESCRIPTION
"ConptyConnection::CreateSettings()" was modified to include some extra parameters related to the environment variable changes. This just updates the call in Scratch.sln so that it builds and deploys properly.