### PR TITLE
Fix a ReadConsoleOutputCharacter regression

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -91,7 +91,6 @@ backgrounding
 backported
 backstory
 barbaz
-Batang
 Bazz
 BBDM
 bbwe
@@ -180,7 +179,6 @@ changelists
 chaof
 charinfo
 CHARSETINFO
-chcbpat
 chh
 chshdng
 CHT
@@ -198,7 +196,6 @@ cloudconsole
 cloudvault
 CLSCTX
 clsids
-CLUSTERMAP
 cmatrix
 cmder
 CMDEXT
@@ -214,7 +211,6 @@ codepages
 codepath
 coinit
 colorizing
-COLORMATRIX
 COLORREFs
 colorschemes
 colorspec
@@ -222,7 +218,6 @@ colortable
 colortbl
 colortest
 colortool
-COLR
 combaseapi
 comctl
 commandline
@@ -367,11 +362,9 @@ DBGFONTS
 DBGOUTPUT
 dbh
 dblclk
-DBlob
 DColor
 DCOLORVALUE
 dcommon
-dcompile
 dcompiler
 DComposition
 dde
@@ -479,7 +472,6 @@ depersist
 deprioritized
 deserializers
 desktopwindowxamlsource
-DESTINATIONNAME
 devicecode
 Dext
 DFactory
@@ -539,7 +531,6 @@ DWORDs
 dwrite
 dxgi
 dxgidwm
-dxguid
 dxinterop
 dxsm
 dxttbmp
@@ -607,7 +598,7 @@ FEEF
 fesb
 FFAF
 FFDE
-FFrom
+FFFDb
 fgbg
 FGCOLOR
 FGHIJ
@@ -719,7 +710,6 @@ GETWAITTOKILLTIMEOUT
 GETWHEELSCROLLCHARACTERS
 GETWHEELSCROLLCHARS
 GETWHEELSCROLLLINES
-GFEh
 Gfun
 gfx
 GGI
@@ -867,7 +857,6 @@ INLINEPREFIX
 inproc
 Inputkeyinfo
 INPUTPROCESSORPROFILE
-inputrc
 Inputreadhandledata
 INSERTMODE
 INTERACTIVITYBASE
@@ -908,10 +897,6 @@ KAttrs
 kawa
 Kazu
 kazum
-kcub
-kcud
-kcuf
-kcuu
 kernelbase
 kernelbasestaging
 KEYBDINPUT
@@ -923,7 +908,6 @@ Keymapping
 keyscan
 keystate
 keyups
-khome
 KILLACTIVE
 KILLFOCUS
 kinda
@@ -1061,7 +1045,6 @@ MBUTTON
 MBUTTONDBLCLK
 MBUTTONDOWN
 MBUTTONUP
-Mbxy
 mdmerge
 MDs
 MEASUREITEM
@@ -1086,7 +1069,6 @@ minkernel
 MINMAXINFO
 minwin
 minwindef
-Mip
 MMBB
 mmcc
 MMCPL
@@ -1123,8 +1105,8 @@ msix
 msrc
 MSVCRTD
 MTSM
-munges
 Munged
+munges
 murmurhash
 muxes
 myapplet
@@ -1221,7 +1203,6 @@ ntdll
 ntifs
 ntlpcapi
 ntm
-nto
 ntrtl
 ntstatus
 NTSYSCALLAPI
@@ -1297,7 +1278,6 @@ parentable
 parms
 PATCOPY
 pathcch
-Pathto
 PATTERNID
 pcat
 pcb
@@ -1456,7 +1436,6 @@ pwsz
 pythonw
 Qaabbcc
 QUERYOPEN
-QUESTIONMARK
 quickedit
 QUZ
 QWER
@@ -1489,8 +1468,6 @@ READCONSOLE
 READCONSOLEOUTPUT
 READCONSOLEOUTPUTSTRING
 READMODE
-reallocs
-reamapping
 rectread
 redef
 redefinable
@@ -1518,7 +1495,6 @@ repositorypath
 Requiresx
 rerasterize
 rescap
-Resequence
 RESETCONTENT
 resheader
 resmimetype
@@ -1551,7 +1527,6 @@ RRRGGGBB
 rsas
 rtcore
 RTEXT
-RTFTo
 RTLREADING
 Rtn
 ruleset
@@ -1699,7 +1674,6 @@ srcsrv
 SRCSRVTRG
 srctool
 srect
-srv
 srvinit
 srvpipe
 ssa
@@ -1731,7 +1705,6 @@ SUA
 subcompartment
 subkeys
 SUBLANG
-subresource
 subsystemconsole
 subsystemwindows
 swapchain
@@ -1835,7 +1808,6 @@ tosign
 touchpad
 Tpp
 Tpqrst
-tracelog
 tracelogging
 traceviewpp
 trackbar
@@ -1846,7 +1818,6 @@ Trd
 TREX
 triaged
 triaging
-TRIANGLESTRIP
 Tribool
 TRIMZEROHEADINGS
 trx
@@ -1888,8 +1859,8 @@ UINTs
 ul
 ulcch
 uld
-uldb
 uldash
+uldb
 ulwave
 Unadvise
 unattend
@@ -1900,7 +1871,6 @@ unhosted
 UNICODETEXT
 UNICRT
 Unintense
-Uniscribe
 unittesting
 unittests
 unk
@@ -1912,8 +1882,8 @@ untextured
 UPDATEDISPLAY
 UPDOWN
 UPKEY
-UPSS
 upss
+UPSS
 uregex
 URegular
 usebackq
@@ -1996,7 +1966,6 @@ VTRGBTo
 vtseq
 vtterm
 vttest
-waitable
 WANSUNG
 WANTARROWS
 WANTTAB
@@ -2121,7 +2090,6 @@ wrkstr
 wrl
 wrp
 WRunoff
-WScript
 wsl
 WSLENV
 wstr
@@ -2156,13 +2124,11 @@ XBUTTONDOWN
 XBUTTONUP
 XCast
 XCENTER
-XColors
 xcopy
 XCount
 xdy
 XEncoding
 xes
-xff
 XFG
 XFile
 XFORM
@@ -2171,7 +2137,6 @@ xinchaof
 xinxinchaof
 XManifest
 XMath
-XMFLOAT
 xorg
 XResource
 xsi

--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -1883,7 +1883,6 @@ UPDATEDISPLAY
 UPDOWN
 UPKEY
 upss
-UPSS
 uregex
 URegular
 usebackq

--- a/src/host/output.cpp
+++ b/src/host/output.cpp
@@ -222,7 +222,12 @@ std::wstring ReadOutputStringW(const SCREEN_INFORMATION& screenInfo,
             // Otherwise, add anything that isn't a trailing cell. (Trailings are duplicate copies of the leading.)
             if (it->DbcsAttr() != DbcsAttribute::Trailing)
             {
-                retVal += it->Chars();
+                auto chars = it->Chars();
+                if (chars.size() > 1)
+                {
+                    chars = { &UNICODE_REPLACEMENT, 1 };
+                }
+                retVal += chars;
             }
         }
 


### PR DESCRIPTION
The `nLength` parameter of `ReadConsoleOutputCharacterW` indicates
the number of columns that should be read. For single-column (narrow)
surrogate pairs this previously clipped a trailing character of the
returned string. In the major Unicode support update in #13626
surrogate pairs truly got stored as atomic units for the first time.
This now meant that a 120 column read with such codepoints resulted
in 121 characters. Other parts of conhost still assume UCS2 however,
and so this results in the entire read failing.

This fixes the issue by turning surrogate pairs into U+FFFD
which makes it UCS2 compatible.

Closes #16892

## Validation Steps Performed
* Write U+F15C0 and read it back with `ReadConsoleOutputCharacterW`
* Read succeeds with a single U+FFFD ✅