### PR TITLE
Add support for turning off full-color Emoji

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -862,6 +862,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         const auto lock = _terminal->LockForWriting();
 
         _builtinGlyphs = _settings->EnableBuiltinGlyphs();
+        _colorGlyphs = _settings->EnableColorGlyphs();
         _cellWidth = CSSLengthPercentage::FromString(_settings->CellWidth().c_str());
         _cellHeight = CSSLengthPercentage::FromString(_settings->CellHeight().c_str());
         _runtimeOpacity = std::nullopt;
@@ -1042,6 +1043,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         _actualFontFaceName = { fontFace };
 
         _desiredFont.SetEnableBuiltinGlyphs(_builtinGlyphs);
+        _desiredFont.SetEnableColorGlyphs(_colorGlyphs);
         _desiredFont.SetCellSize(_cellWidth, _cellHeight);
 
         const auto before = _actualFont.GetSize();

--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -317,6 +317,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         FontInfo _actualFont;
         winrt::hstring _actualFontFaceName;
         bool _builtinGlyphs = true;
+        bool _colorGlyphs = true;
         CSSLengthPercentage _cellWidth;
         CSSLengthPercentage _cellHeight;
 

--- a/src/cascadia/TerminalControl/IControlSettings.idl
+++ b/src/cascadia/TerminalControl/IControlSettings.idl
@@ -42,6 +42,7 @@ namespace Microsoft.Terminal.Control
         Windows.Foundation.Collections.IMap<String, UInt32> FontFeatures { get; };
         Windows.Foundation.Collections.IMap<String, Single> FontAxes { get; };
         Boolean EnableBuiltinGlyphs { get; };
+        Boolean EnableColorGlyphs { get; };
         String CellWidth { get; };
         String CellHeight { get; };
 

--- a/src/cascadia/TerminalSettingsEditor/Appearances.h
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.h
@@ -151,6 +151,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         OBSERVABLE_PROJECTED_SETTING(_appearance.SourceProfile().FontInfo(), FontAxes);
         OBSERVABLE_PROJECTED_SETTING(_appearance.SourceProfile().FontInfo(), FontFeatures);
         OBSERVABLE_PROJECTED_SETTING(_appearance.SourceProfile().FontInfo(), EnableBuiltinGlyphs);
+        OBSERVABLE_PROJECTED_SETTING(_appearance.SourceProfile().FontInfo(), EnableColorGlyphs);
 
         OBSERVABLE_PROJECTED_SETTING(_appearance, RetroTerminalEffect);
         OBSERVABLE_PROJECTED_SETTING(_appearance, CursorShape);

--- a/src/cascadia/TerminalSettingsEditor/Appearances.idl
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.idl
@@ -80,6 +80,7 @@ namespace Microsoft.Terminal.Settings.Editor
         OBSERVABLE_PROJECTED_APPEARANCE_SETTING(Double, LineHeight);
         OBSERVABLE_PROJECTED_APPEARANCE_SETTING(Windows.UI.Text.FontWeight, FontWeight);
         OBSERVABLE_PROJECTED_APPEARANCE_SETTING(Boolean, EnableBuiltinGlyphs);
+        OBSERVABLE_PROJECTED_APPEARANCE_SETTING(Boolean, EnableColorGlyphs);
 
         OBSERVABLE_PROJECTED_APPEARANCE_SETTING(String, DarkColorSchemeName);
         OBSERVABLE_PROJECTED_APPEARANCE_SETTING(String, LightColorSchemeName);

--- a/src/cascadia/TerminalSettingsEditor/Appearances.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.xaml
@@ -423,6 +423,15 @@
                               Style="{StaticResource ToggleSwitchInExpanderStyle}" />
             </local:SettingContainer>
 
+            <!--  Color Glyphs  -->
+            <local:SettingContainer x:Uid="Profile_EnableColorGlyphs"
+                                    ClearSettingValue="{x:Bind Appearance.ClearEnableColorGlyphs}"
+                                    HasSettingValue="{x:Bind Appearance.HasEnableColorGlyphs, Mode=OneWay}"
+                                    SettingOverrideSource="{x:Bind Appearance.EnableColorGlyphsOverrideSource, Mode=OneWay}">
+                <ToggleSwitch IsOn="{x:Bind Appearance.EnableColorGlyphs, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
+
             <!--  Retro Terminal Effect  -->
             <local:SettingContainer x:Uid="Profile_RetroTerminalEffect"
                                     ClearSettingValue="{x:Bind Appearance.ClearRetroTerminalEffect}"

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -914,6 +914,14 @@
     <value>When enabled, the terminal draws custom glyphs for block element and box drawing characters instead of using the font. This feature only works when GPU Acceleration is available.</value>
     <comment>A longer description of the "Profile_EnableBuiltinGlyphs" toggle. "glyphs", "block element" and "box drawing characters" are technical terms from the Unicode specification.</comment>
   </data>
+  <data name="Profile_EnableColorGlyphs.Header" xml:space="preserve">
+    <value>Full-color Emoji</value>
+    <comment>The main label of a toggle. When enabled, certain characters (emoji in this case) are displayed with multiple colors.</comment>
+  </data>
+  <data name="Profile_EnableColorGlyphs.HelpText" xml:space="preserve">
+    <value>When enabled, Emoji are displayed in full color.</value>
+    <comment>A longer description of the "Profile_EnableColorGlyphs" toggle.</comment>
+  </data>
   <data name="Profile_FontWeightComboBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Font weight</value>
     <comment>Name for a control to select the weight (i.e. bold, thin, etc.) of the text in the app.</comment>

--- a/src/cascadia/TerminalSettingsModel/FontConfig.idl
+++ b/src/cascadia/TerminalSettingsModel/FontConfig.idl
@@ -21,6 +21,7 @@ namespace Microsoft.Terminal.Settings.Model
         INHERITABLE_FONT_SETTING(Windows.Foundation.Collections.IMap<String COMMA UInt32>, FontFeatures);
         INHERITABLE_FONT_SETTING(Windows.Foundation.Collections.IMap<String COMMA Single>, FontAxes);
         INHERITABLE_FONT_SETTING(Boolean, EnableBuiltinGlyphs);
+        INHERITABLE_FONT_SETTING(Boolean, EnableColorGlyphs);
         INHERITABLE_FONT_SETTING(String, CellWidth);
         INHERITABLE_FONT_SETTING(String, CellHeight);
     }

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -114,6 +114,7 @@ Author(s):
     X(IFontAxesMap, FontAxes, "axes")                                                  \
     X(IFontFeatureMap, FontFeatures, "features")                                       \
     X(bool, EnableBuiltinGlyphs, "builtinGlyphs", true)                                \
+    X(bool, EnableColorGlyphs, "colorGlyphs", true)                                    \
     X(winrt::hstring, CellWidth, "cellWidth")                                          \
     X(winrt::hstring, CellHeight, "cellHeight")
 

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
@@ -291,6 +291,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         _FontFeatures = fontInfo.FontFeatures();
         _FontAxes = fontInfo.FontAxes();
         _EnableBuiltinGlyphs = fontInfo.EnableBuiltinGlyphs();
+        _EnableColorGlyphs = fontInfo.EnableColorGlyphs();
         _CellWidth = fontInfo.CellWidth();
         _CellHeight = fontInfo.CellHeight();
         _Padding = profile.Padding();

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.h
@@ -130,6 +130,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         INHERITABLE_SETTING(Model::TerminalSettings, IFontAxesMap, FontAxes);
         INHERITABLE_SETTING(Model::TerminalSettings, IFontFeatureMap, FontFeatures);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, EnableBuiltinGlyphs, true);
+        INHERITABLE_SETTING(Model::TerminalSettings, bool, EnableColorGlyphs, true);
         INHERITABLE_SETTING(Model::TerminalSettings, hstring, CellWidth);
         INHERITABLE_SETTING(Model::TerminalSettings, hstring, CellHeight);
 

--- a/src/cascadia/inc/ControlProperties.h
+++ b/src/cascadia/inc/ControlProperties.h
@@ -65,6 +65,7 @@
     X(IFontFeatureMap, FontFeatures)                                                                                                                     \
     X(IFontAxesMap, FontAxes)                                                                                                                            \
     X(bool, EnableBuiltinGlyphs, true)                                                                                                                   \
+    X(bool, EnableColorGlyphs, true)                                                                                                                     \
     X(winrt::hstring, CellWidth)                                                                                                                         \
     X(winrt::hstring, CellHeight)                                                                                                                        \
     X(winrt::Microsoft::Terminal::Control::IKeyBindings, KeyBindings, nullptr)                                                                           \

--- a/src/renderer/atlas/AtlasEngine.api.cpp
+++ b/src/renderer/atlas/AtlasEngine.api.cpp
@@ -794,5 +794,6 @@ void AtlasEngine::_resolveFontMetrics(const wchar_t* requestedFaceName, const Fo
         fontMetrics->overline = { 0, underlineWidthU16 };
 
         fontMetrics->builtinGlyphs = fontInfoDesired.GetEnableBuiltinGlyphs();
+        fontMetrics->colorGlyphs = fontInfoDesired.GetEnableColorGlyphs();
     }
 }

--- a/src/renderer/atlas/BackendD2D.cpp
+++ b/src/renderer/atlas/BackendD2D.cpp
@@ -221,8 +221,14 @@ void BackendD2D::_drawText(RenderingPayload& p)
                 if (glyphRun.fontFace)
                 {
                     D2D1_RECT_F bounds = GlyphRunEmptyBounds;
+                    wil::com_ptr<IDWriteColorGlyphRunEnumerator1> enumerator{ nullptr };
 
-                    if (const auto enumerator = TranslateColorGlyphRun(p.dwriteFactory4.get(), baselineOrigin, &glyphRun))
+                    if (p.s->font->colorGlyphs)
+                    {
+                        enumerator = TranslateColorGlyphRun(p.dwriteFactory4.get(), baselineOrigin, &glyphRun);
+                    }
+
+                    if (enumerator)
                     {
                         while (ColorGlyphRunMoveNext(enumerator.get()))
                         {

--- a/src/renderer/atlas/BackendD2D.cpp
+++ b/src/renderer/atlas/BackendD2D.cpp
@@ -221,7 +221,7 @@ void BackendD2D::_drawText(RenderingPayload& p)
                 if (glyphRun.fontFace)
                 {
                     D2D1_RECT_F bounds = GlyphRunEmptyBounds;
-                    wil::com_ptr<IDWriteColorGlyphRunEnumerator1> enumerator{ nullptr };
+                    wil::com_ptr<IDWriteColorGlyphRunEnumerator1> enumerator;
 
                     if (p.s->font->colorGlyphs)
                     {

--- a/src/renderer/atlas/BackendD3D.cpp
+++ b/src/renderer/atlas/BackendD3D.cpp
@@ -1316,7 +1316,12 @@ BackendD3D::AtlasGlyphEntry* BackendD3D::_drawGlyph(const RenderingPayload& p, c
     });
 
     {
-        const auto enumerator = TranslateColorGlyphRun(p.dwriteFactory4.get(), {}, &glyphRun);
+        wil::com_ptr<IDWriteColorGlyphRunEnumerator1> enumerator{ nullptr };
+
+        if (p.s->font->colorGlyphs)
+        {
+            enumerator = TranslateColorGlyphRun(p.dwriteFactory4.get(), {}, &glyphRun);
+        }
 
         if (!enumerator)
         {

--- a/src/renderer/atlas/BackendD3D.cpp
+++ b/src/renderer/atlas/BackendD3D.cpp
@@ -1316,7 +1316,7 @@ BackendD3D::AtlasGlyphEntry* BackendD3D::_drawGlyph(const RenderingPayload& p, c
     });
 
     {
-        wil::com_ptr<IDWriteColorGlyphRunEnumerator1> enumerator{ nullptr };
+        wil::com_ptr<IDWriteColorGlyphRunEnumerator1> enumerator;
 
         if (p.s->font->colorGlyphs)
         {

--- a/src/renderer/atlas/common.h
+++ b/src/renderer/atlas/common.h
@@ -361,6 +361,7 @@ namespace Microsoft::Console::Render::Atlas
         u16 dpi = 96;
         AntialiasingMode antialiasingMode = DefaultAntialiasingMode;
         bool builtinGlyphs = false;
+        bool colorGlyphs = true;
 
         std::vector<uint16_t> softFontPattern;
         til::size softFontCellSize;

--- a/src/renderer/base/FontInfoDesired.cpp
+++ b/src/renderer/base/FontInfoDesired.cpp
@@ -34,6 +34,11 @@ void FontInfoDesired::SetEnableBuiltinGlyphs(bool builtinGlyphs) noexcept
     _builtinGlyphs = builtinGlyphs;
 }
 
+void FontInfoDesired::SetEnableColorGlyphs(bool colorGlyphs) noexcept
+{
+    _colorGlyphs = colorGlyphs;
+}
+
 const CSSLengthPercentage& FontInfoDesired::GetCellWidth() const noexcept
 {
     return _cellWidth;
@@ -47,6 +52,11 @@ const CSSLengthPercentage& FontInfoDesired::GetCellHeight() const noexcept
 bool FontInfoDesired::GetEnableBuiltinGlyphs() const noexcept
 {
     return _builtinGlyphs;
+}
+
+bool FontInfoDesired::GetEnableColorGlyphs() const noexcept
+{
+    return _colorGlyphs;
 }
 
 float FontInfoDesired::GetFontSize() const noexcept

--- a/src/renderer/inc/FontInfoDesired.hpp
+++ b/src/renderer/inc/FontInfoDesired.hpp
@@ -36,10 +36,12 @@ public:
 
     void SetCellSize(const CSSLengthPercentage& cellWidth, const CSSLengthPercentage& cellHeight) noexcept;
     void SetEnableBuiltinGlyphs(bool builtinGlyphs) noexcept;
+    void SetEnableColorGlyphs(bool colorGlyphs) noexcept;
 
     const CSSLengthPercentage& GetCellWidth() const noexcept;
     const CSSLengthPercentage& GetCellHeight() const noexcept;
     bool GetEnableBuiltinGlyphs() const noexcept;
+    bool GetEnableColorGlyphs() const noexcept;
     float GetFontSize() const noexcept;
     til::size GetEngineSize() const noexcept;
     bool IsDefaultRasterFont() const noexcept;
@@ -50,4 +52,5 @@ private:
     CSSLengthPercentage _cellWidth;
     CSSLengthPercentage _cellHeight;
     bool _builtinGlyphs = false;
+    bool _colorGlyphs = true;
 };


### PR DESCRIPTION
This pull request introduces support for disabling full-color emoji (and technically other COLR-related font features!)

Full-color emoji don't respond to SGR colors, intensity, faint or blink. Some users also just prefer the line art ones.

Related to #15979
Refs #1790
Closes #956


![WindowsTerminal_20240313T183845_225](https://github.com/microsoft/terminal/assets/189190/e9b7f759-2f54-4218-9725-05f6b6b7cff8)

![image](https://github.com/microsoft/terminal/assets/189190/9a1eb721-35bf-4290-8efb-a036de66ab61)
