### PR TITLE
build: roll back to a build container with the 14.38 compiler

### DIFF
--- a/build/pipelines/templates-v2/variables-onebranch-config.yml
+++ b/build/pipelines/templates-v2/variables-onebranch-config.yml
@@ -1,2 +1,2 @@
 variables:
-  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest'
+  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:1.0.02629.38'

--- a/build/pipelines/templates-v2/variables-onebranch-config.yml
+++ b/build/pipelines/templates-v2/variables-onebranch-config.yml
@@ -1,2 +1,2 @@
 variables:
-  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:1.0.02629.38'
+  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:1.0.02566.28'


### PR DESCRIPTION
The 14.39 compiler seems pretty busted.

Refs #16794 