### PR TITLE
Fix a number of minor issues that Clang flagged (again! again!)

### DIFF
--- a/src/buffer/out/OutputCellView.cpp
+++ b/src/buffer/out/OutputCellView.cpp
@@ -29,7 +29,8 @@ OutputCellView::OutputCellView(const std::wstring_view view,
 // - Reference to UTF-16 character data
 // C26445 - suppressed to enable the `TextBufferTextIterator::operator->` method which needs a non-temporary memory location holding the wstring_view.
 // TODO: GH 2681 - remove this suppression by reconciling the probably bad design of the iterators that leads to this being required.
-[[gsl::suppress(26445)]] const std::wstring_view& OutputCellView::Chars() const noexcept
+GSL_SUPPRESS(26445)
+const std::wstring_view& OutputCellView::Chars() const noexcept
 {
     return _view;
 }

--- a/src/buffer/out/textBufferTextIterator.cpp
+++ b/src/buffer/out/textBufferTextIterator.cpp
@@ -25,7 +25,8 @@ TextBufferTextIterator::TextBufferTextIterator(const TextBufferCellIterator& cel
 // Return Value:
 // - Read only UTF-16 text data
 // TODO GH 2682, fix design so this doesn't have to be suppressed.
-[[gsl::suppress(26434)]] const std::wstring_view TextBufferTextIterator::operator*() const noexcept
+GSL_SUPPRESS(26434)
+const std::wstring_view TextBufferTextIterator::operator*() const noexcept
 {
     return _view.Chars();
 }
@@ -35,7 +36,8 @@ TextBufferTextIterator::TextBufferTextIterator(const TextBufferCellIterator& cel
 // Return Value:
 // - Read only UTF-16 text data
 // TODO GH 2682, fix design so this doesn't have to be suppressed.
-[[gsl::suppress(26434)]] const std::wstring_view* TextBufferTextIterator::operator->() const noexcept
+GSL_SUPPRESS(26434)
+const std::wstring_view* TextBufferTextIterator::operator->() const noexcept
 {
     return &_view.Chars();
 }

--- a/src/cascadia/TerminalControl/HwndTerminal.cpp
+++ b/src/cascadia/TerminalControl/HwndTerminal.cpp
@@ -891,7 +891,8 @@ void _stdcall TerminalSetTheme(void* terminal, TerminalTheme theme, LPCWSTR font
         for (size_t tableIndex = 0; tableIndex < 16; tableIndex++)
         {
             // It's using gsl::at to check the index is in bounds, but the analyzer still calls this array-to-pointer-decay
-            [[gsl::suppress(bounds .3)]] renderSettings.SetColorTableEntry(tableIndex, gsl::at(theme.ColorTable, tableIndex));
+            GSL_SUPPRESS(bounds .3)
+            renderSettings.SetColorTableEntry(tableIndex, gsl::at(theme.ColorTable, tableIndex));
         }
 
         publicTerminal->_terminal->SetCursorStyle(static_cast<DispatchTypes::CursorStyle>(theme.CursorStyle));

--- a/src/cascadia/TerminalCore/ITerminalInput.hpp
+++ b/src/cascadia/TerminalCore/ITerminalInput.hpp
@@ -16,10 +16,10 @@ namespace Microsoft::Terminal::Core
         ITerminalInput& operator=(const ITerminalInput&) = default;
         ITerminalInput& operator=(ITerminalInput&&) = default;
 
-        virtual [[nodiscard]] ::Microsoft::Console::VirtualTerminal::TerminalInput::OutputType SendKeyEvent(const WORD vkey, const WORD scanCode, const ControlKeyStates states, const bool keyDown) = 0;
-        virtual [[nodiscard]] ::Microsoft::Console::VirtualTerminal::TerminalInput::OutputType SendMouseEvent(const til::point viewportPos, const unsigned int uiButton, const ControlKeyStates states, const short wheelDelta, const Microsoft::Console::VirtualTerminal::TerminalInput::MouseButtonState state) = 0;
-        virtual [[nodiscard]] ::Microsoft::Console::VirtualTerminal::TerminalInput::OutputType SendCharEvent(const wchar_t ch, const WORD scanCode, const ControlKeyStates states) = 0;
-        virtual [[nodiscard]] ::Microsoft::Console::VirtualTerminal::TerminalInput::OutputType FocusChanged(const bool focused) = 0;
+        [[nodiscard]] virtual ::Microsoft::Console::VirtualTerminal::TerminalInput::OutputType SendKeyEvent(const WORD vkey, const WORD scanCode, const ControlKeyStates states, const bool keyDown) = 0;
+        [[nodiscard]] virtual ::Microsoft::Console::VirtualTerminal::TerminalInput::OutputType SendMouseEvent(const til::point viewportPos, const unsigned int uiButton, const ControlKeyStates states, const short wheelDelta, const Microsoft::Console::VirtualTerminal::TerminalInput::MouseButtonState state) = 0;
+        [[nodiscard]] virtual ::Microsoft::Console::VirtualTerminal::TerminalInput::OutputType SendCharEvent(const wchar_t ch, const WORD scanCode, const ControlKeyStates states) = 0;
+        [[nodiscard]] virtual ::Microsoft::Console::VirtualTerminal::TerminalInput::OutputType FocusChanged(const bool focused) = 0;
 
         [[nodiscard]] virtual HRESULT UserResize(const til::size size) noexcept = 0;
         virtual void UserScrollViewport(const int viewTop) = 0;

--- a/src/types/utils.cpp
+++ b/src/types/utils.cpp
@@ -24,7 +24,8 @@ static constexpr bool _isNumber(const wchar_t wch) noexcept
     return wch >= L'0' && wch <= L'9'; // 0x30 - 0x39
 }
 
-[[gsl::suppress(bounds)]] static std::wstring guidToStringCommon(const GUID& guid, size_t offset, size_t length)
+GSL_SUPPRESS(bounds)
+static std::wstring guidToStringCommon(const GUID& guid, size_t offset, size_t length)
 {
     // This is just like StringFromGUID2 but with lowercase hexadecimal.
     wchar_t buffer[39];
@@ -58,7 +59,8 @@ GUID Utils::GuidFromString(_Null_terminated_ const wchar_t* str)
 //
 // Side-note: An interesting quirk of this method is that the given string doesn't need to be null-terminated.
 // This method could be combined with GuidFromString() so that it also doesn't require null-termination.
-[[gsl::suppress(bounds)]] GUID Utils::GuidFromPlainString(_Null_terminated_ const wchar_t* str)
+GSL_SUPPRESS(bounds)
+GUID Utils::GuidFromPlainString(_Null_terminated_ const wchar_t* str)
 {
     // Add "{}" brackets around our string, as required by IIDFromString().
     wchar_t buffer[39];


### PR DESCRIPTION
* `[[nodiscard]]` and `[[maybe_unused]]` must come before `virtual` and `static` qualifiers
* MSVC and Clang disagree on how `gsl::suppress` should look; fortunately, GSL provides a macro to paper over the difference

Refs #15952