### PR TITLE
Add support for resizing panes with mouse

### DIFF
--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -1889,6 +1889,7 @@ void Pane::_ApplySplitDefinitions()
 
     _root.ManipulationDelta([this](auto&&, auto& args) {
         auto delta = args.Delta().Translation;
+        const auto scaleFactor = DisplayInformation::GetForCurrentView().RawPixelsPerViewPixel();
 
         // Decide on direction based on delta
         ResizeDirection dir = ResizeDirection::None;
@@ -1933,8 +1934,8 @@ void Pane::_ApplySplitDefinitions()
                 // TODO CARLOS: something is wrong here
                 actualDimension = base::ClampedNumeric<float>(_root.ActualHeight());
             }
-
-            const auto percentDelta = amount / actualDimension;
+            const auto scaledAmount = amount * scaleFactor;
+            const auto percentDelta = scaledAmount / actualDimension;
 
             ResizePane(dir, percentDelta.Abs());
         }

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -387,39 +387,8 @@ void Pane::_ManipulationDeltaHandler(const winrt::Windows::Foundation::IInspecta
     }
 
     assert(_IsLeaf());
-    // If we early return out of it, because we're a leaf, then this event will bubble. I think
-    if (_IsLeaf())
-    {
-        //args.Handled(true);
-        // return;
-    }
+
     auto container = args.Container();
-    /*if (container == _firstChild->GetRootElement() || container == _secondChild->GetRootElement())
-    {
-        return;
-    }*/
-
-    //auto sendingBorder = (sender == _borderFirst) ? _borderFirst : (sender == _borderSecond) ? _borderSecond :
-    //                                                                                           nullptr;
-    //if (sendingBorder == nullptr)
-    //{
-    //    return;
-    //}
-    //auto sendersElement = (sender == _borderFirst) ?
-    //                          _firstChild->GetRootElement() :
-    //                      (sender == _borderSecond) ? _secondChild->GetRootElement() :
-    //                                                  nullptr;
-    //if (sendersElement == nullptr)
-    //{
-    //    return;
-    //}
-
-    //const auto borderPosition_transform = sendingBorder.TransformToVisual(sendingBorder.XamlRoot().Content());
-    //const auto childPos_transform = sendingBorder.Child().TransformToVisual(sendingBorder.XamlRoot().Content());
-    //const auto childRelativeToBorder_transform = sendingBorder.Child().TransformToVisual(sendingBorder);
-    //const auto senderToRoot_transform = sendingBorder.TransformToVisual(_root);
-    //const auto sendersElemToRoot_transform = sendersElement.TransformToVisual(_root);
-    //const auto sendersElemToBorder_transform = sendersElement.TransformToVisual(sendingBorder);
 
     auto delta = args.Delta().Translation;
     auto transformOrigin = args.Position();
@@ -427,21 +396,6 @@ void Pane::_ManipulationDeltaHandler(const winrt::Windows::Foundation::IInspecta
     // ourOrigin;
 
     const auto o0 = Point{ 0, 0 };
-
-    //const auto borderPosition_delta = borderPosition_transform.TransformPoint(o0);
-    //const auto childPos_delta = childPos_transform.TransformPoint(o0);
-    //const auto childRelativeToBorder_delta = childRelativeToBorder_transform.TransformPoint(o0);
-    //const auto senderToRoot_delta = senderToRoot_transform.TransformPoint(o0);
-    //const auto sendersElemToRoot_delta = sendersElemToRoot_transform.TransformPoint(o0);
-    //const auto sendersElemToBorder_delta = sendersElemToBorder_transform.TransformPoint(o0);
-    //borderPosition_delta;
-    //childPos_delta;
-    //childRelativeToBorder_delta;
-    //senderToRoot_delta;
-    //sendersElemToRoot_delta;
-    //sendersElemToBorder_delta;
-    //const auto transformFromBorder = childRelativeToBorder_transform.TransformPoint(transformOrigin);
-    //transformFromBorder;
 
     const auto contentSize = _content.GetRoot().ActualSize();
     // const auto transform_contentFromOurRoot = _content.GetRoot().TransformToVisual(_root);
@@ -462,28 +416,13 @@ void Pane::_ManipulationDeltaHandler(const winrt::Windows::Foundation::IInspecta
     //     // clicked past the bounds of our control. This is good, we want to handle this case. This means we clicked on our bottom/right.
     // }
 
-    // else if (transformInControlSpace.X < 0 && transformInControlSpace.Y < 0) // NO
-    // else if (transformInControlSpace.X < 0 || transformInControlSpace.Y < 0) // NO
-    // else if (transformOrigin.X < 0 && transformOrigin.Y < 0)
-    // else if (transformOrigin.X < PaneBorderSize && transformOrigin.Y < PaneBorderSize) // NO
-    // else if (transformOrigin.X < PaneBorderSize || transformOrigin.Y < PaneBorderSize) // nope
-    // else if (transformInControlSpace.X < PaneBorderSize || transformInControlSpace.Y < PaneBorderSize) // Close!
     else if (transformInControlSpace.X < 0 || transformInControlSpace.Y < 0) // Close!
     {
-        //     // clicked above/left of the pane. We're still on the border, but we don't want to resize our parent, we want to resize _their_ parent.
+        // clicked above/left of the pane. We're still on the border, but we don't want to resize our parent, we want to resize _their_ parent.
         ManipulationRequested.raise(shared_from_this(), _splitState, delta, true);
-        //     TODO! THIS DOESN"T WORK
         return;
     }
-    // else if (transformInControlSpace.X < 0 || transformInControlSpace.Y < 0)
-    // {
-    //     if (transformInControlSpace.X < 0){
-    //                 ManipulationRequested.raise(SplitState::Vertical, delta, false);
 
-    //     }
-
-    //      || transformInControlSpace.Y < 0)
-    // }
     else
     {
         const bool pastRight = transformInControlSpace.X > contentSize.x;
@@ -502,51 +441,6 @@ void Pane::_ManipulationDeltaHandler(const winrt::Windows::Foundation::IInspecta
         }
         return;
     }
-
-    const auto weAreVertical = _splitState == SplitState::Vertical;
-    const auto oppositeSplit = weAreVertical ? SplitState::Horizontal : SplitState::Vertical;
-
-    //const auto senderSize = sendingBorder.ActualSize(); // This seems to be the size of the half of the pane where the drag originated
-    //const auto childSize = sendingBorder.Child().ActualSize();
-    //const auto rootSize = _root.ActualSize(); // This is the combined size of both child panes. That makes sense.
-    //const auto sendersElemSize = sendersElement.ActualSize();
-    //senderSize;
-    //childSize;
-    //rootSize;
-    //sendersElemSize;
-
-    if (transformOrigin.X <= 0 || transformOrigin.Y <= 0)
-    {
-        ManipulationRequested.raise(shared_from_this(), oppositeSplit, delta, false);
-        return;
-    }
-    //const auto pastTopLeft = transformOrigin.X > PaneBorderSize && transformOrigin.Y > PaneBorderSize;
-    //const auto beforeRight = transformOrigin.X < (2 * PaneBorderSize + childSize.x);
-    //const auto beforeBottom = transformOrigin.Y < (2 * PaneBorderSize + childSize.y);
-    //if (pastTopLeft || (beforeRight && beforeBottom))
-    //{
-    //    //  return;
-    //}
-
-    const winrt::Windows::Foundation::Point translationForUs = (weAreVertical) ? Point{ delta.X, 0 } : Point{ 0, delta.Y };
-    const winrt::Windows::Foundation::Point translationForParent = (weAreVertical) ? Point{ 0, delta.Y } : Point{ delta.X, 0 };
-
-    // if (transformOrigin.X > ourOrigin.x || transformOrigin.Y > ourOrigin.y)
-    // {
-    _handleManipulation(translationForUs);
-
-    if ((translationForParent.X * translationForParent.X + translationForParent.Y * translationForParent.Y) > 0)
-    {
-        ManipulationRequested.raise(shared_from_this(), oppositeSplit, translationForParent, false);
-    }
-    // }
-    // else
-    // {
-    // ManipulationRequested.raise(_splitState,
-    // delta);
-    // }
-
-    args.Handled(true);
 }
 void Pane::_handleManipulation(const winrt::Windows::Foundation::Point delta)
 {
@@ -596,20 +490,17 @@ void Pane::_handleManipulation(const winrt::Windows::Foundation::Point delta)
         if (dir == ResizeDirection::Left || dir == ResizeDirection::Right)
         {
             amount = translationForUs.X;
-            // TODO CARLOS: something is wrong here
             actualDimension = base::ClampedNumeric<float>(_root.ActualWidth());
         }
         else if (dir == ResizeDirection::Up || dir == ResizeDirection::Down)
         {
             amount = translationForUs.Y;
-            // TODO CARLOS: something is wrong here
             actualDimension = base::ClampedNumeric<float>(_root.ActualHeight());
         }
         const auto scaledAmount = amount * scaleFactor;
         const auto percentDelta = scaledAmount / actualDimension;
 
         _Resize(dir, percentDelta.Abs());
-        // ResizePane(dir, percentDelta.Abs());
     }
 }
 

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -1340,6 +1340,29 @@ TermControl Pane::GetLastFocusedTerminalControl()
     }
 }
 
+IPaneContent Pane::GetLastFocusedContent()
+{
+    if (!_IsLeaf())
+    {
+        if (_lastActive)
+        {
+            auto pane = shared_from_this();
+            while (const auto p = pane->_parentChildPath.lock())
+            {
+                if (p->_IsLeaf())
+                {
+                    return p->_content;
+                }
+                pane = p;
+            }
+            // We didn't find our child somehow, they might have closed under us.
+        }
+        return _firstChild->GetLastFocusedContent();
+    }
+
+    return _content;
+}
+
 // Method Description:
 // - Gets the TermControl of this pane. If this Pane is not a leaf this will
 //   return the nullptr;
@@ -1480,7 +1503,11 @@ void Pane::UpdateVisuals()
 void Pane::_Focus()
 {
     _GotFocusHandlers(shared_from_this(), FocusState::Programmatic);
-    _content.Focus(FocusState::Programmatic);
+    if (const auto& lastContent{ GetLastFocusedContent() })
+    {
+        lastContent.Focus(FocusState::Programmatic);
+    }
+    
 }
 
 // Method Description:
@@ -2176,7 +2203,7 @@ void Pane::_SetupEntranceAnimation()
         auto child = isFirstChild ? _firstChild : _secondChild;
         auto childGrid = child->_root;
         // If we are splitting a parent pane this may be null
-        auto control = child->_content.GetRoot();
+        auto control = child->_content ? child->_content.GetRoot() : nullptr;
         // Build up our animation:
         // * it'll take as long as our duration (200ms)
         // * it'll change the value of our property from 0 to secondSize

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -370,8 +370,8 @@ void Pane::_handleOrBubbleManipulation(std::shared_ptr<Pane> sender, const winrt
     // We want to handle this drag in the following cases
     // * In a vertical split: if we're dragging the right of the first pane or the left of the second
     // * In a horizontal split: if we're dragging the bottom of the first pane or the top of the second
-    const auto sideMatched = (_splitState == SplitState::Vertical)   ? (isFirstChild && WI_IsFlagSet(side, Borders::Right)) || WI_IsFlagSet(side, Borders::Left) :
-                             (_splitState == SplitState::Horizontal) ? (isFirstChild && WI_IsFlagSet(side, Borders::Bottom)) || WI_IsFlagSet(side, Borders::Top) :
+    const auto sideMatched = (_splitState == SplitState::Vertical)   ? (isFirstChild && WI_IsFlagSet(side, Borders::Right)) || (!isFirstChild && WI_IsFlagSet(side, Borders::Left)) :
+                             (_splitState == SplitState::Horizontal) ? (isFirstChild && WI_IsFlagSet(side, Borders::Bottom)) || (!isFirstChild && WI_IsFlagSet(side, Borders::Top)) :
                                                                        false;
 
     if (sideMatched)

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -415,6 +415,12 @@ void Pane::_ManipulationDeltaHandler(const winrt::Windows::Foundation::IInspecta
     // if (container != _root)
     // return;
 
+    // A thought: store our last transformOrigin in an optional on the pane.
+    // If the first transform origin isn't on the border, then store the current one, and bail.
+    // If the next one is now on a border, doesn't matter! bail.
+    //   But also like, find some way to determine if the current manipulation is somehow related to the initial one that started this drag.
+    // On a pointer release, clear it. Or if we get a tapped on this pane, or they start dragging sufficently far away?
+
     auto delta = args.Delta().Translation;
     auto cumulative = args.Cumulative().Translation;
     auto transformCurrentPos = args.Position();

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -378,25 +378,104 @@ void Pane::_ManipulationDeltaHandler(const winrt::Windows::Foundation::IInspecta
     {
         return;
     }
-     if (_IsLeaf())
-     {
-         return;
-     }
+    if (_IsLeaf())
+    {
+        //args.Handled(true);
+        return;
+    }
+    auto container = args.Container();
+    /*if (container == _firstChild->GetRootElement() || container == _secondChild->GetRootElement())
+    {
+        return;
+    }*/
+
+    //auto sendingBorder = (sender == _borderFirst) ? _borderFirst : (sender == _borderSecond) ? _borderSecond :
+    //                                                                                           nullptr;
+    //if (sendingBorder == nullptr)
+    //{
+    //    return;
+    //}
+    //auto sendersElement = (sender == _borderFirst) ?
+    //                          _firstChild->GetRootElement() :
+    //                      (sender == _borderSecond) ? _secondChild->GetRootElement() :
+    //                                                  nullptr;
+    //if (sendersElement == nullptr)
+    //{
+    //    return;
+    //}
+
+    //const auto borderPosition_transform = sendingBorder.TransformToVisual(sendingBorder.XamlRoot().Content());
+    //const auto childPos_transform = sendingBorder.Child().TransformToVisual(sendingBorder.XamlRoot().Content());
+    //const auto childRelativeToBorder_transform = sendingBorder.Child().TransformToVisual(sendingBorder);
+    //const auto senderToRoot_transform = sendingBorder.TransformToVisual(_root);
+    //const auto sendersElemToRoot_transform = sendersElement.TransformToVisual(_root);
+    //const auto sendersElemToBorder_transform = sendersElement.TransformToVisual(sendingBorder);
+
     auto delta = args.Delta().Translation;
+    auto transformOrigin = args.Position();
+    auto ourOrigin = _root.ActualOffset();
+    ourOrigin;
+
+    const auto o0 = Point{ 0, 0 };
+
+    //const auto borderPosition_delta = borderPosition_transform.TransformPoint(o0);
+    //const auto childPos_delta = childPos_transform.TransformPoint(o0);
+    //const auto childRelativeToBorder_delta = childRelativeToBorder_transform.TransformPoint(o0);
+    //const auto senderToRoot_delta = senderToRoot_transform.TransformPoint(o0);
+    //const auto sendersElemToRoot_delta = sendersElemToRoot_transform.TransformPoint(o0);
+    //const auto sendersElemToBorder_delta = sendersElemToBorder_transform.TransformPoint(o0);
+    //borderPosition_delta;
+    //childPos_delta;
+    //childRelativeToBorder_delta;
+    //senderToRoot_delta;
+    //sendersElemToRoot_delta;
+    //sendersElemToBorder_delta;
+    //const auto transformFromBorder = childRelativeToBorder_transform.TransformPoint(transformOrigin);
+    //transformFromBorder;
 
     const auto weAreVertical = _splitState == SplitState::Vertical;
+    const auto oppositeSplit = weAreVertical ? SplitState::Horizontal : SplitState::Vertical;
+
+    //const auto senderSize = sendingBorder.ActualSize(); // This seems to be the size of the half of the pane where the drag originated
+    //const auto childSize = sendingBorder.Child().ActualSize();
+    //const auto rootSize = _root.ActualSize(); // This is the combined size of both child panes. That makes sense.
+    //const auto sendersElemSize = sendersElement.ActualSize();
+    //senderSize;
+    //childSize;
+    //rootSize;
+    //sendersElemSize;
+
+    if (transformOrigin.X <= 0 || transformOrigin.Y <= 0)
+    {
+        ManipulationRequested.raise(oppositeSplit, delta);
+        return;
+    }
+    //const auto pastTopLeft = transformOrigin.X > PaneBorderSize && transformOrigin.Y > PaneBorderSize;
+    //const auto beforeRight = transformOrigin.X < (2 * PaneBorderSize + childSize.x);
+    //const auto beforeBottom = transformOrigin.Y < (2 * PaneBorderSize + childSize.y);
+    //if (pastTopLeft || (beforeRight && beforeBottom))
+    //{
+    //    //  return;
+    //}
+
     const winrt::Windows::Foundation::Point translationForUs = (weAreVertical) ? Point{ delta.X, 0 } : Point{ 0, delta.Y };
     const winrt::Windows::Foundation::Point translationForParent = (weAreVertical) ? Point{ 0, delta.Y } : Point{ delta.X, 0 };
 
+    // if (transformOrigin.X > ourOrigin.x || transformOrigin.Y > ourOrigin.y)
+    // {
     _handleManipulation(translationForUs);
-
-
 
     if ((translationForParent.X * translationForParent.X + translationForParent.Y * translationForParent.Y) > 0)
     {
-        ManipulationRequested.raise(weAreVertical ? SplitState::Horizontal : SplitState::Vertical,
+        ManipulationRequested.raise(oppositeSplit,
                                     translationForParent);
     }
+    // }
+    // else
+    // {
+    // ManipulationRequested.raise(_splitState,
+    // delta);
+    // }
 
     args.Handled(true);
 }
@@ -2405,6 +2484,9 @@ std::pair<std::shared_ptr<Pane>, std::shared_ptr<Pane>> Pane::_Split(SplitDirect
 
     _borderFirst.Child(_firstChild->GetRootElement());
     _borderSecond.Child(_secondChild->GetRootElement());
+
+    // _firstManipulationDeltaRevoker = _borderFirst.ManipulationDelta(winrt::auto_revoke, { this, &Pane::_ManipulationDeltaHandler });
+    // _secondManipulationDeltaRevoker = _borderSecond.ManipulationDelta(winrt::auto_revoke, { this, &Pane::_ManipulationDeltaHandler });
 
     _root.Children().Append(_borderFirst);
     _root.Children().Append(_borderSecond);

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -284,7 +284,6 @@ bool Pane::_Resize(const ResizeDirection& direction, float amount)
         return false;
     }
 
-    // auto amount = .05f;
     if (direction == ResizeDirection::Right || direction == ResizeDirection::Down)
     {
         amount = -amount;
@@ -2088,9 +2087,6 @@ void Pane::_ApplySplitDefinitions()
 
         _firstChild->_ApplySplitDefinitions();
         _secondChild->_ApplySplitDefinitions();
-
-        // Only allow x-axis resizing
-        // _root.ManipulationMode(Xaml::Input::ManipulationModes::TranslateX | Xaml::Input::ManipulationModes::TranslateRailsX);
     }
     else if (_splitState == SplitState::Horizontal)
     {
@@ -2103,9 +2099,6 @@ void Pane::_ApplySplitDefinitions()
 
         _firstChild->_ApplySplitDefinitions();
         _secondChild->_ApplySplitDefinitions();
-
-        // Only allow y-axis resizing
-        // _root.ManipulationMode(Xaml::Input::ManipulationModes::TranslateY | Xaml::Input::ManipulationModes::TranslateRailsY);
     }
     else
     {
@@ -2114,7 +2107,10 @@ void Pane::_ApplySplitDefinitions()
         _manipulationDeltaRevoker = _root.ManipulationDelta(winrt::auto_revoke, { this, &Pane::_ManipulationDeltaHandler });
     }
 
-    _root.ManipulationMode(Xaml::Input::ManipulationModes::TranslateX | Xaml::Input::ManipulationModes::TranslateRailsX | Xaml::Input::ManipulationModes::TranslateY | Xaml::Input::ManipulationModes::TranslateRailsY);
+    _root.ManipulationMode(Xaml::Input::ManipulationModes::TranslateX |
+                           Xaml::Input::ManipulationModes::TranslateRailsX |
+                           Xaml::Input::ManipulationModes::TranslateY |
+                           Xaml::Input::ManipulationModes::TranslateRailsY);
     _UpdateBorders();
 }
 
@@ -2480,8 +2476,6 @@ std::pair<std::shared_ptr<Pane>, std::shared_ptr<Pane>> Pane::_Split(SplitDirect
 {
     auto actualSplitType = _convertAutomaticOrDirectionalSplitState(splitType);
 
-    // _manipulationDeltaRevoker.revoke();
-
     if (_IsLeaf())
     {
         // Remove our old GotFocus handler from the control. We don't want the
@@ -2536,9 +2530,6 @@ std::pair<std::shared_ptr<Pane>, std::shared_ptr<Pane>> Pane::_Split(SplitDirect
     _borderFirst.Child(_firstChild->GetRootElement());
     _borderSecond.Child(_secondChild->GetRootElement());
 
-    // _firstManipulationDeltaRevoker = _borderFirst.ManipulationDelta(winrt::auto_revoke, { this, &Pane::_ManipulationDeltaHandler });
-    // _secondManipulationDeltaRevoker = _borderSecond.ManipulationDelta(winrt::auto_revoke, { this, &Pane::_ManipulationDeltaHandler });
-
     _root.Children().Append(_borderFirst);
     _root.Children().Append(_borderSecond);
 
@@ -2546,7 +2537,6 @@ std::pair<std::shared_ptr<Pane>, std::shared_ptr<Pane>> Pane::_Split(SplitDirect
 
     _firstManipulatedToken = _firstChild->ManipulationRequested({ this, &Pane::_handleOrBubbleManipulation });
     _secondManipulatedToken = _secondChild->ManipulationRequested({ this, &Pane::_handleOrBubbleManipulation });
-    // _secondChild->ManipulationRequested(handler);
 
     // Register event handlers on our children to handle their Close events
     _SetupChildCloseHandlers();

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -261,10 +261,11 @@ private:
     winrt::Windows::UI::Xaml::UIElement::GotFocus_revoker _gotFocusRevoker;
     winrt::Windows::UI::Xaml::UIElement::LostFocus_revoker _lostFocusRevoker;
     winrt::Windows::UI::Xaml::UIElement::ManipulationDelta_revoker _manipulationDeltaRevoker;
+    winrt::Windows::UI::Xaml::UIElement::ManipulationStarted_revoker _manipulationStartedRevoker;
     winrt::Windows::UI::Xaml::UIElement::ManipulationDelta_revoker _firstManipulationDeltaRevoker;
     winrt::Windows::UI::Xaml::UIElement::ManipulationDelta_revoker _secondManipulationDeltaRevoker;
 
-    bool _shouldManipulate{ true };
+    bool _shouldManipulate{ false };
 
     Borders _borders{ Borders::None };
 
@@ -316,6 +317,8 @@ private:
     void _ContentLostFocusHandler(const winrt::Windows::Foundation::IInspectable& sender,
                                   const winrt::Windows::UI::Xaml::RoutedEventArgs& e);
 
+    void _ManipulationStartedHandler(const winrt::Windows::Foundation::IInspectable& sender,
+                                     const winrt::Windows::UI::Xaml::Input::ManipulationStartedRoutedEventArgs& e);
     void _ManipulationDeltaHandler(const winrt::Windows::Foundation::IInspectable& sender,
                                    const winrt::Windows::UI::Xaml::Input::ManipulationDeltaRoutedEventArgs& e);
 

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -254,6 +254,9 @@ private:
     winrt::event_token _firstClosedToken{ 0 };
     winrt::event_token _secondClosedToken{ 0 };
 
+    winrt::event_token _firstManipulatedToken{ 0 };
+    winrt::event_token _secondManipulatedToken{ 0 };
+
     winrt::Windows::UI::Xaml::UIElement::GotFocus_revoker _gotFocusRevoker;
     winrt::Windows::UI::Xaml::UIElement::LostFocus_revoker _lostFocusRevoker;
     winrt::Windows::UI::Xaml::UIElement::ManipulationDelta_revoker _manipulationDeltaRevoker;
@@ -283,6 +286,7 @@ private:
     Borders _GetCommonBorders();
     winrt::Windows::UI::Xaml::Media::SolidColorBrush _ComputeBorderColor();
 
+    void _handleOrBubbleManipulation(const SplitState direction, const winrt::Windows::Foundation::Point delta);
     void _handleManipulation(const winrt::Windows::Foundation::Point delta);
     bool _Resize(const winrt::Microsoft::Terminal::Settings::Model::ResizeDirection& direction, float amount);
 

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -224,7 +224,7 @@ public:
     WINRT_CALLBACK(LostFocus, winrt::delegate<std::shared_ptr<Pane>>);
     WINRT_CALLBACK(PaneRaiseBell, winrt::Windows::Foundation::EventHandler<bool>);
     WINRT_CALLBACK(Detached, winrt::delegate<std::shared_ptr<Pane>>);
-    til::event<winrt::delegate<std::shared_ptr<Pane>, SplitState, winrt::Windows::Foundation::Point, bool>> ManipulationRequested;
+    til::event<winrt::delegate<std::shared_ptr<Pane>, winrt::Windows::Foundation::Point, Borders>> ManipulationRequested;
 
 private:
     struct PanePoint;
@@ -289,7 +289,7 @@ private:
     Borders _GetCommonBorders();
     winrt::Windows::UI::Xaml::Media::SolidColorBrush _ComputeBorderColor();
 
-    void _handleOrBubbleManipulation(std::shared_ptr<Pane> sender, const SplitState direction, const winrt::Windows::Foundation::Point delta, bool skip);
+    void _handleOrBubbleManipulation(std::shared_ptr<Pane> sender, const winrt::Windows::Foundation::Point delta, Borders side);
     void _handleManipulation(const winrt::Windows::Foundation::Point delta);
     bool _Resize(const winrt::Microsoft::Terminal::Settings::Model::ResizeDirection& direction, float amount);
 

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -255,6 +255,7 @@ private:
 
     winrt::Windows::UI::Xaml::UIElement::GotFocus_revoker _gotFocusRevoker;
     winrt::Windows::UI::Xaml::UIElement::LostFocus_revoker _lostFocusRevoker;
+    winrt::Windows::UI::Xaml::UIElement::ManipulationDelta_revoker _manipulationDeltaRevoker;
 
     Borders _borders{ Borders::None };
 
@@ -303,6 +304,9 @@ private:
                                  const winrt::Windows::UI::Xaml::RoutedEventArgs& e);
     void _ContentLostFocusHandler(const winrt::Windows::Foundation::IInspectable& sender,
                                   const winrt::Windows::UI::Xaml::RoutedEventArgs& e);
+
+    void _ManipulationDeltaHandler(const winrt::Windows::Foundation::IInspectable& sender,
+                                   const winrt::Windows::UI::Xaml::Input::ManipulationDeltaRoutedEventArgs& e);
 
     std::pair<float, float> _CalcChildrenSizes(const float fullSize) const;
     SnapChildrenSizeResult _CalcSnappedChildrenSizes(const bool widthOrHeight, const float fullSize) const;

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -262,9 +262,6 @@ private:
     winrt::Windows::UI::Xaml::UIElement::LostFocus_revoker _lostFocusRevoker;
     winrt::Windows::UI::Xaml::UIElement::ManipulationDelta_revoker _manipulationDeltaRevoker;
     winrt::Windows::UI::Xaml::UIElement::ManipulationStarted_revoker _manipulationStartedRevoker;
-    winrt::Windows::UI::Xaml::UIElement::ManipulationDelta_revoker _firstManipulationDeltaRevoker;
-    winrt::Windows::UI::Xaml::UIElement::ManipulationDelta_revoker _secondManipulationDeltaRevoker;
-
     bool _shouldManipulate{ false };
 
     Borders _borders{ Borders::None };

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -223,6 +223,7 @@ public:
     WINRT_CALLBACK(LostFocus, winrt::delegate<std::shared_ptr<Pane>>);
     WINRT_CALLBACK(PaneRaiseBell, winrt::Windows::Foundation::EventHandler<bool>);
     WINRT_CALLBACK(Detached, winrt::delegate<std::shared_ptr<Pane>>);
+    til::event<winrt::delegate<SplitState, winrt::Windows::Foundation::Point>> ManipulationRequested;
 
 private:
     struct PanePoint;
@@ -282,6 +283,7 @@ private:
     Borders _GetCommonBorders();
     winrt::Windows::UI::Xaml::Media::SolidColorBrush _ComputeBorderColor();
 
+    void _handleManipulation(const winrt::Windows::Foundation::Point delta);
     bool _Resize(const winrt::Microsoft::Terminal::Settings::Model::ResizeDirection& direction, float amount);
 
     std::shared_ptr<Pane> _FindParentOfPane(const std::shared_ptr<Pane> pane);

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -108,7 +108,7 @@ public:
     winrt::Microsoft::Terminal::Settings::Model::NewTerminalArgs GetTerminalArgsForPane(const bool asContent = false) const;
 
     void UpdateSettings(const winrt::Microsoft::Terminal::Settings::Model::CascadiaSettings& settings, const winrt::TerminalApp::TerminalSettingsCache& cache);
-    bool ResizePane(const winrt::Microsoft::Terminal::Settings::Model::ResizeDirection& direction);
+    bool ResizePane(const winrt::Microsoft::Terminal::Settings::Model::ResizeDirection& direction, float amount = .05f);
     std::shared_ptr<Pane> NavigateDirection(const std::shared_ptr<Pane> sourcePane,
                                             const winrt::Microsoft::Terminal::Settings::Model::FocusDirection& direction,
                                             const std::vector<uint32_t>& mruPanes);
@@ -281,7 +281,7 @@ private:
     Borders _GetCommonBorders();
     winrt::Windows::UI::Xaml::Media::SolidColorBrush _ComputeBorderColor();
 
-    bool _Resize(const winrt::Microsoft::Terminal::Settings::Model::ResizeDirection& direction);
+    bool _Resize(const winrt::Microsoft::Terminal::Settings::Model::ResizeDirection& direction, float amount);
 
     std::shared_ptr<Pane> _FindParentOfPane(const std::shared_ptr<Pane> pane);
     std::pair<PanePoint, PanePoint> _GetOffsetsForPane(const PanePoint parentOffset) const;

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -260,6 +260,8 @@ private:
     winrt::Windows::UI::Xaml::UIElement::GotFocus_revoker _gotFocusRevoker;
     winrt::Windows::UI::Xaml::UIElement::LostFocus_revoker _lostFocusRevoker;
     winrt::Windows::UI::Xaml::UIElement::ManipulationDelta_revoker _manipulationDeltaRevoker;
+    winrt::Windows::UI::Xaml::UIElement::ManipulationDelta_revoker _firstManipulationDeltaRevoker;
+    winrt::Windows::UI::Xaml::UIElement::ManipulationDelta_revoker _secondManipulationDeltaRevoker;
 
     Borders _borders{ Borders::None };
 

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -224,7 +224,7 @@ public:
     WINRT_CALLBACK(LostFocus, winrt::delegate<std::shared_ptr<Pane>>);
     WINRT_CALLBACK(PaneRaiseBell, winrt::Windows::Foundation::EventHandler<bool>);
     WINRT_CALLBACK(Detached, winrt::delegate<std::shared_ptr<Pane>>);
-    til::event<winrt::delegate<SplitState, winrt::Windows::Foundation::Point, bool>> ManipulationRequested;
+    til::event<winrt::delegate<std::shared_ptr<Pane>, SplitState, winrt::Windows::Foundation::Point, bool>> ManipulationRequested;
 
 private:
     struct PanePoint;
@@ -289,7 +289,7 @@ private:
     Borders _GetCommonBorders();
     winrt::Windows::UI::Xaml::Media::SolidColorBrush _ComputeBorderColor();
 
-    void _handleOrBubbleManipulation(const SplitState direction, const winrt::Windows::Foundation::Point delta, bool skip);
+    void _handleOrBubbleManipulation(std::shared_ptr<Pane> sender, const SplitState direction, const winrt::Windows::Foundation::Point delta, bool skip);
     void _handleManipulation(const winrt::Windows::Foundation::Point delta);
     bool _Resize(const winrt::Microsoft::Terminal::Settings::Model::ResizeDirection& direction, float amount);
 

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -73,6 +73,7 @@ public:
 
     std::shared_ptr<Pane> GetActivePane();
     winrt::Microsoft::Terminal::Control::TermControl GetLastFocusedTerminalControl();
+    winrt::TerminalApp::IPaneContent GetLastFocusedContent();
     winrt::Microsoft::Terminal::Control::TermControl GetTerminalControl() const;
     winrt::Microsoft::Terminal::Settings::Model::Profile GetFocusedProfile();
     bool IsConnectionClosed() const;

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -264,6 +264,8 @@ private:
     winrt::Windows::UI::Xaml::UIElement::ManipulationDelta_revoker _firstManipulationDeltaRevoker;
     winrt::Windows::UI::Xaml::UIElement::ManipulationDelta_revoker _secondManipulationDeltaRevoker;
 
+    bool _shouldManipulate{ true };
+
     Borders _borders{ Borders::None };
 
     bool _zoomed{ false };

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -223,7 +223,7 @@ public:
     WINRT_CALLBACK(LostFocus, winrt::delegate<std::shared_ptr<Pane>>);
     WINRT_CALLBACK(PaneRaiseBell, winrt::Windows::Foundation::EventHandler<bool>);
     WINRT_CALLBACK(Detached, winrt::delegate<std::shared_ptr<Pane>>);
-    til::event<winrt::delegate<SplitState, winrt::Windows::Foundation::Point>> ManipulationRequested;
+    til::event<winrt::delegate<SplitState, winrt::Windows::Foundation::Point, bool>> ManipulationRequested;
 
 private:
     struct PanePoint;
@@ -288,7 +288,7 @@ private:
     Borders _GetCommonBorders();
     winrt::Windows::UI::Xaml::Media::SolidColorBrush _ComputeBorderColor();
 
-    void _handleOrBubbleManipulation(const SplitState direction, const winrt::Windows::Foundation::Point delta);
+    void _handleOrBubbleManipulation(const SplitState direction, const winrt::Windows::Foundation::Point delta, bool skip);
     void _handleManipulation(const winrt::Windows::Foundation::Point delta);
     bool _Resize(const winrt::Microsoft::Terminal::Settings::Model::ResizeDirection& direction, float amount);
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -4598,7 +4598,10 @@ namespace winrt::TerminalApp::implementation
         {
             if (const auto& pane{ tab->GetActivePane() })
             {
-                terminalBrush = pane->GetContent().BackgroundBrush();
+                if (const auto& lastContent{ pane->GetLastFocusedContent() })
+                {
+                    terminalBrush = lastContent.BackgroundBrush();
+                }
             }
         }
 

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1629,6 +1629,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                     _TryStopAutoScroll(ptr.PointerId());
                 }
             }
+            CancelDirectManipulations();
         }
         else if (type == Windows::Devices::Input::PointerDeviceType::Touch)
         {
@@ -1636,6 +1637,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             til::point newTouchPoint{ til::math::rounding, contactRect.X, contactRect.Y };
 
             _interactivity.TouchMoved(newTouchPoint.to_core_point(), _focused);
+            CancelDirectManipulations();
         }
 
         args.Handled(true);

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1816,8 +1816,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         IUIElement uielem;
         if (sender.try_as(uielem))
         {
-            const auto captured = uielem.CapturePointer(args.Pointer());
-            return captured;
+            uielem.CapturePointer(args.Pointer());
+            return true;
         }
         return false;
     }

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1629,7 +1629,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                     _TryStopAutoScroll(ptr.PointerId());
                 }
             }
-            CancelDirectManipulations();
         }
         else if (type == Windows::Devices::Input::PointerDeviceType::Touch)
         {
@@ -1637,7 +1636,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             til::point newTouchPoint{ til::math::rounding, contactRect.X, contactRect.Y };
 
             _interactivity.TouchMoved(newTouchPoint.to_core_point(), _focused);
-            CancelDirectManipulations();
         }
 
         args.Handled(true);

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -333,7 +333,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             // (The window has a min. size that ensures that there's always a scrollbar thumb.)
             if (drawableRange < 0)
             {
-                // assert(false);
                 return;
             }
 

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1816,8 +1816,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         IUIElement uielem;
         if (sender.try_as(uielem))
         {
-            uielem.CapturePointer(args.Pointer());
-            return true;
+            const auto captured = uielem.CapturePointer(args.Pointer());
+            return captured;
         }
         return false;
     }


### PR DESCRIPTION

_targets: #16172_

## Summary of the Pull Request

Adds support for resizing panes by dragging with the mouse.

`ManipulationDelta` is the WinUI event we're using to determine if a pane border was dragged. `ManipulationDelta` is kinda a wacky event in WinUI, but so is the entire `Pane` structure we've built. The important things to know about this PR are:
* Leaf panes are the only panes that actually have a `Border`. 
* We only handle `ManipulationDelta` events directly on leaf panes.  
* Parent panes, however, are the only ones that actually control the position of a split. So we use a special `ManipulationRequested` event to bubble the request from the leaf pane that was clicked on, to the ancestor pane that actually owns the border on the side of the pane. 
* We can't just add a `ManipulationDelta` event handler on the border itself - the event covers all drags in the entire bounding rect of the border. So we've got to use additional logic to make sure that drags originated on a border, not just on content within the border. 

![992-resize-panes](https://github.com/microsoft/terminal/assets/18356694/2ac15c15-54e6-48c1-8a29-c9a123cc20dd)

## other PRs
* #16170
* #16171 
* #16172 
* <-- you are here 