### PR TITLE
Update CommandPalette.cpp to ignore _filterTextChanged on TabSwitchMode

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -852,7 +852,7 @@ namespace winrt::TerminalApp::implementation
         {
             return;
         }
-        
+
         if (_currentMode == CommandPaletteMode::CommandlineMode)
         {
             _evaluatePrefix();

--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -844,9 +844,9 @@ namespace winrt::TerminalApp::implementation
                                             const Windows::UI::Xaml::RoutedEventArgs& /*args*/)
     {
         // When we are executing the _SelectNextTab in the TabManagement.cpp, this method
-        // is getting triggered because we set up the default value for that CommandPallete
+        // is getting triggered because we set up the default value for that CommandPalete
         // with an empty string. Therefore, to avoid the reset of the index when executing
-        // the Next/Prev tab command, we are skiping this execution.
+        // the Next/Prev tab command, we are skipping this execution.
         // Check issue https://github.com/microsoft/terminal/issues/11146
         if (_currentMode == CommandPaletteMode::TabSwitchMode)
         {

--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -843,6 +843,16 @@ namespace winrt::TerminalApp::implementation
     void CommandPalette::_filterTextChanged(const IInspectable& /*sender*/,
                                             const Windows::UI::Xaml::RoutedEventArgs& /*args*/)
     {
+        // When we are executing the _SelectNextTab in the TabManagement.cpp, this method
+        // is getting triggered because we set up the default value for that CommandPallete
+        // with an empty string. Therefore, to avoid the reset of the index when executing
+        // the Next/Prev tab command, we are skiping this execution.
+        // Check issue https://github.com/microsoft/terminal/issues/11146
+        if (_currentMode == CommandPaletteMode::TabSwitchMode)
+        {
+            return;
+        }
+        
         if (_currentMode == CommandPaletteMode::CommandlineMode)
         {
             _evaluatePrefix();

--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -844,7 +844,7 @@ namespace winrt::TerminalApp::implementation
                                             const Windows::UI::Xaml::RoutedEventArgs& /*args*/)
     {
         // When we are executing the _SelectNextTab in the TabManagement.cpp, this method
-        // is getting triggered because we set up the default value for that CommandPalete
+        // is getting triggered because we set up the default value for that CommandPalette
         // with an empty string. Therefore, to avoid the reset of the index when executing
         // the Next/Prev tab command, we are skipping this execution.
         // Check issue https://github.com/microsoft/terminal/issues/11146


### PR DESCRIPTION
## Summary of the Pull Request
As mentioned in the issue [#11146](https://github.com/microsoft/terminal/issues/11146), when the "Next/Prev"  command is executed from the command line with a string in the search bar, this is setting always the first tab.

## References and Relevant Issues
#11146 

## Detailed Description of the Pull Request / Additional comments
When using the command "Next/Previous Tab" from the command line, we are creating another tab (as if we are using the keyboard shortcut), and this triggers the `_filterTextChanged` that resets the index to the first item in because the current mode that it has.

This could be cause because, It seems that it detects as if we are deleting the entered letter or creating an empty string, causing the execution of the mentioned method and resetting its index to 0.

To avoid this, we are making sure that when this action is triggerd and we are in the `TabSwitchMode`, we should ignore the following execution of the method.

## Validation Steps Performed
I tested out the following scenarios:
1. Performing the action with the keyboard shorcut
2. Perfoming the action with an empty string
3. Performing the action with a string in the search bar.

Also validated with the current tests.

https://github.com/microsoft/terminal/assets/40709873/e5748739-2011-4168-866d-fc79cd39fc2d


## PR Checklist
- [X] Closes #11146 
- [X] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
