### PR TITLE
Make ploc translations predictable

### DIFF
--- a/build/pipelines/daily-loc-submission.yml
+++ b/build/pipelines/daily-loc-submission.yml
@@ -75,6 +75,7 @@ steps:
     rm LocOutputMunged.tar
     rm -r -fo LocOutput
     & ./build/scripts/Copy-ContextMenuResourcesToCascadiaPackage.ps1
+    & ./build/scripts/Generate-PseudoLocalizations.ps1
   displayName: Move Loc files to the right places
 
 - pwsh: |-

--- a/build/scripts/Generate-PseudoLocalizations.ps1
+++ b/build/scripts/Generate-PseudoLocalizations.ps1
@@ -1,0 +1,16 @@
+Get-ChildItem -Recurse -Filter *.resw
+    | Where-Object { $_.Directory.Name.StartsWith("qps-ploc") }
+    | ForEach-Object {
+        $source = Join-Path $_.Directory "../en-US/$($_.Name)"
+        $target = $_
+
+        $ploc = ./tools/ConvertTo-PseudoLocalization.ps1 -Path $source
+
+        $writerSettings = [System.Xml.XmlWriterSettings]::new()
+        $writerSettings.NewLineChars = "`r`n"
+        $writerSettings.Indent = $true
+        $writer = [System.Xml.XmlWriter]::Create($target, $writerSettings)
+        $ploc.Save($writer)
+        $writer.Flush()
+        $writer.Close()
+    }

--- a/scratch/ScratchIslandApp/Package/Resources/qps-ploc/Resources.resw
+++ b/scratch/ScratchIslandApp/Package/Resources/qps-ploc/Resources.resw
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppDescription" xml:space="preserve">
-    <value>А şςѓάţćћ ǻрр ƒθŗ χÂΜĿ Íŝĺąήðş ŧеšτş !!! !!! !!! !</value>
+    <value>Ά śςґàτсн ąρφ ƒоř ΧΆΜĻ Ìŝļàиđś τёşτś !!! !!! !!! !</value>
   </data>
 </root>

--- a/scratch/ScratchIslandApp/Package/Resources/qps-ploca/Resources.resw
+++ b/scratch/ScratchIslandApp/Package/Resources/qps-ploca/Resources.resw
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppDescription" xml:space="preserve">
-    <value>Ă šςґаτćĥ àρφ ƒǿя ЖΆΜĹ Іѕℓаñďş ťêšţŝ !!! !!! !!! !</value>
+    <value>Ά śςґàτсн ąρφ ƒоř ΧΆΜĻ Ìŝļàиđś τёşτś !!! !!! !!! !</value>
   </data>
 </root>

--- a/scratch/ScratchIslandApp/Package/Resources/qps-plocm/Resources.resw
+++ b/scratch/ScratchIslandApp/Package/Resources/qps-plocm/Resources.resw
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppDescription" xml:space="preserve">
-    <value>Ă śćяǻт¢н ãрρ ƒσг ХĂМĽ Īşłдήďѕ ťέśτş !!! !!! !!! !</value>
+    <value>Ά śςґàτсн ąρφ ƒоř ΧΆΜĻ Ìŝļàиđś τёşτś !!! !!! !!! !</value>
   </data>
 </root>

--- a/src/cascadia/CascadiaPackage/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/qps-ploc/Resources.resw
@@ -166,7 +166,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Τнĕ Ņëω Ẅίηđŏẃś Ťėŗmįйάĺ !!! !!! !</value>
+    <value>Τĥз Йéщ Ẃįńđôẃѕ Тéѓmĩиâļ !!! !!! !</value>
   </data>
   <data name="AppDescriptionDev" xml:space="preserve">
     <value>The Windows Terminal, but Unofficial</value>
@@ -177,22 +177,22 @@
     <comment>{Locked}</comment>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
-    <value>Ŵíňďōẁŝ Тєřмīπǻļ ωїτĥ å ρѓēνіéŵ θƒ ũφсőмϊπġ ƒєąτΰґёѕ !!! !!! !!! !!! !!! </value>
+    <value>Щΐňδόŵѕ Ŧęřмĭŉäℓ ẅîťħ à φřеνίëẃ θƒ џрсøмΐŉğ ƒĕāŧųřэś !!! !!! !!! !!! !!! </value>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve">
     <value>Open in Terminal (&amp;Dev)</value>
     <comment>{Locked} The dev build will never be seen in multiple languages</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Canary" xml:space="preserve">
-    <value>Ŏрέи ìη Тèřmīŋªŀ (&amp;Cãńãґγ) !!! !!! !</value>
+    <value>Θρēņ ïη Ţéгmĭηäŀ (&amp;Çäņдѓγ) !!! !!! !</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Canary version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
-    <value>Φφєň ΐñ Ŧéгмϊñаľ &amp;Pŕėνĭ℮ώ !!! !!! !</value>
+    <value>Όрèп ìņ Ţêŕmїŉåļ &amp;Рѓзνι℮ω !!! !!! !</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Ωρєⁿ ïπ &amp;Těѓmĭñäĺ !!! !!</value>
+    <value>Óрêп ìл &amp;Ťěѓmιиåĺ !!! !!</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 </root>

--- a/src/cascadia/CascadiaPackage/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/qps-ploca/Resources.resw
@@ -166,7 +166,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Ťĥё Ñēщ Шίⁿðоẅś Ťėгмîήāľ !!! !!! !</value>
+    <value>Τĥз Йéщ Ẃįńđôẃѕ Тéѓmĩиâļ !!! !!! !</value>
   </data>
   <data name="AppDescriptionDev" xml:space="preserve">
     <value>The Windows Terminal, but Unofficial</value>
@@ -177,22 +177,22 @@
     <comment>{Locked}</comment>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
-    <value>Шίηđóŵš Ŧĕяmїйàℓ ẁітħ ª φяęνîёщ όƒ ûφĉбмíήĝ ƒêåťµřεŝ !!! !!! !!! !!! !!! </value>
+    <value>Щΐňδόŵѕ Ŧęřмĭŉäℓ ẅîťħ à φřеνίëẃ θƒ џрсøмΐŉğ ƒĕāŧųřэś !!! !!! !!! !!! !!! </value>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve">
     <value>Open in Terminal (&amp;Dev)</value>
     <comment>{Locked} The dev build will never be seen in multiple languages</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Canary" xml:space="preserve">
-    <value>Óрëπ íи Ťēяmілǻŀ (&amp;Cäηàřÿ) !!! !!! !</value>
+    <value>Θρēņ ïη Ţéгmĭηäŀ (&amp;Çäņдѓγ) !!! !!! !</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Canary version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
-    <value>Óрзń ΐή Ŧěґмιлāℓ &amp;Pѓéνīĕω !!! !!! !</value>
+    <value>Όрèп ìņ Ţêŕmїŉåļ &amp;Рѓзνι℮ω !!! !!! !</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Ôрëη ïп &amp;Tēѓмϊŋãł !!! !!</value>
+    <value>Óрêп ìл &amp;Ťěѓmιиåĺ !!! !!</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 </root>

--- a/src/cascadia/CascadiaPackage/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/qps-plocm/Resources.resw
@@ -166,7 +166,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Тĥё Ńēẁ Шіπđοωš Тěřмιňαŀ !!! !!! !</value>
+    <value>Τĥз Йéщ Ẃįńđôẃѕ Тéѓmĩиâļ !!! !!! !</value>
   </data>
   <data name="AppDescriptionDev" xml:space="preserve">
     <value>The Windows Terminal, but Unofficial</value>
@@ -177,22 +177,22 @@
     <comment>{Locked}</comment>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
-    <value>Шίήďŏшś Ŧêямĩňāľ ŵíτн ă ρѓëνιêω øƒ ũρčŏмįηğ ƒєáţũŗêš !!! !!! !!! !!! !!! </value>
+    <value>Щΐňδόŵѕ Ŧęřмĭŉäℓ ẅîťħ à φřеνίëẃ θƒ џрсøмΐŉğ ƒĕāŧųřэś !!! !!! !!! !!! !!! </value>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve">
     <value>Open in Terminal (&amp;Dev)</value>
     <comment>{Locked} The dev build will never be seen in multiple languages</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Canary" xml:space="preserve">
-    <value>Фφěй ĩń Тêřmιπâł (&amp;Cãⁿǻřу) !!! !!! !</value>
+    <value>Θρēņ ïη Ţéгmĭηäŀ (&amp;Çäņдѓγ) !!! !!! !</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Canary version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
-    <value>Óφ℮ŉ ΐŋ Τėřmīйäĺ &amp;Pяєνϊëẃ !!! !!! !</value>
+    <value>Όрèп ìņ Ţêŕmїŉåļ &amp;Рѓзνι℮ω !!! !!! !</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Ορέл ϊŋ &amp;Téŕmįñāℓ !!! !!</value>
+    <value>Óрêп ìл &amp;Ťěѓmιиåĺ !!! !!</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/qps-ploc/ContextMenu.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-ploc/ContextMenu.resw
@@ -166,7 +166,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Τнĕ Ņëω Ẅίηđŏẃś Ťėŗmįйάĺ !!! !!! !</value>
+    <value>Τĥз Йéщ Ẃįńđôẃѕ Тéѓmĩиâļ !!! !!! !</value>
   </data>
   <data name="AppDescriptionDev" xml:space="preserve">
     <value>The Windows Terminal, but Unofficial</value>
@@ -177,22 +177,22 @@
     <comment>{Locked}</comment>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
-    <value>Ŵíňďōẁŝ Тєřмīπǻļ ωїτĥ å ρѓēνіéŵ θƒ ũφсőмϊπġ ƒєąτΰґёѕ !!! !!! !!! !!! !!! </value>
+    <value>Щΐňδόŵѕ Ŧęřмĭŉäℓ ẅîťħ à φřеνίëẃ θƒ џрсøмΐŉğ ƒĕāŧųřэś !!! !!! !!! !!! !!! </value>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve">
     <value>Open in Terminal (&amp;Dev)</value>
     <comment>{Locked} The dev build will never be seen in multiple languages</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Canary" xml:space="preserve">
-    <value>Ŏрέи ìη Тèřmīŋªŀ (&amp;Cãńãґγ) !!! !!! !</value>
+    <value>Θρēņ ïη Ţéгmĭηäŀ (&amp;Çäņдѓγ) !!! !!! !</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Canary version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
-    <value>Φφєň ΐñ Ŧéгмϊñаľ &amp;Pŕėνĭ℮ώ !!! !!! !</value>
+    <value>Όрèп ìņ Ţêŕmїŉåļ &amp;Рѓзνι℮ω !!! !!! !</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Ωρєⁿ ïπ &amp;Těѓmĭñäĺ !!! !!</value>
+    <value>Óрêп ìл &amp;Ťěѓmιиåĺ !!! !!</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-ploc/Resources.resw
@@ -118,148 +118,148 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InitialJsonParseErrorText" xml:space="preserve">
-    <value>Şĕţţіⁿģѕ ςŏûℓđ ŉθт в℮ ℓòăδēδ ƒřσm ƒіℓε. Çћέĉк ƒòя şŷиτåж эřѓόґş, ΐлсŀµðĭηġ ŧŕàįŀїиĝ ċõmмåş. !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Şετťĭиġś ςòűłď йσт ьé ŀŏдðéď ƒřǿм ƒīļē. Ĉнėćķ ƒσŗ ŝуήтª× ĕяŗбґş, ιйçľůďĩηĝ тŗāіļīňġ ćǿмmāŝ. !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
   </data>
   <data name="MissingDefaultProfileText" xml:space="preserve">
-    <value>Ćǿΰľđ πöт ƒîηđ уоџř đєƒаџļт φгóƒíĺέ įń γσΰґ ľϊѕţ øƒ φřбƒїļēś - ųŝĩηġ тђę ƒίяśт φґθƒĩĺē. €ђéćκ ťб máќë ѕцřз ťħè "defaultProfile" mǻτςĥéѕ ţђè ĞÚІĎ ôƒ õňë òƒ ÿбμř ряǿƒїļĕѕ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ĉōûłδ πбτ ƒΐпď ýǿύѓ ďēƒдûľт ρŕõƒĩłę ìń ўôùґ ļïѕτ ǿƒ φѓôƒĭłеś - µšìήğ ţнε ƒįŗѕт ρřόƒїłê. Ćĥеćķ ťõ måķє şυґę ţнé "defaultProfile" мªţčћéş ťђё ĠŪĨĎ θƒ θŋē оƒ уоùŗ ρґоƒïℓёś. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>{Locked="\"defaultProfile\""}</comment>
   </data>
   <data name="DuplicateProfileText" xml:space="preserve">
-    <value>₣õůήδ мџŀŧĭрłè рѓőƒιĺéŝ ŵїτђ τне šаме ĢŬΪĎ ιή ŷôûя şёţţïňģŝ ƒïļē - ĩĝпоѓĩлğ đűρļіċáť℮ş. Μªќ℮ şúѓё ėǻςн ρґőƒîłè'š ĢЦЇĐ ιś ũŋĩqυέ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>₣óŭиď мύŀťìрŀэ φŕσƒïĺєś ẃïτћ ŧнě ѕámĕ ĠŲІÐ įй ўоűя ѕĕţţîήĝš ƒìŀė - įģŉǿřΐⁿğ δûρľΐçâтéŝ. Мãĸё śμѓέ ĕáĉћ ρяσƒîĺė'ѕ ĢŰĮÐ īş ϋńîqџë. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
   </data>
   <data name="UnknownColorSchemeText" xml:space="preserve">
-    <value>₣ŏџŋð ä ρѓõƒіℓę шîţћ ǻй īпνªŀīð "colorScheme". Đëƒαυľτîпĝ ŧђãť ρřоƒíĺě ŧő тнë ðĕƒãůľŧ çōļóяş. Μâĸè śűřė τћàŧ ώнēη şеŧťįⁿğ д "colorScheme", ţћé νáℓūë máτсħěş ŧнє "name" ōƒ á сóℓöѓ ščнèмë їп тħė "schemes" łîšť. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>₣ŏúņđ ā ρřόƒįľĕ щĭťћ ǻή ϊпνåŀίď "colorScheme". Ďēƒāúłтіиğ ţħąţ ряόƒίŀе ţŏ тĥέ ðеƒãµľţ çбĺбŗś. Мāκέ śûѓè ťћаτ ŵђéň ŝєŧťίńĝ д "colorScheme", τħε νåĺμě мäτςĥέş τнέ "name" όƒ а čòľбя ѕćн℮mē īń тћέ "schemes" ļίŝт. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>{Locked="\"colorScheme\"","\"name\"","\"schemes\""}</comment>
   </data>
   <data name="NoProfilesText" xml:space="preserve">
-    <value>Пò φгŏƒїĺèѕ ẁєґє ƒοúиđ ΐņ ўøûя šзŧţìŋġѕ. !!! !!! !!! !!!</value>
+    <value>Ňǿ ρяóƒíℓěş щ℮ŕέ ƒòμйδ ϊη ỳοūґ ś℮ŧтĭπģѕ. !!! !!! !!! !!!</value>
   </data>
   <data name="AllProfilesHiddenText" xml:space="preserve">
-    <value>Ãļł рŗǿƒíŀέŝ ωėŗě ћіďđέŉ ιⁿ ўòüѓ şėţтΐйĝş. Υōυ мûŝт ĥªνэ àτ ľєäѕţ óňě иôŋ-ђïδđěń φŗõƒΐľé. !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Аℓł ρяοƒįłέš ωèяê ђΐđðěŉ îη ўőϋř śěŧτϊиģş. Ϋŏυ müѕŧ ħäνė άţ ļεǻѕτ οñє пóй-ћίďðēŉ φŗóƒįŀē. !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
   </data>
   <data name="ReloadJsonParseErrorText" xml:space="preserve">
-    <value>Ŝęťтįлġś çǿµŀđ лόţ ьэ яēℓбаďêđ ƒгǿм ƒīľē. Ċћєсќ ƒοг ѕγŋţαх έŗгόѓś, ïπċℓύδϊņĝ ťгąîľϊиĝ čòммªŝ. !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Ѕєŧτĩņğš ¢ŏûłď ποţ ьė řëĺбάδзď ƒŕŏм ƒίľе. Çĥэςκ ƒõг şÿπţаж ěгяōŗš, îņ¢ŀύðīⁿğ ťŕăïŀĩπĝ čǿmмãş. !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
   </data>
   <data name="UsingDefaultSettingsText" xml:space="preserve">
-    <value>Ŧěmрθřǻŕĩℓÿ џśîŋģ ţĥз Ẁĭņðбшѕ Ŧзŗмìήâĺ ðėƒàцľŧ ŝěτтĭņģŝ. !!! !!! !!! !!! !!! !</value>
+    <value>Ťемрőŗāřĩľŷ űśϊⁿģ ťђё Щìπδоωş Ţεѓмîήäĺ δêƒаμłт şèţτïńġś. !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="InitialJsonParseErrorTitle" xml:space="preserve">
-    <value>₣дīłėδ τö ĺōáđ š℮τтіňģś !!! !!! </value>
+    <value>₣äĩľєď τσ ŀőåð ŝέťţĩⁿģŝ !!! !!! </value>
   </data>
   <data name="SettingsValidateErrorTitle" xml:space="preserve">
-    <value>Έлςöůлťëяèδ éґѓőґş ẁђīļé łσǻđιπģ џśёґ ѕ℮ŧтíⁿĝş !!! !!! !!! !!! !</value>
+    <value>Εŋĉőųņŧзяëď зяѓōяś ŵħΐļê ŀθαðĩήġ ùŝéѓ śзťŧĭпģŝ !!! !!! !!! !!! !</value>
   </data>
   <data name="KeyboardServiceDisabledDialog.PrimaryButtonText" xml:space="preserve">
-    <value>ΘК </value>
+    <value>ÓΚ </value>
   </data>
   <data name="KeyboardServiceDisabledDialog.Title" xml:space="preserve">
-    <value>Ŵāŕиĩпģ: !!</value>
+    <value>Ŵаґήĩήģ: !!</value>
   </data>
   <data name="KeyboardServiceWarningText" xml:space="preserve">
-    <value>Ťĥє "{0}" įšή'ŧ řΰňηіпğ θл ŷбυŕ мāĉћіņë. Τĥίѕ ćªñ рŕзνзπт τнέ Τёřmîпǻĺ ƒŗóм ѓéčêîνîñģ ķёŷъǿãŗð ĩⁿφµт. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ŧħє "{0}" ĭşп'ţ řμллĭиġ оŉ ўόùг мàςĥįńë. Ŧħїś ¢áⁿ φřэνєńτ тнэ Тэґмïñăĺ ƒŕöm ŗеς℮íνίиĝ ķēỳвŏαŗδ ĭⁿрΰţ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>{0} will be replaced with the OS-localized name of the TabletInputService</comment>
   </data>
   <data name="Ok" xml:space="preserve">
-    <value>ÒĶ </value>
+    <value>ФĶ </value>
   </data>
   <data name="ReloadJsonParseErrorTitle" xml:space="preserve">
-    <value>₣αĭℓэđ τǿ гэľоāδ śэŧŧįηģš !!! !!! !</value>
+    <value>₣áĭļèđ ťσ ѓéłøǻð şèŧŧíпĝŝ !!! !!! !</value>
   </data>
   <data name="FeedbackUriValue" xml:space="preserve">
     <value>https://go.microsoft.com/fwlink/?linkid=2125419</value>
     <comment>{Locked}This is a FWLink, so it will be localized with the fwlink tool</comment>
   </data>
   <data name="AboutMenuItem" xml:space="preserve">
-    <value>Άвòűт !</value>
+    <value>∆вòΰŧ !</value>
   </data>
   <data name="FeedbackMenuItem" xml:space="preserve">
-    <value>₣ээđъàċк !!</value>
+    <value>₣ęęðъâçќ !!</value>
   </data>
   <data name="SettingsMenuItem" xml:space="preserve">
-    <value>Ŝęťţĩπģş !!</value>
+    <value>Śêŧťіňğŝ !!</value>
   </data>
   <data name="Cancel" xml:space="preserve">
-    <value>Сåήċēĺ !</value>
+    <value>Ĉάπςеŀ !</value>
   </data>
   <data name="CloseAll" xml:space="preserve">
-    <value>Ćłőŝě áľļ !!!</value>
+    <value>Ċľθŝє αŀļ !!!</value>
   </data>
   <data name="Quit" xml:space="preserve">
-    <value>Qûіŧ !</value>
+    <value>Qùíт !</value>
   </data>
   <data name="CloseWindowWarningTitle" xml:space="preserve">
-    <value>Đŏ уǿü ẃάñт тő ¢ľõśé ăℓℓ ŧаъś? !!! !!! !!!</value>
+    <value>Đǿ ÿõű ŵãŋт тŏ ¢ľòŝê ăŀľ ŧãвŝ? !!! !!! !!!</value>
   </data>
   <data name="MultiplePanes" xml:space="preserve">
-    <value>Мũļťįρľê φāńεš !!! !</value>
+    <value>Мµļтíрłĕ φдпėŝ !!! !</value>
   </data>
   <data name="TabCloseSubMenu" xml:space="preserve">
-    <value>Çŀŏѕё... !!</value>
+    <value>Ćļôŝέ... !!</value>
   </data>
   <data name="TabCloseAfter" xml:space="preserve">
-    <value>Čļöѕέ Ţàьś тø ťħě Гïĝнţ !!! !!! </value>
+    <value>Ċĺοşέ Ţаъş ťό ŧђé Яΐğђт !!! !!! </value>
   </data>
   <data name="TabCloseOther" xml:space="preserve">
-    <value>Ĉļőşе Öŧђεŗ Ţдьŝ !!! !</value>
+    <value>Ćĺόѕ℮ Όтђèř Ŧâьś !!! !</value>
   </data>
   <data name="TabClose" xml:space="preserve">
-    <value>Сļŏšè Τàв !!!</value>
+    <value>Сĺôšę Ťăв !!!</value>
   </data>
   <data name="PaneClose" xml:space="preserve">
-    <value>Ćľοšэ Ρàņε !!!</value>
+    <value>Ćŀöśё Раņé !!!</value>
   </data>
   <data name="SplitTabText" xml:space="preserve">
-    <value>Šφľîŧ Ţǻь !!!</value>
+    <value>Šрľīτ Τàв !!!</value>
   </data>
   <data name="SplitPaneText" xml:space="preserve">
-    <value>Şрļĭţ Ραŋè !!!</value>
+    <value>Šрŀіт Ρªňë !!!</value>
   </data>
   <data name="SearchWebText" xml:space="preserve">
-    <value>Щēь Ŝêαřçĥ !!!</value>
+    <value>Ẅёв Şĕаŕčĥ !!!</value>
   </data>
   <data name="TabColorChoose" xml:space="preserve">
-    <value>Ćбłöř... !!</value>
+    <value>Ċõŀόř... !!</value>
   </data>
   <data name="TabColorCustomButton.Content" xml:space="preserve">
-    <value>Сџşţбм... !!!</value>
+    <value>Ċµѕťøм... !!!</value>
   </data>
   <data name="TabColorClearButton.Content" xml:space="preserve">
-    <value>Ŕēśёť !</value>
+    <value>Яěšěŧ !</value>
   </data>
   <data name="RenameTabText" xml:space="preserve">
-    <value>Γёŋάmē Τаъ !!!</value>
+    <value>Γεñамē Ťãв !!!</value>
   </data>
   <data name="DuplicateTabText" xml:space="preserve">
-    <value>Đύφļϊçåţέ Ţάъ !!! </value>
+    <value>Ďϋφľіčάтέ Τàв !!! </value>
   </data>
   <data name="InvalidBackgroundImage" xml:space="preserve">
-    <value>₣σůήđ а рřòƒïłè щíţħ ªŋ îŋνāℓіď "backgroundImage". Ďєƒªϋĺţįпĝ ŧħåť рřθƒίľē ţó нąνê ńǿ ъàċкğѓóūñď îмåğэ. Мàκě ŝμяз ťнªţ ẁĥėл šęτŧΐñġ á "backgroundImage", тђε νáľΰє їś α νдŀĩδ ƒïļë φäŧħ τö ãп ϊмªġę. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>₣σúŋδ ą φѓοƒĩļé ẃϊţħ äй ïηνàĺìď "backgroundImage". Đēƒãųŀŧϊпğ ťнªт φѓőƒĭļè το нªνе πō ьąçќġгθúпδ ιмãġė. Маĸē śμѓē ŧћäţ ẁђēή šêťτϊлġ å "backgroundImage", ţĥě νаłųё ïŝ ά νάľîď ƒĩŀê φąťħ ţŏ άń ΐмąġė. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>{Locked="\"backgroundImage\""}</comment>
   </data>
   <data name="InvalidIcon" xml:space="preserve">
-    <value>₣όūпđ ǻ ргõƒįļє ωĩţђ ªň ϊήνåľīď "icon". Đêƒàùĺţíηģ тнаŧ φřòƒїℓє ţб ħдνĕ ŋò ĭćбñ. Μαќě śüяê τћåţ ωĥëη śзťŧĭηģ áй "icon", ţħє νàĺųэ ίѕ ǻ ναℓїđ ƒíľě φǻτĥ ťθ ăŋ ĭmǻģε. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>₣ǿũиđ à рřöƒϊℓз ŵĩţн аñ įņνàŀїδ "icon". Ðěƒаúľτīŋğ ţħаτ ρřόƒìŀё тб ђâνє пǿ íčой. Мàĸë ŝùřë ŧĥаţ ωĥĕл ŝеτŧīлĝ ăй "icon", τħε νāłϋë ïŝ ă νàľīđ ƒïŀè рªтн ţő äи ïмäģё. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>{Locked="\"icon\""} The word "icon" in quotes is locked, the word icon OUTSIDE of quotes should be localized.</comment>
   </data>
   <data name="AtLeastOneKeybindingWarning" xml:space="preserve">
-    <value>Щдřńіńġš ωεяέ ƒöџήδ ẁнĭŀè ρąґśîήġ γôµґ кęуъїñďϊņģś: !!! !!! !!! !!! !!!</value>
+    <value>Щαѓńΐňģš ώĕřе ƒбŭπδ ώħīļë рăяşìⁿġ ўσυŕ κёỳвĩиðīήġş: !!! !!! !!! !!! !!!</value>
   </data>
   <data name="TooManyKeysForChord" xml:space="preserve">
-    <value>• ₣őûńđ å κєÿьΐпđĩŋģ шíţћ ŧøо mαиў śτřιñĝŝ ƒôг ŧђē "keys" дřгãỳ. Ţнέŕê śћőũŀδ όŋłγ ъę òⁿё śťŗΐņĝ νáℓΰê įη ŧће "keys" ªŕѓдý. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>• ₣бūήð â ķёуьĩńðīⁿģ шĩŧђ τõб mªńÿ ѕťгίńġŝ ƒóř ţћ℮ "keys" åѓгàÿ. Тħėгē ѕĥōμĺđ бñľў вĕ ŏи℮ ѕтřïлģ νăŀůé ĭŉ ţĥė "keys" άřřàγ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>{Locked="\"keys\"","•"} This glyph is a bullet, used in a bulleted list.</comment>
   </data>
   <data name="FailedToParseSubCommands" xml:space="preserve">
-    <value>• ₣αιľęδ τō ρāřşέ αℓļ şũвçőммāпðŝ òƒ ŉęşťёđ ćőмmáйδ. !!! !!! !!! !!! !!! </value>
+    <value>• ₣ąìļ℮đ ţŏ ρǻŕşε âłľ śцъċőммåиðѕ ōƒ л℮śť℮ď сömmąπđ. !!! !!! !!! !!! !!! </value>
   </data>
   <data name="MissingRequiredParameter" xml:space="preserve">
-    <value>• ₣ôцñδ ǻ ќęγъĭŉđϊⁿĝ ţħāτ щąś мĩšŝįņĝ ª řèqυïяеď φǻŗåmетėŗ νáļūé. Τħĩš ķэўвįпđīņğ ẃіľł ь℮ ΐģηòřėδ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>• ₣оůñð ā κėуьίπðîηĝ тħаŧ ẃáś мįѕśϊňģ д ѓ℮qûιŗзð рαřǻмęţεř νăľυë. Тнίѕ кεγьĩņđíņģ щìľļ вє įĝлóяеđ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>{Locked="•"} This glyph is a bullet, used in a bulleted list.</comment>
   </data>
   <data name="UnknownTheme" xml:space="preserve">
-    <value>• Тћĕ ŝρёςĩƒīęď "τћêm℮" ẁаś ηοť ƒōϋηð іŋ ťне ĺιşţ бƒ τћémėś. Ť℮mрσґäяīľŷ ƒдℓŀïŉġ ъáςк ŧó τĥ℮ ďëƒåŭℓť νаľūë. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>• Тћë ѕрèçїƒĭёď "τћ℮мé" ώαѕ ήøţ ƒόûπđ ΐл ťћê ℓíŝť σƒ ťнεmέѕ. Ŧěмрǿŕдѓΐļγ ƒдℓłίńģ вà¢ĸ τő ŧнě đέƒαùŀŧ νǻľΰê. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>{Locked="•"} This glyph is a bullet, used in a bulleted list.</comment>
   </data>
   <data name="LegacyGlobalsProperty" xml:space="preserve">
-    <value>Ťђé "globals" φгöφëŕτγ їѕ ďēφѓē¢áτєδ - ÿòџř ŝетτіήğş mіğђт πє℮đ ϋρδªτîηġ.  !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Τђз "globals" φѓóрεѓţγ ιŝ δęρѓêсâŧėď - ýбųѓ ŝέтŧїпĝš мìġħţ ηзέď црđªтïйġ.  !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>{Locked="\"globals\""} </comment>
   </data>
   <data name="LegacyGlobalsPropertyHrefUrl" xml:space="preserve">
@@ -267,635 +267,635 @@
     <comment>{Locked}This is a FWLink, so it will be localized with the fwlink tool</comment>
   </data>
   <data name="LegacyGlobalsPropertyHrefLabel" xml:space="preserve">
-    <value>₣ôѓ mθřē іпƒő, śэе ťħіš ώéь φάģз. !!! !!! !!! </value>
+    <value>₣οř мòŕе îήƒθ, şéэ ţħìѕ ŵєь рąġé. !!! !!! !!! </value>
   </data>
   <data name="FailedToParseCommandJson" xml:space="preserve">
-    <value>₣åίĺзđ ŧø éхφǻйď а çбмmãņđ ŵíŧħ "iterateOn" ѕ℮ŧ. Ţĥīѕ ċοммąπď ŵіℓļ вέ ιġπǿяёď. !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>₣ăіľέđ ţö ехρåņď ǻ çǿммãηδ ẃìţĥ "iterateOn" şετ. Ťĥīš ćōmмåиď щΐℓĺ ве ĭģňóѓëđ. !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>{Locked="\"iterateOn\""} </comment>
   </data>
   <data name="InvalidColorSchemeInCmd" xml:space="preserve">
-    <value>₣õΰпď ą čоммдⁿδ ẅίτħ ăп íиνаłіð "colorScheme". Тнïş ċσmmãⁿδ ωîĺł ьę їģñóґéδ. Μãķέ ŝũř℮ ŧнǻţ щĥĕп šзτťіⁿğ ã "colorScheme", ŧħє νаłџē måŧćн℮ѕ тђê "name" οƒ ã ċóļőѓ śçĥємє ΐŉ ţђέ "schemes" ļΐѕŧ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>₣óŭйď ã сóмmаńδ ẁϊţђ дή îⁿναļīð "colorScheme". Тћîŝ ĉǿмmαήδ ωïĺĺ вε íğлŏгëð. Мâķэ ѕϋŗê τĥāţ ẅћэй šěτťîņġ å "colorScheme", ţĥé νаļΰé мªŧçћєѕ ţħє "name" őƒ ă ¢ôℓôř ŝςђзмê įň тнε "schemes" ľïşŧ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>{Locked="\"colorScheme\"","\"name\"","\"schemes\""}</comment>
   </data>
   <data name="InvalidSplitSize" xml:space="preserve">
-    <value>₣σùņð α "splitPane" ςöмmǻńđ ŵіťн āⁿ ίňνǻŀιď "size". Τћιş čôмmαñδ ẁĭłļ ъĕ īĝйŏгēđ. Μάкé ѕûřέ тђê śįźе įѕ вëтώєèή 0 äŉδ 1, ĕ×ċłцşìν℮. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>₣ŏΰπđ ā "splitPane" ¢ǿммäήđ ŵìтћ ăη îŋνąłιđ "size". Ţђíѕ ċǿммªпđ ŵīĺℓ ьė ìĝñōгёđ. Мăќέ šύгз τĥě śιźê įѕ ъèτшέëπ 0 äⁿð 1, εхčļûŝίνз. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>{Locked="\"splitPane\"","\"size\""}</comment>
   </data>
   <data name="FailedToParseStartupActions" xml:space="preserve">
-    <value>₣αίŀèď το рàяśё "startupActions". !!! !!! !!! </value>
+    <value>₣âìľęď ťǿ рαяŝé "startupActions". !!! !!! !!! </value>
     <comment>{Locked="\"startupActions\""}</comment>
   </data>
   <data name="InvalidProfileEnvironmentVariables" xml:space="preserve">
-    <value>₣ōũńď mũłťιрļε ĕήνïґőŋмèŋŧ νаřîåъļęš щįţн ťĥё śámê ňämé îń ďĩƒƒзґěňţ ĉãśĕş (ľŏшèґ/ũρрег) - оņłỳ олě νдłūэ щίłℓ ьє ũşęδ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>₣öųñđ múℓтĭφļę èⁿνіŕθлмėňţ ναřίдъľêѕ ẅïτħ ťħз śăмė ήámе їή đїƒƒέřέηт čãşзś (ĺóщěг/ůрρеŕ) - óлℓŷ οиę νǻľµě ẁιľľ вё ųşέď. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
   </data>
   <data name="CmdCommandArgDesc" xml:space="preserve">
-    <value>Λň όφţĩøŋàľ čómmаňδ, ẃΐŧĥ āŗğμмĕŋτѕ, τó ь℮ šφªшлêđ íň тħę ⁿěẅ тαь σř рäńë !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Åŉ ǿртíоñαŀ ċοmмäηď, ẁίŧћ ãŗĝūměŉтş, ţô вέ šρªẃйèđ įņ ťђė πεẁ ŧав ŏŗ рªņε !!! !!! !!! !!! !!! !!! !!! </value>
   </data>
   <data name="CmdFocusTabDesc" xml:space="preserve">
-    <value>Μöνę ƒøсųѕ ŧø αņŏτђзŕ τãв !!! !!! !</value>
+    <value>Μòνê ƒöčµѕ ŧθ ãņøτнёř τåъ !!! !!! !</value>
   </data>
   <data name="CmdFocusTabNextArgDesc" xml:space="preserve">
-    <value>Μőνз ƒθçŭŝ ţŏ ŧђé ñê×т ťªъ !!! !!! !</value>
+    <value>Мõνè ƒòćüŝ τθ ťћé пĕ×т ťαъ !!! !!! !</value>
   </data>
   <data name="CmdFTDesc" xml:space="preserve">
-    <value>Άņ áĺîäš ƒòґ τħè "focus-tab" šϋвċømмáπď. !!! !!! !!! !!!</value>
+    <value>Дŋ äℓĭάş ƒоř τћę "focus-tab" šųъčǿммáñđ. !!! !!! !!! !!!</value>
     <comment>{Locked="\"focus-tab\""}</comment>
   </data>
   <data name="CmdFocusTabPrevArgDesc" xml:space="preserve">
-    <value>Мøνĕ ƒσсûŝ ťő тђе рґένίøŭš ţαв !!! !!! !!!</value>
+    <value>Μöνє ƒоćüŝ ŧó ţĥë рřěνĩομѕ тãь !!! !!! !!!</value>
   </data>
   <data name="CmdFocusTabTargetArgDesc" xml:space="preserve">
-    <value>Μбνέ ƒøĉüŝ ťћĕ ţáв áŧ ťĥě ĝїνеń їпđèж !!! !!! !!! !!</value>
+    <value>Мονé ƒоćűŝ ťħέ τåь àτ ţĥé ĝįνèň іňďėж !!! !!! !!! !!</value>
   </data>
   <data name="CmdMovePaneTabArgDesc" xml:space="preserve">
-    <value>Мôνé ƒσćųşзð ρąπè ťő ţнê тăв ãť ťнз ģìνзл ïпđēж !!! !!! !!! !!! !!</value>
+    <value>Μόνě ƒôçџś℮ď φąπέ τŏ ţħĕ ŧäв ǻτ тћė ģΐνеņ ĭñðěх !!! !!! !!! !!! !!</value>
   </data>
   <data name="CmdMovePaneDesc" xml:space="preserve">
-    <value>Мőν℮ ƒóĉūŝêđ φäлê тò åиόтĥêя τåъ !!! !!! !!! </value>
+    <value>Μǿνê ƒõćυѕěð φâή℮ ťθ ǻлοτĥёŗ τąв !!! !!! !!! </value>
   </data>
   <data name="CmdMPDesc" xml:space="preserve">
-    <value>Áή äĺīàѕ ƒθŗ ţћè "move-pane" šύвćõммαňď. !!! !!! !!! !!!</value>
+    <value>Ăⁿ āℓíąš ƒбŕ тнĕ "move-pane" šúъćбммàⁿδ. !!! !!! !!! !!!</value>
     <comment>{Locked="\"move-pane\""}</comment>
   </data>
   <data name="CmdSplitPaneSizeArgDesc" xml:space="preserve">
-    <value>Ŝрέċΐƒŷ ŧħę śĩžз àŝ á рεŗčзņţαĝê оƒ тћé φáŗêŉŧ ρàηе. Vаļіđ νàļμέš âѓε вêŧẃзĕη (0,1), ė×čĺµѕіνė. !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ѕрёċϊƒÿ тђĕ ѕîžĕ αѕ ǻ ρēŕċêйτдģе őƒ ŧħě φǻґзйť φàņē. Vдℓίδ νǻŀùзş āŗε ьεтщ℮ёň (0,1), е×ςĺúŝινе. !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="CmdNewTabDesc" xml:space="preserve">
-    <value>Čŕěǻтè å лēω тāв !!! !</value>
+    <value>Çґέăťė ã πėш τáв !!! !</value>
   </data>
   <data name="CmdNTDesc" xml:space="preserve">
-    <value>Āŋ аłįαš ƒоґ τĥĕ "new-tab" ѕΰъċômmăñδ. !!! !!! !!! !!</value>
+    <value>Ăи άℓîªŝ ƒōř τħë "new-tab" śμвċόmмãŋδ. !!! !!! !!! !!</value>
     <comment>{Locked="\"new-tab\""}</comment>
   </data>
   <data name="CmdFocusPaneDesc" xml:space="preserve">
-    <value>Мǿνĕ ƒøĉϋŝ ţô аňôťĥэř φаπё !!! !!! !</value>
+    <value>Μǿνé ƒосųŝ тô дπøţћєг рáņė !!! !!! !</value>
   </data>
   <data name="CmdFPDesc" xml:space="preserve">
-    <value>Αń åłĭǻš ƒôґ ŧĥë "focus-pane" šцьçбmмåñð. !!! !!! !!! !!!</value>
+    <value>Áй áℓįãš ƒòŗ тђĕ "focus-pane" şυъĉöммàńđ. !!! !!! !!! !!!</value>
     <comment>{Locked="\"focus-pane\""}</comment>
   </data>
   <data name="CmdFocusPaneTargetArgDesc" xml:space="preserve">
-    <value>₣θċũś ťнę φäñë àт тђє ġινęη ίñďĕх !!! !!! !!! </value>
+    <value>₣ό¢űѕ тнê φàπĕ аţ тђè ğĭνėй ïŋðεж !!! !!! !!! </value>
   </data>
   <data name="CmdProfileArgDesc" xml:space="preserve">
-    <value>Οφεπ ώιŧћ тђė ģĩνëп рřόƒίļé. Ąćсéрţŝ еìτђєř ŧђε ήǻmé òř ĢŨÎÐ ôƒ ą ρѓǿƒìĺê !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Θφêп шĩτћ ťнě ģìνēή ρѓøƒìĺę. Âćĉеφťś ёĩτĥėŗ τђė йάмє øя ĠŮΪÐ õƒ а φŕóƒίℓè !!! !!! !!! !!! !!! !!! !!! </value>
   </data>
   <data name="CmdSplitPaneDesc" xml:space="preserve">
-    <value>Ċґеăτê ä ⁿęẅ šрłιť φåлè !!! !!! </value>
+    <value>Ĉґéáŧе д ήэẅ ŝφĺĭτ рãňё !!! !!! </value>
   </data>
   <data name="CmdSPDesc" xml:space="preserve">
-    <value>Áη åℓįдŝ ƒōŗ тħĕ "split-pane" ŝύвсбмmаñđ. !!! !!! !!! !!!</value>
+    <value>Āл ªļïâś ƒбг ŧћê "split-pane" ŝύвćőммäňδ. !!! !!! !!! !!!</value>
     <comment>{Locked="\"split-pane\""}</comment>
   </data>
   <data name="CmdSplitPaneHorizontalArgDesc" xml:space="preserve">
-    <value>€řĕäţз ťнę ⁿэŵ ρáňë ăŝ á ђòяįżŏиτåĺ šрĺíт (ŧнîņĸ [-]) !!! !!! !!! !!! !!! </value>
+    <value>Ċŕéάťё ťћè ⁿеẁ рâлè åś ǻ ħôŕîžőņτąŀ śρļίτ (ŧнїπĸ [-]) !!! !!! !!! !!! !!! </value>
   </data>
   <data name="CmdSplitPaneVerticalArgDesc" xml:space="preserve">
-    <value>Çŕєăţė ťĥз йєŵ φάиě åѕ α νèřтĩċāℓ šρŀîţ (тђìŋĸ [|]) !!! !!! !!! !!! !!!</value>
+    <value>Ċяěªтĕ ŧнέ ⁿèω ρаηе ªš ā νēѓτîčäŀ ѕрĺįť (тĥїπќ [|]) !!! !!! !!! !!! !!!</value>
   </data>
   <data name="CmdSplitPaneDuplicateArgDesc" xml:space="preserve">
-    <value>€яêàтё ťħє ņėŵ ρàňė ъŷ δûρℓίċāŧïŋģ ţĥё φŗőƒίłé őƒ тђ℮ ƒоçųşеð рâņє !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ĉřεâте тħè пέẁ φаńè ъỳ ďцрłíçăţιηğ ťħе φгоƒíľз оƒ τĥě ƒőċūşëð рāиē !!! !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="CmdStartingDirArgDesc" xml:space="preserve">
-    <value>Ωреń ĭη ŧне ġινĕη ďϊŕëćŧőŗỳ ìňŝτěàδ ŏƒ ŧнε ρřóƒìĺė'ś ŝєт "startingDirectory" !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Óрεŋ ιŋ τћē ĝіνèή ðіґėсťσŗý ΐńѕţêªđ ôƒ тħ℮ рřоƒĭľė'ŝ şĕŧ "startingDirectory" !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>{Locked="\"startingDirectory\""}</comment>
   </data>
   <data name="CmdTitleArgDesc" xml:space="preserve">
-    <value>Оφèñ ţнэ ţēгмίŋáℓ ẅĭτĥ ţнз ргоνίďęð тĭťℓě ίήśтèāď ôƒ τħê ρŗõƒįļε'ŝ šëť "title" !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Òрèи ŧћ℮ тεгміņдľ шįтђ τћз рŕσνϊðэđ ţϊťľё їņšτèāď οƒ ŧħз рѓοƒïℓε'š śēт "title" !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>{Locked="\"title\""}</comment>
   </data>
   <data name="CmdTabColorArgDesc" xml:space="preserve">
-    <value>Õφ℮ņ τĥ℮ ŧäв ẁïŧħ τĥе śрèçīƒíéð çŏļοѓ, įπ #řřģĝъь ƒòŗмáт !!! !!! !!! !!! !!! !</value>
+    <value>Фрєŋ τћę ťāь ẃĭŧĥ ŧĥē ѕρεçíƒĩĕď ċŏĺőŗ, ίŉ #řґģģьь ƒöřмàŧ !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="CmdSuppressApplicationTitleDesc" xml:space="preserve">
-    <value>Ωрέŉ ťђë ťáв ẃîτн ŧаьŤϊŧĺ℮ õνёггĭđΐиğ đēƒāΰŀţ τīťļë âňď ŝûφρгëѕѕíήĝ ţīţłě çĥãήğė мëѕŝàĝєş ƒŕбm ŧħέ äφφĺįçªŧįση !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Όрзи тћê тäъ ŵîтн ŧãвŦìтŀέ øνėřѓĩδіиĝ δęƒåυĺŧ тīτłê ǻйď ѕűррŕ℮ѕśìήĝ τĭťℓé ċћаπġё mεśšàğзš ƒŗøм тћê ªрρĺĩčªτĭóņ !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>{Locked="\"tabTitle\""}</comment>
   </data>
   <data name="CmdInheritEnvDesc" xml:space="preserve">
-    <value>İŉĥëřĩţ тħз тεŕмїήāĺ'ś бщή эŉνìяθⁿмєлτ νåŕįάвŀėѕ ẅћęη çяεąŧĩήġ ţĥє ⁿėẅ тàь ōŕ рдńé, řдτђěѓ τнäπ ćгзâτĩηģ а ƒřëŝħ ĕņνíѓőňмέπτ ъℓøςķ. Ťћĭš ðèƒαµĺŧš ţó šеτ ώћєп ą "command" їš ρǻŝşěδ.  !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>İηĥегïт ţĥě ťεřmĭŉǻł'ŝ õώп εņνĩŕόňмěñť νāřĭáьŀĕś ώнēл ĉгėǻтΐŉġ ţħз πęш ţáь ŏŕ ρäη℮, ŗãŧħёř ťĥªή ¢řēäţіηĝ ǻ ƒŗėśћ èήνιгőŋм℮иť ьļο¢к. Тħїš ďęƒαüłŧŝ τõ ѕёţ ẅħēň ą "command" îş ρãśŝéđ.  !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>{Locked="\"command\""}</comment>
   </data>
   <data name="CmdColorSchemeArgDesc" xml:space="preserve">
-    <value>Őφєŉ ťнє ŧãв ẁīţн тђě şρè¢ĭƒîєđ сοļōг şćĥεmé, ïŋŝтēàď ôƒ ŧнз рŗоƒĭℓэ'ş ѕéτ "colorScheme" !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Øρéη ŧĥē ŧаь щïţђ ţнё ѕрě¢ίƒĩеð ¢θℓôя şĉнем℮, īπѕτêåδ òƒ τĥё φřőƒĭľе'ŝ ѕ℮ť "colorScheme" !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>{Locked="\"colorScheme\""}</comment>
   </data>
   <data name="CmdVersionDesc" xml:space="preserve">
-    <value>Đîśрľáý ţђě άφρļîсåťìǿи νеѓśΐŏŋ !!! !!! !!!</value>
+    <value>Ďìśрℓàÿ тћē åφφłîςдťίøп νēřšįóń !!! !!! !!!</value>
   </data>
   <data name="CmdMaximizedDesc" xml:space="preserve">
-    <value>Ĺąµήçħ ŧћé ωїñδőẁ mджîмĩźέð !!! !!! !!</value>
+    <value>Ļáūńçн тћё ẅïиďоŵ мåжімĩźęð !!! !!! !!</value>
   </data>
   <data name="CmdFullscreenDesc" xml:space="preserve">
-    <value>Ľâųήċћ τнё ωілďöω īŉ ƒΰļŀś¢ѓеëń mоđέ !!! !!! !!! !</value>
+    <value>£âµńĉн тнė щίπđощ їŉ ƒûℓŀşċŕėēη мøđè !!! !!! !!! !</value>
   </data>
   <data name="CmdMoveFocusDesc" xml:space="preserve">
-    <value>Μóνз ƒσ¢ûş ŧø ţће āδјαсэŋŧ ρāήê íŉ ťĥě ѕφесíƒĩëđ δïŗёçтĭǿл !!! !!! !!! !!! !!! !!</value>
+    <value>Мονë ƒόçцŝ τô ţнε дďјαçéŉţ φáπέ ίņ τнë ѕрéςĩƒїĕδ δіŗéćťïőп !!! !!! !!! !!! !!! !!</value>
   </data>
   <data name="CmdMFDesc" xml:space="preserve">
-    <value>Ãŋ åĺϊąş ƒŏя τнë "move-focus" šůъċôммåηď. !!! !!! !!! !!!</value>
+    <value>Åп âℓιāś ƒóř ŧђз "move-focus" šůъçόмmàпð. !!! !!! !!! !!!</value>
     <comment>{Locked="\"move-focus\""}</comment>
   </data>
   <data name="CmdMoveFocusDirectionArgDesc" xml:space="preserve">
-    <value>Τĥë đĩґėċτïσй ţó мöνē ƒбςūś įπ !!! !!! !!!</value>
+    <value>Тнê đιřèсţïöп ţό мøνĕ ƒŏčúś ìή !!! !!! !!!</value>
   </data>
   <data name="CmdSwapPaneDesc" xml:space="preserve">
-    <value>Ѕẁăр ŧђё ƒοсџşèð φàŋé ώίτħ тђз аđĵăĉēŋτ φąñ℮ іл ťђė şφёčìƒī℮δ ďїřεćтίǿń !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Šшдφ ťĥė ƒоčùšěď рдйê ŵīťђ ŧнё ãđĵă¢èņτ φåиé íŋ ťĥē šρêςīƒĭзδ đìѓз¢ţįőñ !!! !!! !!! !!! !!! !!! !!!</value>
   </data>
   <data name="CmdSwapPaneDirectionArgDesc" xml:space="preserve">
-    <value>Ťћê ðįŕэčŧíöй тò мōνε ţħз ƒσčůšèđ рäйë їń !!! !!! !!! !!!</value>
+    <value>Тнě διяèċτîõη ţό mōνе ťћë ƒòčϋš℮δ рαπ℮ īп !!! !!! !!! !!!</value>
   </data>
   <data name="CmdFocusDesc" xml:space="preserve">
-    <value>₤âüήсћ τħě ώίŉďǿώ îη ƒŏčυѕ mōđέ !!! !!! !!!</value>
+    <value>Ľãūлçĥ тħέ щíиδσώ ìй ƒô¢ũš мôďз !!! !!! !!!</value>
   </data>
   <data name="CmdSavedLayoutArgDesc" xml:space="preserve">
-    <value>Ţħìŝ рªŗãmęţėг įş ąй ĩйτέŗпāℓ ΐмφℓēm℮ŉţăŧïöп đεţάїĺ áпδ ŝĥσϋļδ иθт ьė µŝэď. !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ŧћїѕ ρąяáмėŧєѓ ĭş āη їňтεŕήåŀ íмφĺêmёņťдţïòπ ďёŧåĩļ дηð šнŏųļδ ñōţ ьë ųšėð. !!! !!! !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="CmdWindowTargetArgDesc" xml:space="preserve">
-    <value>Šφĕċιƒу å тèѓmĭπåľ ẁίňðощ ŧŏ гûń ŧћз ğïνеñ čόммдⁿđłιňэ įη. "0" åĺẁåγš ґëƒєґş ťō τђє ćūгяєňţ ẅіŉðоẁ.  !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Šрêςĩƒγ а ťĕгmìŋаł ẁϊпðõω τσ ґύŋ τнз ģίνĕи ĉömмαпđľįŉе їй. "0" āℓώąŷš řеƒěŗş ťσ ŧħė çŭґřęπť ẁįŉđǿω.  !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
   </data>
   <data name="CmdPositionDesc" xml:space="preserve">
-    <value>Ѕрε¢íƒÿ тћё φоѕїтîσŉ ƒθř ŧнё ţεямįňàŀ, īй "×,у" ƒõřmąт. !!! !!! !!! !!! !!! !</value>
+    <value>Šрëĉίƒў тћε рόŝíŧιòή ƒōя тнě тėřmįηдŀ, ϊп "х,ÿ" ƒθřмάŧ. !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="CmdSizeDesc" xml:space="preserve">
-    <value>Ѕρєčìƒÿ τĥэ лцмвēг òƒ ¢σļџмηş ǻŉδ řŏщѕ ƒбг тђě τεřмίйãŀ, ĩŉ "ċ,ŕ" ƒоŗмǻτ. !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Ѕφёĉĩƒỳ тнэ ņµmъ℮ґ øƒ ςòļůmйś ăŋð гøшş ƒöŕ тнε τєѓмϊⁿãŀ, ĩŉ "ċ,ř" ƒθяmãţ. !!! !!! !!! !!! !!! !!! !!! </value>
   </data>
   <data name="NewTabSplitButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.HelpText" xml:space="preserve">
-    <value>Рřëŝš ťħе ьűŧтōп тő ǿρĕπ ã ηëẅ ťэяmïňăļ ťáъ ẁïťћ ýőџг δзƒåüĺτ рґσƒĩľé. Øрèŋ ţнε ƒļγõūţ ťο šēℓėсŧ ẅђį¢ĥ ρгθƒìℓě ўбũ щáήŧ ţо όрëŋ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Рґзѕś тђз вůťŧôй ŧǿ ǿφеη ā ŉéẃ ţєѓmîńąŀ ťâв ωϊŧђ ýθůř đęƒăμℓţ ρŗôƒїĺε. Óρĕп τћё ƒłýбцť ţø śεŀèςŧ шĥïčĥ φřŏƒίļê ўσμ ẁάлτ ţσ όрεй. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
   </data>
   <data name="NewTabSplitButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>∏ęш Τäь !!</value>
+    <value>Ňèώ Ŧäъ !!</value>
   </data>
   <data name="NewTabRun.Text" xml:space="preserve">
-    <value>Ώреп à ήєẅ тάв !!! !</value>
+    <value>Όрèπ ª йěŵ ταв !!! !</value>
   </data>
   <data name="NewPaneRun.Text" xml:space="preserve">
-    <value>Ǻŀť+Сŀĩćĸ ţŏ šρŀïт ťĥê ¢ŭŗřεŋτ ẅίⁿðøщ !!! !!! !!! !!</value>
+    <value>Ǻℓт+Сłĩċк тö šрŀîţ ţћë сцřѓèήŧ ẅїпðбω !!! !!! !!! !!</value>
   </data>
   <data name="NewWindowRun.Text" xml:space="preserve">
-    <value>Ѕħιƒť+€ĺīçķ ŧö бφéñ à йêщ ẃϊπδöẅ !!! !!! !!! </value>
+    <value>Śħîƒť+Çľιćĸ тō όрзⁿ ª йзώ ẁίπðôш !!! !!! !!! </value>
   </data>
   <data name="ElevatedRun.Text" xml:space="preserve">
-    <value>Ċţґł+Çļϊςķ ťб ôρęй άš ãδmιňιšŧŗаτоř !!! !!! !!! !</value>
+    <value>€ţŕł+Čℓїčķ τõ ορêņ αŝ аðmìñĩѕτŕăţòг !!! !!! !!! !</value>
   </data>
   <data name="WindowCloseButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>€łǿşę !</value>
+    <value>Ćℓőŝз !</value>
   </data>
   <data name="WindowCloseButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Çłōśê !</value>
+    <value>Ĉļøşз !</value>
   </data>
   <data name="WindowCloseButtonToolTip.Text" xml:space="preserve">
-    <value>Ċĺбšэ !</value>
+    <value>Ĉļόѕě !</value>
   </data>
   <data name="WindowMaximizeButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Мāжįмϊźê !!</value>
+    <value>Μджįmïźэ !!</value>
   </data>
   <data name="WindowMinimizeButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Μïņĩмîžĕ !!</value>
+    <value>Μïиιmіžё !!</value>
   </data>
   <data name="WindowMinimizeButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Мîⁿĩmïźè !!</value>
+    <value>Μîⁿĩmĩż℮ !!</value>
   </data>
   <data name="WindowMinimizeButtonToolTip.Text" xml:space="preserve">
-    <value>Μíηîмĭżє !!</value>
+    <value>Мĩиîmĩżє !!</value>
   </data>
   <data name="AboutDialog.Title" xml:space="preserve">
-    <value>Λъοΰť !</value>
+    <value>Åвōύţ !</value>
   </data>
   <data name="AboutDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Ŝєйδ ₣еëđъдçĸ !!! </value>
+    <value>Ѕеηð ₣ę℮đвäçк !!! </value>
   </data>
   <data name="AboutDialog.CloseButtonText" xml:space="preserve">
-    <value>ФЌ </value>
+    <value>ΦΚ </value>
   </data>
   <data name="AboutDialog_VersionLabel.Text" xml:space="preserve">
-    <value>V℮ґşϊσπ: !!</value>
+    <value>Véяšîõп: !!</value>
     <comment>This is the heading for a version number label</comment>
   </data>
   <data name="AboutDialog_GettingStartedLink.Content" xml:space="preserve">
-    <value>Ġěтţїηġ Ѕтāгŧëð !!! !</value>
+    <value>Ġеťтΐñĝ Ѕτдŗτęď !!! !</value>
     <comment>A hyperlink name for a guide on how to get started using Terminal</comment>
   </data>
   <data name="AboutDialog_SourceCodeLink.Content" xml:space="preserve">
-    <value>Ѕōúяčε €öďé !!!</value>
+    <value>Ѕοџŗсė Çŏđе !!!</value>
     <comment>A hyperlink name for the Terminal's documentation</comment>
   </data>
   <data name="AboutDialog_DocumentationLink.Content" xml:space="preserve">
-    <value>Ðθčμмéпťдťįόŋ !!! </value>
+    <value>Đŏĉµмěⁿтатïõñ !!! </value>
     <comment>A hyperlink name for user documentation</comment>
   </data>
   <data name="AboutDialog_ReleaseNotesLink.Content" xml:space="preserve">
-    <value>Гэĺзăšë Ņσţєš !!! </value>
+    <value>Ŗеľ℮àşε Ŋòτéš !!! </value>
     <comment>A hyperlink name for the Terminal's release notes</comment>
   </data>
   <data name="AboutDialog_PrivacyPolicyLink.Content" xml:space="preserve">
-    <value>Ρѓîνªĉŷ Ρоℓìсỳ !!! !</value>
+    <value>Ρґїνãсÿ Рöĺĩςỳ !!! !</value>
     <comment>A hyperlink name for the Terminal's privacy policy</comment>
   </data>
   <data name="AboutDialog_ThirdPartyNoticesLink.Content" xml:space="preserve">
-    <value>Тђïѓđ-Рăŕŧÿ Ŋστīĉêš !!! !!!</value>
+    <value>Ţћĩřð-Ρářŧγ ∏οŧīĉęŝ !!! !!!</value>
     <comment>A hyperlink name for the Terminal's third-party notices</comment>
   </data>
   <data name="QuitDialog.CloseButtonText" xml:space="preserve">
-    <value>Čαñçĕľ !</value>
+    <value>Ċдйĉέł !</value>
   </data>
   <data name="QuitDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Çĺθšê āĺĺ !!!</value>
+    <value>€ļőşε áļľ !!!</value>
   </data>
   <data name="QuitDialog.Title" xml:space="preserve">
-    <value>Đô ÿόµ ẅąиţ ťо ¢ľόŝĕ дℓĺ ẅîлδσщŝ? !!! !!! !!! </value>
+    <value>Ďõ γбű ẁāŋţ ťó ςℓσśĕ äℓℓ шîйđбẁś? !!! !!! !!! </value>
   </data>
   <data name="CloseAllDialog.CloseButtonText" xml:space="preserve">
-    <value>Çåň¢ęŀ !</value>
+    <value>Ćăŉċęℓ !</value>
   </data>
   <data name="CloseAllDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Ĉĺŏşέ ǻľĺ !!!</value>
+    <value>Ćļõѕέ аłℓ !!!</value>
   </data>
   <data name="CloseAllDialog.Title" xml:space="preserve">
-    <value>Ðσ ўоū ώªπτ ŧθ çľöšє ãŀļ τавŝ? !!! !!! !!!</value>
+    <value>Đσ ŷőū шдиŧ тò čļòŝз αŀľ ţâвŝ? !!! !!! !!!</value>
   </data>
   <data name="CloseReadOnlyDialog.CloseButtonText" xml:space="preserve">
-    <value>Çάⁿčĕļ !</value>
+    <value>Čǻñčėŀ !</value>
   </data>
   <data name="CloseReadOnlyDialog.PrimaryButtonText" xml:space="preserve">
-    <value>€łøşз ąηγŵâÿ !!! </value>
+    <value>Сłŏѕε άñÿẃåγ !!! </value>
   </data>
   <data name="CloseReadOnlyDialog.Title" xml:space="preserve">
-    <value>Шąґйíⁿĝ !!</value>
+    <value>Ẁαгйïņğ !!</value>
   </data>
   <data name="CloseReadOnlyDialog.Content" xml:space="preserve">
-    <value>¥õυ áŕę ǻвòūŧ тô čłôšє ă ѓεąď-öлļý ťëѓmΐηáŀ. Ðο ўоц ẃίşĥ тô ¢οηŧϊпųе? !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ϋôů ářє дъоϋť ŧо ćľōśέ ª гęаð-öйĺу тêřmĩńäĺ. Đǿ ỳøü ωîśђ ŧő ćőŉţїñϋέ? !!! !!! !!! !!! !!! !!! !!!</value>
   </data>
   <data name="LargePasteDialog.CloseButtonText" xml:space="preserve">
-    <value>Ċåŋĉэł !</value>
+    <value>Сâήçеŀ !</value>
   </data>
   <data name="LargePasteDialog.Content" xml:space="preserve">
-    <value>Ύøµ āŗε åъбΰŧ ťò рάšţê ťé×ŧ тћάт īš łõлĝеŕ ŧнăй 5 КĩЬ. Ðο убű ώіšн ťо ¢θńтįпϋĕ? !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ўōµ ąřε ăвőüť ţò ρãѕŧĕ ťê×ŧ тħãт ïš ľôŉğзŗ ŧђąи 5 ЌΐБ. Đθ γŏΰ ẅĩşħ τò ςõиŧĭňūê? !!! !!! !!! !!! !!! !!! !!! !!!</value>
   </data>
   <data name="LargePasteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Ρăŝτě åηýώâŷ !!! </value>
+    <value>Ρâşτз ăπуẅаý !!! </value>
   </data>
   <data name="LargePasteDialog.Title" xml:space="preserve">
-    <value>Ẅáŕпìŋģ !!</value>
+    <value>Ẃâгηïņğ !!</value>
   </data>
   <data name="MultiLinePasteDialog.CloseButtonText" xml:space="preserve">
-    <value>Сâηċэļ !</value>
+    <value>Ćªήĉěł !</value>
   </data>
   <data name="MultiLineWarningText.Text" xml:space="preserve">
-    <value>Ỳøµ άяę ªвøΰţ ţθ рäşтē ŧё×ť τĥąŧ ¢οηŧάίńš мûľтįрļê ŀĭŋêś. Íƒ ÿöũ φâŝŧе тĥїŝ ŧежт įńто ÿóûґ ѕнэłĺ, ïŧ mдý řēşųľτ įή ŧће űňęжρĕċţĕď ê×έćϋťιőň σƒ ćŏmмäŋðŝ. Ðό ўŏù ωϊşђ ŧǿ ςöņτîлμē? !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Ϋбů áяē авôцţ τŏ ρªѕŧê ťĕхţ ťĥâť ĉοлŧäїлš mųŀťїрŀē ĺΐиέš. Ĭƒ ýŏû рαśτё ťђìš ť℮хŧ îήŧø γõũŗ ѕћêℓļ, íτ mду ŗéśμļт įŋ ţħ℮ цпęхρ℮çťêď з×эćúтϊŏⁿ õƒ ςōмmãⁿðş. Đο убŭ ẃīѕн τõ ċôŉŧïñûε? !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
   </data>
   <data name="MultiLinePasteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Рåšте дйÿώªÿ !!! </value>
+    <value>Ρªšţє аńŷẁàŷ !!! </value>
   </data>
   <data name="MultiLinePasteDialog.Title" xml:space="preserve">
-    <value>Шåřŋìńğ !!</value>
+    <value>Щāŕñιπĝ !!</value>
   </data>
   <data name="CommandPalette_SearchBox.PlaceholderText" xml:space="preserve">
-    <value>Ŧγφэ ǻ čбммâņδ ⁿåmε... !!! !!! </value>
+    <value>Ťýφě á ĉθmmāņđ йăмē... !!! !!! </value>
   </data>
   <data name="CommandPalette_NoMatchesText.Text" xml:space="preserve">
-    <value>Ио mάтĉђìήġ сömмäńðѕ !!! !!!</value>
+    <value>Ŋό маŧ¢ĥΐŋğ сóмmăлđš !!! !!!</value>
   </data>
   <data name="CommandPaletteModeAnnouncement_ActionMode" xml:space="preserve">
-    <value>Ǻĉţιόл š℮âřĉн моδє !!! !!</value>
+    <value>∆ćŧìøп şєāяćħ мóδє !!! !!</value>
     <comment>This text will be read aloud using assistive technologies when the command palette switches into action (command search) mode.</comment>
   </data>
   <data name="CommandPaletteModeAnnouncement_TabSearchSwitchMode" xml:space="preserve">
-    <value>Τàь тįţŀé мõδё !!! !</value>
+    <value>Тàв ťїтłé môðэ !!! !</value>
     <comment>This text will be read aloud using assistive technologies when the command palette switches into a mode that filters tab names.</comment>
   </data>
   <data name="CommandPaletteModeAnnouncement_CommandlineMode" xml:space="preserve">
-    <value>Ĉôмmάηδ-ℓĭñè mоðē !!! !!</value>
+    <value>Çοmмăπď-ĺιиé мõđэ !!! !!</value>
     <comment>This text will be read aloud using assistive technologies when the command palette switches into the raw commandline parsing mode.</comment>
   </data>
   <data name="CommandPalette_NestedCommandAnnouncement" xml:space="preserve">
-    <value>Μοřё бρτїõñś ƒŏř "{}" !!! !!!</value>
+    <value>Μояē öφтίóπś ƒőř "{}" !!! !!!</value>
     <comment>This text will be read aloud using assistive technologies when the user selects a command that has additional options. The {} will be expanded to the name of the command containing more options.</comment>
   </data>
   <data name="CommandPalette_ParsedCommandLine" xml:space="preserve">
-    <value>É×ěçüŧìñğ čõммãňð ľíπ℮ щįŀŀ ΐпνöкé τħę ƒōłŀóщιлĝ çõmmăпðś: !!! !!! !!! !!! !!! !!</value>
+    <value>Ėжėсùţīпğ ¢ōmмªñð ĺїπĕ ẁíĺł ĭиνокė тħе ƒöĺℓŏщîпġ çõmмāⁿďѕ: !!! !!! !!! !!! !!! !!</value>
     <comment>Will be followed by a list of strings describing parsed commands</comment>
   </data>
   <data name="CommandPalette_FailedParsingCommandLine" xml:space="preserve">
-    <value>₣діŀėđ ρдŗšιŉğ ćóмmάŋδ ľĩńе: !!! !!! !!</value>
+    <value>₣āіľ℮ď рàгśīпģ ¢бммäⁿδ ĺīñè: !!! !!! !!</value>
   </data>
   <data name="CommandPaletteControlName" xml:space="preserve">
-    <value>Čŏmmªŋđ Ρáľέτŧє !!! !</value>
+    <value>Ćσmmăηδ Рάŀĕтţ℮ !!! !</value>
   </data>
   <data name="TabSwitcherControlName" xml:space="preserve">
-    <value>Ταв Şẃįţĉћэŗ !!! </value>
+    <value>Τăь Ѕωîťςћêг !!! </value>
   </data>
   <data name="TabSwitcher_SearchBoxText" xml:space="preserve">
-    <value>Τўрė à τâь йªмē... !!! !!</value>
+    <value>Ţýρё ă тăъ пâmě... !!! !!</value>
   </data>
   <data name="TabSwitcher_NoMatchesText" xml:space="preserve">
-    <value>Ņб mâţčђιπğ τàв ŉаmè !!! !!!</value>
+    <value>Ńô мατćнìņģ ţдъ пªмĕ !!! !!!</value>
   </data>
   <data name="CmdPalCommandlinePrompt" xml:space="preserve">
-    <value>Елτĕŗ å wt çбmmάпďľϊņε тο ѓũŉ !!! !!! !!!</value>
+    <value>Èηŧĕґ ǻ wt ċθmмаŉđļïŉė тο ŕūŉ !!! !!! !!!</value>
     <comment>{Locked="wt"} </comment>
   </data>
   <data name="SuggestionsControl_NestedCommandAnnouncement" xml:space="preserve">
-    <value>Мǿřё øрτĩøňѕ ƒŏг "{}" !!! !!!</value>
+    <value>Μōŗè σφŧïθлš ƒόŕ "{}" !!! !!!</value>
     <comment>This text will be read aloud using assistive technologies when the user selects a command that has additional options. The {} will be expanded to the name of the command containing more options.</comment>
   </data>
   <data name="SuggestionsControl_SearchBox.PlaceholderText" xml:space="preserve">
-    <value>Ťурέ á ćôмmäйδ ŋåm℮... !!! !!! </value>
+    <value>Ťÿφė å ċοmмªйđ ηаmє... !!! !!! </value>
   </data>
   <data name="SuggestionsControl_NoMatchesText.Text" xml:space="preserve">
-    <value>Ňб мάŧсĥįиĝ ćόмmăŋðš !!! !!!</value>
+    <value>Ņô mάťςћίņĝ ċоmмάņďš !!! !!!</value>
   </data>
   <data name="SuggestionsControlName" xml:space="preserve">
-    <value>Şΰĝĝėśτíόŋѕ мéⁿμ !!! !</value>
+    <value>Šύğġěşţįσпś м℮ŉμ !!! !</value>
   </data>
   <data name="SuggestionsControl_MoreOptions.[using:Windows.UI.Xaml.Automation]AutomationProperties.HelpText" xml:space="preserve">
-    <value>Μŏгε σρťїŏήš !!! </value>
+    <value>Мόѓė ōφťіŏⁿś !!! </value>
   </data>
   <data name="SuggestionsControl_MatchesAvailable" xml:space="preserve">
-    <value>Śŭģĝ℮ŝτΐθŉš ƒοϋиď: {0} !!! !!! </value>
+    <value>Śΰġģ℮šτϊθñѕ ƒöüⁿδ: {0} !!! !!! </value>
     <comment>{0} will be replaced with a number.</comment>
   </data>
   <data name="CrimsonColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Çŗїmśòŉ !!</value>
+    <value>€яïmşǿń !!</value>
   </data>
   <data name="SteelBlueColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ŝŧёēľ Вĺϋέ !!!</value>
+    <value>Ѕťéêℓ βľυэ !!!</value>
   </data>
   <data name="MediumSeaGreenColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Мęδĩûм Śėα Ĝřéел !!! !</value>
+    <value>Μёδιųm Ѕεд Ğґзēη !!! !</value>
   </data>
   <data name="DarkOrangeColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ðаѓķ Öґăиģэ !!!</value>
+    <value>Ďäŕќ Õřäňğè !!!</value>
   </data>
   <data name="MediumVioletRedColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Мёđíμm Vīǿĺēτ Ŗёδ !!! !!</value>
+    <value>Мęðϊům Vĭõľзт Ѓεð !!! !!</value>
   </data>
   <data name="DodgerBlueColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ðŏðġеř Ьłűĕ !!!</value>
+    <value>Ðôđğēг Βĺϋę !!!</value>
   </data>
   <data name="LimeGreenColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ľīмę Ģŕèεń !!!</value>
+    <value>Ĺіmз Ĝґéĕи !!!</value>
   </data>
   <data name="YellowColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ўёľĺθш !</value>
+    <value>¥ęℓłοẃ !</value>
   </data>
   <data name="BlueVioletColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>βłůè Vīοĺêт !!!</value>
+    <value>Ьľùе Vΐбŀэτ !!!</value>
   </data>
   <data name="SlateBlueColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Śłăţĕ Бļцë !!!</value>
+    <value>Şŀаťę Βĺûė !!!</value>
   </data>
   <data name="LimeColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ĺίме !</value>
+    <value>£ϊмз !</value>
   </data>
   <data name="TanColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Тди </value>
+    <value>Ťåπ </value>
   </data>
   <data name="MagentaColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Μªġёиτå !!</value>
+    <value>Μàğэⁿτα !!</value>
   </data>
   <data name="CyanColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ćýãл !</value>
+    <value>Ċуåň !</value>
   </data>
   <data name="SkyBlueColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ŝкý Ьľüз !!</value>
+    <value>Šќŷ ßľϋ℮ !!</value>
   </data>
   <data name="DarkGrayColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ďàяќ Ğґǻу !!!</value>
+    <value>Ðàŗκ Ğѓáγ !!!</value>
   </data>
   <data name="InvalidUriText" xml:space="preserve">
-    <value>Ťђĩš łіήķ îş įπνäļīð: !!! !!!</value>
+    <value>Τћїš ŀĩňк іѕ įňνдŀíď: !!! !!!</value>
   </data>
   <data name="UnsupportedSchemeText" xml:space="preserve">
-    <value>Ţћìś ĺĭⁿĸ тγрε ĩѕ ςµŗяέŋţŀŷ ňόт ŝμрφòгţзð: !!! !!! !!! !!! </value>
+    <value>Ťђïś łϊηќ ŧурē ιş çũґѓзⁿτľÿ ñστ şΰρρоŕŧĕđ: !!! !!! !!! !!! </value>
   </data>
   <data name="CouldNotOpenUriDialog.PrimaryButtonText" xml:space="preserve">
-    <value>€ǻň¢ėĺ !</value>
+    <value>Сąñс℮ł !</value>
   </data>
   <data name="SettingsTab" xml:space="preserve">
-    <value>Ѕзťŧīŋġş !!</value>
+    <value>Śëţťĩпğś !!</value>
   </data>
   <data name="FailedToWriteToSettings" xml:space="preserve">
-    <value>Щέ ςоůℓď πöŧ ωŗĩŧе ŧó γøųŕ ŝěťţїπġś ƒĩĺέ. Ĉнěçķ τђё ρęřмîѕŝîόήš őй ŧĥàŧ ƒίŀє ťó êйѕµřë ťĥаť тнз ŗėªð-ôήľў ƒŀåġ īş ņŏţ şзť ãлδ ŧћãţ шřΐţē àçςéşş ĩŝ ģяǻηťēđ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ẃε ςőűℓđ пòт ωяΐτë ŧô γôύг šěťтïπĝŝ ƒīłě. Çђêĉĸ ţђэ φеřмìşŝΐóпѕ õл ťђàτ ƒĩŀε ţб έπšμґé ţђäť тћê ѓέάδ-õлļỳ ƒŀãġ ΐš ŉοт ŝėт ǻпď ţнăт ẅѓīţĕ ăсċéšş ĩş ģŗдŋτëđ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="ParentCommandBackButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ьąčќ !</value>
+    <value>Бдçķ !</value>
   </data>
   <data name="ParentCommandBackButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Бдćκ !</value>
+    <value>Ьãςк !</value>
   </data>
   <data name="ControlNoticeDialog.PrimaryButtonText" xml:space="preserve">
-    <value>ÒЌ </value>
+    <value>ΘК </value>
   </data>
   <data name="NoticeDebug" xml:space="preserve">
-    <value>Ďęъůģ !</value>
+    <value>Ďêъŭģ !</value>
   </data>
   <data name="NoticeError" xml:space="preserve">
-    <value>Ėяяôґ !</value>
+    <value>∑ŕřοґ !</value>
   </data>
   <data name="NoticeInfo" xml:space="preserve">
-    <value>Ĩηƒθѓmăťїŏп !!!</value>
+    <value>Īπƒóřмąτιŏŉ !!!</value>
   </data>
   <data name="NoticeWarning" xml:space="preserve">
-    <value>Шåгⁿϊņĝ !!</value>
+    <value>Шãřñїņģ !!</value>
   </data>
   <data name="ClipboardTextHeader.Text" xml:space="preserve">
-    <value>Ćļіρъőàŕđ ςбйťêйτŝ (φŕёνϊėẅ): !!! !!! !!!</value>
+    <value>€ℓірьоåŗδ ĉóńťęňтѕ (φѓενĭεẃ): !!! !!! !!!</value>
   </data>
   <data name="CommandPalette_MoreOptions.[using:Windows.UI.Xaml.Automation]AutomationProperties.HelpText" xml:space="preserve">
-    <value>Мοřë òφťîσπś !!! </value>
+    <value>Мθґе бφŧīбπš !!! </value>
   </data>
   <data name="WindowIdLabel" xml:space="preserve">
-    <value>Ẅїņđòẃ !</value>
+    <value>Ẅίńďöщ !</value>
     <comment>This is displayed as a label for a number, like "Window: 10"</comment>
   </data>
   <data name="UnnamedWindowName" xml:space="preserve">
-    <value>ųńņãмëð ωϊηðσẅ !!! !</value>
+    <value>υŉňàмěđ ẅіπďōẅ !!! !</value>
     <comment>text used to identify when a window hasn't been assigned a name by the user</comment>
   </data>
   <data name="WindowRenamer.Subtitle" xml:space="preserve">
-    <value>Ёήтєг ã п℮ẅ ήąмę: !!! !!</value>
+    <value>Єиŧ℮ŗ ă ñéẁ йάmё: !!! !!</value>
   </data>
   <data name="WindowRenamer.ActionButtonContent" xml:space="preserve">
-    <value>ΩĶ </value>
+    <value>ÒК </value>
   </data>
   <data name="WindowRenamer.CloseButtonContent" xml:space="preserve">
-    <value>Ćάηċéℓ !</value>
+    <value>Сªⁿċĕĺ !</value>
   </data>
   <data name="RenameFailedToast.Title" xml:space="preserve">
-    <value>₣àιŀ℮ď ţó řέлāмε ẁΐиδøẁ !!! !!! </value>
+    <value>₣âιļĕđ ŧо ѓëňąмë щϊπδǿω !!! !!! </value>
   </data>
   <data name="RenameFailedToast.Subtitle" xml:space="preserve">
-    <value>Дńõţнėř ωїиδōщ ẅΐťĥ ţђаţ ňǻмę ãłřėãđў ĕхΐśтѕ !!! !!! !!! !!! !</value>
+    <value>Άņόтĥěŗ ẃїлðοω ẁιťĥ ťћаť пâmě ăļřéàδў ёжìśŧѕ !!! !!! !!! !!! !</value>
   </data>
   <data name="WindowMaximizeButtonToolTip" xml:space="preserve">
-    <value>Μā×ΐmïż℮ !!</value>
+    <value>Μą×ìmϊżé !!</value>
   </data>
   <data name="WindowRestoreDownButtonToolTip" xml:space="preserve">
-    <value>Геşťог℮ Ďőωŋ !!! </value>
+    <value>Ŕèšŧòяё Ðǿẃи !!! </value>
   </data>
   <data name="CommandPaletteMenuItem" xml:space="preserve">
-    <value>Ĉοmмдňđ Ρãĺëţтę !!! !</value>
+    <value>Ċòмmāńδ Рªľėτťë !!! !</value>
   </data>
   <data name="NotificationIconFocusTerminal" xml:space="preserve">
-    <value>₣óĉύś Ŧęřмīиǻĺ !!! !</value>
+    <value>₣ôćűŝ Ţеґмĭйâŀ !!! !</value>
     <comment>This is displayed as a label for the context menu item that focuses the terminal.</comment>
   </data>
   <data name="NotificationIconWindowSubmenu" xml:space="preserve">
-    <value>Щіŉδǿẃŝ !!</value>
+    <value>Ẃϊйδοŵš !!</value>
     <comment>This is displayed as a label for the context menu item that holds the submenu of available windows.</comment>
   </data>
   <data name="DropPathTabRun.Text" xml:space="preserve">
-    <value>Οφ℮ŋ á ⁿέẅ ťάъ ιň ģïνėń ŝτåřтіηĝ đíяęçťõѓỳ !!! !!! !!! !!! </value>
+    <value>Фφĕń ª пёẅ ţâь ίи ğīνęņ ѕŧāятĩлğ δįŗęćтŏяγ !!! !!! !!! !!! </value>
   </data>
   <data name="DropPathTabNewWindow.Text" xml:space="preserve">
-    <value>Ŏφεń д иěŵ ẅιπδõω ŵīťн ĝїνëи ŝтăяŧіηğ ďïŕзċτбяў !!! !!! !!! !!! !!</value>
+    <value>Οφэй ä ŋёώ ẅįńðбώ ẁįτђ ĝĩνēη šτáгтϊŋĝ ðĭřěçŧøгγ !!! !!! !!! !!! !!</value>
   </data>
   <data name="DropPathTabSplit.Text" xml:space="preserve">
-    <value>Šрĺîţ ťнз шìŋδóщ àлð ŝτäѓţ ïп ğΐνêп ďίřèċţоŕу !!! !!! !!! !!! !</value>
+    <value>Ŝρℓΐŧ ŧнė ẁίňďõŵ άпδ ŝţâґţ ίń ģįνëŉ δϊгέ¢ŧøяў !!! !!! !!! !!! !</value>
   </data>
   <data name="ExportTabText" xml:space="preserve">
-    <value>Êхφőŕτ Τėхτ !!!</value>
+    <value>Ė×φōŗŧ Ţєхŧ !!!</value>
   </data>
   <data name="ExportFailure" xml:space="preserve">
-    <value>₣ǻĭľēð тǿ ежрõѓť ŧèямїήăļ ¢öлţêит !!! !!! !!! </value>
+    <value>₣ăìľεď ťθ эхроґт ţеґmίñдļ ¢ōйт℮лť !!! !!! !!! </value>
   </data>
   <data name="ExportSuccess" xml:space="preserve">
-    <value>Şΰςċэśѕƒúĺℓў ê×ρóřţэδ ţėŗмїйǻŀ çøⁿтзŋť !!! !!! !!! !!</value>
+    <value>Ŝūĉčєšśƒυłłγ ĕ×φòŗтэð тēгмïŉãℓ ĉοŉťëⁿţ !!! !!! !!! !!</value>
   </data>
   <data name="FindText" xml:space="preserve">
-    <value>₣ϊńđ !</value>
+    <value>₣ìпđ !</value>
   </data>
   <data name="PlainText" xml:space="preserve">
-    <value>Ρℓªïή Тзхť !!!</value>
+    <value>Ρĺáīň Тěхт !!!</value>
   </data>
   <data name="CloseOnExitInfoBar.Message" xml:space="preserve">
-    <value>Τêŗмïйаţĭŏņ ъęĥανіóґ çαп ьē ĉǿñƒíġΰřεđ ΐñ àďναñçεď рґσƒïľе ѕēťťīŉģş. !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Ťéямїлâŧîόň ь℮ћäνįőř čªή вĕ ċοñƒĩġџřèδ įŋ ăδνåл¢êð ряòƒιļє şėŧтіиĝś. !!! !!! !!! !!! !!! !!! !!</value>
   </data>
   <data name="InfoBarDismissButton.Content" xml:space="preserve">
-    <value>Ďôŋ'т šћόώ аĝαιη !!! !</value>
+    <value>Ďόń'ţ šħόω ãĝάϊл !!! !</value>
   </data>
   <data name="ElevationShield.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ŧђïѕ Τèřмîиαŀ ẅїňďôщ îś ґūņйîňġ âş ∆δmій !!! !!! !!! !!!</value>
+    <value>Ţђіś Тĕřмїηǻℓ шĩⁿðöŵ ïѕ ѓüñňĩñģ ãŝ Ãðmĭⁿ !!! !!! !!! !!!</value>
   </data>
   <data name="CommandPalette_MatchesAvailable" xml:space="preserve">
-    <value>Ŝŭģġеšŧіôлś ƒǿμñδ: {0} !!! !!! </value>
+    <value>Ѕũğġεšтįóпş ƒōцŉđ: {0} !!! !!! </value>
     <comment>{0} will be replaced with a number.</comment>
   </data>
   <data name="AboutDialog_CheckingForUpdatesLabel.Text" xml:space="preserve">
-    <value>Снεĉќíлĝ ƒбя úφďàŧєš... !!! !!! </value>
+    <value>Çђęċќїŋğ ƒσř ũρδàτέѕ... !!! !!! </value>
   </data>
   <data name="AboutDialog_UpdateAvailableLabel.Text" xml:space="preserve">
-    <value>Ąп ůρδäŧ℮ îş àνдίļăъľё. !!! !!! </value>
+    <value>Δŉ μρđаŧè ĭś ăνăϊłªвľė. !!! !!! </value>
   </data>
   <data name="AboutDialog_InstallUpdateButton.Content" xml:space="preserve">
-    <value>Ĩпŝťαļł пŏщ !!!</value>
+    <value>Ϊŋśţāŀŀ πбẁ !!!</value>
   </data>
   <data name="DuplicateRemainingProfilesEntry" xml:space="preserve">
-    <value>Τĥε "newTabMenu" ƒΐėŀď ĉοптдїńś мбгз τнǻņ ŏηë éńţŗý óƒ ŧγρē "remainingProfiles". Òⁿŀÿ ŧћę ƒīяѕт όňě щіĺļ ъê ĉôńšĩďēгεď. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ŧђê "newTabMenu" ƒιêŀď čσñţąϊйѕ mōѓé ťђǻñ öŋė ёňτŕý őƒ τýρê "ґёмãīліηģРяöƒïľєś". Φпĺў τђё ƒΐѓšτ όñè ώїłł ьè ĉőлѕìδēяёδ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>{Locked="newTabMenu"} {Locked="remainingProfiles"}</comment>
   </data>
   <data name="InvalidUseOfContent" xml:space="preserve">
-    <value>Ţћĕ "__content" рґöρэřţý îѕ яєŝęѓνέď ƒōŕ ίиţĕŗπáŀ ϋśě !!! !!! !!! !!! !!! </value>
+    <value>Ťђέ "__content" φŕόφέŕτγ íś řêšзřνеð ƒσř ійтėŕňåℓ ΰşè !!! !!! !!! !!! !!! </value>
     <comment>{Locked="__content"}</comment>
   </data>
   <data name="AboutToolTip" xml:space="preserve">
-    <value>Õρёŉ ã ðîäłóĝ ĉôитаϊⁿíñģ φŗøđũćτ įñƒŏґмąтιόⁿ !!! !!! !!! !!! !</value>
+    <value>Фφèη а ðїаļθĝ ćбⁿťáĭηΐñģ ρřσđůčŧ ілƒǿřmãтĩöή !!! !!! !!! !!! !</value>
   </data>
   <data name="ChooseColorToolTip" xml:space="preserve">
-    <value>Øφєń ţнε сöļŏя ριçκэŗ ŧõ ςђőǿšе τћē ĉòļòŕ оƒ ţнïš тåъ !!! !!! !!! !!! !!! </value>
+    <value>Ωφĕй ŧнė ¢óŀοŕ φĩċĸęř τσ ¢ђőōѕė ťħê сõľòŗ бƒ ŧħįѕ τªь !!! !!! !!! !!! !!! </value>
   </data>
   <data name="CommandPaletteToolTip" xml:space="preserve">
-    <value>Őφέи τнĕ ċоmmâпđ рαļетŧ℮ !!! !!! !</value>
+    <value>Øρĕл ţће сǿmмåήđ ρãĺέτŧě !!! !!! !</value>
   </data>
   <data name="DuplicateTabToolTip" xml:space="preserve">
-    <value>Öφėп а πėш тāв űśìňĝ τĥê дсťїνє ρŕõƒїļè ΐй ťђë čцŗřëŉт ðιřεçŧόґỳ !!! !!! !!! !!! !!! !!! !</value>
+    <value>Óρέл â ŉзш τàв ũśĭлġ ŧħё ąċŧîνê ρŕøƒΐĺé ĩи ţħě çúггзηт đĩřзçţøřý !!! !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="ExportTabToolTip" xml:space="preserve">
-    <value>Ε×рøгŧ ŧħë čòлťεŋтš òƒ ţĥè τę×ť вúƒƒëŗ ίⁿťô ã ŧė×ŧ ƒϊľє !!! !!! !!! !!! !!! !</value>
+    <value>Ēхφõґт τĥе сǿήŧĕиŧѕ ōƒ τђė ťε×τ ъũƒƒεř ĩήŧо α ţé×ť ƒιļê !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="FindToolTip" xml:space="preserve">
-    <value>Οφéή тħě ѕěάѓćн ðīāļθĝ !!! !!! </value>
+    <value>Φρéņ ŧнĕ şęâřςћ ðíάŀŏģ !!! !!! </value>
   </data>
   <data name="RenameTabToolTip" xml:space="preserve">
-    <value>Я℮ηдmё ŧħιѕ τâв !!! !</value>
+    <value>Ŗėлαмē тħíŝ тåв !!! !</value>
   </data>
   <data name="SettingsToolTip" xml:space="preserve">
-    <value>Õρęπ тћε ѕеťţįŋģѕ φдġé !!! !!! </value>
+    <value>Òφĕņ тĥе šэτŧīлğš ρдģė !!! !!! </value>
   </data>
   <data name="SplitTabToolTip" xml:space="preserve">
-    <value>Ωρèŋ à и℮ẁ φаŉé ϋşîлģ τĥě ăćŧіνę ρřбƒíłè ίп τĥё ćũŕŕĕŉт ďĩřеċтŏřÿ !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ωрėŋ д πėẁ φâиě űѕīⁿģ тĥэ ã¢τίνë рřŏƒίĺê îŋ ţћэ çūŗгěηт ďíř℮ĉŧõгỳ !!! !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="TabCloseAfterToolTip" xml:space="preserve">
-    <value>Ċŀóśę ąŀŀ τåъś ţô ťħè ŗīġнŧ бƒ тĥíş τäъ !!! !!! !!! !!!</value>
+    <value>Сłǿśе ǻĺľ τăвś ţô ŧн℮ яîĝħť őƒ τђїş тάв !!! !!! !!! !!!</value>
   </data>
   <data name="TabCloseOtherToolTip" xml:space="preserve">
-    <value>Čłǿśе ǻℓļ τǻьŝ ℮жčēφτ ťнιś ťǻъ !!! !!! !!!</value>
+    <value>€ļόѕĕ ªŀŀ ŧáвѕ έ×ćèρт ŧнìş ŧåв !!! !!! !!!</value>
   </data>
   <data name="TabCloseToolTip" xml:space="preserve">
-    <value>Čľõŝě ţђĩş ťåв !!! !</value>
+    <value>Ĉłоśэ ťĥìŝ ţªъ !!! !</value>
   </data>
   <data name="NewTabMenuFolderEmpty" xml:space="preserve">
-    <value>Éмрţу... !!</value>
+    <value>Ёмφţγ... !!</value>
   </data>
   <data name="ClosePaneText" xml:space="preserve">
-    <value>Čĺθŝé Рäŉз !!!</value>
+    <value>Ĉĺοŝе Ρаиę !!!</value>
   </data>
   <data name="ClosePaneToolTip" xml:space="preserve">
-    <value>Сľǿŝέ ŧĥé ªćτΐνέ рдπє ïƒ mûŀŧіρļ℮ рăň℮ş ăяę ρŗеšèñŧ !!! !!! !!! !!! !!!</value>
+    <value>Çĺόś℮ τнĕ ă¢τίν℮ рáлĕ ιƒ mϋŀţїрĺë φàńęś άŗє рřęšеńт !!! !!! !!! !!! !!!</value>
   </data>
   <data name="TabColorClearButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.FullDescription" xml:space="preserve">
-    <value>Řēšėŧ ţâъ ςółоѓ !!! !</value>
+    <value>Ґέšεт τăъ ċǿℓőґ !!! !</value>
     <comment>Text used to identify the reset button</comment>
   </data>
   <data name="MoveTabToNewWindowText" xml:space="preserve">
-    <value>Мøνê Ťãь ŧο ∏έẁ Ŵĩήðôώ !!! !!! </value>
+    <value>Мόνз Ţǻь ŧö П℮ω Щĭŋδōώ !!! !!! </value>
   </data>
   <data name="MoveTabToNewWindowToolTip" xml:space="preserve">
-    <value>Μôνëŝ тдъ τŏ а ŉёẁ ẃїńðσш  !!! !!! !</value>
+    <value>Мøνëŝ ŧªъ ŧǿ ã пεẃ шίŋđоẁ  !!! !!! !</value>
   </data>
   <data name="RunAsAdminFlyout.Text" xml:space="preserve">
-    <value>Γυń ªѕ Åďмĩŉіşτгąτоѓ !!! !!!</value>
+    <value>Ŕμŋ ąś Āďmįиíšťґąţőя !!! !!!</value>
     <comment>This text is displayed on context menu for profile entries in add new tab button.</comment>
   </data>
   <data name="TerminalPage_PaneMovedAnnouncement_ExistingTab" xml:space="preserve">
-    <value>Âċţίν℮ ράл℮ мõνēđ τо "{0}" ťăъ !!! !!! !!!</value>
+    <value>∆çťíνĕ рåⁿэ мôνеð ťб "{0}" ţав !!! !!! !!!</value>
     <comment>{Locked="{0}"}This text is read out by screen readers upon a successful pane movement. {0} is the name of the tab the pane was moved to.</comment>
   </data>
   <data name="TerminalPage_TabMovedAnnouncement_Default" xml:space="preserve">
-    <value>"{0}" ŧαь mōνеď ţθ "{1}" ŵíйðòŵ !!! !!! !!!</value>
+    <value>"{0}" ťāъ мōνęđ τŏ "{1}" шΐπδŏẅ !!! !!! !!!</value>
     <comment>{Locked="{0}"}{Locked="{1}"}This text is read out by screen readers upon a successful tab movement. {0} is the name of the tab. {1} is the name of the window the tab was moved to.</comment>
   </data>
   <data name="TerminalPage_TabMovedAnnouncement_NewWindow" xml:space="preserve">
-    <value>"{0}" ťав мŏνêď τó лěẅ ωìⁿðóŵ !!! !!! !!!</value>
+    <value>"{0}" тąь mǿνєđ ŧσ ήèώ ẅĩŋďøẃ !!! !!! !!!</value>
     <comment>{Locked="{0}"}This text is read out by screen readers upon a successful tab movement. {0} is the name of the tab.</comment>
   </data>
   <data name="TerminalPage_TabMovedAnnouncement_Direction" xml:space="preserve">
-    <value>"{0}" ťªъ mόνêđ ťо рóѕïŧĩǿⁿ "{1}" !!! !!! !!! </value>
+    <value>"{0}" ŧαв мονĕđ το φóŝїŧíŏñ "{1}" !!! !!! !!! </value>
     <comment>{Locked="{0}"}{Locked="{1}"}This text is read out by screen readers upon a successful tab movement. {0} is the name of the tab. {1} is the new tab index in the tab row.</comment>
   </data>
   <data name="TerminalPage_PaneMovedAnnouncement_ExistingWindow" xml:space="preserve">
-    <value>Δçŧϊνέ φǻлę мǿνéð то "{0}" ţåъ īń "{1}" ώïŉđθẅ !!! !!! !!! !!! !</value>
+    <value>Α¢ťϊνë рãņє môνέď τō "{0}" ţâъ ĭή "{1}" ẃĩńδθш !!! !!! !!! !!! !</value>
     <comment>{Locked="{0}"}{Locked="{1}"}This text is read out by screen readers upon a successful pane movement. {0} is the name of the tab the pane was moved to. {1} is the name of the window the pane was moved to. Replaced in 1.19 by TerminalPage_PaneMovedAnnouncement_ExistingWindow2</comment>
   </data>
   <data name="TerminalPage_PaneMovedAnnouncement_ExistingWindow2" xml:space="preserve">
-    <value>Ąćŧіνэ φαņέ мöνэδ τǿ "{0}" шїňðόш !!! !!! !!! </value>
+    <value>Λςťìνє рáиė mόνéð ťб "{0}" ŵîńđθω !!! !!! !!! </value>
     <comment>{Locked="{0}"}This text is read out by screen readers upon a successful pane movement. {0} is the name of the window the pane was moved to.</comment>
   </data>
   <data name="TerminalPage_PaneMovedAnnouncement_NewWindow" xml:space="preserve">
-    <value>Āсţїν℮ φаπе mõνзð τθ ŉëώ ώíлđōẁ !!! !!! !!!</value>
+    <value>Αĉťįνέ ρªņз mσνёđ τǿ ήёẃ ẃîпďǿω !!! !!! !!!</value>
     <comment>This text is read out by screen readers upon a successful pane movement to a new window.</comment>
   </data>
   <data name="TerminalPage_PaneMovedAnnouncement_NewTab" xml:space="preserve">
-    <value>Άĉŧіνэ райэ móνэď τő ńеẃ ţάъ !!! !!! !!</value>
+    <value>Дсţϊνё φαŋє mбν℮ð ťŏ ηеẁ ταв !!! !!! !!</value>
     <comment>This text is read out by screen readers upon a successful pane movement to a new tab within the existing window.</comment>
   </data>
   <data name="CmdAppendCommandLineDesc" xml:space="preserve">
-    <value>Ϊƒ š℮ŧ, ţħе ĉŏмmαήđ щĩľĺ ъé ăррëŉđεđ ţσ ŧђε рřõƒīł℮'ŝ đεƒάΰļт çömmªņð íлѕŧέǻð öƒ řėφłąćïиğ ΐτ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ĩƒ šęţ, ŧнĕ ¢ömmдлδ ŵîĺł ьέ åφрєйδĕđ τσ ŧђė рřŏƒїłє'ş đзƒªūľţ ¢οmмăńδ іñѕţέáđ øƒ ѓēρļąċĭлĝ їţ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="RestartConnectionText" xml:space="preserve">
-    <value>Ґëŝŧâřτ Ĉоⁿη℮ςŧіòή !!! !!</value>
+    <value>Γēѕŧâяŧ Ĉǿńńēčťїöл !!! !!</value>
   </data>
   <data name="RestartConnectionToolTip" xml:space="preserve">
-    <value>Ґêśţåгŧ ťħě ãсţīνè рãŋэ çōлиєċŧīοп !!! !!! !!! !</value>
+    <value>Γėşťáгţ ŧħ℮ ãčтĩνέ ρăйё сǿηńëςтιóņ !!! !!! !!! !</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/qps-ploca/ContextMenu.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-ploca/ContextMenu.resw
@@ -166,7 +166,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Ťĥё Ñēщ Шίⁿðоẅś Ťėгмîήāľ !!! !!! !</value>
+    <value>Τĥз Йéщ Ẃįńđôẃѕ Тéѓmĩиâļ !!! !!! !</value>
   </data>
   <data name="AppDescriptionDev" xml:space="preserve">
     <value>The Windows Terminal, but Unofficial</value>
@@ -177,22 +177,22 @@
     <comment>{Locked}</comment>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
-    <value>Шίηđóŵš Ŧĕяmїйàℓ ẁітħ ª φяęνîёщ όƒ ûφĉбмíήĝ ƒêåťµřεŝ !!! !!! !!! !!! !!! </value>
+    <value>Щΐňδόŵѕ Ŧęřмĭŉäℓ ẅîťħ à φřеνίëẃ θƒ џрсøмΐŉğ ƒĕāŧųřэś !!! !!! !!! !!! !!! </value>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve">
     <value>Open in Terminal (&amp;Dev)</value>
     <comment>{Locked} The dev build will never be seen in multiple languages</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Canary" xml:space="preserve">
-    <value>Óрëπ íи Ťēяmілǻŀ (&amp;Cäηàřÿ) !!! !!! !</value>
+    <value>Θρēņ ïη Ţéгmĭηäŀ (&amp;Çäņдѓγ) !!! !!! !</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Canary version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
-    <value>Óрзń ΐή Ŧěґмιлāℓ &amp;Pѓéνīĕω !!! !!! !</value>
+    <value>Όрèп ìņ Ţêŕmїŉåļ &amp;Рѓзνι℮ω !!! !!! !</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Ôрëη ïп &amp;Tēѓмϊŋãł !!! !!</value>
+    <value>Óрêп ìл &amp;Ťěѓmιиåĺ !!! !!</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-ploca/Resources.resw
@@ -118,148 +118,148 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InitialJsonParseErrorText" xml:space="preserve">
-    <value>Ŝ℮ťтïйģѕ ĉōυĺδ ŋøŧ ъ℮ łоªðзð ƒяòm ƒїļê. Сĥëĉκ ƒôѓ ŝÿŋŧâж έřґöгѕ, ίňćĺμðįŉĝ τřăíŀīňġ сθmмâş. !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Şετťĭиġś ςòűłď йσт ьé ŀŏдðéď ƒřǿм ƒīļē. Ĉнėćķ ƒσŗ ŝуήтª× ĕяŗбґş, ιйçľůďĩηĝ тŗāіļīňġ ćǿмmāŝ. !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
   </data>
   <data name="MissingDefaultProfileText" xml:space="preserve">
-    <value>Сöŭłď ŋόť ƒíńđ ýоùѓ ďёƒāůℓť ρґοƒįℓĕ ĩñ ŷôűг ľīśт ōƒ φяŏƒīĺεŝ - űѕīňĝ тђè ƒιŕśŧ ргσƒіļë. Çĥέĉķ ţο макē ѕμѓє ŧћε "defaultProfile" mąтĉħěš ťђέ ĠЏΪĎ оƒ öήë бƒ уøúŕ ρяöƒΐℓëś. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ĉōûłδ πбτ ƒΐпď ýǿύѓ ďēƒдûľт ρŕõƒĩłę ìń ўôùґ ļïѕτ ǿƒ φѓôƒĭłеś - µšìήğ ţнε ƒįŗѕт ρřόƒїłê. Ćĥеćķ ťõ måķє şυґę ţнé "defaultProfile" мªţčћéş ťђё ĠŪĨĎ θƒ θŋē оƒ уоùŗ ρґоƒïℓёś. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>{Locked="\"defaultProfile\""}</comment>
   </data>
   <data name="DuplicateProfileText" xml:space="preserve">
-    <value>₣оΰпđ мµŀтïφĺé рґòƒïľėѕ ẅìťћ ťђé şªме ĞŲĨĐ îи ўσúř šёťтìηġŝ ƒιŀ℮ - īġņøѓïñģ ðцρľιćăт℮ş. Мǻĸē śūřє ĕäćħ φŗóƒīłè'š ĞŨΊÐ īš ũñïqϋз. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>₣óŭиď мύŀťìрŀэ φŕσƒïĺєś ẃïτћ ŧнě ѕámĕ ĠŲІÐ įй ўоűя ѕĕţţîήĝš ƒìŀė - įģŉǿřΐⁿğ δûρľΐçâтéŝ. Мãĸё śμѓέ ĕáĉћ ρяσƒîĺė'ѕ ĢŰĮÐ īş ϋńîqџë. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
   </data>
   <data name="UnknownColorSchemeText" xml:space="preserve">
-    <value>₣ōûйδ ą φřøƒϊℓε ẁϊŧħ ãй іŉνàℓîδ "colorScheme". Ðзƒªџŀŧīηģ ţĥáт φяσƒιľê ŧσ ŧĥё ðзƒαũļт ςσļôřş. Μåķé šŭŕé ţнäť ẁħёŉ şēτтïпġ ã "colorScheme", τнз νâļúē mªŧ¢ђęš ţђε "name" óƒ ǻ ċσℓôŗ śςħėmэ іŋ ŧħě "schemes" ℓїšť. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>₣ŏúņđ ā ρřόƒįľĕ щĭťћ ǻή ϊпνåŀίď "colorScheme". Ďēƒāúłтіиğ ţħąţ ряόƒίŀе ţŏ тĥέ ðеƒãµľţ çбĺбŗś. Мāκέ śûѓè ťћаτ ŵђéň ŝєŧťίńĝ д "colorScheme", τħε νåĺμě мäτςĥέş τнέ "name" όƒ а čòľбя ѕćн℮mē īń тћέ "schemes" ļίŝт. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>{Locked="\"colorScheme\"","\"name\"","\"schemes\""}</comment>
   </data>
   <data name="NoProfilesText" xml:space="preserve">
-    <value>Ńθ ρгσƒìľёš ẁëŗέ ƒθџиð íⁿ ỳθця ŝéтŧįйġŝ. !!! !!! !!! !!!</value>
+    <value>Ňǿ ρяóƒíℓěş щ℮ŕέ ƒòμйδ ϊη ỳοūґ ś℮ŧтĭπģѕ. !!! !!! !!! !!!</value>
   </data>
   <data name="AllProfilesHiddenText" xml:space="preserve">
-    <value>Àŀł φŕŏƒíľеş шёѓĕ ħīđδєņ íⁿ уоŭя ѕèтťіŋģŝ. Ўøц мųšт ђáνė ǻτ łεàšť бηз пόл-ћíďðęή ρѓоƒĩĺě. !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Аℓł ρяοƒįłέš ωèяê ђΐđðěŉ îη ўőϋř śěŧτϊиģş. Ϋŏυ müѕŧ ħäνė άţ ļεǻѕτ οñє пóй-ћίďðēŉ φŗóƒįŀē. !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
   </data>
   <data name="ReloadJsonParseErrorText" xml:space="preserve">
-    <value>Ѕēтτïйġş čόµľδ ⁿοт ьē ґεłöāď℮ď ƒгом ƒīŀέ. Ĉђэск ƒõг šŷήτă× èѓřóґş, іπсŀцδīņġ тřąіļΐńģ ċοmmаŝ. !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Ѕєŧτĩņğš ¢ŏûłď ποţ ьė řëĺбάδзď ƒŕŏм ƒίľе. Çĥэςκ ƒõг şÿπţаж ěгяōŗš, îņ¢ŀύðīⁿğ ťŕăïŀĩπĝ čǿmмãş. !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
   </data>
   <data name="UsingDefaultSettingsText" xml:space="preserve">
-    <value>Ţзmрőгáѓïłÿ ϋšïпĝ τђě Ŵíиδǿώŝ Ŧεгmïñдĺ đёƒàцℓŧ ŝéтτįиğѕ. !!! !!! !!! !!! !!! !</value>
+    <value>Ťемрőŗāřĩľŷ űśϊⁿģ ťђё Щìπδоωş Ţεѓмîήäĺ δêƒаμłт şèţτïńġś. !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="InitialJsonParseErrorTitle" xml:space="preserve">
-    <value>₣αίℓёď ţó ļŏãď şёτŧîŉģѕ !!! !!! </value>
+    <value>₣äĩľєď τσ ŀőåð ŝέťţĩⁿģŝ !!! !!! </value>
   </data>
   <data name="SettingsValidateErrorTitle" xml:space="preserve">
-    <value>Επčбųňтзřēδ ëŕřõґѕ ŵħϊŀе ļοăđіηğ ŭşёŗ ѕêťţιпģş !!! !!! !!! !!! !</value>
+    <value>Εŋĉőųņŧзяëď зяѓōяś ŵħΐļê ŀθαðĩήġ ùŝéѓ śзťŧĭпģŝ !!! !!! !!! !!! !</value>
   </data>
   <data name="KeyboardServiceDisabledDialog.PrimaryButtonText" xml:space="preserve">
-    <value>ÖĶ </value>
+    <value>ÓΚ </value>
   </data>
   <data name="KeyboardServiceDisabledDialog.Title" xml:space="preserve">
-    <value>Ŵǻŕлιηĝ: !!</value>
+    <value>Ŵаґήĩήģ: !!</value>
   </data>
   <data name="KeyboardServiceWarningText" xml:space="preserve">
-    <value>Тĥέ "{0}" íśŋ'ţ ŕŭñŋĩηġ ǿñ ýōύŕ мдčħĩⁿě. Ťђįş çдⁿ ρřëνεⁿţ ţħę Ţêґмïňªł ƒѓőм яĕс℮īνïŋġ кĕŷвőαŕδ įŋρυť. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ŧħє "{0}" ĭşп'ţ řμллĭиġ оŉ ўόùг мàςĥįńë. Ŧħїś ¢áⁿ φřэνєńτ тнэ Тэґмïñăĺ ƒŕöm ŗеς℮íνίиĝ ķēỳвŏαŗδ ĭⁿрΰţ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>{0} will be replaced with the OS-localized name of the TabletInputService</comment>
   </data>
   <data name="Ok" xml:space="preserve">
-    <value>ÔĶ </value>
+    <value>ФĶ </value>
   </data>
   <data name="ReloadJsonParseErrorTitle" xml:space="preserve">
-    <value>₣αΐĺěđ ťŏ ґεℓǿâδ šĕτťїпģŝ !!! !!! !</value>
+    <value>₣áĭļèđ ťσ ѓéłøǻð şèŧŧíпĝŝ !!! !!! !</value>
   </data>
   <data name="FeedbackUriValue" xml:space="preserve">
     <value>https://go.microsoft.com/fwlink/?linkid=2125419</value>
     <comment>{Locked}This is a FWLink, so it will be localized with the fwlink tool</comment>
   </data>
   <data name="AboutMenuItem" xml:space="preserve">
-    <value>Αъθџţ !</value>
+    <value>∆вòΰŧ !</value>
   </data>
   <data name="FeedbackMenuItem" xml:space="preserve">
-    <value>₣еèðвáċĸ !!</value>
+    <value>₣ęęðъâçќ !!</value>
   </data>
   <data name="SettingsMenuItem" xml:space="preserve">
-    <value>Şзţťΐήģş !!</value>
+    <value>Śêŧťіňğŝ !!</value>
   </data>
   <data name="Cancel" xml:space="preserve">
-    <value>Ĉąñсэŀ !</value>
+    <value>Ĉάπςеŀ !</value>
   </data>
   <data name="CloseAll" xml:space="preserve">
-    <value>Ċłøş℮ äļļ !!!</value>
+    <value>Ċľθŝє αŀļ !!!</value>
   </data>
   <data name="Quit" xml:space="preserve">
-    <value>Qûïŧ !</value>
+    <value>Qùíт !</value>
   </data>
   <data name="CloseWindowWarningTitle" xml:space="preserve">
-    <value>Ďθ ỳσŭ ẃąńŧ ťō čĺбšэ άļĺ тáвѕ? !!! !!! !!!</value>
+    <value>Đǿ ÿõű ŵãŋт тŏ ¢ľòŝê ăŀľ ŧãвŝ? !!! !!! !!!</value>
   </data>
   <data name="MultiplePanes" xml:space="preserve">
-    <value>Μüℓτĩφĺĕ рαŉėş !!! !</value>
+    <value>Мµļтíрłĕ φдпėŝ !!! !</value>
   </data>
   <data name="TabCloseSubMenu" xml:space="preserve">
-    <value>Çℓòѕĕ... !!</value>
+    <value>Ćļôŝέ... !!</value>
   </data>
   <data name="TabCloseAfter" xml:space="preserve">
-    <value>Ćľöśè Ťåвş ŧб ţħė Яîġнŧ !!! !!! </value>
+    <value>Ċĺοşέ Ţаъş ťό ŧђé Яΐğђт !!! !!! </value>
   </data>
   <data name="TabCloseOther" xml:space="preserve">
-    <value>Çļōşэ Φтĥέŗ Тавŝ !!! !</value>
+    <value>Ćĺόѕ℮ Όтђèř Ŧâьś !!! !</value>
   </data>
   <data name="TabClose" xml:space="preserve">
-    <value>Čℓσşэ Ťāв !!!</value>
+    <value>Сĺôšę Ťăв !!!</value>
   </data>
   <data name="PaneClose" xml:space="preserve">
-    <value>Ĉłοŝе Рåŋę !!!</value>
+    <value>Ćŀöśё Раņé !!!</value>
   </data>
   <data name="SplitTabText" xml:space="preserve">
-    <value>Ŝρľιţ Ταв !!!</value>
+    <value>Šрľīτ Τàв !!!</value>
   </data>
   <data name="SplitPaneText" xml:space="preserve">
-    <value>Şφļїτ Ρăňе !!!</value>
+    <value>Šрŀіт Ρªňë !!!</value>
   </data>
   <data name="SearchWebText" xml:space="preserve">
-    <value>Ẃėъ Ѕёâŕςђ !!!</value>
+    <value>Ẅёв Şĕаŕčĥ !!!</value>
   </data>
   <data name="TabColorChoose" xml:space="preserve">
-    <value>Čбŀòř... !!</value>
+    <value>Ċõŀόř... !!</value>
   </data>
   <data name="TabColorCustomButton.Content" xml:space="preserve">
-    <value>Čΰšŧōм... !!!</value>
+    <value>Ċµѕťøм... !!!</value>
   </data>
   <data name="TabColorClearButton.Content" xml:space="preserve">
-    <value>Ѓěŝ℮ţ !</value>
+    <value>Яěšěŧ !</value>
   </data>
   <data name="RenameTabText" xml:space="preserve">
-    <value>Γèпäмĕ Ţǻв !!!</value>
+    <value>Γεñамē Ťãв !!!</value>
   </data>
   <data name="DuplicateTabText" xml:space="preserve">
-    <value>Đùφłιćåτê Ţαъ !!! </value>
+    <value>Ďϋφľіčάтέ Τàв !!! </value>
   </data>
   <data name="InvalidBackgroundImage" xml:space="preserve">
-    <value>₣θůⁿδ д φřбƒîℓе ωîτн äⁿ ΐŋνåŀįð "backgroundImage". Đêƒаūĺтĩйĝ тĥąť рґòƒїĺè ŧó ћãνз ñǿ ьāскģŕòΰйδ îmãĝé. Мäкз śûřє τħàť ŵнεη śèŧτίиğ ά "backgroundImage", ťђè νάłúе ĩš д νªℓїđ ƒιĺĕ рǻтĥ ŧö дñ іmāġз. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>₣σúŋδ ą φѓοƒĩļé ẃϊţħ äй ïηνàĺìď "backgroundImage". Đēƒãųŀŧϊпğ ťнªт φѓőƒĭļè το нªνе πō ьąçќġгθúпδ ιмãġė. Маĸē śμѓē ŧћäţ ẁђēή šêťτϊлġ å "backgroundImage", ţĥě νаłųё ïŝ ά νάľîď ƒĩŀê φąťħ ţŏ άń ΐмąġė. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>{Locked="\"backgroundImage\""}</comment>
   </data>
   <data name="InvalidIcon" xml:space="preserve">
-    <value>₣σúлð ª φŗōƒíŀе щîţђ áñ ìлνăℓΐď "icon". Ďёƒацŀťìиğ τнåŧ φŕöƒїľ℮ τо ђаνě ňό ΐ¢ôл. Мăĸé şûѓė τнаť шћėñ śётţĭńġ дп "icon", тнè νãĺúε ïѕ ª νªłĭď ƒîļз ρåŧĥ τσ âⁿ íмªģė. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>₣ǿũиđ à рřöƒϊℓз ŵĩţн аñ įņνàŀїδ "icon". Ðěƒаúľτīŋğ ţħаτ ρřόƒìŀё тб ђâνє пǿ íčой. Мàĸë ŝùřë ŧĥаţ ωĥĕл ŝеτŧīлĝ ăй "icon", τħε νāłϋë ïŝ ă νàľīđ ƒïŀè рªтн ţő äи ïмäģё. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>{Locked="\"icon\""} The word "icon" in quotes is locked, the word icon OUTSIDE of quotes should be localized.</comment>
   </data>
   <data name="AtLeastOneKeybindingWarning" xml:space="preserve">
-    <value>Ẃăѓηіпğѕ ẃëřė ƒóџπδ ώħīĺ℮ ρдřѕιŋģ γοϋŕ ĸēÿъϊпδΐлġŝ: !!! !!! !!! !!! !!!</value>
+    <value>Щαѓńΐňģš ώĕřе ƒбŭπδ ώħīļë рăяşìⁿġ ўσυŕ κёỳвĩиðīήġş: !!! !!! !!! !!! !!!</value>
   </data>
   <data name="TooManyKeysForChord" xml:space="preserve">
-    <value>• ₣όŭηď α ĸĕўьĩŋðίńĝ ẁĭτħ τõö мαņγ šţяĭŋĝŝ ƒõř ţћê "keys" àŗŕąý. Ťħēŗë ŝнøůŀď ōήłγ вė öлè şτґĩπġ νάłúė îņ тнě "keys" ãггâу. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>• ₣бūήð â ķёуьĩńðīⁿģ шĩŧђ τõб mªńÿ ѕťгίńġŝ ƒóř ţћ℮ "keys" åѓгàÿ. Тħėгē ѕĥōμĺđ бñľў вĕ ŏи℮ ѕтřïлģ νăŀůé ĭŉ ţĥė "keys" άřřàγ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>{Locked="\"keys\"","•"} This glyph is a bullet, used in a bulleted list.</comment>
   </data>
   <data name="FailedToParseSubCommands" xml:space="preserve">
-    <value>• ₣ąίℓєδ ŧó рάřšε ăŀľ šύьсόмmâⁿδş öƒ ñέşтéδ çómмαйđ. !!! !!! !!! !!! !!! </value>
+    <value>• ₣ąìļ℮đ ţŏ ρǻŕşε âłľ śцъċőммåиðѕ ōƒ л℮śť℮ď сömmąπđ. !!! !!! !!! !!! !!! </value>
   </data>
   <data name="MissingRequiredParameter" xml:space="preserve">
-    <value>• ₣ōůπð å ќэŷвĩήðіпğ τĥãţ ŵαŝ mїşşīπġ á ґеqµіřёδ рáяàмěţěг νάłΰέ. Ŧђιś ķэγьіήđϊŉġ ẃîℓľ ь℮ ĩĝņбŗёď. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>• ₣оůñð ā κėуьίπðîηĝ тħаŧ ẃáś мįѕśϊňģ д ѓ℮qûιŗзð рαřǻмęţεř νăľυë. Тнίѕ кεγьĩņđíņģ щìľļ вє įĝлóяеđ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>{Locked="•"} This glyph is a bullet, used in a bulleted list.</comment>
   </data>
   <data name="UnknownTheme" xml:space="preserve">
-    <value>• Ťћė ѕрзčîƒī℮đ "τħêmэ" шаѕ ηστ ƒøùŉď īп τђę łíšŧ ǿƒ тħęm℮ś. Τ℮мφǿґåříłў ƒâļŀíπģ ьą¢ĸ ţõ ťђê đèƒàűℓţ νáļúě. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>• Тћë ѕрèçїƒĭёď "τћ℮мé" ώαѕ ήøţ ƒόûπđ ΐл ťћê ℓíŝť σƒ ťнεmέѕ. Ŧěмрǿŕдѓΐļγ ƒдℓłίńģ вà¢ĸ τő ŧнě đέƒαùŀŧ νǻľΰê. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>{Locked="•"} This glyph is a bullet, used in a bulleted list.</comment>
   </data>
   <data name="LegacyGlobalsProperty" xml:space="preserve">
-    <value>Τħě "globals" ρřōрëѓťỳ їѕ δëφяєćатěδ - ŷόΰŗ śëτŧілğѕ mįģĥτ ⁿеεď üρďάτїйğ.  !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Τђз "globals" φѓóрεѓţγ ιŝ δęρѓêсâŧėď - ýбųѓ ŝέтŧїпĝš мìġħţ ηзέď црđªтïйġ.  !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>{Locked="\"globals\""} </comment>
   </data>
   <data name="LegacyGlobalsPropertyHrefUrl" xml:space="preserve">
@@ -267,635 +267,635 @@
     <comment>{Locked}This is a FWLink, so it will be localized with the fwlink tool</comment>
   </data>
   <data name="LegacyGlobalsPropertyHrefLabel" xml:space="preserve">
-    <value>₣öѓ møŗε ïⁿƒò, š℮з τнìš щέь ρąğ℮. !!! !!! !!! </value>
+    <value>₣οř мòŕе îήƒθ, şéэ ţħìѕ ŵєь рąġé. !!! !!! !!! </value>
   </data>
   <data name="FailedToParseCommandJson" xml:space="preserve">
-    <value>₣ªîļėď ťο éжрǻńð ã ćǿмmąŉď ώїţћ "iterateOn" šēŧ. Τнιŝ çόmmàŋď ẁïłĺ ъе īģпöгèð. !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>₣ăіľέđ ţö ехρåņď ǻ çǿммãηδ ẃìţĥ "iterateOn" şετ. Ťĥīš ćōmмåиď щΐℓĺ ве ĭģňóѓëđ. !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>{Locked="\"iterateOn\""} </comment>
   </data>
   <data name="InvalidColorSchemeInCmd" xml:space="preserve">
-    <value>₣óüņď á ċσmмãπð щīťĥ αŉ ίñνāŀĩð "colorScheme". Ťнìš ćбmmāйď шïℓľ ъё ïğņőŗэď. Μåќę śύѓе ťĥαţ щĥеπ šётťїňġ а "colorScheme", ťħë νàŀΰê măтςђèŝ τнё "name" óƒ ª çôłοŕ ѕсĥемĕ іи ťђε "schemes" ľįѕŧ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>₣óŭйď ã сóмmаńδ ẁϊţђ дή îⁿναļīð "colorScheme". Тћîŝ ĉǿмmαήδ ωïĺĺ вε íğлŏгëð. Мâķэ ѕϋŗê τĥāţ ẅћэй šěτťîņġ å "colorScheme", ţĥé νаļΰé мªŧçћєѕ ţħє "name" őƒ ă ¢ôℓôř ŝςђзмê įň тнε "schemes" ľïşŧ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>{Locked="\"colorScheme\"","\"name\"","\"schemes\""}</comment>
   </data>
   <data name="InvalidSplitSize" xml:space="preserve">
-    <value>₣όµйδ å "splitPane" ςŏmмáņđ ẃìţн ąи їŋνάℓįð "size". Тђĩś çõmмäήð щіłℓ вэ ΐğņøŗêδ. Μǻκє ѕυřé ŧћě śîźě ΐŝ ъěτẅз℮п 0 ªńð 1, ёхςłυѕīνě. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>₣ŏΰπđ ā "splitPane" ¢ǿммäήđ ŵìтћ ăη îŋνąłιđ "size". Ţђíѕ ċǿммªпđ ŵīĺℓ ьė ìĝñōгёđ. Мăќέ šύгз τĥě śιźê įѕ ъèτшέëπ 0 äⁿð 1, εхčļûŝίνз. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>{Locked="\"splitPane\"","\"size\""}</comment>
   </data>
   <data name="FailedToParseStartupActions" xml:space="preserve">
-    <value>₣āΐłęð тò φάŗšě "startupActions". !!! !!! !!! </value>
+    <value>₣âìľęď ťǿ рαяŝé "startupActions". !!! !!! !!! </value>
     <comment>{Locked="\"startupActions\""}</comment>
   </data>
   <data name="InvalidProfileEnvironmentVariables" xml:space="preserve">
-    <value>₣öŭňđ mûℓţϊφłē έņνіяоимĕŉт νáгΐάвļęś ωìŧħ тĥĕ šąmё ñдmě ĩи ďīƒƒěŗęήт ĉáŝéś (ľοщèя/ùррēя) - õπℓý бŉэ νąłϋз ŵïłℓ вє ùѕêđ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>₣öųñđ múℓтĭφļę èⁿνіŕθлмėňţ ναřίдъľêѕ ẅïτħ ťħз śăмė ήámе їή đїƒƒέřέηт čãşзś (ĺóщěг/ůрρеŕ) - óлℓŷ οиę νǻľµě ẁιľľ вё ųşέď. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
   </data>
   <data name="CmdCommandArgDesc" xml:space="preserve">
-    <value>Ąπ öρŧîòлäŀ ¢ǿмmãπđ, ŵĭтћ äřġůmĕηтš, το вε šράщπєď ĭπ ţђē ņέщ τãъ õř рàйё !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Åŉ ǿртíоñαŀ ċοmмäηď, ẁίŧћ ãŗĝūměŉтş, ţô вέ šρªẃйèđ įņ ťђė πεẁ ŧав ŏŗ рªņε !!! !!! !!! !!! !!! !!! !!! </value>
   </data>
   <data name="CmdFocusTabDesc" xml:space="preserve">
-    <value>Мôνę ƒŏсűş тö аńбτћęŗ тàъ !!! !!! !</value>
+    <value>Μòνê ƒöčµѕ ŧθ ãņøτнёř τåъ !!! !!! !</value>
   </data>
   <data name="CmdFocusTabNextArgDesc" xml:space="preserve">
-    <value>Μονэ ƒοčũš τό ťĥе ⁿзжť тäв !!! !!! !</value>
+    <value>Мõνè ƒòćüŝ τθ ťћé пĕ×т ťαъ !!! !!! !</value>
   </data>
   <data name="CmdFTDesc" xml:space="preserve">
-    <value>∆ņ ãłíäŝ ƒθг ţĥэ "focus-tab" ѕűвĉòмmáηď. !!! !!! !!! !!!</value>
+    <value>Дŋ äℓĭάş ƒоř τћę "focus-tab" šųъčǿммáñđ. !!! !!! !!! !!!</value>
     <comment>{Locked="\"focus-tab\""}</comment>
   </data>
   <data name="CmdFocusTabPrevArgDesc" xml:space="preserve">
-    <value>Мőνē ƒоċμś τō ŧђę φŕēνϊóцş ťàъ !!! !!! !!!</value>
+    <value>Μöνє ƒоćüŝ ŧó ţĥë рřěνĩομѕ тãь !!! !!! !!!</value>
   </data>
   <data name="CmdFocusTabTargetArgDesc" xml:space="preserve">
-    <value>Моνë ƒöçûŝ τĥε ţαъ äт ţħε ĝίνëŋ ίņďěх !!! !!! !!! !!</value>
+    <value>Мονé ƒоćűŝ ťħέ τåь àτ ţĥé ĝįνèň іňďėж !!! !!! !!! !!</value>
   </data>
   <data name="CmdMovePaneTabArgDesc" xml:space="preserve">
-    <value>Мöνē ƒòçυšęð φăņé ŧô τĥё тāъ āτ ţĥë ğįνёņ ΐŉδêж !!! !!! !!! !!! !!</value>
+    <value>Μόνě ƒôçџś℮ď φąπέ τŏ ţħĕ ŧäв ǻτ тћė ģΐνеņ ĭñðěх !!! !!! !!! !!! !!</value>
   </data>
   <data name="CmdMovePaneDesc" xml:space="preserve">
-    <value>Μόνê ƒǿćμśèð ρåиė τō åпбŧћзř ŧåъ !!! !!! !!! </value>
+    <value>Μǿνê ƒõćυѕěð φâή℮ ťθ ǻлοτĥёŗ τąв !!! !!! !!! </value>
   </data>
   <data name="CmdMPDesc" xml:space="preserve">
-    <value>Ąń ąłîäŝ ƒöѓ тħé "move-pane" śцв¢òмmăπδ. !!! !!! !!! !!!</value>
+    <value>Ăⁿ āℓíąš ƒбŕ тнĕ "move-pane" šúъćбммàⁿδ. !!! !!! !!! !!!</value>
     <comment>{Locked="\"move-pane\""}</comment>
   </data>
   <data name="CmdSplitPaneSizeArgDesc" xml:space="preserve">
-    <value>Şρέçĩƒỳ ťћё šїźę âš ª φέŕçέлťαġě θƒ ŧħē φǻŕėńť φªηĕ. Vàŀíď νǻłµ℮ś ªřе ъēťώёэŋ (0,1), ē×ĉłϋşĩνė. !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ѕрёċϊƒÿ тђĕ ѕîžĕ αѕ ǻ ρēŕċêйτдģе őƒ ŧħě φǻґзйť φàņē. Vдℓίδ νǻŀùзş āŗε ьεтщ℮ёň (0,1), е×ςĺúŝινе. !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="CmdNewTabDesc" xml:space="preserve">
-    <value>Сŕěăтě ă йεŵ тàъ !!! !</value>
+    <value>Çґέăťė ã πėш τáв !!! !</value>
   </data>
   <data name="CmdNTDesc" xml:space="preserve">
-    <value>Άп âłìàś ƒбř ţћè "new-tab" šûьĉòmмąйδ. !!! !!! !!! !!</value>
+    <value>Ăи άℓîªŝ ƒōř τħë "new-tab" śμвċόmмãŋδ. !!! !!! !!! !!</value>
     <comment>{Locked="\"new-tab\""}</comment>
   </data>
   <data name="CmdFocusPaneDesc" xml:space="preserve">
-    <value>Мόνę ƒöčυś τø ăиŏтнëґ φάňę !!! !!! !</value>
+    <value>Μǿνé ƒосųŝ тô дπøţћєг рáņė !!! !!! !</value>
   </data>
   <data name="CmdFPDesc" xml:space="preserve">
-    <value>Дŋ ąľιàš ƒôř ŧħё "focus-pane" śûъĉбmмаŉđ. !!! !!! !!! !!!</value>
+    <value>Áй áℓįãš ƒòŗ тђĕ "focus-pane" şυъĉöммàńđ. !!! !!! !!! !!!</value>
     <comment>{Locked="\"focus-pane\""}</comment>
   </data>
   <data name="CmdFocusPaneTargetArgDesc" xml:space="preserve">
-    <value>₣ôςűş ţħέ φâиє дт ťћέ ġίνéи ιņδĕх !!! !!! !!! </value>
+    <value>₣ό¢űѕ тнê φàπĕ аţ тђè ğĭνėй ïŋðεж !!! !!! !!! </value>
   </data>
   <data name="CmdProfileArgDesc" xml:space="preserve">
-    <value>Öφěй щíţħ ťћε ğīνёⁿ φґõƒіĺė. ∆ςćëρťş ēįţнèя тĥě ņάмé бř ĜÛΊĎ ǿƒ ª рŕόƒϊłê !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Θφêп шĩτћ ťнě ģìνēή ρѓøƒìĺę. Âćĉеφťś ёĩτĥėŗ τђė йάмє øя ĠŮΪÐ õƒ а φŕóƒίℓè !!! !!! !!! !!! !!! !!! !!! </value>
   </data>
   <data name="CmdSplitPaneDesc" xml:space="preserve">
-    <value>Ćřεàτę ª пєẃ ŝρℓîŧ ρãйę !!! !!! </value>
+    <value>Ĉґéáŧе д ήэẅ ŝφĺĭτ рãňё !!! !!! </value>
   </data>
   <data name="CmdSPDesc" xml:space="preserve">
-    <value>∆ň àŀîåš ƒоŕ тђе "split-pane" śµвсômmāñδ. !!! !!! !!! !!!</value>
+    <value>Āл ªļïâś ƒбг ŧћê "split-pane" ŝύвćőммäňδ. !!! !!! !!! !!!</value>
     <comment>{Locked="\"split-pane\""}</comment>
   </data>
   <data name="CmdSplitPaneHorizontalArgDesc" xml:space="preserve">
-    <value>Ċгéåτє ţнė ñĕŵ ρáπė ąš á ħôřїżöñтάľ šрℓϊт (τћíñĸ [-]) !!! !!! !!! !!! !!! </value>
+    <value>Ċŕéάťё ťћè ⁿеẁ рâлè åś ǻ ħôŕîžőņτąŀ śρļίτ (ŧнїπĸ [-]) !!! !!! !!! !!! !!! </value>
   </data>
   <data name="CmdSplitPaneVerticalArgDesc" xml:space="preserve">
-    <value>Ĉѓέāтė ţнê πёẃ ρäņё āš ā νеřťîĉâľ ŝρŀϊť (τћϊņк [|]) !!! !!! !!! !!! !!!</value>
+    <value>Ċяěªтĕ ŧнέ ⁿèω ρаηе ªš ā νēѓτîčäŀ ѕрĺįť (тĥїπќ [|]) !!! !!! !!! !!! !!!</value>
   </data>
   <data name="CmdSplitPaneDuplicateArgDesc" xml:space="preserve">
-    <value>Ĉřēâťє ŧћê πέŵ φàńε ъў đûρĺϊςάтίńğ ţћε рŕóƒïℓē ôƒ ŧħ℮ ƒôċŭśεδ φâήë !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ĉřεâте тħè пέẁ φаńè ъỳ ďцрłíçăţιηğ ťħе φгоƒíľз оƒ τĥě ƒőċūşëð рāиē !!! !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="CmdStartingDirArgDesc" xml:space="preserve">
-    <value>Ŏφēή ĭл τĥé ġΐνэñ đīřĕĉťǿґу îņşţěαð оƒ ŧђе φřōƒΐļė'ŝ ŝ℮ţ "startingDirectory" !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Óрεŋ ιŋ τћē ĝіνèή ðіґėсťσŗý ΐńѕţêªđ ôƒ тħ℮ рřоƒĭľė'ŝ şĕŧ "startingDirectory" !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>{Locked="\"startingDirectory\""}</comment>
   </data>
   <data name="CmdTitleArgDesc" xml:space="preserve">
-    <value>Όρεⁿ тћ℮ ťėґmíŉªĺ ώĩтћ τнé φѓŏνįďèď ŧιťŀ℮ ϊŋşťéāď őƒ тђε рřǿƒĩľë'ş şêţ "title" !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Òрèи ŧћ℮ тεгміņдľ шįтђ τћз рŕσνϊðэđ ţϊťľё їņšτèāď οƒ ŧħз рѓοƒïℓε'š śēт "title" !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>{Locked="\"title\""}</comment>
   </data>
   <data name="CmdTabColorArgDesc" xml:space="preserve">
-    <value>Оρêή ţђë ŧαв ωĩŧћ τћê ŝρēčίƒιęð ćôļóŗ, īη #ггģģвв ƒǿřmåτ !!! !!! !!! !!! !!! !</value>
+    <value>Фрєŋ τћę ťāь ẃĭŧĥ ŧĥē ѕρεçíƒĩĕď ċŏĺőŗ, ίŉ #řґģģьь ƒöřмàŧ !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="CmdSuppressApplicationTitleDesc" xml:space="preserve">
-    <value>Ορĕņ тĥë таь ωįŧђ тăвŤιтłё ον℮ґŕìδĭπġ ďэƒάùľť ţΐŧłę ăⁿď śüφрřĕşšΐŉğ тíтļè ĉђąиġë měşšąģĕś ƒяőm ţћ℮ ąρφĺΐсаτίöй !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Όрзи тћê тäъ ŵîтн ŧãвŦìтŀέ øνėřѓĩδіиĝ δęƒåυĺŧ тīτłê ǻйď ѕűррŕ℮ѕśìήĝ τĭťℓé ċћаπġё mεśšàğзš ƒŗøм тћê ªрρĺĩčªτĭóņ !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>{Locked="\"tabTitle\""}</comment>
   </data>
   <data name="CmdInheritEnvDesc" xml:space="preserve">
-    <value>Ϊπħěřïт тĥέ ťэґmιŋąℓ'ŝ оẅή ëŉνīŕőпmєŋτ νâřϊǻьľėś ẁħĕη ċѓĕаťіпğ ţħë ήэщ ťäь όг ρâлë, гáтнэя τћαή ςгęâŧìñġ â ƒřеŝћ єйνιŕőñmĕπŧ ъļõĉķ. Ŧнĩś δёƒàùŀτš ţо ŝéт ωћ℮π ª "command" ιŝ ράşśеđ.  !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>İηĥегïт ţĥě ťεřmĭŉǻł'ŝ õώп εņνĩŕόňмěñť νāřĭáьŀĕś ώнēл ĉгėǻтΐŉġ ţħз πęш ţáь ŏŕ ρäη℮, ŗãŧħёř ťĥªή ¢řēäţіηĝ ǻ ƒŗėśћ èήνιгőŋм℮иť ьļο¢к. Тħїš ďęƒαüłŧŝ τõ ѕёţ ẅħēň ą "command" îş ρãśŝéđ.  !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>{Locked="\"command\""}</comment>
   </data>
   <data name="CmdColorSchemeArgDesc" xml:space="preserve">
-    <value>Ωрêй тħĕ ťάв ώїτħ τĥë şφěςíƒįеď сòŀõŗ ѕĉнзmе, їŋšτέåđ őƒ ŧħέ ρѓбƒîłε'ŝ ѕęŧ "colorScheme" !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Øρéη ŧĥē ŧаь щïţђ ţнё ѕрě¢ίƒĩеð ¢θℓôя şĉнем℮, īπѕτêåδ òƒ τĥё φřőƒĭľе'ŝ ѕ℮ť "colorScheme" !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>{Locked="\"colorScheme\""}</comment>
   </data>
   <data name="CmdVersionDesc" xml:space="preserve">
-    <value>Ďĩѕρłăγ ťне äφρļϊćąτìôñ νęŕѕïǿⁿ !!! !!! !!!</value>
+    <value>Ďìśрℓàÿ тћē åφφłîςдťίøп νēřšįóń !!! !!! !!!</value>
   </data>
   <data name="CmdMaximizedDesc" xml:space="preserve">
-    <value>Ŀâύйĉħ ťнє ẅїñðõẃ мª×ĩмĭżэď !!! !!! !!</value>
+    <value>Ļáūńçн тћё ẅïиďоŵ мåжімĩźęð !!! !!! !!</value>
   </data>
   <data name="CmdFullscreenDesc" xml:space="preserve">
-    <value>Ŀãűисћ тнё ωįлδøẃ ĩŉ ƒůłℓś¢гεέи mбðє !!! !!! !!! !</value>
+    <value>£âµńĉн тнė щίπđощ їŉ ƒûℓŀşċŕėēη мøđè !!! !!! !!! !</value>
   </data>
   <data name="CmdMoveFocusDesc" xml:space="preserve">
-    <value>Μöνě ƒǿćųś ţø ťђе ǻðјå¢℮йт φąήë іπ ťћė ѕρėćїƒіεď đϊřеċтîóñ !!! !!! !!! !!! !!! !!</value>
+    <value>Мονë ƒόçцŝ τô ţнε дďјαçéŉţ φáπέ ίņ τнë ѕрéςĩƒїĕδ δіŗéćťïőп !!! !!! !!! !!! !!! !!</value>
   </data>
   <data name="CmdMFDesc" xml:space="preserve">
-    <value>Ǻπ ªℓïǻŝ ƒόŕ ţĥз "move-focus" ŝűъčοмmάπδ. !!! !!! !!! !!!</value>
+    <value>Åп âℓιāś ƒóř ŧђз "move-focus" šůъçόмmàпð. !!! !!! !!! !!!</value>
     <comment>{Locked="\"move-focus\""}</comment>
   </data>
   <data name="CmdMoveFocusDirectionArgDesc" xml:space="preserve">
-    <value>Тнė ďίѓèċţϊōň ťö мøνè ƒθсųş ίή !!! !!! !!!</value>
+    <value>Тнê đιřèсţïöп ţό мøνĕ ƒŏčúś ìή !!! !!! !!!</value>
   </data>
   <data name="CmdSwapPaneDesc" xml:space="preserve">
-    <value>Šẅаφ τћë ƒŏçŭšėđ ρąήè ώĭŧħ ŧĥē аďјā¢ēйτ рǻńë ĩп ţħε ѕφĕĉĩƒīēď đîŕэċŧїòň !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Šшдφ ťĥė ƒоčùšěď рдйê ŵīťђ ŧнё ãđĵă¢èņτ φåиé íŋ ťĥē šρêςīƒĭзδ đìѓз¢ţįőñ !!! !!! !!! !!! !!! !!! !!!</value>
   </data>
   <data name="CmdSwapPaneDirectionArgDesc" xml:space="preserve">
-    <value>Ŧħε ďΐřéċтїŏй τö mθνĕ τћέ ƒőćυѕзđ рàиĕ ĩń !!! !!! !!! !!!</value>
+    <value>Тнě διяèċτîõη ţό mōνе ťћë ƒòčϋš℮δ рαπ℮ īп !!! !!! !!! !!!</value>
   </data>
   <data name="CmdFocusDesc" xml:space="preserve">
-    <value>Ŀаµп¢ђ ťћė шϊⁿδǿẃ íй ƒôćûş мöđē !!! !!! !!!</value>
+    <value>Ľãūлçĥ тħέ щíиδσώ ìй ƒô¢ũš мôďз !!! !!! !!!</value>
   </data>
   <data name="CmdSavedLayoutArgDesc" xml:space="preserve">
-    <value>Ŧħιš рáгàмĕтêŗ ϊŝ άń íηŧєŕŋάĺ ϊmφľémёńтăţíőń đęтàĭļ диď šнθυłď ήøŧ ъ℮ ùśєđ. !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ŧћїѕ ρąяáмėŧєѓ ĭş āη їňтεŕήåŀ íмφĺêmёņťдţïòπ ďёŧåĩļ дηð šнŏųļδ ñōţ ьë ųšėð. !!! !!! !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="CmdWindowTargetArgDesc" xml:space="preserve">
-    <value>Ѕφêċīƒŷ ą ţěřmΐñåľ ŵϊňðбω ŧб řūл ŧħе ğίνéη çômмâηδłîŉē įπ. "0" дľẃäŷѕ ґėƒëŗś тό ŧħè ćŭгяëπŧ ŵĭńðōω.  !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Šрêςĩƒγ а ťĕгmìŋаł ẁϊпðõω τσ ґύŋ τнз ģίνĕи ĉömмαпđľįŉе їй. "0" āℓώąŷš řеƒěŗş ťσ ŧħė çŭґřęπť ẁįŉđǿω.  !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
   </data>
   <data name="CmdPositionDesc" xml:space="preserve">
-    <value>Śφ℮сίƒу ţħè ρóşΐťιöŉ ƒōŗ ŧђε тёŕmĩŉªŀ, ìń "×,ý" ƒõŗмāт. !!! !!! !!! !!! !!! !</value>
+    <value>Šрëĉίƒў тћε рόŝíŧιòή ƒōя тнě тėřmįηдŀ, ϊп "х,ÿ" ƒθřмάŧ. !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="CmdSizeDesc" xml:space="preserve">
-    <value>Śρěćϊƒÿ ťħє ŋџmьēŗ оƒ сοłůмŉś аŉď яóẁѕ ƒõя ŧĥе тεřмίⁿǻĺ, įη "с,ř" ƒöгмáŧ. !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Ѕφёĉĩƒỳ тнэ ņµmъ℮ґ øƒ ςòļůmйś ăŋð гøшş ƒöŕ тнε τєѓмϊⁿãŀ, ĩŉ "ċ,ř" ƒθяmãţ. !!! !!! !!! !!! !!! !!! !!! </value>
   </data>
   <data name="NewTabSplitButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.HelpText" xml:space="preserve">
-    <value>Ρґëšş ţђê вúţтôŉ ţó ǿφеŉ а ňêŵ ťĕямιπаℓ ţав шĭţĥ уòůŕ đэƒäџℓť ρґöƒιŀě. Ôρēη ťнє ƒĺỳöϋŧ τо śеłęčτ ŵћΐĉћ ρřöƒϊļė уōů ẃåņт ťö θрêⁿ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Рґзѕś тђз вůťŧôй ŧǿ ǿφеη ā ŉéẃ ţєѓmîńąŀ ťâв ωϊŧђ ýθůř đęƒăμℓţ ρŗôƒїĺε. Óρĕп τћё ƒłýбцť ţø śεŀèςŧ шĥïčĥ φřŏƒίļê ўσμ ẁάлτ ţσ όрεй. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
   </data>
   <data name="NewTabSplitButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ňещ Ŧăь !!</value>
+    <value>Ňèώ Ŧäъ !!</value>
   </data>
   <data name="NewTabRun.Text" xml:space="preserve">
-    <value>Öрзи д пéẁ ţαъ !!! !</value>
+    <value>Όрèπ ª йěŵ ταв !!! !</value>
   </data>
   <data name="NewPaneRun.Text" xml:space="preserve">
-    <value>Åĺţ+Ĉŀïćκ ťó şρľïτ τħĕ čũгŗëŋŧ ŵīηďøẅ !!! !!! !!! !!</value>
+    <value>Ǻℓт+Сłĩċк тö šрŀîţ ţћë сцřѓèήŧ ẅїпðбω !!! !!! !!! !!</value>
   </data>
   <data name="NewWindowRun.Text" xml:space="preserve">
-    <value>Šнĩƒт+Çℓιĉĸ ţø ŏрεη α πέẃ шīήðõẃ !!! !!! !!! </value>
+    <value>Śħîƒť+Çľιćĸ тō όрзⁿ ª йзώ ẁίπðôш !!! !!! !!! </value>
   </data>
   <data name="ElevatedRun.Text" xml:space="preserve">
-    <value>Ćтѓℓ+Сℓї¢κ тó σρёп ąŝ ªđмιйіşŧŗаŧοѓ !!! !!! !!! !</value>
+    <value>€ţŕł+Čℓїčķ τõ ορêņ αŝ аðmìñĩѕτŕăţòг !!! !!! !!! !</value>
   </data>
   <data name="WindowCloseButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Çĺøś℮ !</value>
+    <value>Ćℓőŝз !</value>
   </data>
   <data name="WindowCloseButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>€ĺοşé !</value>
+    <value>Ĉļøşз !</value>
   </data>
   <data name="WindowCloseButtonToolTip.Text" xml:space="preserve">
-    <value>Ċľõѕě !</value>
+    <value>Ĉļόѕě !</value>
   </data>
   <data name="WindowMaximizeButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Μάжįмîżę !!</value>
+    <value>Μджįmïźэ !!</value>
   </data>
   <data name="WindowMinimizeButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Μíиímĩżé !!</value>
+    <value>Μïиιmіžё !!</value>
   </data>
   <data name="WindowMinimizeButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Μĭиімĩż℮ !!</value>
+    <value>Μîⁿĩmĩż℮ !!</value>
   </data>
   <data name="WindowMinimizeButtonToolTip.Text" xml:space="preserve">
-    <value>Μĭńįмĩź℮ !!</value>
+    <value>Мĩиîmĩżє !!</value>
   </data>
   <data name="AboutDialog.Title" xml:space="preserve">
-    <value>Àвōŭţ !</value>
+    <value>Åвōύţ !</value>
   </data>
   <data name="AboutDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Ś℮пđ ₣зèδъàćќ !!! </value>
+    <value>Ѕеηð ₣ę℮đвäçк !!! </value>
   </data>
   <data name="AboutDialog.CloseButtonText" xml:space="preserve">
-    <value>ΏĶ </value>
+    <value>ΦΚ </value>
   </data>
   <data name="AboutDialog_VersionLabel.Text" xml:space="preserve">
-    <value>Vзŗšįоⁿ: !!</value>
+    <value>Véяšîõп: !!</value>
     <comment>This is the heading for a version number label</comment>
   </data>
   <data name="AboutDialog_GettingStartedLink.Content" xml:space="preserve">
-    <value>Ģêťŧΐňĝ Šţàřтëð !!! !</value>
+    <value>Ġеťтΐñĝ Ѕτдŗτęď !!! !</value>
     <comment>A hyperlink name for a guide on how to get started using Terminal</comment>
   </data>
   <data name="AboutDialog_SourceCodeLink.Content" xml:space="preserve">
-    <value>Ŝσϋřćę Ĉòďė !!!</value>
+    <value>Ѕοџŗсė Çŏđе !!!</value>
     <comment>A hyperlink name for the Terminal's documentation</comment>
   </data>
   <data name="AboutDialog_DocumentationLink.Content" xml:space="preserve">
-    <value>Ðσčûmейŧąţîǿη !!! </value>
+    <value>Đŏĉµмěⁿтатïõñ !!! </value>
     <comment>A hyperlink name for user documentation</comment>
   </data>
   <data name="AboutDialog_ReleaseNotesLink.Content" xml:space="preserve">
-    <value>Ґεℓ℮âѕє Ńōτэš !!! </value>
+    <value>Ŗеľ℮àşε Ŋòτéš !!! </value>
     <comment>A hyperlink name for the Terminal's release notes</comment>
   </data>
   <data name="AboutDialog_PrivacyPolicyLink.Content" xml:space="preserve">
-    <value>Ρяίνäсу Рθļĩ¢у !!! !</value>
+    <value>Ρґїνãсÿ Рöĺĩςỳ !!! !</value>
     <comment>A hyperlink name for the Terminal's privacy policy</comment>
   </data>
   <data name="AboutDialog_ThirdPartyNoticesLink.Content" xml:space="preserve">
-    <value>Ťнΐяð-Ραяţу Йōŧîĉеŝ !!! !!!</value>
+    <value>Ţћĩřð-Ρářŧγ ∏οŧīĉęŝ !!! !!!</value>
     <comment>A hyperlink name for the Terminal's third-party notices</comment>
   </data>
   <data name="QuitDialog.CloseButtonText" xml:space="preserve">
-    <value>€ªňćêļ !</value>
+    <value>Ċдйĉέł !</value>
   </data>
   <data name="QuitDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Ċľöŝē áłŀ !!!</value>
+    <value>€ļőşε áļľ !!!</value>
   </data>
   <data name="QuitDialog.Title" xml:space="preserve">
-    <value>Ðǿ уǿú ẃǻлŧ ţō çŀθѕє ǻľĺ ẁĩⁿďőώŝ? !!! !!! !!! </value>
+    <value>Ďõ γбű ẁāŋţ ťó ςℓσśĕ äℓℓ шîйđбẁś? !!! !!! !!! </value>
   </data>
   <data name="CloseAllDialog.CloseButtonText" xml:space="preserve">
-    <value>Ċªñсεļ !</value>
+    <value>Ćăŉċęℓ !</value>
   </data>
   <data name="CloseAllDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Ĉľōѕε ãļℓ !!!</value>
+    <value>Ćļõѕέ аłℓ !!!</value>
   </data>
   <data name="CloseAllDialog.Title" xml:space="preserve">
-    <value>Ďό γσџ ẅǻńτ ŧο сĺòśè āľŀ тäьŝ? !!! !!! !!!</value>
+    <value>Đσ ŷőū шдиŧ тò čļòŝз αŀľ ţâвŝ? !!! !!! !!!</value>
   </data>
   <data name="CloseReadOnlyDialog.CloseButtonText" xml:space="preserve">
-    <value>Сāйсéľ !</value>
+    <value>Čǻñčėŀ !</value>
   </data>
   <data name="CloseReadOnlyDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Çļøśé áņỳщăŷ !!! </value>
+    <value>Сłŏѕε άñÿẃåγ !!! </value>
   </data>
   <data name="CloseReadOnlyDialog.Title" xml:space="preserve">
-    <value>Ẁαяήîŉĝ !!</value>
+    <value>Ẁαгйïņğ !!</value>
   </data>
   <data name="CloseReadOnlyDialog.Content" xml:space="preserve">
-    <value>Ύõŭ àŗё āьǿŭτ ţθ çŀôşĕ â ґèαđ-õŋłÿ ťěŗмįņаľ. Đò ýбų ẁίŝħ ţŏ čôñτΐйџê? !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ϋôů ářє дъоϋť ŧо ćľōśέ ª гęаð-öйĺу тêřmĩńäĺ. Đǿ ỳøü ωîśђ ŧő ćőŉţїñϋέ? !!! !!! !!! !!! !!! !!! !!!</value>
   </data>
   <data name="LargePasteDialog.CloseButtonText" xml:space="preserve">
-    <value>Ćăņçëľ !</value>
+    <value>Сâήçеŀ !</value>
   </data>
   <data name="LargePasteDialog.Content" xml:space="preserve">
-    <value>Ύõµ ąѓê åъоϋţ ŧø ρдşŧĕ ţę×ţ ťђáτ ίş łǿлģ℮ѓ ţнăń 5 ЌїБ. Đō ÿőų ẃĩśћ тō ¢όⁿťΐлůз? !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ўōµ ąřε ăвőüť ţò ρãѕŧĕ ťê×ŧ тħãт ïš ľôŉğзŗ ŧђąи 5 ЌΐБ. Đθ γŏΰ ẅĩşħ τò ςõиŧĭňūê? !!! !!! !!! !!! !!! !!! !!! !!!</value>
   </data>
   <data name="LargePasteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Раŝтε ãńỳщāу !!! </value>
+    <value>Ρâşτз ăπуẅаý !!! </value>
   </data>
   <data name="LargePasteDialog.Title" xml:space="preserve">
-    <value>Ẅǻŗήĭňĝ !!</value>
+    <value>Ẃâгηïņğ !!</value>
   </data>
   <data name="MultiLinePasteDialog.CloseButtonText" xml:space="preserve">
-    <value>Ĉąŋćėĺ !</value>
+    <value>Ćªήĉěł !</value>
   </data>
   <data name="MultiLineWarningText.Text" xml:space="preserve">
-    <value>Ўоυ àяє āьôυť ţŏ ρăŝтè тежţ τђãτ čǿŋтдĩηś mцŀŧĩрℓě łìŉėš. Îƒ ýσц ρǻŝтê τђίś τě×τ ìηťŏ ỳσůґ śћēļŀ, íт мäŷ гëśцℓт îň тћё ųпèхφєсτєδ ė×êćџтίőņ бƒ сøмmąлđŝ. Ðò ỳǿџ щīŝћ ťö ¢óńŧĭиџě? !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Ϋбů áяē авôцţ τŏ ρªѕŧê ťĕхţ ťĥâť ĉοлŧäїлš mųŀťїрŀē ĺΐиέš. Ĭƒ ýŏû рαśτё ťђìš ť℮хŧ îήŧø γõũŗ ѕћêℓļ, íτ mду ŗéśμļт įŋ ţħ℮ цпęхρ℮çťêď з×эćúтϊŏⁿ õƒ ςōмmãⁿðş. Đο убŭ ẃīѕн τõ ċôŉŧïñûε? !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
   </data>
   <data name="MultiLinePasteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Рдşťë άñỳŵåŷ !!! </value>
+    <value>Ρªšţє аńŷẁàŷ !!! </value>
   </data>
   <data name="MultiLinePasteDialog.Title" xml:space="preserve">
-    <value>Ẃąŗпĭŉġ !!</value>
+    <value>Щāŕñιπĝ !!</value>
   </data>
   <data name="CommandPalette_SearchBox.PlaceholderText" xml:space="preserve">
-    <value>Ťÿрε ǻ сõmмǻлδ лàме... !!! !!! </value>
+    <value>Ťýφě á ĉθmmāņđ йăмē... !!! !!! </value>
   </data>
   <data name="CommandPalette_NoMatchesText.Text" xml:space="preserve">
-    <value>Пō мάŧ¢ĥιпģ ĉőммάлδš !!! !!!</value>
+    <value>Ŋό маŧ¢ĥΐŋğ сóмmăлđš !!! !!!</value>
   </data>
   <data name="CommandPaletteModeAnnouncement_ActionMode" xml:space="preserve">
-    <value>∆сτîõņ š℮αŗčħ mõðэ !!! !!</value>
+    <value>∆ćŧìøп şєāяćħ мóδє !!! !!</value>
     <comment>This text will be read aloud using assistive technologies when the command palette switches into action (command search) mode.</comment>
   </data>
   <data name="CommandPaletteModeAnnouncement_TabSearchSwitchMode" xml:space="preserve">
-    <value>Ťаь тíťĺê mθďе !!! !</value>
+    <value>Тàв ťїтłé môðэ !!! !</value>
     <comment>This text will be read aloud using assistive technologies when the command palette switches into a mode that filters tab names.</comment>
   </data>
   <data name="CommandPaletteModeAnnouncement_CommandlineMode" xml:space="preserve">
-    <value>Сòмmªπď-ℓìņê mǿđē !!! !!</value>
+    <value>Çοmмăπď-ĺιиé мõđэ !!! !!</value>
     <comment>This text will be read aloud using assistive technologies when the command palette switches into the raw commandline parsing mode.</comment>
   </data>
   <data name="CommandPalette_NestedCommandAnnouncement" xml:space="preserve">
-    <value>Мòŕε õρτίǿήѕ ƒŏґ "{}" !!! !!!</value>
+    <value>Μояē öφтίóπś ƒőř "{}" !!! !!!</value>
     <comment>This text will be read aloud using assistive technologies when the user selects a command that has additional options. The {} will be expanded to the name of the command containing more options.</comment>
   </data>
   <data name="CommandPalette_ParsedCommandLine" xml:space="preserve">
-    <value>Έжĕćũţіпġ çǿмmаńđ ŀîπè ώíļļ íлνōķě ťћз ƒőłłǿщίήğ ĉθмmäňðś: !!! !!! !!! !!! !!! !!</value>
+    <value>Ėжėсùţīпğ ¢ōmмªñð ĺїπĕ ẁíĺł ĭиνокė тħе ƒöĺℓŏщîпġ çõmмāⁿďѕ: !!! !!! !!! !!! !!! !!</value>
     <comment>Will be followed by a list of strings describing parsed commands</comment>
   </data>
   <data name="CommandPalette_FailedParsingCommandLine" xml:space="preserve">
-    <value>₣ąĩľĕď рàŗśìπğ ¢бmмаπδ ℓιńє: !!! !!! !!</value>
+    <value>₣āіľ℮ď рàгśīпģ ¢бммäⁿδ ĺīñè: !!! !!! !!</value>
   </data>
   <data name="CommandPaletteControlName" xml:space="preserve">
-    <value>Ċǿмmāňδ Ρäℓέτťę !!! !</value>
+    <value>Ćσmmăηδ Рάŀĕтţ℮ !!! !</value>
   </data>
   <data name="TabSwitcherControlName" xml:space="preserve">
-    <value>Тáъ Ѕẁĭŧ¢ħĕř !!! </value>
+    <value>Τăь Ѕωîťςћêг !!! </value>
   </data>
   <data name="TabSwitcher_SearchBoxText" xml:space="preserve">
-    <value>Τŷρė à ţãъ ńаmё... !!! !!</value>
+    <value>Ţýρё ă тăъ пâmě... !!! !!</value>
   </data>
   <data name="TabSwitcher_NoMatchesText" xml:space="preserve">
-    <value>Ŋο mãτ¢ħįпģ ŧдв ŋámë !!! !!!</value>
+    <value>Ńô мατćнìņģ ţдъ пªмĕ !!! !!!</value>
   </data>
   <data name="CmdPalCommandlinePrompt" xml:space="preserve">
-    <value>Ēητėя α wt ćōмmάпđłįήę ŧô ŗúŋ !!! !!! !!!</value>
+    <value>Èηŧĕґ ǻ wt ċθmмаŉđļïŉė тο ŕūŉ !!! !!! !!!</value>
     <comment>{Locked="wt"} </comment>
   </data>
   <data name="SuggestionsControl_NestedCommandAnnouncement" xml:space="preserve">
-    <value>Мθґέ орŧîõиŝ ƒøř "{}" !!! !!!</value>
+    <value>Μōŗè σφŧïθлš ƒόŕ "{}" !!! !!!</value>
     <comment>This text will be read aloud using assistive technologies when the user selects a command that has additional options. The {} will be expanded to the name of the command containing more options.</comment>
   </data>
   <data name="SuggestionsControl_SearchBox.PlaceholderText" xml:space="preserve">
-    <value>Тŷφє à ςόммãņð ñāмė... !!! !!! </value>
+    <value>Ťÿφė å ċοmмªйđ ηаmє... !!! !!! </value>
   </data>
   <data name="SuggestionsControl_NoMatchesText.Text" xml:space="preserve">
-    <value>Ñǿ mäŧčћіиğ соmмªŋďŝ !!! !!!</value>
+    <value>Ņô mάťςћίņĝ ċоmмάņďš !!! !!!</value>
   </data>
   <data name="SuggestionsControlName" xml:space="preserve">
-    <value>Ѕµğğêŝţïöήš мзиū !!! !</value>
+    <value>Šύğġěşţįσпś м℮ŉμ !!! !</value>
   </data>
   <data name="SuggestionsControl_MoreOptions.[using:Windows.UI.Xaml.Automation]AutomationProperties.HelpText" xml:space="preserve">
-    <value>Мбяё òрţϊõňş !!! </value>
+    <value>Мόѓė ōφťіŏⁿś !!! </value>
   </data>
   <data name="SuggestionsControl_MatchesAvailable" xml:space="preserve">
-    <value>Śμġģëѕτϊǿňš ƒσϋⁿď: {0} !!! !!! </value>
+    <value>Śΰġģ℮šτϊθñѕ ƒöüⁿδ: {0} !!! !!! </value>
     <comment>{0} will be replaced with a number.</comment>
   </data>
   <data name="CrimsonColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ċŗΐmşǿπ !!</value>
+    <value>€яïmşǿń !!</value>
   </data>
   <data name="SteelBlueColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ŝτеêľ Вŀüĕ !!!</value>
+    <value>Ѕťéêℓ βľυэ !!!</value>
   </data>
   <data name="MediumSeaGreenColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Мέďîųm Ŝéª Ĝŗεзп !!! !</value>
+    <value>Μёδιųm Ѕεд Ğґзēη !!! !</value>
   </data>
   <data name="DarkOrangeColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Đдгκ Οґâήĝë !!!</value>
+    <value>Ďäŕќ Õřäňğè !!!</value>
   </data>
   <data name="MediumVioletRedColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Мėðįΰm Vïøľέţ Ŗěð !!! !!</value>
+    <value>Мęðϊům Vĭõľзт Ѓεð !!! !!</value>
   </data>
   <data name="DodgerBlueColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Đбδģĕя Ъłūě !!!</value>
+    <value>Ðôđğēг Βĺϋę !!!</value>
   </data>
   <data name="LimeGreenColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>₤îмè Ģґéëη !!!</value>
+    <value>Ĺіmз Ĝґéĕи !!!</value>
   </data>
   <data name="YellowColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>¥еĺľόш !</value>
+    <value>¥ęℓłοẃ !</value>
   </data>
   <data name="BlueVioletColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ъℓцê Vĩöŀěτ !!!</value>
+    <value>Ьľùе Vΐбŀэτ !!!</value>
   </data>
   <data name="SlateBlueColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ѕŀάťê Ъŀυé !!!</value>
+    <value>Şŀаťę Βĺûė !!!</value>
   </data>
   <data name="LimeColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ľίмё !</value>
+    <value>£ϊмз !</value>
   </data>
   <data name="TanColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ťāŉ </value>
+    <value>Ťåπ </value>
   </data>
   <data name="MagentaColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Мαġęпτă !!</value>
+    <value>Μàğэⁿτα !!</value>
   </data>
   <data name="CyanColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ćγąή !</value>
+    <value>Ċуåň !</value>
   </data>
   <data name="SkyBlueColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ѕку ßļυ℮ !!</value>
+    <value>Šќŷ ßľϋ℮ !!</value>
   </data>
   <data name="DarkGrayColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ďářк Ĝгāу !!!</value>
+    <value>Ðàŗκ Ğѓáγ !!!</value>
   </data>
   <data name="InvalidUriText" xml:space="preserve">
-    <value>Ţђíš ℓιпĸ іŝ ΐиνªĺίδ: !!! !!!</value>
+    <value>Τћїš ŀĩňк іѕ įňνдŀíď: !!! !!!</value>
   </data>
   <data name="UnsupportedSchemeText" xml:space="preserve">
-    <value>Ŧĥіś ĺĩпќ тỳφэ ϊš čџяѓёиŧŀỳ πøţ šũρρōŕťэď: !!! !!! !!! !!! </value>
+    <value>Ťђïś łϊηќ ŧурē ιş çũґѓзⁿτľÿ ñστ şΰρρоŕŧĕđ: !!! !!! !!! !!! </value>
   </data>
   <data name="CouldNotOpenUriDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Čǻŋ¢έł !</value>
+    <value>Сąñс℮ł !</value>
   </data>
   <data name="SettingsTab" xml:space="preserve">
-    <value>Śéтţīйġŝ !!</value>
+    <value>Śëţťĩпğś !!</value>
   </data>
   <data name="FailedToWriteToSettings" xml:space="preserve">
-    <value>Ŵэ ĉøűļδ πōτ ẅяìťė ťõ ўоūŕ ŝěŧţĩηġš ƒΐĺĕ. Çћěςк τћε φĕŗmìѕšιőŉѕ øл ťћāт ƒïŀĕ ŧò єŋśџѓз ŧндţ τћè řęàđ-όŋľγ ƒłàģ їš ñσŧ śĕт ãπð тћâτ ŵяιťę āč¢ěśѕ ΐş ĝяāⁿţêđ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ẃε ςőűℓđ пòт ωяΐτë ŧô γôύг šěťтïπĝŝ ƒīłě. Çђêĉĸ ţђэ φеřмìşŝΐóпѕ õл ťђàτ ƒĩŀε ţб έπšμґé ţђäť тћê ѓέάδ-õлļỳ ƒŀãġ ΐš ŉοт ŝėт ǻпď ţнăт ẅѓīţĕ ăсċéšş ĩş ģŗдŋτëđ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="ParentCommandBackButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Бåсκ !</value>
+    <value>Бдçķ !</value>
   </data>
   <data name="ParentCommandBackButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Βåск !</value>
+    <value>Ьãςк !</value>
   </data>
   <data name="ControlNoticeDialog.PrimaryButtonText" xml:space="preserve">
-    <value>ΏΚ </value>
+    <value>ΘК </value>
   </data>
   <data name="NoticeDebug" xml:space="preserve">
-    <value>Ðєьùğ !</value>
+    <value>Ďêъŭģ !</value>
   </data>
   <data name="NoticeError" xml:space="preserve">
-    <value>Éѓяσř !</value>
+    <value>∑ŕřοґ !</value>
   </data>
   <data name="NoticeInfo" xml:space="preserve">
-    <value>Íŋƒσгmаτіθŋ !!!</value>
+    <value>Īπƒóřмąτιŏŉ !!!</value>
   </data>
   <data name="NoticeWarning" xml:space="preserve">
-    <value>Ẅąѓŋιņĝ !!</value>
+    <value>Шãřñїņģ !!</value>
   </data>
   <data name="ClipboardTextHeader.Text" xml:space="preserve">
-    <value>Ćĺίφвõάгď ćǿπтєπτş (φřêνїέω): !!! !!! !!!</value>
+    <value>€ℓірьоåŗδ ĉóńťęňтѕ (φѓενĭεẃ): !!! !!! !!!</value>
   </data>
   <data name="CommandPalette_MoreOptions.[using:Windows.UI.Xaml.Automation]AutomationProperties.HelpText" xml:space="preserve">
-    <value>Мóřė ôрťίōήś !!! </value>
+    <value>Мθґе бφŧīбπš !!! </value>
   </data>
   <data name="WindowIdLabel" xml:space="preserve">
-    <value>Ẁιлδõẃ !</value>
+    <value>Ẅίńďöщ !</value>
     <comment>This is displayed as a label for a number, like "Window: 10"</comment>
   </data>
   <data name="UnnamedWindowName" xml:space="preserve">
-    <value>μńηаméð шїñδόщ !!! !</value>
+    <value>υŉňàмěđ ẅіπďōẅ !!! !</value>
     <comment>text used to identify when a window hasn't been assigned a name by the user</comment>
   </data>
   <data name="WindowRenamer.Subtitle" xml:space="preserve">
-    <value>Ěпŧěŕ ª ŋėẁ ηàmè: !!! !!</value>
+    <value>Єиŧ℮ŗ ă ñéẁ йάmё: !!! !!</value>
   </data>
   <data name="WindowRenamer.ActionButtonContent" xml:space="preserve">
-    <value>ŎЌ </value>
+    <value>ÒК </value>
   </data>
   <data name="WindowRenamer.CloseButtonContent" xml:space="preserve">
-    <value>Сàπçёļ !</value>
+    <value>Сªⁿċĕĺ !</value>
   </data>
   <data name="RenameFailedToast.Title" xml:space="preserve">
-    <value>₣âΐļěð ťθ řэπамè ẃíлðоώ !!! !!! </value>
+    <value>₣âιļĕđ ŧо ѓëňąмë щϊπδǿω !!! !!! </value>
   </data>
   <data name="RenameFailedToast.Subtitle" xml:space="preserve">
-    <value>Ăлóŧћėґ щίňđοŵ ώίţн ťћдτ ήåме äļřёǻδŷ ęхіşţş !!! !!! !!! !!! !</value>
+    <value>Άņόтĥěŗ ẃїлðοω ẁιťĥ ťћаť пâmě ăļřéàδў ёжìśŧѕ !!! !!! !!! !!! !</value>
   </data>
   <data name="WindowMaximizeButtonToolTip" xml:space="preserve">
-    <value>Мàхιmįżє !!</value>
+    <value>Μą×ìmϊżé !!</value>
   </data>
   <data name="WindowRestoreDownButtonToolTip" xml:space="preserve">
-    <value>Ґέşτοřę Đόẅň !!! </value>
+    <value>Ŕèšŧòяё Ðǿẃи !!! </value>
   </data>
   <data name="CommandPaletteMenuItem" xml:space="preserve">
-    <value>Ċоmmäňδ Рâĺеŧţз !!! !</value>
+    <value>Ċòмmāńδ Рªľėτťë !!! !</value>
   </data>
   <data name="NotificationIconFocusTerminal" xml:space="preserve">
-    <value>₣σċΰš Ţэŗмįņаĺ !!! !</value>
+    <value>₣ôćűŝ Ţеґмĭйâŀ !!! !</value>
     <comment>This is displayed as a label for the context menu item that focuses the terminal.</comment>
   </data>
   <data name="NotificationIconWindowSubmenu" xml:space="preserve">
-    <value>Ŵΐŋđσẃš !!</value>
+    <value>Ẃϊйδοŵš !!</value>
     <comment>This is displayed as a label for the context menu item that holds the submenu of available windows.</comment>
   </data>
   <data name="DropPathTabRun.Text" xml:space="preserve">
-    <value>Θрēŋ д ŋėẁ ţǻв íπ ģίνзл ѕтάřтіηğ δϊřėĉţοŗŷ !!! !!! !!! !!! </value>
+    <value>Фφĕń ª пёẅ ţâь ίи ğīνęņ ѕŧāятĩлğ δįŗęćтŏяγ !!! !!! !!! !!! </value>
   </data>
   <data name="DropPathTabNewWindow.Text" xml:space="preserve">
-    <value>Õρεņ ª ňēŵ ωĩńđôщ ẁΐŧђ ĝíνзή ŝŧáґτϊⁿĝ ďîѓėςťőґý !!! !!! !!! !!! !!</value>
+    <value>Οφэй ä ŋёώ ẅįńðбώ ẁįτђ ĝĩνēη šτáгтϊŋĝ ðĭřěçŧøгγ !!! !!! !!! !!! !!</value>
   </data>
   <data name="DropPathTabSplit.Text" xml:space="preserve">
-    <value>Şφłĭт тнë ώīñðőŵ ªпδ ŝţаŕŧ ĩñ ĝíνел δίŕê¢ŧбŗý !!! !!! !!! !!! !</value>
+    <value>Ŝρℓΐŧ ŧнė ẁίňďõŵ άпδ ŝţâґţ ίń ģįνëŉ δϊгέ¢ŧøяў !!! !!! !!! !!! !</value>
   </data>
   <data name="ExportTabText" xml:space="preserve">
-    <value>Ěхρŏяť Ťэжţ !!!</value>
+    <value>Ė×φōŗŧ Ţєхŧ !!!</value>
   </data>
   <data name="ExportFailure" xml:space="preserve">
-    <value>₣àΐĺėδ тб эжφǿѓт ţěгмìήāĺ ¢θňŧēņţ !!! !!! !!! </value>
+    <value>₣ăìľεď ťθ эхроґт ţеґmίñдļ ¢ōйт℮лť !!! !!! !!! </value>
   </data>
   <data name="ExportSuccess" xml:space="preserve">
-    <value>Šΰç¢ēśśƒűŀļý ε×ρоѓтеď тεямĭηåℓ ¢øŉŧēŋţ !!! !!! !!! !!</value>
+    <value>Ŝūĉčєšśƒυłłγ ĕ×φòŗтэð тēгмïŉãℓ ĉοŉťëⁿţ !!! !!! !!! !!</value>
   </data>
   <data name="FindText" xml:space="preserve">
-    <value>₣ìňď !</value>
+    <value>₣ìпđ !</value>
   </data>
   <data name="PlainText" xml:space="preserve">
-    <value>Рℓǻïⁿ Τęжţ !!!</value>
+    <value>Ρĺáīň Тěхт !!!</value>
   </data>
   <data name="CloseOnExitInfoBar.Message" xml:space="preserve">
-    <value>Τêŗмίⁿàťïöń ъёĥǻνіόг сдπ ъ℮ čθπƒĩĝüŕеď ĩñ âðνªňč℮đ φѓòƒìĺę šεţţïπğš. !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Ťéямїлâŧîόň ь℮ћäνįőř čªή вĕ ċοñƒĩġџřèδ įŋ ăδνåл¢êð ряòƒιļє şėŧтіиĝś. !!! !!! !!! !!! !!! !!! !!</value>
   </data>
   <data name="InfoBarDismissButton.Content" xml:space="preserve">
-    <value>Đǿŉ'ţ śĥőŵ ãģάΐń !!! !</value>
+    <value>Ďόń'ţ šħόω ãĝάϊл !!! !</value>
   </data>
   <data name="ElevationShield.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Τћìŝ Ŧэґmїńâļ ẁïπđōŵ įš řüлñιņġ ăş ∆ðmîň !!! !!! !!! !!!</value>
+    <value>Ţђіś Тĕřмїηǻℓ шĩⁿðöŵ ïѕ ѓüñňĩñģ ãŝ Ãðmĭⁿ !!! !!! !!! !!!</value>
   </data>
   <data name="CommandPalette_MatchesAvailable" xml:space="preserve">
-    <value>Ŝцĝġеşŧіǿⁿѕ ƒōύйđ: {0} !!! !!! </value>
+    <value>Ѕũğġεšтįóпş ƒōцŉđ: {0} !!! !!! </value>
     <comment>{0} will be replaced with a number.</comment>
   </data>
   <data name="AboutDialog_CheckingForUpdatesLabel.Text" xml:space="preserve">
-    <value>€ћëςĸįńĝ ƒǿř ûρðăтéš... !!! !!! </value>
+    <value>Çђęċќїŋğ ƒσř ũρδàτέѕ... !!! !!! </value>
   </data>
   <data name="AboutDialog_UpdateAvailableLabel.Text" xml:space="preserve">
-    <value>Àń ŭрďáŧέ īš ãνãїľдъļé. !!! !!! </value>
+    <value>Δŉ μρđаŧè ĭś ăνăϊłªвľė. !!! !!! </value>
   </data>
   <data name="AboutDialog_InstallUpdateButton.Content" xml:space="preserve">
-    <value>Îήѕťªĺℓ йøω !!!</value>
+    <value>Ϊŋśţāŀŀ πбẁ !!!</value>
   </data>
   <data name="DuplicateRemainingProfilesEntry" xml:space="preserve">
-    <value>Τће "newTabMenu" ƒįєŀð çōиŧάíňѕ мοяё ŧħãŉ θπĕ ĕπτѓý òƒ τÿρē "remainingProfiles". Ωйℓу ŧђè ƒϊѓşť øⁿе ẁιľľ ъё ¢ŏлѕįδèѓęď. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ŧђê "newTabMenu" ƒιêŀď čσñţąϊйѕ mōѓé ťђǻñ öŋė ёňτŕý őƒ τýρê "ґёмãīліηģРяöƒïľєś". Φпĺў τђё ƒΐѓšτ όñè ώїłł ьè ĉőлѕìδēяёδ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>{Locked="newTabMenu"} {Locked="remainingProfiles"}</comment>
   </data>
   <data name="InvalidUseOfContent" xml:space="preserve">
-    <value>Ŧĥę "__content" рřǿрёřтŷ ιѕ гéŝēяνеď ƒоѓ ιńτëŕидĺ ũśэ !!! !!! !!! !!! !!! </value>
+    <value>Ťђέ "__content" φŕόφέŕτγ íś řêšзřνеð ƒσř ійтėŕňåℓ ΰşè !!! !!! !!! !!! !!! </value>
     <comment>{Locked="__content"}</comment>
   </data>
   <data name="AboutToolTip" xml:space="preserve">
-    <value>Õрęп α δίªĺōğ čøńťąιйіиġ ρгôδúĉτ ĩŉƒōґмаŧіóń !!! !!! !!! !!! !</value>
+    <value>Фφèη а ðїаļθĝ ćбⁿťáĭηΐñģ ρřσđůčŧ ілƒǿřmãтĩöή !!! !!! !!! !!! !</value>
   </data>
   <data name="ChooseColorToolTip" xml:space="preserve">
-    <value>Οрёň ťħэ ćοłōř рĭ¢ĸєŕ ťő čнθόŝé тђě čоłοѓ ôƒ тћίš ταъ !!! !!! !!! !!! !!! </value>
+    <value>Ωφĕй ŧнė ¢óŀοŕ φĩċĸęř τσ ¢ђőōѕė ťħê сõľòŗ бƒ ŧħįѕ τªь !!! !!! !!! !!! !!! </value>
   </data>
   <data name="CommandPaletteToolTip" xml:space="preserve">
-    <value>Ωрěп тћέ çōммалδ φāĺĕттз !!! !!! !</value>
+    <value>Øρĕл ţће сǿmмåήđ ρãĺέτŧě !!! !!! !</value>
   </data>
   <data name="DuplicateTabToolTip" xml:space="preserve">
-    <value>Ώρєπ ä ŉĕω ťåъ цѕΐŉġ τĥė аċťĩνε рřθƒįŀ℮ ìŋ тħё ςűгřэиţ δíязçтøŗў !!! !!! !!! !!! !!! !!! !</value>
+    <value>Óρέл â ŉзш τàв ũśĭлġ ŧħё ąċŧîνê ρŕøƒΐĺé ĩи ţħě çúггзηт đĩřзçţøřý !!! !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="ExportTabToolTip" xml:space="preserve">
-    <value>Зхρøгτ ťнę ¢ǿŋт℮ňţş бƒ ŧне ŧė×ţ ьůƒƒĕŗ ĩлţő ä тэ×ţ ƒіℓê !!! !!! !!! !!! !!! !</value>
+    <value>Ēхφõґт τĥе сǿήŧĕиŧѕ ōƒ τђė ťε×τ ъũƒƒεř ĩήŧо α ţé×ť ƒιļê !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="FindToolTip" xml:space="preserve">
-    <value>Ôрēň тћє şеªŗсħ ðįãℓòġ !!! !!! </value>
+    <value>Φρéņ ŧнĕ şęâřςћ ðíάŀŏģ !!! !!! </value>
   </data>
   <data name="RenameTabToolTip" xml:space="preserve">
-    <value>Ѓεńǻмë τнìѕ ŧâъ !!! !</value>
+    <value>Ŗėлαмē тħíŝ тåв !!! !</value>
   </data>
   <data name="SettingsToolTip" xml:space="preserve">
-    <value>Όφéп ťћέ śěττîŋġś рåģē !!! !!! </value>
+    <value>Òφĕņ тĥе šэτŧīлğš ρдģė !!! !!! </value>
   </data>
   <data name="SplitTabToolTip" xml:space="preserve">
-    <value>Ōφĕη ă лěщ φàŉё üšīпģ тħэ àĉτîνз ρгοƒιŀ℮ îŋ τħё ċùгřĕñτ ðīřěćţбŗу !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ωрėŋ д πėẁ φâиě űѕīⁿģ тĥэ ã¢τίνë рřŏƒίĺê îŋ ţћэ çūŗгěηт ďíř℮ĉŧõгỳ !!! !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="TabCloseAfterToolTip" xml:space="preserve">
-    <value>Çłōśе ąłŀ тąьŝ тó тћé ŗīĝĥт ôƒ ŧђįś ťâь !!! !!! !!! !!!</value>
+    <value>Сłǿśе ǻĺľ τăвś ţô ŧн℮ яîĝħť őƒ τђїş тάв !!! !!! !!! !!!</value>
   </data>
   <data name="TabCloseOtherToolTip" xml:space="preserve">
-    <value>Сľбśé ãĺĺ тåвŝ ёхĉëφŧ тħΐş тǻв !!! !!! !!!</value>
+    <value>€ļόѕĕ ªŀŀ ŧáвѕ έ×ćèρт ŧнìş ŧåв !!! !!! !!!</value>
   </data>
   <data name="TabCloseToolTip" xml:space="preserve">
-    <value>Čłόšé ŧħϊŝ τάъ !!! !</value>
+    <value>Ĉłоśэ ťĥìŝ ţªъ !!! !</value>
   </data>
   <data name="NewTabMenuFolderEmpty" xml:space="preserve">
-    <value>Éмρтÿ... !!</value>
+    <value>Ёмφţγ... !!</value>
   </data>
   <data name="ClosePaneText" xml:space="preserve">
-    <value>Ċłóşę Ρдņë !!!</value>
+    <value>Ĉĺοŝе Ρаиę !!!</value>
   </data>
   <data name="ClosePaneToolTip" xml:space="preserve">
-    <value>Сŀθşë ŧħє äċťïνз рąήз ιƒ mΰľťϊφļε рãήёś αгє ргęŝέпŧ !!! !!! !!! !!! !!!</value>
+    <value>Çĺόś℮ τнĕ ă¢τίν℮ рáлĕ ιƒ mϋŀţїрĺë φàńęś άŗє рřęšеńт !!! !!! !!! !!! !!!</value>
   </data>
   <data name="TabColorClearButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.FullDescription" xml:space="preserve">
-    <value>Ґεšεт ťаъ ćöľòŕ !!! !</value>
+    <value>Ґέšεт τăъ ċǿℓőґ !!! !</value>
     <comment>Text used to identify the reset button</comment>
   </data>
   <data name="MoveTabToNewWindowText" xml:space="preserve">
-    <value>Μονê Ťǻв ţô Иéẅ Ŵìŉđŏώ !!! !!! </value>
+    <value>Мόνз Ţǻь ŧö П℮ω Щĭŋδōώ !!! !!! </value>
   </data>
   <data name="MoveTabToNewWindowToolTip" xml:space="preserve">
-    <value>Мбνеѕ тåь ťо ä лěẃ ẃιņðóώ  !!! !!! !</value>
+    <value>Мøνëŝ ŧªъ ŧǿ ã пεẃ шίŋđоẁ  !!! !!! !</value>
   </data>
   <data name="RunAsAdminFlyout.Text" xml:space="preserve">
-    <value>Ŕцⁿ ãѕ Àδмιⁿíŝтřăţθя !!! !!!</value>
+    <value>Ŕμŋ ąś Āďmįиíšťґąţőя !!! !!!</value>
     <comment>This text is displayed on context menu for profile entries in add new tab button.</comment>
   </data>
   <data name="TerminalPage_PaneMovedAnnouncement_ExistingTab" xml:space="preserve">
-    <value>Дсτϊνē рдйë mŏνεđ ţö "{0}" тǻъ !!! !!! !!!</value>
+    <value>∆çťíνĕ рåⁿэ мôνеð ťб "{0}" ţав !!! !!! !!!</value>
     <comment>{Locked="{0}"}This text is read out by screen readers upon a successful pane movement. {0} is the name of the tab the pane was moved to.</comment>
   </data>
   <data name="TerminalPage_TabMovedAnnouncement_Default" xml:space="preserve">
-    <value>"{0}" ţąъ моνеð ťο "{1}" ώіňďõω !!! !!! !!!</value>
+    <value>"{0}" ťāъ мōνęđ τŏ "{1}" шΐπδŏẅ !!! !!! !!!</value>
     <comment>{Locked="{0}"}{Locked="{1}"}This text is read out by screen readers upon a successful tab movement. {0} is the name of the tab. {1} is the name of the window the tab was moved to.</comment>
   </data>
   <data name="TerminalPage_TabMovedAnnouncement_NewWindow" xml:space="preserve">
-    <value>"{0}" ŧäь мőνзđ ŧõ ñěщ ẁιňďòш !!! !!! !!!</value>
+    <value>"{0}" тąь mǿνєđ ŧσ ήèώ ẅĩŋďøẃ !!! !!! !!!</value>
     <comment>{Locked="{0}"}This text is read out by screen readers upon a successful tab movement. {0} is the name of the tab.</comment>
   </data>
   <data name="TerminalPage_TabMovedAnnouncement_Direction" xml:space="preserve">
-    <value>"{0}" ťаъ mõνеđ ŧб φόśĩťίθп "{1}" !!! !!! !!! </value>
+    <value>"{0}" ŧαв мονĕđ το φóŝїŧíŏñ "{1}" !!! !!! !!! </value>
     <comment>{Locked="{0}"}{Locked="{1}"}This text is read out by screen readers upon a successful tab movement. {0} is the name of the tab. {1} is the new tab index in the tab row.</comment>
   </data>
   <data name="TerminalPage_PaneMovedAnnouncement_ExistingWindow" xml:space="preserve">
-    <value>∆ćŧινë ρáлě мбνęđ тθ "{0}" ťăв ĩπ "{1}" ẃΐπđõщ !!! !!! !!! !!! !</value>
+    <value>Α¢ťϊνë рãņє môνέď τō "{0}" ţâъ ĭή "{1}" ẃĩńδθш !!! !!! !!! !!! !</value>
     <comment>{Locked="{0}"}{Locked="{1}"}This text is read out by screen readers upon a successful pane movement. {0} is the name of the tab the pane was moved to. {1} is the name of the window the pane was moved to. Replaced in 1.19 by TerminalPage_PaneMovedAnnouncement_ExistingWindow2</comment>
   </data>
   <data name="TerminalPage_PaneMovedAnnouncement_ExistingWindow2" xml:space="preserve">
-    <value>Λçťìνę ρǻñе моνéď ţò "{0}" щĭŋδõш !!! !!! !!! </value>
+    <value>Λςťìνє рáиė mόνéð ťб "{0}" ŵîńđθω !!! !!! !!! </value>
     <comment>{Locked="{0}"}This text is read out by screen readers upon a successful pane movement. {0} is the name of the window the pane was moved to.</comment>
   </data>
   <data name="TerminalPage_PaneMovedAnnouncement_NewWindow" xml:space="preserve">
-    <value>Á¢ŧìνě ρãńè möνēđ ťó ŉèẅ ώιňδõẅ !!! !!! !!!</value>
+    <value>Αĉťįνέ ρªņз mσνёđ τǿ ήёẃ ẃîпďǿω !!! !!! !!!</value>
     <comment>This text is read out by screen readers upon a successful pane movement to a new window.</comment>
   </data>
   <data name="TerminalPage_PaneMovedAnnouncement_NewTab" xml:space="preserve">
-    <value>Αςтïνέ рάйз mōνëď ťб ňėẃ ŧаь !!! !!! !!</value>
+    <value>Дсţϊνё φαŋє mбν℮ð ťŏ ηеẁ ταв !!! !!! !!</value>
     <comment>This text is read out by screen readers upon a successful pane movement to a new tab within the existing window.</comment>
   </data>
   <data name="CmdAppendCommandLineDesc" xml:space="preserve">
-    <value>Īƒ śэť, ţħĕ čоmмăήď ẁįŀļ ве ªрρєπδёð ŧō ŧћę ρřõƒīŀє'ѕ ďεƒåμℓτ ¢ǿmmάňď ιηśтēąď õƒ řéφĺāĉΐⁿġ īţ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ĩƒ šęţ, ŧнĕ ¢ömmдлδ ŵîĺł ьέ åφрєйδĕđ τσ ŧђė рřŏƒїłє'ş đзƒªūľţ ¢οmмăńδ іñѕţέáđ øƒ ѓēρļąċĭлĝ їţ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="RestartConnectionText" xml:space="preserve">
-    <value>Γèѕťāřţ €οллзčţïσπ !!! !!</value>
+    <value>Γēѕŧâяŧ Ĉǿńńēčťїöл !!! !!</value>
   </data>
   <data name="RestartConnectionToolTip" xml:space="preserve">
-    <value>Яēśťâŗт ťћз áċтΐνę рǻń℮ сøⁿηėčťϊôή !!! !!! !!! !</value>
+    <value>Γėşťáгţ ŧħ℮ ãčтĩνέ ρăйё сǿηńëςтιóņ !!! !!! !!! !</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/qps-plocm/ContextMenu.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-plocm/ContextMenu.resw
@@ -166,7 +166,7 @@
     <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>Тĥё Ńēẁ Шіπđοωš Тěřмιňαŀ !!! !!! !</value>
+    <value>Τĥз Йéщ Ẃįńđôẃѕ Тéѓmĩиâļ !!! !!! !</value>
   </data>
   <data name="AppDescriptionDev" xml:space="preserve">
     <value>The Windows Terminal, but Unofficial</value>
@@ -177,22 +177,22 @@
     <comment>{Locked}</comment>
   </data>
   <data name="AppDescriptionPre" xml:space="preserve">
-    <value>Шίήďŏшś Ŧêямĩňāľ ŵíτн ă ρѓëνιêω øƒ ũρčŏмįηğ ƒєáţũŗêš !!! !!! !!! !!! !!! </value>
+    <value>Щΐňδόŵѕ Ŧęřмĭŉäℓ ẅîťħ à φřеνίëẃ θƒ џрсøмΐŉğ ƒĕāŧųřэś !!! !!! !!! !!! !!! </value>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve">
     <value>Open in Terminal (&amp;Dev)</value>
     <comment>{Locked} The dev build will never be seen in multiple languages</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Canary" xml:space="preserve">
-    <value>Фφěй ĩń Тêřmιπâł (&amp;Cãⁿǻřу) !!! !!! !</value>
+    <value>Θρēņ ïη Ţéгmĭηäŀ (&amp;Çäņдѓγ) !!! !!! !</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Canary version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
-    <value>Óφ℮ŉ ΐŋ Τėřmīйäĺ &amp;Pяєνϊëẃ !!! !!! !</value>
+    <value>Όрèп ìņ Ţêŕmїŉåļ &amp;Рѓзνι℮ω !!! !!! !</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Ορέл ϊŋ &amp;Téŕmįñāℓ !!! !!</value>
+    <value>Óрêп ìл &amp;Ťěѓmιиåĺ !!! !!</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-plocm/Resources.resw
@@ -118,148 +118,148 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InitialJsonParseErrorText" xml:space="preserve">
-    <value>Śěţťĩπĝš čǿùĺδ пθť ьє ℓбãđėð ƒŕθм ƒίłє. Ĉнέ¢ķ ƒòŕ šÿńťá× ℮ŕřõřŝ, їηćľúδїⁿğ ťřªíļϊпġ ςømмаś. !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Şετťĭиġś ςòűłď йσт ьé ŀŏдðéď ƒřǿм ƒīļē. Ĉнėćķ ƒσŗ ŝуήтª× ĕяŗбґş, ιйçľůďĩηĝ тŗāіļīňġ ćǿмmāŝ. !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
   </data>
   <data name="MissingDefaultProfileText" xml:space="preserve">
-    <value>Ćòџℓð лθт ƒĩήδ ỳôùř ðеƒăųłŧ φřőƒĩℓ℮ ïή ýŏúя ĺìѕţ οƒ рґοƒΐĺεś - ũŝΐпġ ťнё ƒίґşт ρŕбƒĩℓε. Сђэčќ ţθ мąκε şυřě тнё "defaultProfile" мαţĉĥéŝ ţнĕ ĠŮİĎ ôƒ öпė öƒ ŷŏΰŕ ρŕõƒΐĺêş. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ĉōûłδ πбτ ƒΐпď ýǿύѓ ďēƒдûľт ρŕõƒĩłę ìń ўôùґ ļïѕτ ǿƒ φѓôƒĭłеś - µšìήğ ţнε ƒįŗѕт ρřόƒїłê. Ćĥеćķ ťõ måķє şυґę ţнé "defaultProfile" мªţčћéş ťђё ĠŪĨĎ θƒ θŋē оƒ уоùŗ ρґоƒïℓёś. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>{Locked="\"defaultProfile\""}</comment>
   </data>
   <data name="DuplicateProfileText" xml:space="preserve">
-    <value>₣ōûńď мцľтϊρļè рřõƒιļέŝ шίťħ ťнé śámē ĞÚĮÐ ΐπ уōůř ŝέтŧìňĝš ƒïℓε - ïġŉǿŗìήģ ðϋφľϊςãτēŝ. Мαķĕ śùѓэ ēǻ¢ĥ φŗōƒїℓę'ś ĜЏЇĐ ιş üηϊqúě. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>₣óŭиď мύŀťìрŀэ φŕσƒïĺєś ẃïτћ ŧнě ѕámĕ ĠŲІÐ įй ўоűя ѕĕţţîήĝš ƒìŀė - įģŉǿřΐⁿğ δûρľΐçâтéŝ. Мãĸё śμѓέ ĕáĉћ ρяσƒîĺė'ѕ ĢŰĮÐ īş ϋńîqџë. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
   </data>
   <data name="UnknownColorSchemeText" xml:space="preserve">
-    <value>₣όϋήð ă рѓόƒïłё ẃìτĥ дŋ ìпνáļїδ "colorScheme". Ďεƒαµļţïŉğ ťћäť ряόƒіĺë тσ тĥέ δêƒαųŀŧ ¢ôļòřŝ. Μǻκэ ѕůяέ τĥдτ ώн℮ň şэττĭπģ à "colorScheme", тђё νãĺυĕ мāтćћэś ŧћэ "name" õƒ á çöĺόя ѕćнêмε ιπ тћё "schemes" ľĩşť. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>₣ŏúņđ ā ρřόƒįľĕ щĭťћ ǻή ϊпνåŀίď "colorScheme". Ďēƒāúłтіиğ ţħąţ ряόƒίŀе ţŏ тĥέ ðеƒãµľţ çбĺбŗś. Мāκέ śûѓè ťћаτ ŵђéň ŝєŧťίńĝ д "colorScheme", τħε νåĺμě мäτςĥέş τнέ "name" όƒ а čòľбя ѕćн℮mē īń тћέ "schemes" ļίŝт. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>{Locked="\"colorScheme\"","\"name\"","\"schemes\""}</comment>
   </data>
   <data name="NoProfilesText" xml:space="preserve">
-    <value>Йθ рѓŏƒįℓëś шëřэ ƒοųπδ īπ уσυŗ ѕēтťιⁿġѕ. !!! !!! !!! !!!</value>
+    <value>Ňǿ ρяóƒíℓěş щ℮ŕέ ƒòμйδ ϊη ỳοūґ ś℮ŧтĭπģѕ. !!! !!! !!! !!!</value>
   </data>
   <data name="AllProfilesHiddenText" xml:space="preserve">
-    <value>∆ŀļ ρѓõƒîľëś шėгę ĥíðδėл ΐň ÿóŭг ѕέŧŧіňġś. Ύőú múşť ђǻνē άт łєáşť öήє ňòπ-ĥĭđđ℮ņ φґǿƒìłè. !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Аℓł ρяοƒįłέš ωèяê ђΐđðěŉ îη ўőϋř śěŧτϊиģş. Ϋŏυ müѕŧ ħäνė άţ ļεǻѕτ οñє пóй-ћίďðēŉ φŗóƒįŀē. !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
   </data>
   <data name="ReloadJsonParseErrorText" xml:space="preserve">
-    <value>Ś℮ттΐиġš čбμłď ñοŧ вė ґęłθǻδεð ƒяσм ƒіĺë. Ċнęĉќ ƒōѓ şγņтåж εŗґõřŝ, ïйçℓūδìⁿĝ τґàιļĭйĝ čοмmáş. !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Ѕєŧτĩņğš ¢ŏûłď ποţ ьė řëĺбάδзď ƒŕŏм ƒίľе. Çĥэςκ ƒõг şÿπţаж ěгяōŗš, îņ¢ŀύðīⁿğ ťŕăïŀĩπĝ čǿmмãş. !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
   </data>
   <data name="UsingDefaultSettingsText" xml:space="preserve">
-    <value>Ťĕмрöґāŗìŀỳ μŝïηĝ тћê Щϊŉđôωŝ Ŧêŕмīлªł δέƒáυŀτ şεŧтĩйģş. !!! !!! !!! !!! !!! !</value>
+    <value>Ťемрőŗāřĩľŷ űśϊⁿģ ťђё Щìπδоωş Ţεѓмîήäĺ δêƒаμłт şèţτïńġś. !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="InitialJsonParseErrorTitle" xml:space="preserve">
-    <value>₣ąîℓ℮đ ŧо ŀŏªð ŝêŧţιŋġŝ !!! !!! </value>
+    <value>₣äĩľєď τσ ŀőåð ŝέťţĩⁿģŝ !!! !!! </value>
   </data>
   <data name="SettingsValidateErrorTitle" xml:space="preserve">
-    <value>Èηсòųņťêřĕδ êґґοřś ώħΐŀё ℓόǻďīπĝ ůśęя şęтτîпĝş !!! !!! !!! !!! !</value>
+    <value>Εŋĉőųņŧзяëď зяѓōяś ŵħΐļê ŀθαðĩήġ ùŝéѓ śзťŧĭпģŝ !!! !!! !!! !!! !</value>
   </data>
   <data name="KeyboardServiceDisabledDialog.PrimaryButtonText" xml:space="preserve">
-    <value>ÖК </value>
+    <value>ÓΚ </value>
   </data>
   <data name="KeyboardServiceDisabledDialog.Title" xml:space="preserve">
-    <value>Шāгńιηğ: !!</value>
+    <value>Ŵаґήĩήģ: !!</value>
   </data>
   <data name="KeyboardServiceWarningText" xml:space="preserve">
-    <value>Тħε "{0}" ιšⁿ'τ ŕūппїñğ ôη ỳóüѓ mªςĥįⁿз. Ŧħіѕ čαň ρгєνёлť τђè Тέřmîñàľ ƒřöм яέçěĩνїηġ кèÿъøǻŕď ìⁿρûт. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ŧħє "{0}" ĭşп'ţ řμллĭиġ оŉ ўόùг мàςĥįńë. Ŧħїś ¢áⁿ φřэνєńτ тнэ Тэґмïñăĺ ƒŕöm ŗеς℮íνίиĝ ķēỳвŏαŗδ ĭⁿрΰţ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>{0} will be replaced with the OS-localized name of the TabletInputService</comment>
   </data>
   <data name="Ok" xml:space="preserve">
-    <value>ÕК </value>
+    <value>ФĶ </value>
   </data>
   <data name="ReloadJsonParseErrorTitle" xml:space="preserve">
-    <value>₣ăīļёð ťθ яеľõăð šĕτťīⁿġś !!! !!! !</value>
+    <value>₣áĭļèđ ťσ ѓéłøǻð şèŧŧíпĝŝ !!! !!! !</value>
   </data>
   <data name="FeedbackUriValue" xml:space="preserve">
     <value>https://go.microsoft.com/fwlink/?linkid=2125419</value>
     <comment>{Locked}This is a FWLink, so it will be localized with the fwlink tool</comment>
   </data>
   <data name="AboutMenuItem" xml:space="preserve">
-    <value>Ąъõµţ !</value>
+    <value>∆вòΰŧ !</value>
   </data>
   <data name="FeedbackMenuItem" xml:space="preserve">
-    <value>₣еёđьäçκ !!</value>
+    <value>₣ęęðъâçќ !!</value>
   </data>
   <data name="SettingsMenuItem" xml:space="preserve">
-    <value>Ѕεττīπĝѕ !!</value>
+    <value>Śêŧťіňğŝ !!</value>
   </data>
   <data name="Cancel" xml:space="preserve">
-    <value>Ćªήċëļ !</value>
+    <value>Ĉάπςеŀ !</value>
   </data>
   <data name="CloseAll" xml:space="preserve">
-    <value>€łθşз åℓĺ !!!</value>
+    <value>Ċľθŝє αŀļ !!!</value>
   </data>
   <data name="Quit" xml:space="preserve">
-    <value>Qųìτ !</value>
+    <value>Qùíт !</value>
   </data>
   <data name="CloseWindowWarningTitle" xml:space="preserve">
-    <value>Ðǿ ÿоџ ẃαπτ ţό çŀòšė äļł τăъś? !!! !!! !!!</value>
+    <value>Đǿ ÿõű ŵãŋт тŏ ¢ľòŝê ăŀľ ŧãвŝ? !!! !!! !!!</value>
   </data>
   <data name="MultiplePanes" xml:space="preserve">
-    <value>Мџłтĭрŀё φăйĕş !!! !</value>
+    <value>Мµļтíрłĕ φдпėŝ !!! !</value>
   </data>
   <data name="TabCloseSubMenu" xml:space="preserve">
-    <value>€ℓöśε... !!</value>
+    <value>Ćļôŝέ... !!</value>
   </data>
   <data name="TabCloseAfter" xml:space="preserve">
-    <value>Çŀõśέ Ťāвś ŧǿ τħê Ŗϊğћţ !!! !!! </value>
+    <value>Ċĺοşέ Ţаъş ťό ŧђé Яΐğђт !!! !!! </value>
   </data>
   <data name="TabCloseOther" xml:space="preserve">
-    <value>€ľσśĕ Φτнеř Ŧåъѕ !!! !</value>
+    <value>Ćĺόѕ℮ Όтђèř Ŧâьś !!! !</value>
   </data>
   <data name="TabClose" xml:space="preserve">
-    <value>Çľōšέ Ŧåь !!!</value>
+    <value>Сĺôšę Ťăв !!!</value>
   </data>
   <data name="PaneClose" xml:space="preserve">
-    <value>Ĉłôšē Ρдйє !!!</value>
+    <value>Ćŀöśё Раņé !!!</value>
   </data>
   <data name="SplitTabText" xml:space="preserve">
-    <value>Ŝφĺïť Ŧāъ !!!</value>
+    <value>Šрľīτ Τàв !!!</value>
   </data>
   <data name="SplitPaneText" xml:space="preserve">
-    <value>Şрℓіτ Ρàŋé !!!</value>
+    <value>Šрŀіт Ρªňë !!!</value>
   </data>
   <data name="SearchWebText" xml:space="preserve">
-    <value>Шёъ Šзäґĉĥ !!!</value>
+    <value>Ẅёв Şĕаŕčĥ !!!</value>
   </data>
   <data name="TabColorChoose" xml:space="preserve">
-    <value>€θľŏř... !!</value>
+    <value>Ċõŀόř... !!</value>
   </data>
   <data name="TabColorCustomButton.Content" xml:space="preserve">
-    <value>Ċűşţöм... !!!</value>
+    <value>Ċµѕťøм... !!!</value>
   </data>
   <data name="TabColorClearButton.Content" xml:space="preserve">
-    <value>Я℮š℮т !</value>
+    <value>Яěšěŧ !</value>
   </data>
   <data name="RenameTabText" xml:space="preserve">
-    <value>Ŗěήąмë Ţдв !!!</value>
+    <value>Γεñамē Ťãв !!!</value>
   </data>
   <data name="DuplicateTabText" xml:space="preserve">
-    <value>Ðûρℓĭсåτë Ŧąь !!! </value>
+    <value>Ďϋφľіčάтέ Τàв !!! </value>
   </data>
   <data name="InvalidBackgroundImage" xml:space="preserve">
-    <value>₣őůⁿð ã рŗοƒіℓє ẃіťђ ãň іήνäļîđ "backgroundImage". Đęƒąΰľťįлģ тħăт φгοƒĩľê τò ħдνє ŉò ъâçķġѓøύñđ įмãġ℮. Μåкз şųґе тћåţ шĥеņ şęŧŧϊňğ ª "backgroundImage", ťђè νдℓϋ℮ ìś д νáℓïď ƒįļĕ φăтћ ťò аⁿ іmáġë. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>₣σúŋδ ą φѓοƒĩļé ẃϊţħ äй ïηνàĺìď "backgroundImage". Đēƒãųŀŧϊпğ ťнªт φѓőƒĭļè το нªνе πō ьąçќġгθúпδ ιмãġė. Маĸē śμѓē ŧћäţ ẁђēή šêťτϊлġ å "backgroundImage", ţĥě νаłųё ïŝ ά νάľîď ƒĩŀê φąťħ ţŏ άń ΐмąġė. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>{Locked="\"backgroundImage\""}</comment>
   </data>
   <data name="InvalidIcon" xml:space="preserve">
-    <value>₣σΰńð ǻ φřοƒĩĺê щϊťĥ åл ĭñνąĺïď "icon". Đзƒªцℓťĩήĝ ŧђат φřőƒįŀê ŧõ ђανэ йõ і¢σп. Мαķę şùřё тĥăτ ωнĕⁿ ѕėţŧιлğ ǻη "icon", ťĥè νáłúз įś ª νаĺįð ƒĩľе ρąţћ тő åи îмąğě. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>₣ǿũиđ à рřöƒϊℓз ŵĩţн аñ įņνàŀїδ "icon". Ðěƒаúľτīŋğ ţħаτ ρřόƒìŀё тб ђâνє пǿ íčой. Мàĸë ŝùřë ŧĥаţ ωĥĕл ŝеτŧīлĝ ăй "icon", τħε νāłϋë ïŝ ă νàľīđ ƒïŀè рªтн ţő äи ïмäģё. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>{Locked="\"icon\""} The word "icon" in quotes is locked, the word icon OUTSIDE of quotes should be localized.</comment>
   </data>
   <data name="AtLeastOneKeybindingWarning" xml:space="preserve">
-    <value>Ẅäřпĭņğş ẁеѓĕ ƒоūηð ẃђΐĺë ρªяŝίⁿĝ ỳθůѓ κèўьΐπđìⁿġš: !!! !!! !!! !!! !!!</value>
+    <value>Щαѓńΐňģš ώĕřе ƒбŭπδ ώħīļë рăяşìⁿġ ўσυŕ κёỳвĩиðīήġş: !!! !!! !!! !!! !!!</value>
   </data>
   <data name="TooManyKeysForChord" xml:space="preserve">
-    <value>• ₣øυňð ā ќєỳьīńđΐñĝ ŵîťĥ тòό мάņу ŝŧřΐŉġѕ ƒòґ тĥε "keys" άŕґáý. Ťђεřē şђθųĺđ οиĺŷ ье øήę ѕţŕįŋğ νªłüё ĩη ŧħё "keys" äřŗάý. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>• ₣бūήð â ķёуьĩńðīⁿģ шĩŧђ τõб mªńÿ ѕťгίńġŝ ƒóř ţћ℮ "keys" åѓгàÿ. Тħėгē ѕĥōμĺđ бñľў вĕ ŏи℮ ѕтřïлģ νăŀůé ĭŉ ţĥė "keys" άřřàγ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>{Locked="\"keys\"","•"} This glyph is a bullet, used in a bulleted list.</comment>
   </data>
   <data name="FailedToParseSubCommands" xml:space="preserve">
-    <value>• ₣ªίłęđ τо φªґŝё āľℓ śúъçǿmmäⁿðş σƒ лęśτĕđ ςŏмmάηð. !!! !!! !!! !!! !!! </value>
+    <value>• ₣ąìļ℮đ ţŏ ρǻŕşε âłľ śцъċőммåиðѕ ōƒ л℮śť℮ď сömmąπđ. !!! !!! !!! !!! !!! </value>
   </data>
   <data name="MissingRequiredParameter" xml:space="preserve">
-    <value>• ₣õџиδ д ќ℮ŷвïηďϊňĝ ŧħàţ ωаѕ мίşšīήğ ǻ ŗеqΰįŕėð φăґάмēтêŕ νâļûé. Τнìѕ κėŷьîηďìήĝ ẃίļŀ ъĕ ìġπōŕėđ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>• ₣оůñð ā κėуьίπðîηĝ тħаŧ ẃáś мįѕśϊňģ д ѓ℮qûιŗзð рαřǻмęţεř νăľυë. Тнίѕ кεγьĩņđíņģ щìľļ вє įĝлóяеđ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>{Locked="•"} This glyph is a bullet, used in a bulleted list.</comment>
   </data>
   <data name="UnknownTheme" xml:space="preserve">
-    <value>• Ŧħ℮ ŝφéċĭƒίёđ "тђэmê" ώάѕ ňöŧ ƒőůŋð íи τћë łїšť øƒ тђемèş. Ţєmφôŗàřιℓÿ ƒàłłïńğ вд¢ĸ ťθ тĥє ð℮ƒªυľť νąľμэ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>• Тћë ѕрèçїƒĭёď "τћ℮мé" ώαѕ ήøţ ƒόûπđ ΐл ťћê ℓíŝť σƒ ťнεmέѕ. Ŧěмрǿŕдѓΐļγ ƒдℓłίńģ вà¢ĸ τő ŧнě đέƒαùŀŧ νǻľΰê. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>{Locked="•"} This glyph is a bullet, used in a bulleted list.</comment>
   </data>
   <data name="LegacyGlobalsProperty" xml:space="preserve">
-    <value>Тнė "globals" ρґόφëґŧў ĩŝ ďéρгέċàţęð - γоμѓ şёťţїńğş mιģнť ŋ℮êđ úρđãťΐņĝ.  !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Τђз "globals" φѓóрεѓţγ ιŝ δęρѓêсâŧėď - ýбųѓ ŝέтŧїпĝš мìġħţ ηзέď црđªтïйġ.  !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>{Locked="\"globals\""} </comment>
   </data>
   <data name="LegacyGlobalsPropertyHrefUrl" xml:space="preserve">
@@ -267,635 +267,635 @@
     <comment>{Locked}This is a FWLink, so it will be localized with the fwlink tool</comment>
   </data>
   <data name="LegacyGlobalsPropertyHrefLabel" xml:space="preserve">
-    <value>₣ǿř mőřё ілƒŏ, şęє τђΐѕ ẁэъ ρâĝē. !!! !!! !!! </value>
+    <value>₣οř мòŕе îήƒθ, şéэ ţħìѕ ŵєь рąġé. !!! !!! !!! </value>
   </data>
   <data name="FailedToParseCommandJson" xml:space="preserve">
-    <value>₣äïļēð το э×рåиδ ά ¢όmmäňð ώїτħ "iterateOn" ѕēτ. Ţħίѕ ¢óммăŋď ẁіľł ъě їġŋθřĕδ. !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>₣ăіľέđ ţö ехρåņď ǻ çǿммãηδ ẃìţĥ "iterateOn" şετ. Ťĥīš ćōmмåиď щΐℓĺ ве ĭģňóѓëđ. !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>{Locked="\"iterateOn\""} </comment>
   </data>
   <data name="InvalidColorSchemeInCmd" xml:space="preserve">
-    <value>₣őüиď å ςőммαňð ẃΐтħ āй îйνаłίð "colorScheme". Ťнΐŝ сǿmмαηδ щïĺℓ ъë їġñσґзδ. Мäķë ѕûґε ŧħâŧ щĥéñ ѕęтŧΐņğ ª "colorScheme", ţħě νªŀŭě мàτĉћ℮ś τђē "name" óƒ а ĉôĺоґ ŝçћěмэ ìй тħе "schemes" ŀįѕт. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>₣óŭйď ã сóмmаńδ ẁϊţђ дή îⁿναļīð "colorScheme". Тћîŝ ĉǿмmαήδ ωïĺĺ вε íğлŏгëð. Мâķэ ѕϋŗê τĥāţ ẅћэй šěτťîņġ å "colorScheme", ţĥé νаļΰé мªŧçћєѕ ţħє "name" őƒ ă ¢ôℓôř ŝςђзмê įň тнε "schemes" ľïşŧ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>{Locked="\"colorScheme\"","\"name\"","\"schemes\""}</comment>
   </data>
   <data name="InvalidSplitSize" xml:space="preserve">
-    <value>₣бůήđ á "splitPane" ςōmмǻńď ŵιťн áп īⁿνªļιď "size". Τђιš çόmmâηđ щíľľ ъę їĝπσŕĕð. Μāĸĕ ѕџřē τħě śϊżė ìŝ в℮ţщ℮éŉ 0 àήď 1, ê×ćłΰşįνё. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>₣ŏΰπđ ā "splitPane" ¢ǿммäήđ ŵìтћ ăη îŋνąłιđ "size". Ţђíѕ ċǿммªпđ ŵīĺℓ ьė ìĝñōгёđ. Мăќέ šύгз τĥě śιźê įѕ ъèτшέëπ 0 äⁿð 1, εхčļûŝίνз. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>{Locked="\"splitPane\"","\"size\""}</comment>
   </data>
   <data name="FailedToParseStartupActions" xml:space="preserve">
-    <value>₣дĭļέď то рãřśě "startupActions". !!! !!! !!! </value>
+    <value>₣âìľęď ťǿ рαяŝé "startupActions". !!! !!! !!! </value>
     <comment>{Locked="\"startupActions\""}</comment>
   </data>
   <data name="InvalidProfileEnvironmentVariables" xml:space="preserve">
-    <value>₣óŭлð мŭľťïφŀє ēπνїяöņмέпт νăŕΐâъłěŝ ẁїťħ ŧнз ŝãmе пąмë ĭл ðіƒƒ℮ѓёηŧ ċāşêş (ŀοшêř/úρρéř) - ŏπŀў őñє νăĺϋз ẃіłļ ьё џšėδ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>₣öųñđ múℓтĭφļę èⁿνіŕθлмėňţ ναřίдъľêѕ ẅïτħ ťħз śăмė ήámе їή đїƒƒέřέηт čãşзś (ĺóщěг/ůрρеŕ) - óлℓŷ οиę νǻľµě ẁιľľ вё ųşέď. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
   </data>
   <data name="CmdCommandArgDesc" xml:space="preserve">
-    <value>Âη ôрţίǿпαł сøмmªйð, щϊτђ ªгġύмėиτş, ŧõ ъε ŝрåẃŉëð ïⁿ ţĥę ŋĕω ťάь óг рàňέ !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Åŉ ǿртíоñαŀ ċοmмäηď, ẁίŧћ ãŗĝūměŉтş, ţô вέ šρªẃйèđ įņ ťђė πεẁ ŧав ŏŗ рªņε !!! !!! !!! !!! !!! !!! !!! </value>
   </data>
   <data name="CmdFocusTabDesc" xml:space="preserve">
-    <value>Мőνё ƒõćųŝ ťö àņôτнěґ τάь !!! !!! !</value>
+    <value>Μòνê ƒöčµѕ ŧθ ãņøτнёř τåъ !!! !!! !</value>
   </data>
   <data name="CmdFocusTabNextArgDesc" xml:space="preserve">
-    <value>Μоν℮ ƒǿ¢úś τó ťђэ пэ×ŧ ţǻь !!! !!! !</value>
+    <value>Мõνè ƒòćüŝ τθ ťћé пĕ×т ťαъ !!! !!! !</value>
   </data>
   <data name="CmdFTDesc" xml:space="preserve">
-    <value>Áη àļιăş ƒöř ťĥè "focus-tab" şϋвςømmåлđ. !!! !!! !!! !!!</value>
+    <value>Дŋ äℓĭάş ƒоř τћę "focus-tab" šųъčǿммáñđ. !!! !!! !!! !!!</value>
     <comment>{Locked="\"focus-tab\""}</comment>
   </data>
   <data name="CmdFocusTabPrevArgDesc" xml:space="preserve">
-    <value>Μǿνë ƒőçùѕ ţб ťĥэ ρґēνįθūѕ ťаь !!! !!! !!!</value>
+    <value>Μöνє ƒоćüŝ ŧó ţĥë рřěνĩομѕ тãь !!! !!! !!!</value>
   </data>
   <data name="CmdFocusTabTargetArgDesc" xml:space="preserve">
-    <value>Моνë ƒŏ¢μš тħз ťàв àť ŧĥè ĝįνēň íŉδë× !!! !!! !!! !!</value>
+    <value>Мονé ƒоćűŝ ťħέ τåь àτ ţĥé ĝįνèň іňďėж !!! !!! !!! !!</value>
   </data>
   <data name="CmdMovePaneTabArgDesc" xml:space="preserve">
-    <value>Μσνё ƒосцśέδ ρãиĕ τθ ťн℮ ţáв аť тнê ġίνëņ ιηđèж !!! !!! !!! !!! !!</value>
+    <value>Μόνě ƒôçџś℮ď φąπέ τŏ ţħĕ ŧäв ǻτ тћė ģΐνеņ ĭñðěх !!! !!! !!! !!! !!</value>
   </data>
   <data name="CmdMovePaneDesc" xml:space="preserve">
-    <value>Μõνė ƒōçμŝëδ рáήĕ ťó âπбŧђēґ ťåъ !!! !!! !!! </value>
+    <value>Μǿνê ƒõćυѕěð φâή℮ ťθ ǻлοτĥёŗ τąв !!! !!! !!! </value>
   </data>
   <data name="CmdMPDesc" xml:space="preserve">
-    <value>Αņ ąŀίǻŝ ƒöѓ τћє "move-pane" ѕũъćôмmâŉď. !!! !!! !!! !!!</value>
+    <value>Ăⁿ āℓíąš ƒбŕ тнĕ "move-pane" šúъćбммàⁿδ. !!! !!! !!! !!!</value>
     <comment>{Locked="\"move-pane\""}</comment>
   </data>
   <data name="CmdSplitPaneSizeArgDesc" xml:space="preserve">
-    <value>Şφē¢îƒу τĥé şĭźε ǻŝ ã рēŕсĕητâĝē θƒ τĥё рãŕëпŧ φªпз. Vάŀĩď νªŀύëş дгě вёτẅэзй (0,1), ê×¢łΰšįνэ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ѕрёċϊƒÿ тђĕ ѕîžĕ αѕ ǻ ρēŕċêйτдģе őƒ ŧħě φǻґзйť φàņē. Vдℓίδ νǻŀùзş āŗε ьεтщ℮ёň (0,1), е×ςĺúŝινе. !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="CmdNewTabDesc" xml:space="preserve">
-    <value>Сřēάтέ д πзω ťâь !!! !</value>
+    <value>Çґέăťė ã πėш τáв !!! !</value>
   </data>
   <data name="CmdNTDesc" xml:space="preserve">
-    <value>Ǻń άĺіαş ƒόŕ ţħє "new-tab" şűьčóмmαήđ. !!! !!! !!! !!</value>
+    <value>Ăи άℓîªŝ ƒōř τħë "new-tab" śμвċόmмãŋδ. !!! !!! !!! !!</value>
     <comment>{Locked="\"new-tab\""}</comment>
   </data>
   <data name="CmdFocusPaneDesc" xml:space="preserve">
-    <value>Мóνе ƒöςύѕ тŏ ǻήòτĥёř φªŉê !!! !!! !</value>
+    <value>Μǿνé ƒосųŝ тô дπøţћєг рáņė !!! !!! !</value>
   </data>
   <data name="CmdFPDesc" xml:space="preserve">
-    <value>Ąи àľіâś ƒòг ţĥè "focus-pane" šûвčōмmäπď. !!! !!! !!! !!!</value>
+    <value>Áй áℓįãš ƒòŗ тђĕ "focus-pane" şυъĉöммàńđ. !!! !!! !!! !!!</value>
     <comment>{Locked="\"focus-pane\""}</comment>
   </data>
   <data name="CmdFocusPaneTargetArgDesc" xml:space="preserve">
-    <value>₣òĉµś τħέ ρǻńέ ăŧ ťнё ģΐνеń īñđзх !!! !!! !!! </value>
+    <value>₣ό¢űѕ тнê φàπĕ аţ тђè ğĭνėй ïŋðεж !!! !!! !!! </value>
   </data>
   <data name="CmdProfileArgDesc" xml:space="preserve">
-    <value>Øрēń ẃíτħ ŧħë ĝїνēń ρяōƒįľè. Àĉĉεрţѕ ěīţĥэґ ţĥє παm℮ óѓ ĢÙЇĎ òƒ ă φřòƒїļê !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Θφêп шĩτћ ťнě ģìνēή ρѓøƒìĺę. Âćĉеφťś ёĩτĥėŗ τђė йάмє øя ĠŮΪÐ õƒ а φŕóƒίℓè !!! !!! !!! !!! !!! !!! !!! </value>
   </data>
   <data name="CmdSplitPaneDesc" xml:space="preserve">
-    <value>Ĉяéâт℮ α ñёẃ ѕρļίт рãηз !!! !!! </value>
+    <value>Ĉґéáŧе д ήэẅ ŝφĺĭτ рãňё !!! !!! </value>
   </data>
   <data name="CmdSPDesc" xml:space="preserve">
-    <value>Ǻņ ãŀĩàş ƒôґ ţĥ℮ "split-pane" šџьςоmmâņδ. !!! !!! !!! !!!</value>
+    <value>Āл ªļïâś ƒбг ŧћê "split-pane" ŝύвćőммäňδ. !!! !!! !!! !!!</value>
     <comment>{Locked="\"split-pane\""}</comment>
   </data>
   <data name="CmdSplitPaneHorizontalArgDesc" xml:space="preserve">
-    <value>Ĉŕєăтз ťнё ⁿзẁ ρàŉё àŝ а ћõѓϊžőⁿţªℓ ŝρłіт (тнįηк [-]) !!! !!! !!! !!! !!! </value>
+    <value>Ċŕéάťё ťћè ⁿеẁ рâлè åś ǻ ħôŕîžőņτąŀ śρļίτ (ŧнїπĸ [-]) !!! !!! !!! !!! !!! </value>
   </data>
   <data name="CmdSplitPaneVerticalArgDesc" xml:space="preserve">
-    <value>Çгêåтз ťнė йèẃ рãиέ άŝ д νέґťίĉάļ šρĺĩť (τћїŉķ [|]) !!! !!! !!! !!! !!!</value>
+    <value>Ċяěªтĕ ŧнέ ⁿèω ρаηе ªš ā νēѓτîčäŀ ѕрĺįť (тĥїπќ [|]) !!! !!! !!! !!! !!!</value>
   </data>
   <data name="CmdSplitPaneDuplicateArgDesc" xml:space="preserve">
-    <value>Ćřзãτ℮ тђę ŉėẃ φâйέ ьý ďΰρℓíčäтïňģ ťĥė φяοƒíłє θƒ τђэ ƒòćцśеð ρąлέ !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ĉřεâте тħè пέẁ φаńè ъỳ ďцрłíçăţιηğ ťħе φгоƒíľз оƒ τĥě ƒőċūşëð рāиē !!! !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="CmdStartingDirArgDesc" xml:space="preserve">
-    <value>Õрëñ їń ţĥë ġìνєń đĭґĕĉťθŕý іⁿѕťεàð οƒ ţђę ρřǿƒĩĺę'š ŝєŧ "startingDirectory" !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Óрεŋ ιŋ τћē ĝіνèή ðіґėсťσŗý ΐńѕţêªđ ôƒ тħ℮ рřоƒĭľė'ŝ şĕŧ "startingDirectory" !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>{Locked="\"startingDirectory\""}</comment>
   </data>
   <data name="CmdTitleArgDesc" xml:space="preserve">
-    <value>Ǿφěⁿ ŧĥē τεŗмīņâļ щíţĥ ťн℮ φřőνīðĕď ţїţłê íйšŧęāď øƒ тнë ρŕőƒιļέ'š ѕéŧ "title" !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Òрèи ŧћ℮ тεгміņдľ шįтђ τћз рŕσνϊðэđ ţϊťľё їņšτèāď οƒ ŧħз рѓοƒïℓε'š śēт "title" !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>{Locked="\"title\""}</comment>
   </data>
   <data name="CmdTabColorArgDesc" xml:space="preserve">
-    <value>Φрєл ŧĥэ тãъ ŵíŧħ ŧћё ŝρэ¢ìƒϊэδ ¢őłŏř, įи #ѓŗģġьъ ƒöŗmäŧ !!! !!! !!! !!! !!! !</value>
+    <value>Фрєŋ τћę ťāь ẃĭŧĥ ŧĥē ѕρεçíƒĩĕď ċŏĺőŗ, ίŉ #řґģģьь ƒöřмàŧ !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="CmdSuppressApplicationTitleDesc" xml:space="preserve">
-    <value>Òφéл ŧђέ ţàь ẁíţħ τªьŢітŀè ǿνёŕřĭďιŋģ ďēƒάџľţ τīťℓé åňđ śûφрŕėşšΐⁿĝ ŧįŧĺє ĉћαŉģĕ мéśšáġēś ƒґбm ťħë арρℓĩςāтїσⁿ !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Όрзи тћê тäъ ŵîтн ŧãвŦìтŀέ øνėřѓĩδіиĝ δęƒåυĺŧ тīτłê ǻйď ѕűррŕ℮ѕśìήĝ τĭťℓé ċћаπġё mεśšàğзš ƒŗøм тћê ªрρĺĩčªτĭóņ !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>{Locked="\"tabTitle\""}</comment>
   </data>
   <data name="CmdInheritEnvDesc" xml:space="preserve">
-    <value>Ĩηнěѓїт тħè τèŗмιŋāļ'ş óωŉ εήνīřōπméлť νâґįâвĺέş ẅĥēŉ ćřеàţιήġ ţнэ йеω тåь òř ρǻⁿе, řãťħĕѓ τђåл ¢ŕéάťĩήġ α ƒгёşн злνΐřõŉmèⁿτ ъłōçќ. Ťћĭš đéƒąúłŧѕ тö šēт ẁħéή α "command" ΐŝ ρаśšéđ.  !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>İηĥегïт ţĥě ťεřmĭŉǻł'ŝ õώп εņνĩŕόňмěñť νāřĭáьŀĕś ώнēл ĉгėǻтΐŉġ ţħз πęш ţáь ŏŕ ρäη℮, ŗãŧħёř ťĥªή ¢řēäţіηĝ ǻ ƒŗėśћ èήνιгőŋм℮иť ьļο¢к. Тħїš ďęƒαüłŧŝ τõ ѕёţ ẅħēň ą "command" îş ρãśŝéđ.  !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>{Locked="\"command\""}</comment>
   </data>
   <data name="CmdColorSchemeArgDesc" xml:space="preserve">
-    <value>Όφέŋ τĥē ŧаъ шĭтĥ τĥë ѕφęсìƒìέď čõŀόŕ śċћêmë, ìńѕţĕαđ όƒ ţћε φґöƒιłě'š şĕť "colorScheme" !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Øρéη ŧĥē ŧаь щïţђ ţнё ѕрě¢ίƒĩеð ¢θℓôя şĉнем℮, īπѕτêåδ òƒ τĥё φřőƒĭľе'ŝ ѕ℮ť "colorScheme" !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>{Locked="\"colorScheme\""}</comment>
   </data>
   <data name="CmdVersionDesc" xml:space="preserve">
-    <value>Ďìśφłäу ţђê аφφŀīċâŧĩοπ νεŗśіőŋ !!! !!! !!!</value>
+    <value>Ďìśрℓàÿ тћē åφφłîςдťίøп νēřšįóń !!! !!! !!!</value>
   </data>
   <data name="CmdMaximizedDesc" xml:space="preserve">
-    <value>₤ąűņčħ ťĥĕ ẁіπðǿẃ måхíмïźĕď !!! !!! !!</value>
+    <value>Ļáūńçн тћё ẅïиďоŵ мåжімĩźęð !!! !!! !!</value>
   </data>
   <data name="CmdFullscreenDesc" xml:space="preserve">
-    <value>Ĺάцńĉђ ţђє ŵïпđôщ іⁿ ƒüŀłšċѓéëň мσđе !!! !!! !!! !</value>
+    <value>£âµńĉн тнė щίπđощ їŉ ƒûℓŀşċŕėēη мøđè !!! !!! !!! !</value>
   </data>
   <data name="CmdMoveFocusDesc" xml:space="preserve">
-    <value>Мøνέ ƒŏčΰş ŧθ ŧђέ åδĵаćёŉт рάлë ïη ţĥě ŝφėċΐƒίεď đіґэсŧįóń !!! !!! !!! !!! !!! !!</value>
+    <value>Мονë ƒόçцŝ τô ţнε дďјαçéŉţ φáπέ ίņ τнë ѕрéςĩƒїĕδ δіŗéćťïőп !!! !!! !!! !!! !!! !!</value>
   </data>
   <data name="CmdMFDesc" xml:space="preserve">
-    <value>Āη ǻľїαš ƒöř τħê "move-focus" şůвčøмmåⁿđ. !!! !!! !!! !!!</value>
+    <value>Åп âℓιāś ƒóř ŧђз "move-focus" šůъçόмmàпð. !!! !!! !!! !!!</value>
     <comment>{Locked="\"move-focus\""}</comment>
   </data>
   <data name="CmdMoveFocusDirectionArgDesc" xml:space="preserve">
-    <value>Ťђê ðîгèсτîбň ŧǿ мøνё ƒöćμś īπ !!! !!! !!!</value>
+    <value>Тнê đιřèсţïöп ţό мøνĕ ƒŏčúś ìή !!! !!! !!!</value>
   </data>
   <data name="CmdSwapPaneDesc" xml:space="preserve">
-    <value>Ŝẅáφ тĥê ƒθĉŭѕєđ рâńé ŵîτђ ťћэ ªďĵдćėŉτ ρдŋз ιņ ţђε ѕρęċϊƒίèđ δíŗеćτīóŋ !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Šшдφ ťĥė ƒоčùšěď рдйê ŵīťђ ŧнё ãđĵă¢èņτ φåиé íŋ ťĥē šρêςīƒĭзδ đìѓз¢ţįőñ !!! !!! !!! !!! !!! !!! !!!</value>
   </data>
   <data name="CmdSwapPaneDirectionArgDesc" xml:space="preserve">
-    <value>Τĥë đΐґэçτїøŋ ŧθ mòνє ťħĕ ƒŏςΰşеđ рąⁿě ίň !!! !!! !!! !!!</value>
+    <value>Тнě διяèċτîõη ţό mōνе ťћë ƒòčϋš℮δ рαπ℮ īп !!! !!! !!! !!!</value>
   </data>
   <data name="CmdFocusDesc" xml:space="preserve">
-    <value>Ļǻŭйĉђ τнę ẁιŉďõẃ ιи ƒôčųş мøδė !!! !!! !!!</value>
+    <value>Ľãūлçĥ тħέ щíиδσώ ìй ƒô¢ũš мôďз !!! !!! !!!</value>
   </data>
   <data name="CmdSavedLayoutArgDesc" xml:space="preserve">
-    <value>Тнîś раřǻмеτêř ĭѕ άň ϊлтëяņãŀ ĩmрļєméⁿţаţīøи δěτąîĺ аηđ šђоцĺð лŏτ ъě ūşęď. !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ŧћїѕ ρąяáмėŧєѓ ĭş āη їňтεŕήåŀ íмφĺêmёņťдţïòπ ďёŧåĩļ дηð šнŏųļδ ñōţ ьë ųšėð. !!! !!! !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="CmdWindowTargetArgDesc" xml:space="preserve">
-    <value>Ѕρέςïƒγ ä ŧёяmįŉāļ ẁϊņδōẅ ţб řцή ŧн℮ ġïνëŋ ċŏмmàπďľíňε ίń. "0" ãŀẃăуş ŕєƒεґş ţô тнé ¢ūřřзňτ щįήδοŵ.  !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Šрêςĩƒγ а ťĕгmìŋаł ẁϊпðõω τσ ґύŋ τнз ģίνĕи ĉömмαпđľįŉе їй. "0" āℓώąŷš řеƒěŗş ťσ ŧħė çŭґřęπť ẁįŉđǿω.  !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
   </data>
   <data name="CmdPositionDesc" xml:space="preserve">
-    <value>Śρēсíƒý ţнę φóśїťіòⁿ ƒоŕ τħē τėřmìпàĺ, îπ "х,ý" ƒøŕmăţ. !!! !!! !!! !!! !!! !</value>
+    <value>Šрëĉίƒў тћε рόŝíŧιòή ƒōя тнě тėřmįηдŀ, ϊп "х,ÿ" ƒθřмάŧ. !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="CmdSizeDesc" xml:space="preserve">
-    <value>Ѕрëсιƒŷ τнë ήύmьėř óƒ ςθĺùmиš αήď ґσωş ƒòř ťĥз τèґmіŋąľ, ĩŋ "č,ŗ" ƒöŗмªτ. !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Ѕφёĉĩƒỳ тнэ ņµmъ℮ґ øƒ ςòļůmйś ăŋð гøшş ƒöŕ тнε τєѓмϊⁿãŀ, ĩŉ "ċ,ř" ƒθяmãţ. !!! !!! !!! !!! !!! !!! !!! </value>
   </data>
   <data name="NewTabSplitButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.HelpText" xml:space="preserve">
-    <value>Рŗзšş ţђ℮ ъџŧţοи тô òрēń ã ήėщ ŧεґmīñãŀ ţãъ ẅΐтн γōμř đ℮ƒâųļţ φŗōƒĩĺє. Ŏρ℮ή ŧнè ƒĺýöũţ ţô ŝёļĕċτ ẁĥī¢ħ ρґóƒίℓε ýοŭ ẁªñŧ тó ǿφзп. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Рґзѕś тђз вůťŧôй ŧǿ ǿφеη ā ŉéẃ ţєѓmîńąŀ ťâв ωϊŧђ ýθůř đęƒăμℓţ ρŗôƒїĺε. Óρĕп τћё ƒłýбцť ţø śεŀèςŧ шĥïčĥ φřŏƒίļê ўσμ ẁάлτ ţσ όрεй. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
   </data>
   <data name="NewTabSplitButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ņ℮ω Тǻв !!</value>
+    <value>Ňèώ Ŧäъ !!</value>
   </data>
   <data name="NewTabRun.Text" xml:space="preserve">
-    <value>Òρêň â ήęώ ţäь !!! !</value>
+    <value>Όрèπ ª йěŵ ταв !!! !</value>
   </data>
   <data name="NewPaneRun.Text" xml:space="preserve">
-    <value>Λľť+Čℓίčк τö šρŀіт ŧћз ĉűŗяęñт ẅілðοẁ !!! !!! !!! !!</value>
+    <value>Ǻℓт+Сłĩċк тö šрŀîţ ţћë сцřѓèήŧ ẅїпðбω !!! !!! !!! !!</value>
   </data>
   <data name="NewWindowRun.Text" xml:space="preserve">
-    <value>Şнįƒт+Čŀĩćκ ťò θφэη а πèẁ ώίŋďōẅ !!! !!! !!! </value>
+    <value>Śħîƒť+Çľιćĸ тō όрзⁿ ª йзώ ẁίπðôш !!! !!! !!! </value>
   </data>
   <data name="ElevatedRun.Text" xml:space="preserve">
-    <value>Ĉτřł+Ċľìċκ ţò θр℮й ăś àδmίŉìşтгáтöг !!! !!! !!! !</value>
+    <value>€ţŕł+Čℓїčķ τõ ορêņ αŝ аðmìñĩѕτŕăţòг !!! !!! !!! !</value>
   </data>
   <data name="WindowCloseButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Čļőšë !</value>
+    <value>Ćℓőŝз !</value>
   </data>
   <data name="WindowCloseButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>€ľőš℮ !</value>
+    <value>Ĉļøşз !</value>
   </data>
   <data name="WindowCloseButtonToolTip.Text" xml:space="preserve">
-    <value>Çļоšě !</value>
+    <value>Ĉļόѕě !</value>
   </data>
   <data name="WindowMaximizeButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Μå×ίмīžĕ !!</value>
+    <value>Μджįmïźэ !!</value>
   </data>
   <data name="WindowMinimizeButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Μĩńιміžë !!</value>
+    <value>Μïиιmіžё !!</value>
   </data>
   <data name="WindowMinimizeButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Μĩηĭмĩžе !!</value>
+    <value>Μîⁿĩmĩż℮ !!</value>
   </data>
   <data name="WindowMinimizeButtonToolTip.Text" xml:space="preserve">
-    <value>Μîņïmīźè !!</value>
+    <value>Мĩиîmĩżє !!</value>
   </data>
   <data name="AboutDialog.Title" xml:space="preserve">
-    <value>Âъθŭт !</value>
+    <value>Åвōύţ !</value>
   </data>
   <data name="AboutDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Ŝέήδ ₣ěеđвαсķ !!! </value>
+    <value>Ѕеηð ₣ę℮đвäçк !!! </value>
   </data>
   <data name="AboutDialog.CloseButtonText" xml:space="preserve">
-    <value>ΘК </value>
+    <value>ΦΚ </value>
   </data>
   <data name="AboutDialog_VersionLabel.Text" xml:space="preserve">
-    <value>Vэŗşισή: !!</value>
+    <value>Véяšîõп: !!</value>
     <comment>This is the heading for a version number label</comment>
   </data>
   <data name="AboutDialog_GettingStartedLink.Content" xml:space="preserve">
-    <value>Ġėŧτįлġ Śŧăѓтĕð !!! !</value>
+    <value>Ġеťтΐñĝ Ѕτдŗτęď !!! !</value>
     <comment>A hyperlink name for a guide on how to get started using Terminal</comment>
   </data>
   <data name="AboutDialog_SourceCodeLink.Content" xml:space="preserve">
-    <value>Šоúѓс℮ Ĉóðĕ !!!</value>
+    <value>Ѕοџŗсė Çŏđе !!!</value>
     <comment>A hyperlink name for the Terminal's documentation</comment>
   </data>
   <data name="AboutDialog_DocumentationLink.Content" xml:space="preserve">
-    <value>Đóċűm℮ņťâтĭθñ !!! </value>
+    <value>Đŏĉµмěⁿтатïõñ !!! </value>
     <comment>A hyperlink name for user documentation</comment>
   </data>
   <data name="AboutDialog_ReleaseNotesLink.Content" xml:space="preserve">
-    <value>Ѓęłєąśε Ņθтėš !!! </value>
+    <value>Ŗеľ℮àşε Ŋòτéš !!! </value>
     <comment>A hyperlink name for the Terminal's release notes</comment>
   </data>
   <data name="AboutDialog_PrivacyPolicyLink.Content" xml:space="preserve">
-    <value>Ρŕΐναçγ Ρõℓĭčý !!! !</value>
+    <value>Ρґїνãсÿ Рöĺĩςỳ !!! !</value>
     <comment>A hyperlink name for the Terminal's privacy policy</comment>
   </data>
   <data name="AboutDialog_ThirdPartyNoticesLink.Content" xml:space="preserve">
-    <value>Τћїřđ-Ράŕтŷ Ńôţι¢ęś !!! !!!</value>
+    <value>Ţћĩřð-Ρářŧγ ∏οŧīĉęŝ !!! !!!</value>
     <comment>A hyperlink name for the Terminal's third-party notices</comment>
   </data>
   <data name="QuitDialog.CloseButtonText" xml:space="preserve">
-    <value>€áйċêł !</value>
+    <value>Ċдйĉέł !</value>
   </data>
   <data name="QuitDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Сľŏѕè āłℓ !!!</value>
+    <value>€ļőşε áļľ !!!</value>
   </data>
   <data name="QuitDialog.Title" xml:space="preserve">
-    <value>Đò ўθü ẁаⁿŧ ŧб ćŀǿѕё āľℓ ωіⁿđőщš? !!! !!! !!! </value>
+    <value>Ďõ γбű ẁāŋţ ťó ςℓσśĕ äℓℓ шîйđбẁś? !!! !!! !!! </value>
   </data>
   <data name="CloseAllDialog.CloseButtonText" xml:space="preserve">
-    <value>Ćдлčєľ !</value>
+    <value>Ćăŉċęℓ !</value>
   </data>
   <data name="CloseAllDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Çŀóśė άłł !!!</value>
+    <value>Ćļõѕέ аłℓ !!!</value>
   </data>
   <data name="CloseAllDialog.Title" xml:space="preserve">
-    <value>Ðό ỳőΰ ẃàŋτ τõ čŀőśё åĺļ ťāъś? !!! !!! !!!</value>
+    <value>Đσ ŷőū шдиŧ тò čļòŝз αŀľ ţâвŝ? !!! !!! !!!</value>
   </data>
   <data name="CloseReadOnlyDialog.CloseButtonText" xml:space="preserve">
-    <value>Сάήćêł !</value>
+    <value>Čǻñčėŀ !</value>
   </data>
   <data name="CloseReadOnlyDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Čľόşë дйγŵаỳ !!! </value>
+    <value>Сłŏѕε άñÿẃåγ !!! </value>
   </data>
   <data name="CloseReadOnlyDialog.Title" xml:space="preserve">
-    <value>Ẅãŗήĭйģ !!</value>
+    <value>Ẁαгйïņğ !!</value>
   </data>
   <data name="CloseReadOnlyDialog.Content" xml:space="preserve">
-    <value>Υőū ąŗę āвõųт τô ĉℓôśĕ ā ŕęăδ-õήļγ ŧēгмĩņął. Ďø уôü ŵΐѕн ŧö čöŉţìйџè? !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ϋôů ářє дъоϋť ŧо ćľōśέ ª гęаð-öйĺу тêřmĩńäĺ. Đǿ ỳøü ωîśђ ŧő ćőŉţїñϋέ? !!! !!! !!! !!! !!! !!! !!!</value>
   </data>
   <data name="LargePasteDialog.CloseButtonText" xml:space="preserve">
-    <value>Ċдņçëℓ !</value>
+    <value>Сâήçеŀ !</value>
   </data>
   <data name="LargePasteDialog.Content" xml:space="preserve">
-    <value>Ўòџ āřε àьоŭт ťô φªşтĕ τêхť τĥǻŧ ĩѕ ļоñĝёŗ ťĥдⁿ 5 Ќΐß. Ðő γöύ ẅιšђ ţø ċòπτīŋϋė? !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ўōµ ąřε ăвőüť ţò ρãѕŧĕ ťê×ŧ тħãт ïš ľôŉğзŗ ŧђąи 5 ЌΐБ. Đθ γŏΰ ẅĩşħ τò ςõиŧĭňūê? !!! !!! !!! !!! !!! !!! !!! !!!</value>
   </data>
   <data name="LargePasteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Ρåŝтę ąηýẅªγ !!! </value>
+    <value>Ρâşτз ăπуẅаý !!! </value>
   </data>
   <data name="LargePasteDialog.Title" xml:space="preserve">
-    <value>Ẁǻґñīņĝ !!</value>
+    <value>Ẃâгηïņğ !!</value>
   </data>
   <data name="MultiLinePasteDialog.CloseButtonText" xml:space="preserve">
-    <value>Саńčеļ !</value>
+    <value>Ćªήĉěł !</value>
   </data>
   <data name="MultiLineWarningText.Text" xml:space="preserve">
-    <value>Ϋσų ąгε ąвőûτ τо ρдѕťз τзхŧ ŧђàţ ¢õитαίņŝ mύĺтïρľė ĺĭñêѕ. Íƒ ÿσΰ рάѕţè τнϊş ŧèжŧ ìйŧõ ÿοŭґ şнéľĺ, ΐт mаý řëśϋℓŧ îň ŧħě ϋñĕхφ℮¢ţзð ε×эĉûτιбņ οƒ čømмãпðś. Ðō ÿôû ẁίѕĥ ţó сöñţïñûĕ? !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Ϋбů áяē авôцţ τŏ ρªѕŧê ťĕхţ ťĥâť ĉοлŧäїлš mųŀťїрŀē ĺΐиέš. Ĭƒ ýŏû рαśτё ťђìš ť℮хŧ îήŧø γõũŗ ѕћêℓļ, íτ mду ŗéśμļт įŋ ţħ℮ цпęхρ℮çťêď з×эćúтϊŏⁿ õƒ ςōмmãⁿðş. Đο убŭ ẃīѕн τõ ċôŉŧïñûε? !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
   </data>
   <data name="MultiLinePasteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Раşтё ǻлýщáỳ !!! </value>
+    <value>Ρªšţє аńŷẁàŷ !!! </value>
   </data>
   <data name="MultiLinePasteDialog.Title" xml:space="preserve">
-    <value>Ẃăřиїńğ !!</value>
+    <value>Щāŕñιπĝ !!</value>
   </data>
   <data name="CommandPalette_SearchBox.PlaceholderText" xml:space="preserve">
-    <value>Ţỳрε а ċθммªňď ŋămэ... !!! !!! </value>
+    <value>Ťýφě á ĉθmmāņđ йăмē... !!! !!! </value>
   </data>
   <data name="CommandPalette_NoMatchesText.Text" xml:space="preserve">
-    <value>Ŋô măŧĉђįñġ ćõммâиďš !!! !!!</value>
+    <value>Ŋό маŧ¢ĥΐŋğ сóмmăлđš !!! !!!</value>
   </data>
   <data name="CommandPaletteModeAnnouncement_ActionMode" xml:space="preserve">
-    <value>Аĉŧíòи šêдŗćħ möđε !!! !!</value>
+    <value>∆ćŧìøп şєāяćħ мóδє !!! !!</value>
     <comment>This text will be read aloud using assistive technologies when the command palette switches into action (command search) mode.</comment>
   </data>
   <data name="CommandPaletteModeAnnouncement_TabSearchSwitchMode" xml:space="preserve">
-    <value>Ŧаь ţìτłē мöďё !!! !</value>
+    <value>Тàв ťїтłé môðэ !!! !</value>
     <comment>This text will be read aloud using assistive technologies when the command palette switches into a mode that filters tab names.</comment>
   </data>
   <data name="CommandPaletteModeAnnouncement_CommandlineMode" xml:space="preserve">
-    <value>Çоммаиđ-łĭпê mσďę !!! !!</value>
+    <value>Çοmмăπď-ĺιиé мõđэ !!! !!</value>
     <comment>This text will be read aloud using assistive technologies when the command palette switches into the raw commandline parsing mode.</comment>
   </data>
   <data name="CommandPalette_NestedCommandAnnouncement" xml:space="preserve">
-    <value>Мõґē бρтīøńŝ ƒõѓ "{}" !!! !!!</value>
+    <value>Μояē öφтίóπś ƒőř "{}" !!! !!!</value>
     <comment>This text will be read aloud using assistive technologies when the user selects a command that has additional options. The {} will be expanded to the name of the command containing more options.</comment>
   </data>
   <data name="CommandPalette_ParsedCommandLine" xml:space="preserve">
-    <value>Ĕхёсûţîπġ ćõмmáⁿδ ℓīňë ŵìℓĺ ĩⁿνōκè ŧħę ƒôłľόшîпğ ċømmåņðş: !!! !!! !!! !!! !!! !!</value>
+    <value>Ėжėсùţīпğ ¢ōmмªñð ĺїπĕ ẁíĺł ĭиνокė тħе ƒöĺℓŏщîпġ çõmмāⁿďѕ: !!! !!! !!! !!! !!! !!</value>
     <comment>Will be followed by a list of strings describing parsed commands</comment>
   </data>
   <data name="CommandPalette_FailedParsingCommandLine" xml:space="preserve">
-    <value>₣дìĺέď ρǻяšΐňģ čǿмmдиď ľïñέ: !!! !!! !!</value>
+    <value>₣āіľ℮ď рàгśīпģ ¢бммäⁿδ ĺīñè: !!! !!! !!</value>
   </data>
   <data name="CommandPaletteControlName" xml:space="preserve">
-    <value>€οmмдиδ Ρãℓėŧţė !!! !</value>
+    <value>Ćσmmăηδ Рάŀĕтţ℮ !!! !</value>
   </data>
   <data name="TabSwitcherControlName" xml:space="preserve">
-    <value>Ŧав Ѕώįťċнзя !!! </value>
+    <value>Τăь Ѕωîťςћêг !!! </value>
   </data>
   <data name="TabSwitcher_SearchBoxText" xml:space="preserve">
-    <value>Ţýρе ǻ ťåв ήáмє... !!! !!</value>
+    <value>Ţýρё ă тăъ пâmě... !!! !!</value>
   </data>
   <data name="TabSwitcher_NoMatchesText" xml:space="preserve">
-    <value>Ñό màŧĉĥĩпģ тåв лąмę !!! !!!</value>
+    <value>Ńô мατćнìņģ ţдъ пªмĕ !!! !!!</value>
   </data>
   <data name="CmdPalCommandlinePrompt" xml:space="preserve">
-    <value>Ęⁿţέŕ а wt ςōммǻŋđłïηé ťò гůņ !!! !!! !!!</value>
+    <value>Èηŧĕґ ǻ wt ċθmмаŉđļïŉė тο ŕūŉ !!! !!! !!!</value>
     <comment>{Locked="wt"} </comment>
   </data>
   <data name="SuggestionsControl_NestedCommandAnnouncement" xml:space="preserve">
-    <value>Μŏѓê øφţįőńş ƒóř "{}" !!! !!!</value>
+    <value>Μōŗè σφŧïθлš ƒόŕ "{}" !!! !!!</value>
     <comment>This text will be read aloud using assistive technologies when the user selects a command that has additional options. The {} will be expanded to the name of the command containing more options.</comment>
   </data>
   <data name="SuggestionsControl_SearchBox.PlaceholderText" xml:space="preserve">
-    <value>Тÿрє ā čомmäŉð ńаmэ... !!! !!! </value>
+    <value>Ťÿφė å ċοmмªйđ ηаmє... !!! !!! </value>
   </data>
   <data name="SuggestionsControl_NoMatchesText.Text" xml:space="preserve">
-    <value>Иô мǻţčђїńġ ćõmmåŋđŝ !!! !!!</value>
+    <value>Ņô mάťςћίņĝ ċоmмάņďš !!! !!!</value>
   </data>
   <data name="SuggestionsControlName" xml:space="preserve">
-    <value>Ѕцğĝēѕтĩóⁿŝ mεйű !!! !</value>
+    <value>Šύğġěşţįσпś м℮ŉμ !!! !</value>
   </data>
   <data name="SuggestionsControl_MoreOptions.[using:Windows.UI.Xaml.Automation]AutomationProperties.HelpText" xml:space="preserve">
-    <value>Мòřε ōрťïóⁿš !!! </value>
+    <value>Мόѓė ōφťіŏⁿś !!! </value>
   </data>
   <data name="SuggestionsControl_MatchesAvailable" xml:space="preserve">
-    <value>Ŝűģĝзšŧïõлѕ ƒǿûňδ: {0} !!! !!! </value>
+    <value>Śΰġģ℮šτϊθñѕ ƒöüⁿδ: {0} !!! !!! </value>
     <comment>{0} will be replaced with a number.</comment>
   </data>
   <data name="CrimsonColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ċґįmśõņ !!</value>
+    <value>€яïmşǿń !!</value>
   </data>
   <data name="SteelBlueColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Şţêēļ Вľΰë !!!</value>
+    <value>Ѕťéêℓ βľυэ !!!</value>
   </data>
   <data name="MediumSeaGreenColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Мěďīųм Ŝęά Ğřĕ℮ņ !!! !</value>
+    <value>Μёδιųm Ѕεд Ğґзēη !!! !</value>
   </data>
   <data name="DarkOrangeColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ďåґķ Φѓăŋġé !!!</value>
+    <value>Ďäŕќ Õřäňğè !!!</value>
   </data>
   <data name="MediumVioletRedColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Мēðіΰm Vϊόŀěť Яєď !!! !!</value>
+    <value>Мęðϊům Vĭõľзт Ѓεð !!! !!</value>
   </data>
   <data name="DodgerBlueColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ðοďĝέґ βľυę !!!</value>
+    <value>Ðôđğēг Βĺϋę !!!</value>
   </data>
   <data name="LimeGreenColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ŀімě Ġŕеéň !!!</value>
+    <value>Ĺіmз Ĝґéĕи !!!</value>
   </data>
   <data name="YellowColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ŷέļłőẃ !</value>
+    <value>¥ęℓłοẃ !</value>
   </data>
   <data name="BlueVioletColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Вŀûє Vĩöĺеť !!!</value>
+    <value>Ьľùе Vΐбŀэτ !!!</value>
   </data>
   <data name="SlateBlueColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Šĺàŧĕ Бłůέ !!!</value>
+    <value>Şŀаťę Βĺûė !!!</value>
   </data>
   <data name="LimeColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ŀíмё !</value>
+    <value>£ϊмз !</value>
   </data>
   <data name="TanColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ťдπ </value>
+    <value>Ťåπ </value>
   </data>
   <data name="MagentaColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Мâġėňтα !!</value>
+    <value>Μàğэⁿτα !!</value>
   </data>
   <data name="CyanColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>€ÿàй !</value>
+    <value>Ċуåň !</value>
   </data>
   <data name="SkyBlueColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Śκŷ ßłúë !!</value>
+    <value>Šќŷ ßľϋ℮ !!</value>
   </data>
   <data name="DarkGrayColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Đąřķ Ģґăý !!!</value>
+    <value>Ðàŗκ Ğѓáγ !!!</value>
   </data>
   <data name="InvalidUriText" xml:space="preserve">
-    <value>Τĥīś łīлĸ ĭś īⁿνдļîď: !!! !!!</value>
+    <value>Τћїš ŀĩňк іѕ įňνдŀíď: !!! !!!</value>
   </data>
   <data name="UnsupportedSchemeText" xml:space="preserve">
-    <value>Ťђιš ļĭπк ŧγρę ιş ςύґŗёηťľỳ ŋôт śũрρόятзđ: !!! !!! !!! !!! </value>
+    <value>Ťђïś łϊηќ ŧурē ιş çũґѓзⁿτľÿ ñστ şΰρρоŕŧĕđ: !!! !!! !!! !!! </value>
   </data>
   <data name="CouldNotOpenUriDialog.PrimaryButtonText" xml:space="preserve">
-    <value>€дⁿĉεℓ !</value>
+    <value>Сąñс℮ł !</value>
   </data>
   <data name="SettingsTab" xml:space="preserve">
-    <value>Ŝêттΐŉġş !!</value>
+    <value>Śëţťĩпğś !!</value>
   </data>
   <data name="FailedToWriteToSettings" xml:space="preserve">
-    <value>Щз сőυĺδ йότ шříтз тθ ўоџŕ šėτţįŋĝš ƒïĺε. €ħесќ ţђε рëѓmĩšşîбñŝ òη ťћăţ ƒíļе ţό ěήѕüяē тĥāт ťħе гεάđ-øñℓý ƒℓªğ ϊś ņōт ѕзτ āиđ ŧнàт ẅřіţê áςčεѕş їѕ ĝѓăήτєđ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ẃε ςőűℓđ пòт ωяΐτë ŧô γôύг šěťтïπĝŝ ƒīłě. Çђêĉĸ ţђэ φеřмìşŝΐóпѕ õл ťђàτ ƒĩŀε ţб έπšμґé ţђäť тћê ѓέάδ-õлļỳ ƒŀãġ ΐš ŉοт ŝėт ǻпď ţнăт ẅѓīţĕ ăсċéšş ĩş ģŗдŋτëđ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="ParentCommandBackButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Βãčκ !</value>
+    <value>Бдçķ !</value>
   </data>
   <data name="ParentCommandBackButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>βāċķ !</value>
+    <value>Ьãςк !</value>
   </data>
   <data name="ControlNoticeDialog.PrimaryButtonText" xml:space="preserve">
-    <value>ФК </value>
+    <value>ΘК </value>
   </data>
   <data name="NoticeDebug" xml:space="preserve">
-    <value>Ðéвµģ !</value>
+    <value>Ďêъŭģ !</value>
   </data>
   <data name="NoticeError" xml:space="preserve">
-    <value>Ēŕřθř !</value>
+    <value>∑ŕřοґ !</value>
   </data>
   <data name="NoticeInfo" xml:space="preserve">
-    <value>Ϊήƒόѓмâŧїōл !!!</value>
+    <value>Īπƒóřмąτιŏŉ !!!</value>
   </data>
   <data name="NoticeWarning" xml:space="preserve">
-    <value>Ẅάѓŉιⁿğ !!</value>
+    <value>Шãřñїņģ !!</value>
   </data>
   <data name="ClipboardTextHeader.Text" xml:space="preserve">
-    <value>Сłįръοåřđ čôπŧέŉŧš (ρŗзνįēŵ): !!! !!! !!!</value>
+    <value>€ℓірьоåŗδ ĉóńťęňтѕ (φѓενĭεẃ): !!! !!! !!!</value>
   </data>
   <data name="CommandPalette_MoreOptions.[using:Windows.UI.Xaml.Automation]AutomationProperties.HelpText" xml:space="preserve">
-    <value>Μōгę øрţïбŉś !!! </value>
+    <value>Мθґе бφŧīбπš !!! </value>
   </data>
   <data name="WindowIdLabel" xml:space="preserve">
-    <value>Шϊиđŏώ !</value>
+    <value>Ẅίńďöщ !</value>
     <comment>This is displayed as a label for a number, like "Window: 10"</comment>
   </data>
   <data name="UnnamedWindowName" xml:space="preserve">
-    <value>ûйηãмзđ ŵĩņðőώ !!! !</value>
+    <value>υŉňàмěđ ẅіπďōẅ !!! !</value>
     <comment>text used to identify when a window hasn't been assigned a name by the user</comment>
   </data>
   <data name="WindowRenamer.Subtitle" xml:space="preserve">
-    <value>Ėⁿŧęѓ ä ňèŵ ñāмė: !!! !!</value>
+    <value>Єиŧ℮ŗ ă ñéẁ йάmё: !!! !!</value>
   </data>
   <data name="WindowRenamer.ActionButtonContent" xml:space="preserve">
-    <value>ΦΚ </value>
+    <value>ÒК </value>
   </data>
   <data name="WindowRenamer.CloseButtonContent" xml:space="preserve">
-    <value>Čǻŉςёŀ !</value>
+    <value>Сªⁿċĕĺ !</value>
   </data>
   <data name="RenameFailedToast.Title" xml:space="preserve">
-    <value>₣åϊłеď ťō ŕэñάмę ẅϊпďöẁ !!! !!! </value>
+    <value>₣âιļĕđ ŧо ѓëňąмë щϊπδǿω !!! !!! </value>
   </data>
   <data name="RenameFailedToast.Subtitle" xml:space="preserve">
-    <value>Äлôţħêř ωīńδõẃ ẁίтћ τђаŧ ńªмě áłŗěаďŷ ё×ĩşťѕ !!! !!! !!! !!! !</value>
+    <value>Άņόтĥěŗ ẃїлðοω ẁιťĥ ťћаť пâmě ăļřéàδў ёжìśŧѕ !!! !!! !!! !!! !</value>
   </data>
   <data name="WindowMaximizeButtonToolTip" xml:space="preserve">
-    <value>Μā×ΐmĭźё !!</value>
+    <value>Μą×ìmϊżé !!</value>
   </data>
   <data name="WindowRestoreDownButtonToolTip" xml:space="preserve">
-    <value>Г℮šţòґě Ďôẁл !!! </value>
+    <value>Ŕèšŧòяё Ðǿẃи !!! </value>
   </data>
   <data name="CommandPaletteMenuItem" xml:space="preserve">
-    <value>Ćőmmªňď Ρăľёŧţε !!! !</value>
+    <value>Ċòмmāńδ Рªľėτťë !!! !</value>
   </data>
   <data name="NotificationIconFocusTerminal" xml:space="preserve">
-    <value>₣õĉΰѕ Ŧέгмîŋäľ !!! !</value>
+    <value>₣ôćűŝ Ţеґмĭйâŀ !!! !</value>
     <comment>This is displayed as a label for the context menu item that focuses the terminal.</comment>
   </data>
   <data name="NotificationIconWindowSubmenu" xml:space="preserve">
-    <value>Ẅϊŉďθẁş !!</value>
+    <value>Ẃϊйδοŵš !!</value>
     <comment>This is displayed as a label for the context menu item that holds the submenu of available windows.</comment>
   </data>
   <data name="DropPathTabRun.Text" xml:space="preserve">
-    <value>Óφêй â лέώ ŧâв ĭŉ ğΐνéņ şţăřτíήġ ďįяе¢тоѓγ !!! !!! !!! !!! </value>
+    <value>Фφĕń ª пёẅ ţâь ίи ğīνęņ ѕŧāятĩлğ δįŗęćтŏяγ !!! !!! !!! !!! </value>
   </data>
   <data name="DropPathTabNewWindow.Text" xml:space="preserve">
-    <value>Фφēή ä ñēώ щїήďθẅ ώϊτħ ġіνėй ѕŧαŕтїйğ đïřéĉтõŗý !!! !!! !!! !!! !!</value>
+    <value>Οφэй ä ŋёώ ẅįńðбώ ẁįτђ ĝĩνēη šτáгтϊŋĝ ðĭřěçŧøгγ !!! !!! !!! !!! !!</value>
   </data>
   <data name="DropPathTabSplit.Text" xml:space="preserve">
-    <value>Ŝрļîţ ťнε ωΐήđõẃ άήδ ѕтăřŧ ĭπ ġіνэŋ δΐяëĉŧоŗу !!! !!! !!! !!! !</value>
+    <value>Ŝρℓΐŧ ŧнė ẁίňďõŵ άпδ ŝţâґţ ίń ģįνëŉ δϊгέ¢ŧøяў !!! !!! !!! !!! !</value>
   </data>
   <data name="ExportTabText" xml:space="preserve">
-    <value>Е×ρōґт Τ℮хŧ !!!</value>
+    <value>Ė×φōŗŧ Ţєхŧ !!!</value>
   </data>
   <data name="ExportFailure" xml:space="preserve">
-    <value>₣ăīļēđ ţǿ έжρõřŧ τëřмïňãĺ ćóñτëητ !!! !!! !!! </value>
+    <value>₣ăìľεď ťθ эхроґт ţеґmίñдļ ¢ōйт℮лť !!! !!! !!! </value>
   </data>
   <data name="ExportSuccess" xml:space="preserve">
-    <value>Şυčć℮ѕŝƒϋĺŀŷ ε×ρøяťзđ ŧэґмϊйáļ ćõņťεлţ !!! !!! !!! !!</value>
+    <value>Ŝūĉčєšśƒυłłγ ĕ×φòŗтэð тēгмïŉãℓ ĉοŉťëⁿţ !!! !!! !!! !!</value>
   </data>
   <data name="FindText" xml:space="preserve">
-    <value>₣їŋð !</value>
+    <value>₣ìпđ !</value>
   </data>
   <data name="PlainText" xml:space="preserve">
-    <value>Рľάïŉ Τėхт !!!</value>
+    <value>Ρĺáīň Тěхт !!!</value>
   </data>
   <data name="CloseOnExitInfoBar.Message" xml:space="preserve">
-    <value>Тёѓmĩŋáŧΐôń ъεђàνĭöґ ĉáл ьέ ćôлƒιģџřěď ĩń ąďνάиĉëđ φяóƒίłĕ ŝеţτϊпĝś. !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Ťéямїлâŧîόň ь℮ћäνįőř čªή вĕ ċοñƒĩġџřèδ įŋ ăδνåл¢êð ряòƒιļє şėŧтіиĝś. !!! !!! !!! !!! !!! !!! !!</value>
   </data>
   <data name="InfoBarDismissButton.Content" xml:space="preserve">
-    <value>Ðόπ'т śħöω ãġāїй !!! !</value>
+    <value>Ďόń'ţ šħόω ãĝάϊл !!! !</value>
   </data>
   <data name="ElevationShield.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ţђīѕ Тёřмíņàĺ щίńďόщ ĩѕ яџиńίйğ дś Δδmϊⁿ !!! !!! !!! !!!</value>
+    <value>Ţђіś Тĕřмїηǻℓ шĩⁿðöŵ ïѕ ѓüñňĩñģ ãŝ Ãðmĭⁿ !!! !!! !!! !!!</value>
   </data>
   <data name="CommandPalette_MatchesAvailable" xml:space="preserve">
-    <value>Śυģģєşτîòиŝ ƒοųņδ: {0} !!! !!! </value>
+    <value>Ѕũğġεšтįóпş ƒōцŉđ: {0} !!! !!! </value>
     <comment>{0} will be replaced with a number.</comment>
   </data>
   <data name="AboutDialog_CheckingForUpdatesLabel.Text" xml:space="preserve">
-    <value>Ċĥēćкîñģ ƒθř ūρďάţēŝ... !!! !!! </value>
+    <value>Çђęċќїŋğ ƒσř ũρδàτέѕ... !!! !!! </value>
   </data>
   <data name="AboutDialog_UpdateAvailableLabel.Text" xml:space="preserve">
-    <value>Ăŋ űрδάтē ΐś ãνāїļâвł℮. !!! !!! </value>
+    <value>Δŉ μρđаŧè ĭś ăνăϊłªвľė. !!! !!! </value>
   </data>
   <data name="AboutDialog_InstallUpdateButton.Content" xml:space="preserve">
-    <value>Ĭńšτдℓℓ пøш !!!</value>
+    <value>Ϊŋśţāŀŀ πбẁ !!!</value>
   </data>
   <data name="DuplicateRemainingProfilesEntry" xml:space="preserve">
-    <value>Τħē "newTabMenu" ƒĩêłď сöήťåïŋş mōřé ŧĥдл оņě êηтřγ őƒ ţỳφë "remainingProfiles". Õňľỳ ŧнė ƒîґšŧ οήз ώìłļ в℮ čσņšїďèгеð. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ŧђê "newTabMenu" ƒιêŀď čσñţąϊйѕ mōѓé ťђǻñ öŋė ёňτŕý őƒ τýρê "ґёмãīліηģРяöƒïľєś". Φпĺў τђё ƒΐѓšτ όñè ώїłł ьè ĉőлѕìδēяёδ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>{Locked="newTabMenu"} {Locked="remainingProfiles"}</comment>
   </data>
   <data name="InvalidUseOfContent" xml:space="preserve">
-    <value>Ţнé "__content" φѓορεяτў ĭѕ řêŝęѓνеď ƒǿř įйтзѓйäļ űşе !!! !!! !!! !!! !!! </value>
+    <value>Ťђέ "__content" φŕόφέŕτγ íś řêšзřνеð ƒσř ійтėŕňåℓ ΰşè !!! !!! !!! !!! !!! </value>
     <comment>{Locked="__content"}</comment>
   </data>
   <data name="AboutToolTip" xml:space="preserve">
-    <value>Ωρēп ǻ ďîаľôĝ сōňŧдįńΐņģ ρгόďϋčţ ĩήƒбŗмâтîõń !!! !!! !!! !!! !</value>
+    <value>Фφèη а ðїаļθĝ ćбⁿťáĭηΐñģ ρřσđůčŧ ілƒǿřmãтĩöή !!! !!! !!! !!! !</value>
   </data>
   <data name="ChooseColorToolTip" xml:space="preserve">
-    <value>Öφέη ťħē ĉôℓôг ρįςќēґ ŧǿ ςћóőšе ţћє ċόłöŕ όƒ ţĥįŝ ťãь !!! !!! !!! !!! !!! </value>
+    <value>Ωφĕй ŧнė ¢óŀοŕ φĩċĸęř τσ ¢ђőōѕė ťħê сõľòŗ бƒ ŧħįѕ τªь !!! !!! !!! !!! !!! </value>
   </data>
   <data name="CommandPaletteToolTip" xml:space="preserve">
-    <value>Óφεŉ ŧħе ςóмmǻηð φąŀëŧτε !!! !!! !</value>
+    <value>Øρĕл ţће сǿmмåήđ ρãĺέτŧě !!! !!! !</value>
   </data>
   <data name="DuplicateTabToolTip" xml:space="preserve">
-    <value>Öρěń α ηёω ţâь ųśìπğ тћė áċτíνĕ φŗôƒìĺе ιŋ тћé çΰгřєŋŧ đířéċťσѓÿ !!! !!! !!! !!! !!! !!! !</value>
+    <value>Óρέл â ŉзш τàв ũśĭлġ ŧħё ąċŧîνê ρŕøƒΐĺé ĩи ţħě çúггзηт đĩřзçţøřý !!! !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="ExportTabToolTip" xml:space="preserve">
-    <value>Έ×ρøѓť τħέ čôлтзⁿťѕ õƒ ţћë τехť вцƒƒêя įήţǿ â ťέжţ ƒīĺє !!! !!! !!! !!! !!! !</value>
+    <value>Ēхφõґт τĥе сǿήŧĕиŧѕ ōƒ τђė ťε×τ ъũƒƒεř ĩήŧо α ţé×ť ƒιļê !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="FindToolTip" xml:space="preserve">
-    <value>Øрëй тђê šěāřćђ đïªłôģ !!! !!! </value>
+    <value>Φρéņ ŧнĕ şęâřςћ ðíάŀŏģ !!! !!! </value>
   </data>
   <data name="RenameTabToolTip" xml:space="preserve">
-    <value>Γёńāмę ţħιѕ тáъ !!! !</value>
+    <value>Ŗėлαмē тħíŝ тåв !!! !</value>
   </data>
   <data name="SettingsToolTip" xml:space="preserve">
-    <value>Θрėń ţћē ѕèŧţΐŋğŝ рãģĕ !!! !!! </value>
+    <value>Òφĕņ тĥе šэτŧīлğš ρдģė !!! !!! </value>
   </data>
   <data name="SplitTabToolTip" xml:space="preserve">
-    <value>Ŏρеи ǻ лěẁ рăηë űŝĭňģ ťћэ ªсťįνέ ρгбƒίļ℮ ιň ťђ℮ čŭѓŕėйŧ ďįѓęčťōґу !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ωрėŋ д πėẁ φâиě űѕīⁿģ тĥэ ã¢τίνë рřŏƒίĺê îŋ ţћэ çūŗгěηт ďíř℮ĉŧõгỳ !!! !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="TabCloseAfterToolTip" xml:space="preserve">
-    <value>Ĉŀôśё àłł τáъś ťǿ ŧĥє ŕįĝнт ŏƒ ţĥìš ťâь !!! !!! !!! !!!</value>
+    <value>Сłǿśе ǻĺľ τăвś ţô ŧн℮ яîĝħť őƒ τђїş тάв !!! !!! !!! !!!</value>
   </data>
   <data name="TabCloseOtherToolTip" xml:space="preserve">
-    <value>Ćŀǿŝē âłĺ ŧǻъş ë×ćзρţ ťђïš ŧăь !!! !!! !!!</value>
+    <value>€ļόѕĕ ªŀŀ ŧáвѕ έ×ćèρт ŧнìş ŧåв !!! !!! !!!</value>
   </data>
   <data name="TabCloseToolTip" xml:space="preserve">
-    <value>Çℓôѕé τнĭš τăь !!! !</value>
+    <value>Ĉłоśэ ťĥìŝ ţªъ !!! !</value>
   </data>
   <data name="NewTabMenuFolderEmpty" xml:space="preserve">
-    <value>Έmрту... !!</value>
+    <value>Ёмφţγ... !!</value>
   </data>
   <data name="ClosePaneText" xml:space="preserve">
-    <value>€ŀοşē Ρǻйė !!!</value>
+    <value>Ĉĺοŝе Ρаиę !!!</value>
   </data>
   <data name="ClosePaneToolTip" xml:space="preserve">
-    <value>€ℓöśė ţħэ âćτīνз ρªπę ϊƒ mυŀтïрℓэ рάñęş ǻřě φґĕŝëηţ !!! !!! !!! !!! !!!</value>
+    <value>Çĺόś℮ τнĕ ă¢τίν℮ рáлĕ ιƒ mϋŀţїрĺë φàńęś άŗє рřęšеńт !!! !!! !!! !!! !!!</value>
   </data>
   <data name="TabColorClearButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.FullDescription" xml:space="preserve">
-    <value>Γĕşęŧ ţåъ ċθłõŗ !!! !</value>
+    <value>Ґέšεт τăъ ċǿℓőґ !!! !</value>
     <comment>Text used to identify the reset button</comment>
   </data>
   <data name="MoveTabToNewWindowText" xml:space="preserve">
-    <value>Μøνέ Ťãъ ŧø Ņ℮ẃ Ŵїŋđóш !!! !!! </value>
+    <value>Мόνз Ţǻь ŧö П℮ω Щĭŋδōώ !!! !!! </value>
   </data>
   <data name="MoveTabToNewWindowToolTip" xml:space="preserve">
-    <value>Μονèѕ τäь το д пěẃ шϊлδǿẃ  !!! !!! !</value>
+    <value>Мøνëŝ ŧªъ ŧǿ ã пεẃ шίŋđоẁ  !!! !!! !</value>
   </data>
   <data name="RunAsAdminFlyout.Text" xml:space="preserve">
-    <value>Ŗμń ąś Áđмįпįśŧѓăτőř !!! !!!</value>
+    <value>Ŕμŋ ąś Āďmįиíšťґąţőя !!! !!!</value>
     <comment>This text is displayed on context menu for profile entries in add new tab button.</comment>
   </data>
   <data name="TerminalPage_PaneMovedAnnouncement_ExistingTab" xml:space="preserve">
-    <value>∆çţіνė ρªňè möνéδ ťõ "{0}" ťªъ !!! !!! !!!</value>
+    <value>∆çťíνĕ рåⁿэ мôνеð ťб "{0}" ţав !!! !!! !!!</value>
     <comment>{Locked="{0}"}This text is read out by screen readers upon a successful pane movement. {0} is the name of the tab the pane was moved to.</comment>
   </data>
   <data name="TerminalPage_TabMovedAnnouncement_Default" xml:space="preserve">
-    <value>"{0}" тăъ мǿνèδ тб "{1}" ώілδòẁ !!! !!! !!!</value>
+    <value>"{0}" ťāъ мōνęđ τŏ "{1}" шΐπδŏẅ !!! !!! !!!</value>
     <comment>{Locked="{0}"}{Locked="{1}"}This text is read out by screen readers upon a successful tab movement. {0} is the name of the tab. {1} is the name of the window the tab was moved to.</comment>
   </data>
   <data name="TerminalPage_TabMovedAnnouncement_NewWindow" xml:space="preserve">
-    <value>"{0}" τäь môνėđ ťö ηęω ωĩⁿđοш !!! !!! !!!</value>
+    <value>"{0}" тąь mǿνєđ ŧσ ήèώ ẅĩŋďøẃ !!! !!! !!!</value>
     <comment>{Locked="{0}"}This text is read out by screen readers upon a successful tab movement. {0} is the name of the tab.</comment>
   </data>
   <data name="TerminalPage_TabMovedAnnouncement_Direction" xml:space="preserve">
-    <value>"{0}" ťáь мòνέð τό ρôšìťϊǿñ "{1}" !!! !!! !!! </value>
+    <value>"{0}" ŧαв мονĕđ το φóŝїŧíŏñ "{1}" !!! !!! !!! </value>
     <comment>{Locked="{0}"}{Locked="{1}"}This text is read out by screen readers upon a successful tab movement. {0} is the name of the tab. {1} is the new tab index in the tab row.</comment>
   </data>
   <data name="TerminalPage_PaneMovedAnnouncement_ExistingWindow" xml:space="preserve">
-    <value>Δсτîνę ρдηё мσνëđ ŧǿ "{0}" ŧâь ĩŉ "{1}" щΐńδоω !!! !!! !!! !!! !</value>
+    <value>Α¢ťϊνë рãņє môνέď τō "{0}" ţâъ ĭή "{1}" ẃĩńδθш !!! !!! !!! !!! !</value>
     <comment>{Locked="{0}"}{Locked="{1}"}This text is read out by screen readers upon a successful pane movement. {0} is the name of the tab the pane was moved to. {1} is the name of the window the pane was moved to. Replaced in 1.19 by TerminalPage_PaneMovedAnnouncement_ExistingWindow2</comment>
   </data>
   <data name="TerminalPage_PaneMovedAnnouncement_ExistingWindow2" xml:space="preserve">
-    <value>Αĉтīνĕ рάňè мбνéδ тŏ "{0}" ŵιⁿđŏω !!! !!! !!! </value>
+    <value>Λςťìνє рáиė mόνéð ťб "{0}" ŵîńđθω !!! !!! !!! </value>
     <comment>{Locked="{0}"}This text is read out by screen readers upon a successful pane movement. {0} is the name of the window the pane was moved to.</comment>
   </data>
   <data name="TerminalPage_PaneMovedAnnouncement_NewWindow" xml:space="preserve">
-    <value>Δċŧίνë рăпε möν℮ď ţό ή℮ẁ ẃίⁿδõŵ !!! !!! !!!</value>
+    <value>Αĉťįνέ ρªņз mσνёđ τǿ ήёẃ ẃîпďǿω !!! !!! !!!</value>
     <comment>This text is read out by screen readers upon a successful pane movement to a new window.</comment>
   </data>
   <data name="TerminalPage_PaneMovedAnnouncement_NewTab" xml:space="preserve">
-    <value>∆ĉŧïνε φâй℮ мσνěð ŧő пèẃ τдв !!! !!! !!</value>
+    <value>Дсţϊνё φαŋє mбν℮ð ťŏ ηеẁ ταв !!! !!! !!</value>
     <comment>This text is read out by screen readers upon a successful pane movement to a new tab within the existing window.</comment>
   </data>
   <data name="CmdAppendCommandLineDesc" xml:space="preserve">
-    <value>Іƒ šεт, ťĥē ċōмmáиð ŵіĺℓ ъė áφρėηďéδ тō ťћĕ ρřσƒĩℓз'ş ďēƒªцľŧ çõммâŉđ їⁿŝťèàď σƒ яёрľάĉіŉĝ іт. !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ĩƒ šęţ, ŧнĕ ¢ömmдлδ ŵîĺł ьέ åφрєйδĕđ τσ ŧђė рřŏƒїłє'ş đзƒªūľţ ¢οmмăńδ іñѕţέáđ øƒ ѓēρļąċĭлĝ їţ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="RestartConnectionText" xml:space="preserve">
-    <value>Ѓёѕťąřτ Čόņńěċтīōņ !!! !!</value>
+    <value>Γēѕŧâяŧ Ĉǿńńēčťїöл !!! !!</value>
   </data>
   <data name="RestartConnectionToolTip" xml:space="preserve">
-    <value>Гєšťάřŧ ťђé ǻсťїνę рдйε ςσлήеςťїõπ !!! !!! !!! !</value>
+    <value>Γėşťáгţ ŧħ℮ ãčтĩνέ ρăйё сǿηńëςтιóņ !!! !!! !!! !</value>
   </data>
 </root>

--- a/src/cascadia/TerminalConnection/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalConnection/Resources/qps-ploc/Resources.resw
@@ -118,81 +118,81 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AzureCodeExpiry" xml:space="preserve">
-    <value>Τђîš çόδέ ẅĩℓľ ехρĭяę ϊи 15 mїήμτėš. !!! !!! !!! !</value>
+    <value>Ŧнιŝ ςøδё ẅіℓŀ зхρîґέ íи 15 mїπųŧęś. !!! !!! !!! !</value>
   </data>
   <data name="AzureEnterTenant" xml:space="preserve">
-    <value>Рŀзаѕ℮ éñтзя ŧħέ ďеšΐř℮ð теńąпŧ ⁿμmвêř. !!! !!! !!! !!!</value>
+    <value>Рĺέåŝē еňţéŗ τĥĕ ďєśįřєđ τëņåńŧ иџмьэŗ. !!! !!! !!! !!!</value>
   </data>
   <data name="AzureNewLogin" xml:space="preserve">
-    <value>Єитэя {0} ťŏ ŀσġįñ ẅīŧћ â ńзш āč¢бũⁿť !!! !!! !!! !!</value>
+    <value>Ĕńťèѓ {0} ťō łøģΐŋ ώіŧĥ ā ńèώ άčĉøŭпţ !!! !!! !!! !!</value>
     <comment>{0} will be replaced with the resource from AzureUserEntry_NewLogin; it is intended to be a single-character shorthand for "new account"</comment>
   </data>
   <data name="AzureRemoveStored" xml:space="preserve">
-    <value>Ęŉţέґ {0} ťο яěмσνе τħě äвσν℮ šăνёď čøⁿŋэčţΐóŉ şэтτĩñģś. !!! !!! !!! !!! !!! !</value>
+    <value>Σлтзґ {0} ŧø ŕэмôνз τђε авóνе şǻνеð сσñńзčťιôⁿ ѕĕťťїňġš. !!! !!! !!! !!! !!! !</value>
     <comment>{0} will be replaced with the resource from AzureUserEntry_RemoveStored; it is intended to be a single-character shorthand for "remove stored"</comment>
   </data>
   <data name="AzureInvalidAccessInput" xml:space="preserve">
-    <value>Рĺēǻŝê ёŉτεя å νäℓĩđ ⁿüмьэř τό åςĉëśŝ тĥė śτóřèð çôñηěčŧîóń šéτťίńģѕ, {0} ţǿ ļöġ ιп щīтħ â ⁿёω áĉĉбυйţ, θґ {1} ťο ŕëmόνέ τнз ŝανέď çбⁿņэςťîǿη šëτţĭñģş. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Рľεдşê ěπτэг ă νàĺįδ йΰmьēя ŧó àсĉĕŝѕ тђέ ŝтøяěð çøⁿñέĉтïǿŋ šєţτĭηģś, {0} тø ľóĝ īп ẅϊτђ â лęщ āς¢òŭñŧ, ôѓ {1} ŧŏ язмôνё тħέ śάνēδ čσňпęċτīôη šėŧŧíпĝѕ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>{0} will be replaced with the resource from AzureUserEntry_NewLogin, and {1} will be replaced with AzureUserEntry_RemoveStored. This is an error message, used after AzureNewLogin/AzureRemoveStored if the user enters an invalid value.</comment>
   </data>
   <data name="AzureNonNumberError" xml:space="preserve">
-    <value>Ρĺεàŝе éņŧєг ª пűмьěŗ. !!! !!! </value>
+    <value>Ρŀєáśе ёňŧεг ª ňύмъēг. !!! !!! </value>
   </data>
   <data name="AzureNumOutOfBoundsError" xml:space="preserve">
-    <value>Лũмьëг øΰт οƒ ьбμⁿďš. Рłêąѕέ ēπτĕг â νäℓιď ⁿΰмь℮ґ. !!! !!! !!! !!! !!!</value>
+    <value>Пϋмъęґ óΰť õƒ воµήďş. Ρŀεäŝé эⁿťєг â νãŀϊδ пцмъёř. !!! !!! !!! !!! !!!</value>
   </data>
   <data name="AzureNoTenants" xml:space="preserve">
-    <value>Сόύŀđ ŋот ƒìņď дπγ ţёηªηŧş. !!! !!! !!</value>
+    <value>Сôµłď ηǿť ƒіπđ ãñŷ ţ℮ηáńŧş. !!! !!! !!</value>
   </data>
   <data name="AzureNoCloudAccount" xml:space="preserve">
-    <value>Ύŏû ĥдνе ņőť ѕэť μр ýőűг ĉĺôυð śħёĺℓ âċćõüпť ŷёт. Ρļéāŝέ ģò τø https://shell.azure.com τб şеţ īť ϋφ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ϋσΰ ђáνě ņоť śéт ūφ ỳθϋг сŀоůδ šђęļĺ áćçθùηт ўеτ. Рĺėåŝê ĝο ŧό https://shell.azure.com το šёť ΐт úр. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>{Locked="https://shell.azure.com"} This URL should not be localized. Everything else should.</comment>
   </data>
   <data name="AzureStorePrompt" xml:space="preserve">
-    <value>Ðό уοϋ ώάπτ ţο şάνε τħèѕĕ ĉòⁿйєçťìοй šèτţϊлĝѕ ƒöѓ ƒüтµřэ ĺθģіпѕ? [{0}/{1}] !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Đò ÿóΰ ẁâňт ŧŏ ŝàνè ťђėšē сôиⁿе¢ŧιŏñ şετтΐńģѕ ƒøѓ ƒϋŧûґē ĺоġΐñş? [{0}/{1}] !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>{0} and {1} will be replaced with AzureUserEntry_Yes and AzureUserEntry_No. They are single-character shorthands for "yes" and "no" in this language.</comment>
   </data>
   <data name="AzureInvalidStoreInput" xml:space="preserve">
-    <value>Ρŀэåšє ěñτ℮ѓ {0} ôѓ {1} !!! !!! </value>
+    <value>Ρĺèªѕê εňţēŕ {0} оŗ {1} !!! !!! </value>
     <comment>{0} and {1} will be replaced with AzureUserEntry_Yes and AzureUserEntry_No. This resource will be used as an error response after AzureStorePrompt.</comment>
   </data>
   <data name="AzureRequestingCloud" xml:space="preserve">
-    <value>Ґεqùęşŧιπġ ã сľóμď śĥεļŀ īⁿşτάπсє... !!! !!! !!! !</value>
+    <value>Ґĕqμ℮šŧїŋĝ ã ćŀòμð śнёĺŀ íņşťąňċз... !!! !!! !!! !</value>
   </data>
   <data name="AzureSuccess" xml:space="preserve">
-    <value>Ŝцćċёęðĕð. !!!</value>
+    <value>Śűċćêёđέď. !!!</value>
   </data>
   <data name="AzureRequestingTerminal" xml:space="preserve">
-    <value>Яėqüεŝτĩлĝ ά тēгмïпąļ (ŧĥĩѕ mϊģĥт ţáκε α ẅĥίļè)... !!! !!! !!! !!! !!!</value>
+    <value>Яεqůęŝτίñĝ д тėґmΐπаľ (ťнĭś мìģĥť ţªќĕ ā ẁĥΐĺé)... !!! !!! !!! !!! !!!</value>
   </data>
   <data name="AzureTokensStored" xml:space="preserve">
-    <value>Ўôųŗ ċόńñέĉťíöй ŝěťτїлġѕ ĥάνэ ьéèп ѕдνĕđ ƒбř ƒμŧϋřе ŀθģĭπŝ. !!! !!! !!! !!! !!! !!!</value>
+    <value>Ỳσûř čθñňĕ¢ţįõŉ ѕεтţĭňğš наνē вёэŉ śǻνēδ ƒόг ƒμţüŗè ĺõģìйś. !!! !!! !!! !!! !!! !!!</value>
   </data>
   <data name="AzureNoTokens" xml:space="preserve">
-    <value>Йø τòκëñš тο ŗěмõνē. !!! !!!</value>
+    <value>Ňŏ ŧōкèйś ţő яэmονе. !!! !!!</value>
   </data>
   <data name="AzureTokensRemoved" xml:space="preserve">
-    <value>Śдνêď ćбñńёĉŧíōй śеττĭлģš яémòνёð. !!! !!! !!! !</value>
+    <value>Śανеđ ċσйñз¢ťìόń şєŧтιŋğѕ яёмǿνёđ. !!! !!! !!! !</value>
   </data>
   <data name="AzureOldCredentialsFlushedMessage" xml:space="preserve">
-    <value>Δúţħєŋтïςãŧіōň рāґåmêтĕѓś ¢ĥáиĝĕď. Ỳõų'ℓļ πєεð ţō łøĝ īη àġąĭń. !!! !!! !!! !!! !!! !!! </value>
+    <value>Āΰτнėиŧΐċâтīбŋ рářáмęŧéгŝ сħåⁿģëď. Ϋοц'ļľ ⁿêэð τô ĺσĝ ϊņ àġαĭπ. !!! !!! !!! !!! !!! !!! </value>
   </data>
   <data name="AzureUnknownTenantName" xml:space="preserve">
-    <value>&lt;υηĸήοẃⁿ τёñâńţ ņąмє&gt; !!! !!!</value>
+    <value>&lt;ϋпкйôẁи ŧēņàлτ ňămё&gt; !!! !!!</value>
   </data>
   <data name="AzureIthTenant" xml:space="preserve">
-    <value>Ŧèŋαпţ {0}: {1} ({2}) !!! !!!</value>
+    <value>Ťėηªŋт {0}: {1} ({2}) !!! !!!</value>
     <comment>{0} is the tenant's number, which the user will enter to connect to the tenant. {1} is the tenant's display name, which will be meaningful for the user. {2} is the tenant's internal ID number.</comment>
   </data>
   <data name="AzureSuccessfullyAuthenticated" xml:space="preserve">
-    <value>Āųţĥёņţīĉατèđ. !!! !</value>
+    <value>Ąűŧħēπτįсáτèđ. !!! !</value>
   </data>
   <data name="AzureUserEntry_NewLogin" xml:space="preserve">
-    <value>п</value>
+    <value>ņ</value>
     <comment>This is shorthand for "new login". The user must enter this character to activate the New Login feature (AzureInvalidAccessInput, AzureNewLogin)</comment>
   </data>
   <data name="AzureUserEntry_RemoveStored" xml:space="preserve">
-    <value>ѓ</value>
+    <value>ґ</value>
     <comment>This is shorthand for "remove saved connections". The user must enter this character to activate the Remove Saved Logins feature (AzureRemoveStored, AzureInvalidAccessInput)</comment>
   </data>
   <data name="AzureUserEntry_Yes" xml:space="preserve">
@@ -200,24 +200,24 @@
     <comment>This is shorthand for "yes". The user must enter this character to CONFIRM a prompt.</comment>
   </data>
   <data name="AzureUserEntry_No" xml:space="preserve">
-    <value>η</value>
+    <value>ń</value>
     <comment>This is shorthand for "no". The user must enter this character to DECLINE a prompt.</comment>
   </data>
   <data name="ProcessExited" xml:space="preserve">
-    <value>[ρřō¢ëśŝ ėжιťéđ щϊťн сθďё {0}] !!! !!! !!!</value>
+    <value>[рѓос℮śš ёхіţεð ẃιţĥ ćōďë {0}] !!! !!! !!!</value>
     <comment>The first argument {0} is the error code of the process. When there is no error, the number ZERO will be displayed. </comment>
   </data>
   <data name="CtrlDToClose" xml:space="preserve">
-    <value>Υбΰ ċαň пοẅ ċļǿşę тђìś ťєгмìŉâł ωїτħ Ċτřℓ+Đ, бг ρяęśš Зйţëŕ ţб ѓęѕŧąřŧ. !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ỳóŭ ćǻή иòω сĺøѕè ťнįş тёѓмîήªŀ ωīťђ Çťѓℓ+Ď, όг ргéšѕ Σñтèř το ґèšтªят. !!! !!! !!! !!! !!! !!! !!!</value>
 	  <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
   </data>
   <data name="ProcessFailedToLaunch" xml:space="preserve">
-    <value>[эгřбѓ {0} шђεñ łăΰήсĥįŉģ `{1}'] !!! !!! !!! </value>
+    <value>[℮ѓѓŏŕ {0} ωĥєй łåύñćђίηğ `{1}'] !!! !!! !!! </value>
     <comment>The first argument {0} is the error code. The second argument {1} is the user-specified path to a program.
       If this string is broken to multiple lines, it will not be displayed properly.</comment>
   </data>
   <data name="BadPathText" xml:space="preserve">
-    <value>Сбùℓδ иоţ дçсзśѕ šťªřţīŋġ δîŗĕčŧσŕγ "{0}" !!! !!! !!! !!!</value>
+    <value>Ċőŭľđ йōť ª¢čеѕş şτāŗťΐиğ ðιѓεςтоŗγ "{0}" !!! !!! !!! !!!</value>
     <comment>The first argument {0} is a path to a directory on the filesystem, as provided by the user.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalConnection/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalConnection/Resources/qps-ploca/Resources.resw
@@ -118,77 +118,77 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AzureCodeExpiry" xml:space="preserve">
-    <value>Ťђĩš ¢бðĕ щΐľĺ é×φΐŗè ίń 15 міņūťèś. !!! !!! !!! !</value>
+    <value>Ŧнιŝ ςøδё ẅіℓŀ зхρîґέ íи 15 mїπųŧęś. !!! !!! !!! !</value>
   </data>
   <data name="AzureEnterTenant" xml:space="preserve">
-    <value>Ρℓēάśě єñτęŕ τђĕ đĕśìŗéđ ŧ℮йάит ήůmъεř. !!! !!! !!! !!!</value>
+    <value>Рĺέåŝē еňţéŗ τĥĕ ďєśįřєđ τëņåńŧ иџмьэŗ. !!! !!! !!! !!!</value>
   </data>
   <data name="AzureNewLogin" xml:space="preserve">
-    <value>Єŋťĕř {0} ťο ļòġįи ώιťĥ ā ņĕŵ аċсôúñţ !!! !!! !!! !!</value>
+    <value>Ĕńťèѓ {0} ťō łøģΐŋ ώіŧĥ ā ńèώ άčĉøŭпţ !!! !!! !!! !!</value>
     <comment>{0} will be replaced with the resource from AzureUserEntry_NewLogin; it is intended to be a single-character shorthand for "new account"</comment>
   </data>
   <data name="AzureRemoveStored" xml:space="preserve">
-    <value>Епŧěя {0} ŧό ŗęmбνε τђέ αвòνė şāνέđ ċóпñêçťĩбñ şéţŧįήģѕ. !!! !!! !!! !!! !!! !</value>
+    <value>Σлтзґ {0} ŧø ŕэмôνз τђε авóνе şǻνеð сσñńзčťιôⁿ ѕĕťťїňġš. !!! !!! !!! !!! !!! !</value>
     <comment>{0} will be replaced with the resource from AzureUserEntry_RemoveStored; it is intended to be a single-character shorthand for "remove stored"</comment>
   </data>
   <data name="AzureInvalidAccessInput" xml:space="preserve">
-    <value>Рℓёäśэ èŋţęґ à νăℓіδ ńцmвєя ťό α¢čëşš тће şτθŗэď ςöйŉесţїôⁿ ѕзτťϊňğş, {0} τö ℓöġ ίη ẃĭţĥ ã ñеẁ åċčσųńт, οŗ {1} ŧθ ґèmöνе ťнě ѕāνεđ ćǿπйёсťìöл šèţтіŉġѕ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Рľεдşê ěπτэг ă νàĺįδ йΰmьēя ŧó àсĉĕŝѕ тђέ ŝтøяěð çøⁿñέĉтïǿŋ šєţτĭηģś, {0} тø ľóĝ īп ẅϊτђ â лęщ āς¢òŭñŧ, ôѓ {1} ŧŏ язмôνё тħέ śάνēδ čσňпęċτīôη šėŧŧíпĝѕ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>{0} will be replaced with the resource from AzureUserEntry_NewLogin, and {1} will be replaced with AzureUserEntry_RemoveStored. This is an error message, used after AzureNewLogin/AzureRemoveStored if the user enters an invalid value.</comment>
   </data>
   <data name="AzureNonNumberError" xml:space="preserve">
-    <value>Рł℮āѕê êηţěŗ а ñцmвēг. !!! !!! </value>
+    <value>Ρŀєáśе ёňŧεг ª ňύмъēг. !!! !!! </value>
   </data>
   <data name="AzureNumOutOfBoundsError" xml:space="preserve">
-    <value>Νűmъεґ όµŧ бƒ ьσΰиδš. Рŀ℮âŝэ ëŉтзř â νаℓįð πúmъêŗ. !!! !!! !!! !!! !!!</value>
+    <value>Пϋмъęґ óΰť õƒ воµήďş. Ρŀεäŝé эⁿťєг â νãŀϊδ пцмъёř. !!! !!! !!! !!! !!!</value>
   </data>
   <data name="AzureNoTenants" xml:space="preserve">
-    <value>Сουļδ ńǿŧ ƒïŋď āπγ ţέⁿаŉτŝ. !!! !!! !!</value>
+    <value>Сôµłď ηǿť ƒіπđ ãñŷ ţ℮ηáńŧş. !!! !!! !!</value>
   </data>
   <data name="AzureNoCloudAccount" xml:space="preserve">
-    <value>Ỳōù ћανē ŋŏт ѕęţ ΰρ ỳõûř ćľòùđ şĥěļŀ à¢ćōŭŉť ýėτ. Ρļèάšέ ĝø тσ https://shell.azure.com τò ѕ℮ť їτ ũρ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ϋσΰ ђáνě ņоť śéт ūφ ỳθϋг сŀоůδ šђęļĺ áćçθùηт ўеτ. Рĺėåŝê ĝο ŧό https://shell.azure.com το šёť ΐт úр. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>{Locked="https://shell.azure.com"} This URL should not be localized. Everything else should.</comment>
   </data>
   <data name="AzureStorePrompt" xml:space="preserve">
-    <value>Ðό ýóü шаήт τǿ ŝąνę τĥęŝê ¢øŉńέсţĩōи şéтτîиĝś ƒōŕ ƒùτµřê ļøĝĩπş? [{0}/{1}] !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Đò ÿóΰ ẁâňт ŧŏ ŝàνè ťђėšē сôиⁿе¢ŧιŏñ şετтΐńģѕ ƒøѓ ƒϋŧûґē ĺоġΐñş? [{0}/{1}] !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>{0} and {1} will be replaced with AzureUserEntry_Yes and AzureUserEntry_No. They are single-character shorthands for "yes" and "no" in this language.</comment>
   </data>
   <data name="AzureInvalidStoreInput" xml:space="preserve">
-    <value>Ρľ℮аşě ęпτэř {0} óг {1} !!! !!! </value>
+    <value>Ρĺèªѕê εňţēŕ {0} оŗ {1} !!! !!! </value>
     <comment>{0} and {1} will be replaced with AzureUserEntry_Yes and AzureUserEntry_No. This resource will be used as an error response after AzureStorePrompt.</comment>
   </data>
   <data name="AzureRequestingCloud" xml:space="preserve">
-    <value>Řèqυėşтϊŉĝ д ćĺοûđ šĥēłĺ įŉŝťàňčĕ... !!! !!! !!! !</value>
+    <value>Ґĕqμ℮šŧїŋĝ ã ćŀòμð śнёĺŀ íņşťąňċз... !!! !!! !!! !</value>
   </data>
   <data name="AzureSuccess" xml:space="preserve">
-    <value>Śŭ¢¢εēðéď. !!!</value>
+    <value>Śűċćêёđέď. !!!</value>
   </data>
   <data name="AzureRequestingTerminal" xml:space="preserve">
-    <value>Геqūеѕтĭńģ α ťёямϊⁿдļ (ŧђīŝ мïğћτ тáκē á щħìŀė)... !!! !!! !!! !!! !!!</value>
+    <value>Яεqůęŝτίñĝ д тėґmΐπаľ (ťнĭś мìģĥť ţªќĕ ā ẁĥΐĺé)... !!! !!! !!! !!! !!!</value>
   </data>
   <data name="AzureTokensStored" xml:space="preserve">
-    <value>Ύθμг čöŋπεċτĩθņ śεťţιŋĝŝ ђáνę ьέêй śăν℮ď ƒőŕ ƒџтцгē ℓőĝϊлş. !!! !!! !!! !!! !!! !!!</value>
+    <value>Ỳσûř čθñňĕ¢ţįõŉ ѕεтţĭňğš наνē вёэŉ śǻνēδ ƒόг ƒμţüŗè ĺõģìйś. !!! !!! !!! !!! !!! !!!</value>
   </data>
   <data name="AzureNoTokens" xml:space="preserve">
-    <value>Ňö ťσĸëиѕ ţö гĕmŏνē. !!! !!!</value>
+    <value>Ňŏ ŧōкèйś ţő яэmονе. !!! !!!</value>
   </data>
   <data name="AzureTokensRemoved" xml:space="preserve">
-    <value>Śªνёð ćōňиēĉτîóл ѕėτтілġş řĕмǿνêđ. !!! !!! !!! !</value>
+    <value>Śανеđ ċσйñз¢ťìόń şєŧтιŋğѕ яёмǿνёđ. !!! !!! !!! !</value>
   </data>
   <data name="AzureOldCredentialsFlushedMessage" xml:space="preserve">
-    <value>Άūтћĕлŧĭĉªтίοñ рäѓàmëтεґş ¢нåñğēď. Ўοů'ŀĺ ŉęёð ţθ ĺоģ ίñ ąġаĩň. !!! !!! !!! !!! !!! !!! </value>
+    <value>Āΰτнėиŧΐċâтīбŋ рářáмęŧéгŝ сħåⁿģëď. Ϋοц'ļľ ⁿêэð τô ĺσĝ ϊņ àġαĭπ. !!! !!! !!! !!! !!! !!! </value>
   </data>
   <data name="AzureUnknownTenantName" xml:space="preserve">
-    <value>&lt;ūŋкиόώň τёńдⁿτ ñªmĕ&gt; !!! !!!</value>
+    <value>&lt;ϋпкйôẁи ŧēņàлτ ňămё&gt; !!! !!!</value>
   </data>
   <data name="AzureIthTenant" xml:space="preserve">
-    <value>Τεиäиţ {0}: {1} ({2}) !!! !!!</value>
+    <value>Ťėηªŋт {0}: {1} ({2}) !!! !!!</value>
     <comment>{0} is the tenant's number, which the user will enter to connect to the tenant. {1} is the tenant's display name, which will be meaningful for the user. {2} is the tenant's internal ID number.</comment>
   </data>
   <data name="AzureSuccessfullyAuthenticated" xml:space="preserve">
-    <value>Àůтнęńтīċаτέđ. !!! !</value>
+    <value>Ąűŧħēπτįсáτèđ. !!! !</value>
   </data>
   <data name="AzureUserEntry_NewLogin" xml:space="preserve">
-    <value>ŉ</value>
+    <value>ņ</value>
     <comment>This is shorthand for "new login". The user must enter this character to activate the New Login feature (AzureInvalidAccessInput, AzureNewLogin)</comment>
   </data>
   <data name="AzureUserEntry_RemoveStored" xml:space="preserve">
@@ -196,28 +196,28 @@
     <comment>This is shorthand for "remove saved connections". The user must enter this character to activate the Remove Saved Logins feature (AzureRemoveStored, AzureInvalidAccessInput)</comment>
   </data>
   <data name="AzureUserEntry_Yes" xml:space="preserve">
-    <value>ŷ</value>
+    <value>ў</value>
     <comment>This is shorthand for "yes". The user must enter this character to CONFIRM a prompt.</comment>
   </data>
   <data name="AzureUserEntry_No" xml:space="preserve">
-    <value>η</value>
+    <value>ń</value>
     <comment>This is shorthand for "no". The user must enter this character to DECLINE a prompt.</comment>
   </data>
   <data name="ProcessExited" xml:space="preserve">
-    <value>[рřøĉзšŝ èхіťзď ώīťћ ċőδе {0}] !!! !!! !!!</value>
+    <value>[рѓос℮śš ёхіţεð ẃιţĥ ćōďë {0}] !!! !!! !!!</value>
     <comment>The first argument {0} is the error code of the process. When there is no error, the number ZERO will be displayed. </comment>
   </data>
   <data name="CtrlDToClose" xml:space="preserve">
-    <value>Ŷóц çåп ñøώ ćŀõśĕ ťћίś ŧεѓміήāļ ẁĩţђ Ćţѓℓ+Ď, ǿя φяεŝѕ Ēήτеř тб ґêşţâŕť. !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ỳóŭ ćǻή иòω сĺøѕè ťнįş тёѓмîήªŀ ωīťђ Çťѓℓ+Ď, όг ргéšѕ Σñтèř το ґèšтªят. !!! !!! !!! !!! !!! !!! !!!</value>
 	  <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
   </data>
   <data name="ProcessFailedToLaunch" xml:space="preserve">
-    <value>[ĕяґöґ {0} ẁĥęл ŀǻûŋċħīņģ `{1}'] !!! !!! !!! </value>
+    <value>[℮ѓѓŏŕ {0} ωĥєй łåύñćђίηğ `{1}'] !!! !!! !!! </value>
     <comment>The first argument {0} is the error code. The second argument {1} is the user-specified path to a program.
       If this string is broken to multiple lines, it will not be displayed properly.</comment>
   </data>
   <data name="BadPathText" xml:space="preserve">
-    <value>Ĉǿΰļδ ŉбτ ãċсёśŝ ѕţăŕŧîñġ đіřêςţóяγ "{0}" !!! !!! !!! !!!</value>
+    <value>Ċőŭľđ йōť ª¢čеѕş şτāŗťΐиğ ðιѓεςтоŗγ "{0}" !!! !!! !!! !!!</value>
     <comment>The first argument {0} is a path to a directory on the filesystem, as provided by the user.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalConnection/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalConnection/Resources/qps-plocm/Resources.resw
@@ -118,77 +118,77 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AzureCodeExpiry" xml:space="preserve">
-    <value>Тђįš ςŏðè ώïľľ єжφίřё îŉ 15 mīπµţéš. !!! !!! !!! !</value>
+    <value>Ŧнιŝ ςøδё ẅіℓŀ зхρîґέ íи 15 mїπųŧęś. !!! !!! !!! !</value>
   </data>
   <data name="AzureEnterTenant" xml:space="preserve">
-    <value>Рľėãş℮ еñţěг тђз δ℮śįŗéď ţёņǻηť пűmьёř. !!! !!! !!! !!!</value>
+    <value>Рĺέåŝē еňţéŗ τĥĕ ďєśįřєđ τëņåńŧ иџмьэŗ. !!! !!! !!! !!!</value>
   </data>
   <data name="AzureNewLogin" xml:space="preserve">
-    <value>Σпŧзř {0} тο ĺǿģíй ẃĩтħ ă ⁿěẅ ªċčόυńт !!! !!! !!! !!</value>
+    <value>Ĕńťèѓ {0} ťō łøģΐŋ ώіŧĥ ā ńèώ άčĉøŭпţ !!! !!! !!! !!</value>
     <comment>{0} will be replaced with the resource from AzureUserEntry_NewLogin; it is intended to be a single-character shorthand for "new account"</comment>
   </data>
   <data name="AzureRemoveStored" xml:space="preserve">
-    <value>Σπŧеř {0} ţб řέmθνě τђέ àъονë ŝàνëð сθйņ℮çťíбň şēţтїиğš. !!! !!! !!! !!! !!! !</value>
+    <value>Σлтзґ {0} ŧø ŕэмôνз τђε авóνе şǻνеð сσñńзčťιôⁿ ѕĕťťїňġš. !!! !!! !!! !!! !!! !</value>
     <comment>{0} will be replaced with the resource from AzureUserEntry_RemoveStored; it is intended to be a single-character shorthand for "remove stored"</comment>
   </data>
   <data name="AzureInvalidAccessInput" xml:space="preserve">
-    <value>Рℓèãśэ έиţєґ ã νåŀΐď иûмьеř ŧσ â¢сέѕš ţђë ŝťòя℮ð ¢ǿлήęčŧΐόл ѕєтŧīŋģѕ, {0} τǿ ℓόğ ĭŉ шĩţĥ â ŋзω àсčőűñт, оŗ {1} ţō řêmŏνę ťнё śâνėđ ċбππ℮ĉťϊοň ѕєťŧιňĝѕ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Рľεдşê ěπτэг ă νàĺįδ йΰmьēя ŧó àсĉĕŝѕ тђέ ŝтøяěð çøⁿñέĉтïǿŋ šєţτĭηģś, {0} тø ľóĝ īп ẅϊτђ â лęщ āς¢òŭñŧ, ôѓ {1} ŧŏ язмôνё тħέ śάνēδ čσňпęċτīôη šėŧŧíпĝѕ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>{0} will be replaced with the resource from AzureUserEntry_NewLogin, and {1} will be replaced with AzureUserEntry_RemoveStored. This is an error message, used after AzureNewLogin/AzureRemoveStored if the user enters an invalid value.</comment>
   </data>
   <data name="AzureNonNumberError" xml:space="preserve">
-    <value>Рĺěǻśє ēņтęŗ á ŉŭmъ℮ř. !!! !!! </value>
+    <value>Ρŀєáśе ёňŧεг ª ňύмъēг. !!! !!! </value>
   </data>
   <data name="AzureNumOutOfBoundsError" xml:space="preserve">
-    <value>Иūmьéŗ őųτ òƒ ъоµñďѕ. Ρļзαşé êήтεя а νāľίđ лυmъèř. !!! !!! !!! !!! !!!</value>
+    <value>Пϋмъęґ óΰť õƒ воµήďş. Ρŀεäŝé эⁿťєг â νãŀϊδ пцмъёř. !!! !!! !!! !!! !!!</value>
   </data>
   <data name="AzureNoTenants" xml:space="preserve">
-    <value>Ćοµļđ лσţ ƒīńð ǻñý тēйáⁿτś. !!! !!! !!</value>
+    <value>Сôµłď ηǿť ƒіπđ ãñŷ ţ℮ηáńŧş. !!! !!! !!</value>
   </data>
   <data name="AzureNoCloudAccount" xml:space="preserve">
-    <value>Ϋŏű нâνє пòт ŝ℮τ ũρ ỳőũŗ ĉļőυď ѕћέļľ äсčόúŋŧ ỳèт. Рľ℮äѕє ģõ тō https://shell.azure.com ŧő šêţ ϊţ ύφ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ϋσΰ ђáνě ņоť śéт ūφ ỳθϋг сŀоůδ šђęļĺ áćçθùηт ўеτ. Рĺėåŝê ĝο ŧό https://shell.azure.com το šёť ΐт úр. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>{Locked="https://shell.azure.com"} This URL should not be localized. Everything else should.</comment>
   </data>
   <data name="AzureStorePrompt" xml:space="preserve">
-    <value>Đο ўομ ẁдηţ τø šàνĕ ŧĥęśз čбπņєςтΐοη ŝєττîπģѕ ƒόг ƒΰτůяė ĺőġìⁿš? [{0}/{1}] !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Đò ÿóΰ ẁâňт ŧŏ ŝàνè ťђėšē сôиⁿе¢ŧιŏñ şετтΐńģѕ ƒøѓ ƒϋŧûґē ĺоġΐñş? [{0}/{1}] !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>{0} and {1} will be replaced with AzureUserEntry_Yes and AzureUserEntry_No. They are single-character shorthands for "yes" and "no" in this language.</comment>
   </data>
   <data name="AzureInvalidStoreInput" xml:space="preserve">
-    <value>Рļзâšє зŉţэґ {0} õѓ {1} !!! !!! </value>
+    <value>Ρĺèªѕê εňţēŕ {0} оŗ {1} !!! !!! </value>
     <comment>{0} and {1} will be replaced with AzureUserEntry_Yes and AzureUserEntry_No. This resource will be used as an error response after AzureStorePrompt.</comment>
   </data>
   <data name="AzureRequestingCloud" xml:space="preserve">
-    <value>Ŗĕqūзşťįήĝ ā ćłôūđ ѕнэŀĺ іŋşťáйςè... !!! !!! !!! !</value>
+    <value>Ґĕqμ℮šŧїŋĝ ã ćŀòμð śнёĺŀ íņşťąňċз... !!! !!! !!! !</value>
   </data>
   <data name="AzureSuccess" xml:space="preserve">
-    <value>Šϋć¢ėзðèđ. !!!</value>
+    <value>Śűċćêёđέď. !!!</value>
   </data>
   <data name="AzureRequestingTerminal" xml:space="preserve">
-    <value>Γèqΰёşτіńğ ǻ ŧĕŕмΐйáł (ťђìѕ mīġнť ţãĸē à щĥіℓ℮)... !!! !!! !!! !!! !!!</value>
+    <value>Яεqůęŝτίñĝ д тėґmΐπаľ (ťнĭś мìģĥť ţªќĕ ā ẁĥΐĺé)... !!! !!! !!! !!! !!!</value>
   </data>
   <data name="AzureTokensStored" xml:space="preserve">
-    <value>Ŷöùѓ čόпήёсťĩθⁿ ś℮ţτїηĝŝ ĥåνē вęĕņ šǻνēδ ƒöř ƒџţμге ĺǿğîлŝ. !!! !!! !!! !!! !!! !!!</value>
+    <value>Ỳσûř čθñňĕ¢ţįõŉ ѕεтţĭňğš наνē вёэŉ śǻνēδ ƒόг ƒμţüŗè ĺõģìйś. !!! !!! !!! !!! !!! !!!</value>
   </data>
   <data name="AzureNoTokens" xml:space="preserve">
-    <value>Νő тŏкéпѕ тŏ ґзmòνě. !!! !!!</value>
+    <value>Ňŏ ŧōкèйś ţő яэmονе. !!! !!!</value>
   </data>
   <data name="AzureTokensRemoved" xml:space="preserve">
-    <value>Ŝąνеđ čöŋπĕĉťĩоŋ šĕţţīňġѕ гêмōνĕď. !!! !!! !!! !</value>
+    <value>Śανеđ ċσйñз¢ťìόń şєŧтιŋğѕ яёмǿνёđ. !!! !!! !!! !</value>
   </data>
   <data name="AzureOldCredentialsFlushedMessage" xml:space="preserve">
-    <value>Δϋτћęňτĭčαťíóп ρдřàмёŧèřş сђªńğ℮ď. Ύőú'ľł ņёĕð ţǿ ľöĝ ίπ ãĝâĭп. !!! !!! !!! !!! !!! !!! </value>
+    <value>Āΰτнėиŧΐċâтīбŋ рářáмęŧéгŝ сħåⁿģëď. Ϋοц'ļľ ⁿêэð τô ĺσĝ ϊņ àġαĭπ. !!! !!! !!! !!! !!! !!! </value>
   </data>
   <data name="AzureUnknownTenantName" xml:space="preserve">
-    <value>&lt;ũńкňǿŵŋ τелдŋŧ ŉăмє&gt; !!! !!!</value>
+    <value>&lt;ϋпкйôẁи ŧēņàлτ ňămё&gt; !!! !!!</value>
   </data>
   <data name="AzureIthTenant" xml:space="preserve">
-    <value>Тĕηάπŧ {0}: {1} ({2}) !!! !!!</value>
+    <value>Ťėηªŋт {0}: {1} ({2}) !!! !!!</value>
     <comment>{0} is the tenant's number, which the user will enter to connect to the tenant. {1} is the tenant's display name, which will be meaningful for the user. {2} is the tenant's internal ID number.</comment>
   </data>
   <data name="AzureSuccessfullyAuthenticated" xml:space="preserve">
-    <value>∆υτнêήτĭćåтéδ. !!! !</value>
+    <value>Ąűŧħēπτįсáτèđ. !!! !</value>
   </data>
   <data name="AzureUserEntry_NewLogin" xml:space="preserve">
-    <value>ή</value>
+    <value>ņ</value>
     <comment>This is shorthand for "new login". The user must enter this character to activate the New Login feature (AzureInvalidAccessInput, AzureNewLogin)</comment>
   </data>
   <data name="AzureUserEntry_RemoveStored" xml:space="preserve">
@@ -196,28 +196,28 @@
     <comment>This is shorthand for "remove saved connections". The user must enter this character to activate the Remove Saved Logins feature (AzureRemoveStored, AzureInvalidAccessInput)</comment>
   </data>
   <data name="AzureUserEntry_Yes" xml:space="preserve">
-    <value>у</value>
+    <value>ў</value>
     <comment>This is shorthand for "yes". The user must enter this character to CONFIRM a prompt.</comment>
   </data>
   <data name="AzureUserEntry_No" xml:space="preserve">
-    <value>η</value>
+    <value>ń</value>
     <comment>This is shorthand for "no". The user must enter this character to DECLINE a prompt.</comment>
   </data>
   <data name="ProcessExited" xml:space="preserve">
-    <value>[рґŏ¢℮şѕ ĕ×ĭŧēδ ẅįтĥ ςòðе {0}] !!! !!! !!!</value>
+    <value>[рѓос℮śš ёхіţεð ẃιţĥ ćōďë {0}] !!! !!! !!!</value>
     <comment>The first argument {0} is the error code of the process. When there is no error, the number ZERO will be displayed. </comment>
   </data>
   <data name="CtrlDToClose" xml:space="preserve">
-    <value>Ϋôμ čǻή ńόщ ċĺбѕё ţђįš ť℮ŗmΐⁿáľ щīţђ Ċτґℓ+Ð, οѓ φŗэśş Ěŋťĕŗ ţő řěśτäѓŧ. !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ỳóŭ ćǻή иòω сĺøѕè ťнįş тёѓмîήªŀ ωīťђ Çťѓℓ+Ď, όг ргéšѕ Σñтèř το ґèšтªят. !!! !!! !!! !!! !!! !!! !!!</value>
 	  <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
   </data>
   <data name="ProcessFailedToLaunch" xml:space="preserve">
-    <value>[ëґѓøř {0} ωнеи ľãμńĉħïňğ `{1}'] !!! !!! !!! </value>
+    <value>[℮ѓѓŏŕ {0} ωĥєй łåύñćђίηğ `{1}'] !!! !!! !!! </value>
     <comment>The first argument {0} is the error code. The second argument {1} is the user-specified path to a program.
       If this string is broken to multiple lines, it will not be displayed properly.</comment>
   </data>
   <data name="BadPathText" xml:space="preserve">
-    <value>Čőυĺδ ŋõť аçĉěšŝ ŝŧäřтϊиģ ðϊřèςťοŕў "{0}" !!! !!! !!! !!!</value>
+    <value>Ċőŭľđ йōť ª¢čеѕş şτāŗťΐиğ ðιѓεςтоŗγ "{0}" !!! !!! !!! !!!</value>
     <comment>The first argument {0} is a path to a directory on the filesystem, as provided by the user.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalControl/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalControl/Resources/qps-ploc/Resources.resw
@@ -118,72 +118,72 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="SearchBox_CaseSensitivity.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Μåťĉĥ Ĉãѕё !!!</value>
+    <value>Мåţ¢н Čдŝë !!!</value>
     <comment>The tooltip text for the case sensitivity button on the search box control.</comment>
   </data>
   <data name="SearchBox_Close.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ćĺσśė !</value>
+    <value>Çŀŏŝė !</value>
     <comment>The tooltip text for the close button on the search box control.</comment>
   </data>
   <data name="SearchBox_SearchBackwards.ToolTipService.ToolTip" xml:space="preserve">
-    <value>₣іňď Цφ !!</value>
+    <value>₣ϊņδ Ûρ !!</value>
     <comment>The tooltip text for the search backward button.</comment>
   </data>
   <data name="SearchBox_SearchForwards.ToolTipService.ToolTip" xml:space="preserve">
-    <value>₣īŋđ Đбẁņ !!!</value>
+    <value>₣îńð Đόщπ !!!</value>
     <comment>The tooltip text for the search forward button.</comment>
   </data>
   <data name="SearchBox_TextBox.PlaceholderText" xml:space="preserve">
-    <value>₣ĭлđ !</value>
+    <value>₣įńď !</value>
     <comment>The placeholder text in the search box control.</comment>
   </data>
   <data name="DragFileCaption" xml:space="preserve">
-    <value>Рåѕťĕ рǻťћ тó ƒíļз !!! !!</value>
+    <value>Рáşтĕ ρāτн ŧб ƒїŀè !!! !!</value>
     <comment>The displayed caption for dragging a file onto a terminal.</comment>
   </data>
   <data name="DragTextCaption" xml:space="preserve">
-    <value>Ρªѕţē ŧэ×ţ !!!</value>
+    <value>Рāśŧë τ℮жţ !!!</value>
     <comment>The displayed caption for dragging text onto a terminal.</comment>
   </data>
   <data name="SearchBox_CaseSensitivity.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ċăѕë Ѕεŋŝíŧіνιτγ !!! !</value>
+    <value>Čαŝė Śèňśίтīνίτγ !!! !</value>
     <comment>The name of the case sensitivity button on the search box control for accessibility.</comment>
   </data>
   <data name="SearchBox_SearchForwards.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Šёăґċħ ₣οѓŵāґð !!! !</value>
+    <value>Şêǻгсĥ ₣őгώдřδ !!! !</value>
     <comment>The name of the search forward button for accessibility.</comment>
   </data>
   <data name="SearchBox_SearchBackwards.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ŝзàřçћ Ьά¢κẁàŕδ !!! !</value>
+    <value>Šеąŕсђ βáćкщâřð !!! !</value>
     <comment>The name of the search backward button for accessibility.</comment>
   </data>
   <data name="SearchBox_TextBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>₣ίήď !</value>
+    <value>₣īηď !</value>
     <comment>The name of the text box on the search box control for accessibility. This should match "SearchBox_TextBox.PlaceholderText"</comment>
   </data>
   <data name="TerminalControl_ControlType" xml:space="preserve">
-    <value>ŧĕŗmįŋãł !!</value>
+    <value>тêŕmіŉāŀ !!</value>
     <comment>The type of control that the terminal adheres to. Used to identify how a user can interact with this kind of control.</comment>
   </data>
   <data name="SearchBox_Close.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Сļбŝê Ŝэαřçн Бŏ× !!! !</value>
+    <value>€ŀοşэ Şеàґćĥ βǿх !!! !</value>
     <comment>The explanation of the search box close button used by Narrator and other screen readers.</comment>
   </data>
   <data name="TermControl_RendererFailedTextBlock.Text" xml:space="preserve">
-    <value>Тћϊŝ тέяmϊиàł ђãš ëпçőůŉŧєřėď àⁿ ΐŝśűє шĩŧħ ťђє ĝřăрĥīćѕ δґіνĕŕ âηδ їт ċōüľď ŋőт яэĉоνĕг ïή тїмэ. Íŧ ħãş ъêєл šųşρęпðзð. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ťђіş ţēгmϊⁿàŀ ħáѕ εńçøüπτèґеδ ªņ ΐѕşϋё ẁíţђ ŧћέ ĝřāрħіςš δřїνëґ аπδ ïт çõúļð ňøτ ѓèċоνėг ìή ťĩm℮. Ìţ ђǻѕ ъέêŉ ѕũşрέпðєď. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
   </data>
   <data name="TermControl_RendererRetryButton.Content" xml:space="preserve">
-    <value>Ŕέşцмę !</value>
+    <value>Ѓèşυмè !</value>
   </data>
   <data name="HowToOpenRun.Text" xml:space="preserve">
-    <value>€тřŀ+Сłί¢ķ тō ƒǿļℓбш ļïлќ !!! !!! !</value>
+    <value>Сŧŗļ+Čŀĩčķ тô ƒőĺľόш łîņĸ !!! !!! !</value>
   </data>
   <data name="TermControl_NoMatch" xml:space="preserve">
-    <value>Ňő řęŝųłтś !!!</value>
+    <value>Νθ ѓéšцℓťş !!!</value>
     <comment>Will be presented near the search box when Find operation returned no results.</comment>
   </data>
   <data name="TermControl_Searching" xml:space="preserve">
-    <value>Şēαřĉћìńĝ... !!! </value>
+    <value>Ѕěαя¢ђìпğ... !!! </value>
     <comment>Will be presented near the search box when Find operation is running.</comment>
   </data>
   <data name="TermControl_NumResults" xml:space="preserve">
@@ -191,101 +191,101 @@
     <comment>Will be displayed to indicate what result the user has selected, of how many total results. {0} will be replaced with the index of the current result. {1} will be replaced with the total number of results.</comment>
   </data>
   <data name="InvalidUri" xml:space="preserve">
-    <value>Ĭлνäŀìď ÚЃĨ !!!</value>
+    <value>Íņνãľîđ ÚŔİ !!!</value>
     <comment>Whenever we encounter an invalid URI or URL we show this string as a warning.</comment>
   </data>
   <data name="NoticeFontNotFound" xml:space="preserve">
-    <value>Ùлâьľě τö ƒíńð тħз ŝéĺзсţэδ ƒоñť "{0}". !!! !!! !!! !!!
+    <value>Ůŉäвľė ťö ƒΐńđ τħé şèℓ℮ĉťēδ ƒòñŧ "{0}".
 
-"{1}" ђдš ъè℮π ѕèľεĉŧєď ΐήşťēãď. !!! !!! !!! 
+"{1}" ђàś ъëęñ šеŀесťĕđ ιñśтёąδ.
 
-Ρℓėãšé éīţђěŗ ϊⁿŝţăľŀ ŧђэ mιşśϊñğ ƒοňţ ŏґ ςћобŝε ąпǿтħèŗ оп℮. !!! !!! !!! !!! !!! !!!</value>
+Ρℓēάŝę ėїţħěř ĭлşţäļł ťнз mîşśĭηģ ƒóⁿт òґ ¢ћōóşę άηŏťнєѓ ôŋє. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>0 and 1 are names of fonts provided by the user and system respectively.</comment>
   </data>
   <data name="PixelShaderNotFound" xml:space="preserve">
-    <value>Џňαьļě τǿ ƒĩлð ťħё φřőνįδėð šħąđёŗ "{0}". !!! !!! !!! !!!</value>
+    <value>Üидьŀэ τθ ƒìņď ťнė ρяóνίðěď ŝђάðèѓ "{0}". !!! !!! !!! !!!</value>
     <comment>{0} is a file name</comment>
   </data>
   <data name="PixelShaderCompileFailed" xml:space="preserve">
-    <value>Цńáвℓё ţõ ςōmрїĺэ ŧнè şφëсίƒϊéđ ρì×еł šћαđэř. !!! !!! !!! !!! !</value>
+    <value>Ūňåъļë ťб ćóмφïĺє ťћз şрęςíƒĩêð ριх℮ĺ şħâđеŕ. !!! !!! !!! !!! !</value>
   </data>
   <data name="UnexpectedRendererError" xml:space="preserve">
-    <value>Řέňδĕŗзѓ ℮ⁿçøϋńţέřëð άⁿ ύлę×рёċтëď ēѓѓσŕ: {0} !!! !!! !!! !!! !</value>
+    <value>Řєŉδέгęř зйĉóűňтëř℮δ âη ûⁿėхрєĉţēð ℮ѓґоŗ: {0} !!! !!! !!! !!! !</value>
     <comment>{0} is an error code.</comment>
   </data>
   <data name="TermControlReadOnly" xml:space="preserve">
-    <value>Яĕåď-őлļŷ mόďé ϊŝ єņǻвłέď. !!! !!! !</value>
+    <value>Гėāδ-σπļỳ mőðê īŝ ėńäвļεδ. !!! !!! !</value>
   </data>
   <data name="SearchBox_MatchesAvailable" xml:space="preserve">
-    <value>Řёşŭļτѕ ƒбύлδ !!! </value>
+    <value>Γĕšµľţş ƒбŭⁿð !!! </value>
     <comment>Announced to a screen reader when the user searches for some text and there are matches for that text in the terminal.</comment>
   </data>
   <data name="SearchBox_NoMatches" xml:space="preserve">
-    <value>Ñó ѓёşûĺτš ƒōüńδ !!! !</value>
+    <value>Ńō гēśџĺŧѕ ƒσúπđ !!! !</value>
     <comment>Announced to a screen reader when the user searches for some text and there are no matches for that text in the terminal.</comment>
   </data>
   <data name="PasteCommandButton.Label" xml:space="preserve">
-    <value>Рåѕŧĕ !</value>
+    <value>Рăşţε !</value>
     <comment>The label of a button for pasting the contents of the clipboard.</comment>
   </data>
   <data name="PasteCommandButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Рáѕţε !</value>
+    <value>Ρåśŧē !</value>
     <comment>The tooltip for a paste button</comment>
   </data>
   <data name="CopyCommandButton.Label" xml:space="preserve">
-    <value>€óφγ !</value>
+    <value>€ǿру !</value>
     <comment>The label of a button for copying the selected text to the clipboard.</comment>
   </data>
   <data name="CopyCommandButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ċøρу !</value>
+    <value>Ćŏφỳ !</value>
     <comment>The tooltip for a copy button</comment>
   </data>
   <data name="PasteWithSelectionCommandButton.Label" xml:space="preserve">
-    <value>Ρâѕťë !</value>
+    <value>Рāŝтę !</value>
     <comment>The label of a button for pasting the contents of the clipboard.</comment>
   </data>
   <data name="PasteWithSelectionCommandButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Рáśτз !</value>
+    <value>Рáşţê !</value>
     <comment>The tooltip for a paste button</comment>
   </data>
   <data name="SearchCommandButton.Label" xml:space="preserve">
-    <value>₣îпď... !!</value>
+    <value>₣їņď... !!</value>
     <comment>The label of a button for searching for the selected text</comment>
   </data>
   <data name="SearchCommandButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>₣ĭиď !</value>
+    <value>₣ΐņđ !</value>
     <comment>The tooltip for a button for searching for the selected text</comment>
   </data>
   <data name="SelectCommandButton.Label" xml:space="preserve">
-    <value>Ŝėľĕсť ςòмmдηð !!! !</value>
+    <value>Šéļэςţ çǿммàñδ !!! !</value>
     <comment>The label of a button for selecting all of the text of a command</comment>
   </data>
   <data name="SelectCommandButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Şёľэĉţ ćõмmãлð !!! !</value>
+    <value>Ѕеłєçŧ ċοмmàлđ !!! !</value>
     <comment>The tooltip for a button for selecting all of the text of a command</comment>
   </data>
   <data name="SelectOutputButton.Label" xml:space="preserve">
-    <value>Ŝèļέćτ őüţрůţ !!! </value>
+    <value>Ѕεŀэċт σцτφūţ !!! </value>
     <comment>The label of a button for selecting all of a command's output</comment>
   </data>
   <data name="SelectOutputButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Şėľë¢τ óúтрŭт !!! </value>
+    <value>Şèℓëċτ ōϋťρŭţ !!! </value>
     <comment>The tooltip for a button for selecting all of a command's output</comment>
   </data>
   <data name="SelectCommandWithSelectionButton.Label" xml:space="preserve">
-    <value>Ŝėļе¢τ ¢õmмàŋđ !!! !</value>
+    <value>Šěľēĉť ćǿмmăŋð !!! !</value>
     <comment>The label of a button for selecting all of the text of a command</comment>
   </data>
   <data name="SelectCommandWithSelectionButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ŝëļэсŧ čбммάñð !!! !</value>
+    <value>Şēľεςŧ сõmmäηδ !!! !</value>
     <comment>The tooltip for a button for selecting all of the text of a command</comment>
   </data>
   <data name="SelectOutputWithSelectionButton.Label" xml:space="preserve">
-    <value>Ѕеļèĉť οūťрůт !!! </value>
+    <value>Ŝęļëćť σùτρύť !!! </value>
     <comment>The label of a button for selecting all of a command's output</comment>
   </data>
   <data name="SelectOutputWithSelectionButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ŝėℓēςт öůŧрűт !!! </value>
+    <value>Ŝ℮ĺèčť οùτφųţ !!! </value>
     <comment>The tooltip for a button for selecting all of a command's output</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalControl/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalControl/Resources/qps-ploca/Resources.resw
@@ -118,72 +118,72 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="SearchBox_CaseSensitivity.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Μаŧçĥ Сàšę !!!</value>
+    <value>Мåţ¢н Čдŝë !!!</value>
     <comment>The tooltip text for the case sensitivity button on the search box control.</comment>
   </data>
   <data name="SearchBox_Close.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ċļôšê !</value>
+    <value>Çŀŏŝė !</value>
     <comment>The tooltip text for the close button on the search box control.</comment>
   </data>
   <data name="SearchBox_SearchBackwards.ToolTipService.ToolTip" xml:space="preserve">
-    <value>₣ΐñð Ŭр !!</value>
+    <value>₣ϊņδ Ûρ !!</value>
     <comment>The tooltip text for the search backward button.</comment>
   </data>
   <data name="SearchBox_SearchForwards.ToolTipService.ToolTip" xml:space="preserve">
-    <value>₣ĭñđ Ďόщи !!!</value>
+    <value>₣îńð Đόщπ !!!</value>
     <comment>The tooltip text for the search forward button.</comment>
   </data>
   <data name="SearchBox_TextBox.PlaceholderText" xml:space="preserve">
-    <value>₣ìлď !</value>
+    <value>₣įńď !</value>
     <comment>The placeholder text in the search box control.</comment>
   </data>
   <data name="DragFileCaption" xml:space="preserve">
-    <value>Ρªšŧĕ φàтн ţô ƒїℓę !!! !!</value>
+    <value>Рáşтĕ ρāτн ŧб ƒїŀè !!! !!</value>
     <comment>The displayed caption for dragging a file onto a terminal.</comment>
   </data>
   <data name="DragTextCaption" xml:space="preserve">
-    <value>Ρášŧę ţэжт !!!</value>
+    <value>Рāśŧë τ℮жţ !!!</value>
     <comment>The displayed caption for dragging text onto a terminal.</comment>
   </data>
   <data name="SearchBox_CaseSensitivity.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>€дѕē Ŝèлşĩţϊνĩτў !!! !</value>
+    <value>Čαŝė Śèňśίтīνίτγ !!! !</value>
     <comment>The name of the case sensitivity button on the search box control for accessibility.</comment>
   </data>
   <data name="SearchBox_SearchForwards.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ѕèăřсħ ₣σґώářδ !!! !</value>
+    <value>Şêǻгсĥ ₣őгώдřδ !!! !</value>
     <comment>The name of the search forward button for accessibility.</comment>
   </data>
   <data name="SearchBox_SearchBackwards.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ѕёàяçĥ Вäċќẁāřđ !!! !</value>
+    <value>Šеąŕсђ βáćкщâřð !!! !</value>
     <comment>The name of the search backward button for accessibility.</comment>
   </data>
   <data name="SearchBox_TextBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>₣їйđ !</value>
+    <value>₣īηď !</value>
     <comment>The name of the text box on the search box control for accessibility. This should match "SearchBox_TextBox.PlaceholderText"</comment>
   </data>
   <data name="TerminalControl_ControlType" xml:space="preserve">
-    <value>ţέŗмīηăĺ !!</value>
+    <value>тêŕmіŉāŀ !!</value>
     <comment>The type of control that the terminal adheres to. Used to identify how a user can interact with this kind of control.</comment>
   </data>
   <data name="SearchBox_Close.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ċłöšè Śêãгċђ βσ× !!! !</value>
+    <value>€ŀοşэ Şеàґćĥ βǿх !!! !</value>
     <comment>The explanation of the search box close button used by Narrator and other screen readers.</comment>
   </data>
   <data name="TermControl_RendererFailedTextBlock.Text" xml:space="preserve">
-    <value>Ţħíś т℮гмїňął ĥåѕ зпċǿûήтéѓ℮đ äņ ΐѕšϋз ẁĭтћ ťћё ĝřαρħïςѕ đřïνęя αⁿð ĭť ćŏúŀð ňǿт яэčöν℮ŕ ΐη тįmέ. Ίτ ĥªş ьēęŋ śϋśрęⁿðėδ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ťђіş ţēгmϊⁿàŀ ħáѕ εńçøüπτèґеδ ªņ ΐѕşϋё ẁíţђ ŧћέ ĝřāрħіςš δřїνëґ аπδ ïт çõúļð ňøτ ѓèċоνėг ìή ťĩm℮. Ìţ ђǻѕ ъέêŉ ѕũşрέпðєď. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
   </data>
   <data name="TermControl_RendererRetryButton.Content" xml:space="preserve">
-    <value>Ґěşůмз !</value>
+    <value>Ѓèşυмè !</value>
   </data>
   <data name="HowToOpenRun.Text" xml:space="preserve">
-    <value>Čţяľ+Ċļĩčĸ τő ƒôŀŀôщ ľįňќ !!! !!! !</value>
+    <value>Сŧŗļ+Čŀĩčķ тô ƒőĺľόш łîņĸ !!! !!! !</value>
   </data>
   <data name="TermControl_NoMatch" xml:space="preserve">
-    <value>Ńô я℮šúĺτѕ !!!</value>
+    <value>Νθ ѓéšцℓťş !!!</value>
     <comment>Will be presented near the search box when Find operation returned no results.</comment>
   </data>
   <data name="TermControl_Searching" xml:space="preserve">
-    <value>Śēаŕĉħîŋģ... !!! </value>
+    <value>Ѕěαя¢ђìпğ... !!! </value>
     <comment>Will be presented near the search box when Find operation is running.</comment>
   </data>
   <data name="TermControl_NumResults" xml:space="preserve">
@@ -191,101 +191,101 @@
     <comment>Will be displayed to indicate what result the user has selected, of how many total results. {0} will be replaced with the index of the current result. {1} will be replaced with the total number of results.</comment>
   </data>
   <data name="InvalidUri" xml:space="preserve">
-    <value>İŋναĺїď ЦҐĨ !!!</value>
+    <value>Íņνãľîđ ÚŔİ !!!</value>
     <comment>Whenever we encounter an invalid URI or URL we show this string as a warning.</comment>
   </data>
   <data name="NoticeFontNotFound" xml:space="preserve">
-    <value>Ůŋªъĺэ ŧò ƒįņð ţђέ ѕĕℓéçţэđ ƒбŋт "{0}". !!! !!! !!! !!!
+    <value>Ůŉäвľė ťö ƒΐńđ τħé şèℓ℮ĉťēδ ƒòñŧ "{0}".
 
-"{1}" ħªş ь℮ėŋ śєĺĕсţзď íπŝŧёáď. !!! !!! !!! 
+"{1}" ђàś ъëęñ šеŀесťĕđ ιñśтёąδ.
 
-Ρŀέаşé еïŧђêŗ îñşţαłļ τћέ mìšŝіŉğ ƒŏлτ бѓ ςђбǿšę ăηøτђёř οⁿė. !!! !!! !!! !!! !!! !!!</value>
+Ρℓēάŝę ėїţħěř ĭлşţäļł ťнз mîşśĭηģ ƒóⁿт òґ ¢ћōóşę άηŏťнєѓ ôŋє. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>0 and 1 are names of fonts provided by the user and system respectively.</comment>
   </data>
   <data name="PixelShaderNotFound" xml:space="preserve">
-    <value>Űήåьℓέ ŧθ ƒïŉδ ťнэ ρŗōνĩδзď ŝĥªđĕŕ "{0}". !!! !!! !!! !!!</value>
+    <value>Üидьŀэ τθ ƒìņď ťнė ρяóνίðěď ŝђάðèѓ "{0}". !!! !!! !!! !!!</value>
     <comment>{0} is a file name</comment>
   </data>
   <data name="PixelShaderCompileFailed" xml:space="preserve">
-    <value>Ŭήâвℓє τõ ĉσmφìŀέ ŧнĕ šрěċїƒїěδ φíх℮ℓ śђąδεř. !!! !!! !!! !!! !</value>
+    <value>Ūňåъļë ťб ćóмφïĺє ťћз şрęςíƒĩêð ριх℮ĺ şħâđеŕ. !!! !!! !!! !!! !</value>
   </data>
   <data name="UnexpectedRendererError" xml:space="preserve">
-    <value>Řёпðєгéŕ ℮ⁿсόΰňтεѓèđ àй ŭñε×φєċţêδ єřѓбŕ: {0} !!! !!! !!! !!! !</value>
+    <value>Řєŉδέгęř зйĉóűňтëř℮δ âη ûⁿėхрєĉţēð ℮ѓґоŗ: {0} !!! !!! !!! !!! !</value>
     <comment>{0} is an error code.</comment>
   </data>
   <data name="TermControlReadOnly" xml:space="preserve">
-    <value>Яēάð-òŋŀγ møđé ìş ĕńâьℓзδ. !!! !!! !</value>
+    <value>Гėāδ-σπļỳ mőðê īŝ ėńäвļεδ. !!! !!! !</value>
   </data>
   <data name="SearchBox_MatchesAvailable" xml:space="preserve">
-    <value>Ѓéѕџŀтѕ ƒóϋйδ !!! </value>
+    <value>Γĕšµľţş ƒбŭⁿð !!! </value>
     <comment>Announced to a screen reader when the user searches for some text and there are matches for that text in the terminal.</comment>
   </data>
   <data name="SearchBox_NoMatches" xml:space="preserve">
-    <value>Йô řēşùĺτŝ ƒоũņď !!! !</value>
+    <value>Ńō гēśџĺŧѕ ƒσúπđ !!! !</value>
     <comment>Announced to a screen reader when the user searches for some text and there are no matches for that text in the terminal.</comment>
   </data>
   <data name="PasteCommandButton.Label" xml:space="preserve">
-    <value>Рαŝŧę !</value>
+    <value>Рăşţε !</value>
     <comment>The label of a button for pasting the contents of the clipboard.</comment>
   </data>
   <data name="PasteCommandButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Рàŝτê !</value>
+    <value>Ρåśŧē !</value>
     <comment>The tooltip for a paste button</comment>
   </data>
   <data name="CopyCommandButton.Label" xml:space="preserve">
-    <value>Çôρý !</value>
+    <value>€ǿру !</value>
     <comment>The label of a button for copying the selected text to the clipboard.</comment>
   </data>
   <data name="CopyCommandButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>€õφў !</value>
+    <value>Ćŏφỳ !</value>
     <comment>The tooltip for a copy button</comment>
   </data>
   <data name="PasteWithSelectionCommandButton.Label" xml:space="preserve">
-    <value>Рäŝťè !</value>
+    <value>Рāŝтę !</value>
     <comment>The label of a button for pasting the contents of the clipboard.</comment>
   </data>
   <data name="PasteWithSelectionCommandButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ραşτé !</value>
+    <value>Рáşţê !</value>
     <comment>The tooltip for a paste button</comment>
   </data>
   <data name="SearchCommandButton.Label" xml:space="preserve">
-    <value>₣ĩⁿď... !!</value>
+    <value>₣їņď... !!</value>
     <comment>The label of a button for searching for the selected text</comment>
   </data>
   <data name="SearchCommandButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>₣ìⁿδ !</value>
+    <value>₣ΐņđ !</value>
     <comment>The tooltip for a button for searching for the selected text</comment>
   </data>
   <data name="SelectCommandButton.Label" xml:space="preserve">
-    <value>Śěļęčť ĉómmăиδ !!! !</value>
+    <value>Šéļэςţ çǿммàñδ !!! !</value>
     <comment>The label of a button for selecting all of the text of a command</comment>
   </data>
   <data name="SelectCommandButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Śēļεćţ çоммªŋδ !!! !</value>
+    <value>Ѕеłєçŧ ċοмmàлđ !!! !</value>
     <comment>The tooltip for a button for selecting all of the text of a command</comment>
   </data>
   <data name="SelectOutputButton.Label" xml:space="preserve">
-    <value>Šėℓέςŧ ǿµťρüť !!! </value>
+    <value>Ѕεŀэċт σцτφūţ !!! </value>
     <comment>The label of a button for selecting all of a command's output</comment>
   </data>
   <data name="SelectOutputButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ѕэℓз¢τ ǿυťφùţ !!! </value>
+    <value>Şèℓëċτ ōϋťρŭţ !!! </value>
     <comment>The tooltip for a button for selecting all of a command's output</comment>
   </data>
   <data name="SelectCommandWithSelectionButton.Label" xml:space="preserve">
-    <value>Šзℓèçţ сöммāйð !!! !</value>
+    <value>Šěľēĉť ćǿмmăŋð !!! !</value>
     <comment>The label of a button for selecting all of the text of a command</comment>
   </data>
   <data name="SelectCommandWithSelectionButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ѕĕĺëст ċбmмâпδ !!! !</value>
+    <value>Şēľεςŧ сõmmäηδ !!! !</value>
     <comment>The tooltip for a button for selecting all of the text of a command</comment>
   </data>
   <data name="SelectOutputWithSelectionButton.Label" xml:space="preserve">
-    <value>Šêļêčτ øύτрųт !!! </value>
+    <value>Ŝęļëćť σùτρύť !!! </value>
     <comment>The label of a button for selecting all of a command's output</comment>
   </data>
   <data name="SelectOutputWithSelectionButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Šëℓэčт ŏцτρũτ !!! </value>
+    <value>Ŝ℮ĺèčť οùτφųţ !!! </value>
     <comment>The tooltip for a button for selecting all of a command's output</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalControl/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalControl/Resources/qps-plocm/Resources.resw
@@ -118,72 +118,72 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="SearchBox_CaseSensitivity.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Μдŧčђ Ĉåşё !!!</value>
+    <value>Мåţ¢н Čдŝë !!!</value>
     <comment>The tooltip text for the case sensitivity button on the search box control.</comment>
   </data>
   <data name="SearchBox_Close.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Çℓøśé !</value>
+    <value>Çŀŏŝė !</value>
     <comment>The tooltip text for the close button on the search box control.</comment>
   </data>
   <data name="SearchBox_SearchBackwards.ToolTipService.ToolTip" xml:space="preserve">
-    <value>₣іⁿď Úφ !!</value>
+    <value>₣ϊņδ Ûρ !!</value>
     <comment>The tooltip text for the search backward button.</comment>
   </data>
   <data name="SearchBox_SearchForwards.ToolTipService.ToolTip" xml:space="preserve">
-    <value>₣íńð Đσŵи !!!</value>
+    <value>₣îńð Đόщπ !!!</value>
     <comment>The tooltip text for the search forward button.</comment>
   </data>
   <data name="SearchBox_TextBox.PlaceholderText" xml:space="preserve">
-    <value>₣įηδ !</value>
+    <value>₣įńď !</value>
     <comment>The placeholder text in the search box control.</comment>
   </data>
   <data name="DragFileCaption" xml:space="preserve">
-    <value>Ρãšŧ℮ рåтн тó ƒīŀē !!! !!</value>
+    <value>Рáşтĕ ρāτн ŧб ƒїŀè !!! !!</value>
     <comment>The displayed caption for dragging a file onto a terminal.</comment>
   </data>
   <data name="DragTextCaption" xml:space="preserve">
-    <value>Рάşţé ŧē×ţ !!!</value>
+    <value>Рāśŧë τ℮жţ !!!</value>
     <comment>The displayed caption for dragging text onto a terminal.</comment>
   </data>
   <data name="SearchBox_CaseSensitivity.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ĉâšē Ŝėиŝĭтïνîτу !!! !</value>
+    <value>Čαŝė Śèňśίтīνίτγ !!! !</value>
     <comment>The name of the case sensitivity button on the search box control for accessibility.</comment>
   </data>
   <data name="SearchBox_SearchForwards.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ŝзãгсĥ ₣όŗшãřð !!! !</value>
+    <value>Şêǻгсĥ ₣őгώдřδ !!! !</value>
     <comment>The name of the search forward button for accessibility.</comment>
   </data>
   <data name="SearchBox_SearchBackwards.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ŝěäřçђ Βą¢ĸшàгδ !!! !</value>
+    <value>Šеąŕсђ βáćкщâřð !!! !</value>
     <comment>The name of the search backward button for accessibility.</comment>
   </data>
   <data name="SearchBox_TextBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>₣ĭπđ !</value>
+    <value>₣īηď !</value>
     <comment>The name of the text box on the search box control for accessibility. This should match "SearchBox_TextBox.PlaceholderText"</comment>
   </data>
   <data name="TerminalControl_ControlType" xml:space="preserve">
-    <value>ŧéямîⁿåļ !!</value>
+    <value>тêŕmіŉāŀ !!</value>
     <comment>The type of control that the terminal adheres to. Used to identify how a user can interact with this kind of control.</comment>
   </data>
   <data name="SearchBox_Close.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>€ℓőѕє Śéдгςн βŏх !!! !</value>
+    <value>€ŀοşэ Şеàґćĥ βǿх !!! !</value>
     <comment>The explanation of the search box close button used by Narrator and other screen readers.</comment>
   </data>
   <data name="TermControl_RendererFailedTextBlock.Text" xml:space="preserve">
-    <value>Ŧħĩѕ тёřmίⁿάℓ ћáѕ ěп¢ŏџŋţéŗėď дŋ ìššµé ωįţн ŧне ğгäφĥΐćš ďřίνзѓ āήď íť ĉоùĺδ πότ яеĉòνег ιñ τіmę. Íţ нǻŝ ьêέň śцŝφèŋðєđ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ťђіş ţēгmϊⁿàŀ ħáѕ εńçøüπτèґеδ ªņ ΐѕşϋё ẁíţђ ŧћέ ĝřāрħіςš δřїνëґ аπδ ïт çõúļð ňøτ ѓèċоνėг ìή ťĩm℮. Ìţ ђǻѕ ъέêŉ ѕũşрέпðєď. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
   </data>
   <data name="TermControl_RendererRetryButton.Content" xml:space="preserve">
-    <value>Ґēŝцm℮ !</value>
+    <value>Ѓèşυмè !</value>
   </data>
   <data name="HowToOpenRun.Text" xml:space="preserve">
-    <value>Ĉτгĺ+Сľιĉќ тö ƒŏľŀòщ ļιńк !!! !!! !</value>
+    <value>Сŧŗļ+Čŀĩčķ тô ƒőĺľόш łîņĸ !!! !!! !</value>
   </data>
   <data name="TermControl_NoMatch" xml:space="preserve">
-    <value>Йо ґ℮şûļтš !!!</value>
+    <value>Νθ ѓéšцℓťş !!!</value>
     <comment>Will be presented near the search box when Find operation returned no results.</comment>
   </data>
   <data name="TermControl_Searching" xml:space="preserve">
-    <value>Ŝēάґćнίñġ... !!! </value>
+    <value>Ѕěαя¢ђìпğ... !!! </value>
     <comment>Will be presented near the search box when Find operation is running.</comment>
   </data>
   <data name="TermControl_NumResults" xml:space="preserve">
@@ -191,101 +191,101 @@
     <comment>Will be displayed to indicate what result the user has selected, of how many total results. {0} will be replaced with the index of the current result. {1} will be replaced with the total number of results.</comment>
   </data>
   <data name="InvalidUri" xml:space="preserve">
-    <value>Ĩπνāļϊð ŰŘЇ !!!</value>
+    <value>Íņνãľîđ ÚŔİ !!!</value>
     <comment>Whenever we encounter an invalid URI or URL we show this string as a warning.</comment>
   </data>
   <data name="NoticeFontNotFound" xml:space="preserve">
-    <value>Џņªвŀë τθ ƒĩпď ŧнэ ѕèℓє¢ţęđ ƒōлť "{0}". !!! !!! !!! !!!
+    <value>Ůŉäвľė ťö ƒΐńđ τħé şèℓ℮ĉťēδ ƒòñŧ "{0}".
 
-"{1}" ħăš ьє℮ⁿ śēļéçŧёđ ĭņşţэαď. !!! !!! !!! 
+"{1}" ђàś ъëęñ šеŀесťĕđ ιñśтёąδ.
 
-Рłëаŝз ėìτћęř īпŝτăľļ ŧћě міŝŝįиģ ƒōлŧ όŕ çнǿőŝё áńøτнĕŗ ôи℮. !!! !!! !!! !!! !!! !!!</value>
+Ρℓēάŝę ėїţħěř ĭлşţäļł ťнз mîşśĭηģ ƒóⁿт òґ ¢ћōóşę άηŏťнєѓ ôŋє. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>0 and 1 are names of fonts provided by the user and system respectively.</comment>
   </data>
   <data name="PixelShaderNotFound" xml:space="preserve">
-    <value>Ůŉäъĺє ŧσ ƒīπð ŧħë ρґøνïđзδ ѕнаđêґ "{0}". !!! !!! !!! !!!</value>
+    <value>Üидьŀэ τθ ƒìņď ťнė ρяóνίðěď ŝђάðèѓ "{0}". !!! !!! !!! !!!</value>
     <comment>{0} is a file name</comment>
   </data>
   <data name="PixelShaderCompileFailed" xml:space="preserve">
-    <value>Ùⁿαъļє ŧó ςбmφîŀ℮ ťĥè šρêċїƒіêđ рι×ëĺ ŝђдðέŗ. !!! !!! !!! !!! !</value>
+    <value>Ūňåъļë ťб ćóмφïĺє ťћз şрęςíƒĩêð ριх℮ĺ şħâđеŕ. !!! !!! !!! !!! !</value>
   </data>
   <data name="UnexpectedRendererError" xml:space="preserve">
-    <value>Яέŉďёřёŗ ěп¢ōŭŋτеѓęď άй ùйěхрєçτëđ ёгřσя: {0} !!! !!! !!! !!! !</value>
+    <value>Řєŉδέгęř зйĉóűňтëř℮δ âη ûⁿėхрєĉţēð ℮ѓґоŗ: {0} !!! !!! !!! !!! !</value>
     <comment>{0} is an error code.</comment>
   </data>
   <data name="TermControlReadOnly" xml:space="preserve">
-    <value>Ѓєαđ-øńŀŷ мöδĕ ĭş ęηάъĺĕď. !!! !!! !</value>
+    <value>Гėāδ-σπļỳ mőðê īŝ ėńäвļεδ. !!! !!! !</value>
   </data>
   <data name="SearchBox_MatchesAvailable" xml:space="preserve">
-    <value>Řзšųľŧŝ ƒöųήð !!! </value>
+    <value>Γĕšµľţş ƒбŭⁿð !!! </value>
     <comment>Announced to a screen reader when the user searches for some text and there are matches for that text in the terminal.</comment>
   </data>
   <data name="SearchBox_NoMatches" xml:space="preserve">
-    <value>Ņò гέšůľŧѕ ƒôџήδ !!! !</value>
+    <value>Ńō гēśџĺŧѕ ƒσúπđ !!! !</value>
     <comment>Announced to a screen reader when the user searches for some text and there are no matches for that text in the terminal.</comment>
   </data>
   <data name="PasteCommandButton.Label" xml:space="preserve">
-    <value>Ράśтé !</value>
+    <value>Рăşţε !</value>
     <comment>The label of a button for pasting the contents of the clipboard.</comment>
   </data>
   <data name="PasteCommandButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Рãšť℮ !</value>
+    <value>Ρåśŧē !</value>
     <comment>The tooltip for a paste button</comment>
   </data>
   <data name="CopyCommandButton.Label" xml:space="preserve">
-    <value>Сбрÿ !</value>
+    <value>€ǿру !</value>
     <comment>The label of a button for copying the selected text to the clipboard.</comment>
   </data>
   <data name="CopyCommandButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ĉορў !</value>
+    <value>Ćŏφỳ !</value>
     <comment>The tooltip for a copy button</comment>
   </data>
   <data name="PasteWithSelectionCommandButton.Label" xml:space="preserve">
-    <value>Ρàŝŧе !</value>
+    <value>Рāŝтę !</value>
     <comment>The label of a button for pasting the contents of the clipboard.</comment>
   </data>
   <data name="PasteWithSelectionCommandButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Раŝŧ℮ !</value>
+    <value>Рáşţê !</value>
     <comment>The tooltip for a paste button</comment>
   </data>
   <data name="SearchCommandButton.Label" xml:space="preserve">
-    <value>₣ϊňð... !!</value>
+    <value>₣їņď... !!</value>
     <comment>The label of a button for searching for the selected text</comment>
   </data>
   <data name="SearchCommandButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>₣ϊпđ !</value>
+    <value>₣ΐņđ !</value>
     <comment>The tooltip for a button for searching for the selected text</comment>
   </data>
   <data name="SelectCommandButton.Label" xml:space="preserve">
-    <value>Ѕĕŀεςť čθммąпð !!! !</value>
+    <value>Šéļэςţ çǿммàñδ !!! !</value>
     <comment>The label of a button for selecting all of the text of a command</comment>
   </data>
   <data name="SelectCommandButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Śэľεćŧ ċómmάⁿď !!! !</value>
+    <value>Ѕеłєçŧ ċοмmàлđ !!! !</value>
     <comment>The tooltip for a button for selecting all of the text of a command</comment>
   </data>
   <data name="SelectOutputButton.Label" xml:space="preserve">
-    <value>Ŝέĺєсţ ǿϋтφúτ !!! </value>
+    <value>Ѕεŀэċт σцτφūţ !!! </value>
     <comment>The label of a button for selecting all of a command's output</comment>
   </data>
   <data name="SelectOutputButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Śэℓєçţ σũτρύť !!! </value>
+    <value>Şèℓëċτ ōϋťρŭţ !!! </value>
     <comment>The tooltip for a button for selecting all of a command's output</comment>
   </data>
   <data name="SelectCommandWithSelectionButton.Label" xml:space="preserve">
-    <value>Ŝєļёĉτ ćόmmалδ !!! !</value>
+    <value>Šěľēĉť ćǿмmăŋð !!! !</value>
     <comment>The label of a button for selecting all of the text of a command</comment>
   </data>
   <data name="SelectCommandWithSelectionButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Šéľęĉť čøмmāňď !!! !</value>
+    <value>Şēľεςŧ сõmmäηδ !!! !</value>
     <comment>The tooltip for a button for selecting all of the text of a command</comment>
   </data>
   <data name="SelectOutputWithSelectionButton.Label" xml:space="preserve">
-    <value>Šèĺэст оцŧφμţ !!! </value>
+    <value>Ŝęļëćť σùτρύť !!! </value>
     <comment>The label of a button for selecting all of a command's output</comment>
   </data>
   <data name="SelectOutputWithSelectionButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ŝêĺėćτ óυţφμţ !!! </value>
+    <value>Ŝ℮ĺèčť οùτφųţ !!! </value>
     <comment>The tooltip for a button for selecting all of a command's output</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
@@ -118,237 +118,237 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AddProfile_AddNewButton.Tag" xml:space="preserve">
-    <value>€ŗёãťè Ńєщ βυţτøŉ !!! !!</value>
+    <value>Čгéªţë Ŋещ Бϋτţбⁿ !!! !!</value>
   </data>
   <data name="AddProfile_AddNewTextBlock.Text" xml:space="preserve">
-    <value>Лεẅ ℮мрťў ρřόƒïłě !!! !!</value>
+    <value>Ŋ℮ω ĕmρŧý рŗőƒîļё !!! !!</value>
     <comment>Button label that creates a new profile with default settings.</comment>
   </data>
   <data name="AddProfile_Duplicate.Header" xml:space="preserve">
-    <value>Ďϋρĺíςаτέ à ргòƒĩĺé !!! !!!</value>
+    <value>Ďύφľίċåте ã φґǿƒïłē !!! !!!</value>
     <comment>This is the header for a control that lets the user duplicate one of their existing profiles.</comment>
   </data>
   <data name="AddProfile_DuplicateButton.Tag" xml:space="preserve">
-    <value>Ďüρℓїçάţε Ъūťŧǿŋ !!! !</value>
+    <value>Ðùρłīĉāţз Вµτŧσň !!! !</value>
   </data>
   <data name="AddProfile_DuplicateTextBlock.Text" xml:space="preserve">
-    <value>Ðµрℓίċâт℮ !!!</value>
+    <value>Đŭρŀī¢ατê !!!</value>
     <comment>Button label that duplicates the selected profile and navigates to the duplicate's page.</comment>
   </data>
   <data name="ColorScheme_InboxSchemeDuplicate.Header" xml:space="preserve">
-    <value>Тħϊś ¢öłóř ѕċĥëме įѕ φāяŧ öƒ ťђё вµīľŧ-ïπ ѕэŧŧιñğѕ öя дⁿ їŋşţåłŀєď ĕхŧęлŝïоņ !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ţħīѕ ċøłǿґ ŝςħèм℮ îś рăŗţ õƒ тнè ъûĩľт-íπ śéţťΐлĝś õř дŋ íńşťªłĺèð èжťęлşίοη !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment></comment>
   </data>
   <data name="ColorScheme_InboxSchemeDuplicate.HelpText" xml:space="preserve">
-    <value>Ŧô mąκε çĥªиĝεŝ тò ţĥїş ςθŀθя šĉħémέ, ўôџ мџѕт måќз å сŏрỳ òƒ īŧ. !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ţό màќз ¢ћдņĝзş тő ťђїš ĉǿℓöř śсђзmė, ÿŏú мũŝт măĸę α сòφў σƒ ΐť. !!! !!! !!! !!! !!! !!! !</value>
     <comment></comment>
   </data>
   <data name="ColorScheme_DuplicateButton.Content" xml:space="preserve">
-    <value>Μåк℮ ά сõрỳ !!!</value>
+    <value>Маĸέ α ċōρý !!!</value>
     <comment>This is a call to action; the user can click the button to make a copy of the current color scheme.</comment>
   </data>
   <data name="ColorScheme_SetAsDefault.Header" xml:space="preserve">
-    <value>Śĕţ ςőľбґ ѕсħêмę ǻś ď℮ƒάùľŧ !!! !!! !!</value>
+    <value>Śèţ ćŏŀθґ šςħëmĕ âŝ δĕƒдϋŀţ !!! !!! !!</value>
     <comment>This is the header for a control that allows the user to set the currently selected color scheme as their default.</comment>
   </data>
   <data name="ColorScheme_SetAsDefault.HelpText" xml:space="preserve">
-    <value>Αρρļŷ ţђîş ¢őľŏг şćĥёmė тô âļℓ ýǿũř рŕσƒіľĕś, вγ đ℮ƒǻùļţ. Îⁿðίνìδµāŀ ρŕøƒïŀêѕ ¢аŉ ѕťíļĺ śέľĕĉţ ţђєίř ōшñ čοľǿř ščĥĕměš. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Áφρļу τђìš čǿℓóѓ ѕςĥеmё ţò âļℓ ўσùґ φѓôƒίļеš, ъÿ ðεƒăŭļŧ. Īиðїνιďμäĺ φяöƒíłĕš çǻп şťíĺļ ŝзĺëĉτ тнĕιř ǿшŋ сόļöѓ şčĥêмέѕ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A description explaining how this control changes the user's default color scheme.</comment>
   </data>
   <data name="ColorScheme_Rename.Header" xml:space="preserve">
-    <value>Ŕėⁿăмз ĉøℓøѓ ś¢ĥèmε !!! !!!</value>
+    <value>Ŕêпªmè сθłόя ŝçħémë !!! !!!</value>
     <comment>This is the header for a control that allows the user to rename the currently selected color scheme.</comment>
   </data>
   <data name="ColorScheme_Background.Text" xml:space="preserve">
-    <value>Ъâсĸĝŗõũήð !!!</value>
+    <value>Ъāċкġřőůņð !!!</value>
     <comment>This is the header for a control that lets the user select the background color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_Black.Text" xml:space="preserve">
-    <value>ßļªçķ !</value>
+    <value>Вľд¢κ !</value>
     <comment>This is the header for a control that lets the user select the black color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_Blue.Text" xml:space="preserve">
-    <value>Ьŀúε !</value>
+    <value>Ьĺųε !</value>
     <comment>This is the header for a control that lets the user select the blue color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_BrightBlack.Text" xml:space="preserve">
-    <value>Ъŗιğђţ вľªçк !!! </value>
+    <value>Ьŗίĝħť ьľā¢к !!! </value>
     <comment>This is the header for a control that lets the user select the bright black color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_BrightBlue.Text" xml:space="preserve">
-    <value>Ьřĩġћţ ъŀµē !!!</value>
+    <value>βґίġнť вŀµё !!!</value>
     <comment>This is the header for a control that lets the user select the bright blue color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_BrightCyan.Text" xml:space="preserve">
-    <value>Βřīġħţ сýåπ !!!</value>
+    <value>Вяίģћŧ ĉуǻл !!!</value>
     <comment>This is the header for a control that lets the user select the bright cyan color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_BrightGreen.Text" xml:space="preserve">
-    <value>Вŕīģħт ģгēзň !!! </value>
+    <value>ßѓΐĝђŧ ğґęêп !!! </value>
     <comment>This is the header for a control that lets the user select the bright green color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_BrightPurple.Text" xml:space="preserve">
-    <value>ßŗϊğħт ρűřφĺé !!! </value>
+    <value>Бяīğнŧ ρùŗрľĕ !!! </value>
     <comment>This is the header for a control that lets the user select the bright purple color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_BrightRed.Text" xml:space="preserve">
-    <value>βѓΐğћτ ŕĕď !!!</value>
+    <value>Ъŕίğћт гėđ !!!</value>
     <comment>This is the header for a control that lets the user select the bright red color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_BrightWhite.Text" xml:space="preserve">
-    <value>Ъгîġнŧ ωћĩтē !!! </value>
+    <value>Ьгīģђţ ωђĭτê !!! </value>
     <comment>This is the header for a control that lets the user select the bright white color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_BrightYellow.Text" xml:space="preserve">
-    <value>ßѓїĝћť ýèļŀōώ !!! </value>
+    <value>Вříĝħŧ ÿéĺĺóẃ !!! </value>
     <comment>This is the header for a control that lets the user select the bright yellow color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_CursorColor.Text" xml:space="preserve">
-    <value>Ċџŕŝøґ çóĺőѓ !!! </value>
+    <value>Ćμŕšσґ ćθŀθя !!! </value>
     <comment>This is the header for a control that lets the user select the text cursor's color displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_Cyan.Text" xml:space="preserve">
-    <value>Ċŷăń !</value>
+    <value>Сÿāⁿ !</value>
     <comment>This is the header for a control that lets the user select the cyan color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_Foreground.Text" xml:space="preserve">
-    <value>₣őř℮ġŕоμŋđ !!!</value>
+    <value>₣οŕėĝřσűлđ !!!</value>
     <comment>This is the header for a control that lets the user select the foreground color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_Green.Text" xml:space="preserve">
-    <value>Ģѓēёи !</value>
+    <value>Ġязêή !</value>
     <comment>This is the header for a control that lets the user select the green color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_Purple.Text" xml:space="preserve">
-    <value>Ρυŗρŀє !</value>
+    <value>Рµгρļě !</value>
     <comment>This is the header for a control that lets the user select the purple color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_SelectionBackground.Text" xml:space="preserve">
-    <value>Şēłэ¢тíοñ ьά¢кğѓбυňď !!! !!!</value>
+    <value>Š℮ŀзςŧίθл ьâĉĸġřōŭńδ !!! !!!</value>
     <comment>This is the header for a control that lets the user select the background color for selected text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_Red.Text" xml:space="preserve">
-    <value>Ѓèð </value>
+    <value>Ŗ℮ď </value>
     <comment>This is the header for a control that lets the user select the red color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_White.Text" xml:space="preserve">
-    <value>Ẁнíтė !</value>
+    <value>Щнϊтè !</value>
     <comment>This is the header for a control that lets the user select the white color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_Yellow.Text" xml:space="preserve">
-    <value>¥ěłļбẅ !</value>
+    <value>Υéĺľоŵ !</value>
     <comment>This is the header for a control that lets the user select the yellow color for text displayed on the screen.</comment>
   </data>
   <data name="Globals_Language.Header" xml:space="preserve">
-    <value>Łâⁿğμąĝе (řзqũìѓěş ѓéℓāúŋčħ) !!! !!! !!</value>
+    <value>Ŀąŉģüǻğз (řêqџĭŗэś яёłдũⁿ¢ħ) !!! !!! !!</value>
     <comment>The header for a control allowing users to choose the app's language.</comment>
   </data>
   <data name="Globals_Language.HelpText" xml:space="preserve">
-    <value>Ѕēłêĉţś á ðіśрĺãγ łàиĝυâğę ƒŏř ŧн℮ άррĺіċâţĭоņ. Ťћîŝ шįľļ ονėŕřìðě ỳõυѓ ďеƒãџĺт Windows ïňťеґƒäĉέ ĺáлģΰâģε. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Ѕęļéćŧѕ ā ďįŝρℓду łàйģцâğέ ƒǿř ťћз ǻρрľïčдŧíòŉ. Ťħϊş ωіŀľ όνëґŗίďē уǿüř ďèƒăμľţ Ẃïñďбŵś įñτéŗƒαсэ ŀåŋġύдğé. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>A description explaining how this control changes the app's language. {Locked="Windows"}</comment>
   </data>
   <data name="Globals_LanguageDefault" xml:space="preserve">
-    <value>Ũѕé śỳśť℮м ďëƒäμļť !!! !!</value>
+    <value>Ůŝê ѕŷŝτėм đєƒāùľŧ !!! !!</value>
     <comment>The app contains a control allowing users to choose the app's language. If this value is chosen, the language preference list of the system settings is used instead.</comment>
   </data>
   <data name="Globals_AlwaysShowTabs.Header" xml:space="preserve">
-    <value>∆ĺщãγѕ ѕнοщ ŧąвš !!! !</value>
+    <value>Άľώāŷš şђǿŵ тãвŝ !!! !</value>
     <comment>Header for a control to toggle if the app should always show the tabs (similar to a website browser).</comment>
   </data>
   <data name="Globals_AlwaysShowTabs.HelpText" xml:space="preserve">
-    <value>Ẅħєň δîśάьł℮δ, тĥê тáв ъдŗ щϊŀĺ ǻрρęáѓ ẃћэπ д ňεŵ ţáъ ίѕ ĉґєάťєď. Ćάйņōŧ ве ðîşäьĺéð ẅћîĺε "Ĥϊδê тђé ťїťļе ъãŕ" ιŝ Ώη. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Шħεń ďίѕªъľеð, ţĥё ŧāъ ъаŕ ώіļℓ аρρëâř ẃн℮ŋ ª ŋëẁ ťаъ ιš сгęǻţеď. Ćâиňбŧ ьε ďîśαъŀ℮đ ωħϊŀē "Ĥίδē τђę ţĭτľέ ъάѓ" įś Ωń. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>A description for what the "always show tabs" setting does. Presented near "Globals_AlwaysShowTabs.Header". This setting cannot be disabled while "Globals_ShowTitlebar.Header" is enabled.</comment>
   </data>
   <data name="Globals_NewTabPosition.Header" xml:space="preserve">
-    <value>Ρθšΐτιöņ øƒ ŋéωłỳ çřĕāŧěð ťãъŝ !!! !!! !!!</value>
+    <value>Ρόšîŧϊøņ őƒ йĕŵℓу ĉřēάţεđ τдьš !!! !!! !!!</value>
     <comment>Header for a control to select position of newly created tabs.</comment>
   </data>
   <data name="Globals_NewTabPosition.HelpText" xml:space="preserve">
-    <value>Ѕρє¢ĩƒιεѕ ẁħєŕě ņĕẃ τªвš дφφèåг ĭи ťћě тåъ ґǿω. !!! !!! !!! !!! !!</value>
+    <value>Śφзćїƒíеş шĥëřē ⁿêŵ τâъś ªρρёáґ ĭп тћé τåв яøш. !!! !!! !!! !!! !!</value>
     <comment>A description for what the "Position of newly created tabs" setting does.</comment>
   </data>
   <data name="Globals_NewTabPositionAfterLastTab.Content" xml:space="preserve">
-    <value>Åƒťεŕ ţђê ļªšţ ŧąв !!! !!</value>
+    <value>Äƒτёř ţнė ĺąśţ τаъ !!! !!</value>
     <comment>An option to choose from for the "Position of newly created tabs" setting. When selected new tab appears after the last tab.</comment>
   </data>
   <data name="Globals_NewTabPositionAfterCurrentTab.Content" xml:space="preserve">
-    <value>Λƒτěґ ţђз çųřŕёŋŧ ŧдь !!! !!!</value>
+    <value>Αƒŧëѓ ťнė сúѓŗėπτ τăъ !!! !!!</value>
     <comment>An option to choose from for the "Position of newly created tabs" setting. When selected new tab appears after the current tab.</comment>
   </data>
   <data name="Globals_CopyOnSelect.Header" xml:space="preserve">
-    <value>Ąũтоmатïсáłŀу сθφý śēļëçŧïôи τó çļιρъόдřď !!! !!! !!! !!!</value>
+    <value>Āúтǿmаţιĉąľľў сοφý şèℓэċтïøñ ţō ĉļĩρьóąґď !!! !!! !!! !!!</value>
     <comment>Header for a control to toggle whether selected text should be copied to the clipboard automatically, or not.</comment>
   </data>
   <data name="Globals_DetectURLs.Header" xml:space="preserve">
-    <value>Áμτοmáτîċǻŀĺγ đęťёçť ЏΓĿŝ áŉð мāķё ţђέм ¢ļĭċќдьĺέ !!! !!! !!! !!! !!!</value>
+    <value>Λυτοмдτìćăŀŀÿ đзťēćτ ЦŖĿš аňđ máĸë ţнэм сŀĭçќάвłĕ !!! !!! !!! !!! !!!</value>
     <comment>Header for a control to toggle whether the terminal should automatically detect URLs and make them clickable, or not.</comment>
   </data>
   <data name="Globals_TrimBlockSelection.Header" xml:space="preserve">
-    <value>Řëмσνē ťŗåίľїήġ ẁћĩτē-śрāčέ ϊņ ŗёçŧäⁿğùĺдř ŝэļзċτïóŋ !!! !!! !!! !!! !!! </value>
+    <value>Ѓëmονĕ тŕáìĺїŉġ ẃђϊτë-ѕρá¢ę ĭл ѓеċτåηğцĺăŗ ş℮ŀěčŧĭõň !!! !!! !!! !!! !!! </value>
     <comment>Header for a control to toggle whether a text selected with block selection should be trimmed of white spaces when copied to the clipboard, or not.</comment>
   </data>
   <data name="Globals_TrimPaste.Header" xml:space="preserve">
-    <value>Γемоνė ŧŕǻіŀīñģ ŵнΐţē-ŝρäċе ẅђеñ φâšŧĭŉĝ !!! !!! !!! !!!</value>
+    <value>Ґεmθνе ťѓªįŀíŉĝ шĥіťе-šрäčė ẃнзň φâśťίņġ !!! !!! !!! !!!</value>
     <comment>Header for a control to toggle whether pasted text should be trimmed of white spaces, or not.</comment>
   </data>
   <data name="Globals_KeybindingsDisclaimer.Text" xml:space="preserve">
-    <value>Взľбẅ αяė ţнě ĉùŗřеņтℓγ вóûŋď кęуş, ẅĥΐçђ ċąη вĕ mбδīƒīέđ ъỳ έðĭŧĩňğ τнě ĴŜǾ∏ ŝĕŧťîńġś ƒιľέ. !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Вêļσώ áяэ τĥє сûѓгεπтľý ъόůηð κєÿş, ώĥīćн čāñ ъз мοðïƒīěð ьý зðїŧįńģ τћė ЈŜÖΝ şзťŧίñğѕ ƒΐłέ. !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>A disclaimer located at the top of the actions page that presents the list of keybindings.</comment>
   </data>
   <data name="Globals_DefaultProfile.Header" xml:space="preserve">
-    <value>Ðёƒāμĺτ φгǿƒīłé !!! !</value>
+    <value>Đėƒªûľť рґøƒϊľê !!! !</value>
     <comment>Header for a control to select your default profile from the list of profiles you've created.</comment>
   </data>
   <data name="Globals_DefaultProfile.HelpText" xml:space="preserve">
-    <value>Ρřòƒìĺę тĥат öρëйş шћêŉ ĉŀϊςκîŉğ ţħе '+' íċóп όŗ вў ťýφįиġ τћė иęш тâъ кέÿ вΐŋďíŉģ. !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Ρŗσƒιℓê тнǻт ōреŋś ώнèи ¢ļíčкïñğ ťћέ '+' ίçôи ŏґ ьў ţýрϊńğ тĥє ņěẁ тªв ќèý ъϊήðїńġ. !!! !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>A description for what the default profile is and when it's used.</comment>
   </data>
   <data name="Globals_DefaultTerminal.Header" xml:space="preserve">
-    <value>Ðёƒâцľť ťêгмîйάļ аρρľϊςαтįőŉ !!! !!! !!</value>
+    <value>Ðêƒάϋℓτ ŧέřmìпάℓ аρφĺΐςàţїōŋ !!! !!! !!</value>
     <comment>Header for a drop down that permits the user to select which installed Terminal application will launch when command line tools like CMD are run from the Windows Explorer run box or start menu or anywhere else that they do not already have a graphical window assigned.</comment>
   </data>
   <data name="Globals_DefaultTerminal.HelpText" xml:space="preserve">
-    <value>Ŧĥê τéŕmϊŉдℓ āρρĺìčåťĭŏή τĥåт łàцπсħёś ẃĥëπ ǻ čσmмäñδ-ℓιń℮ áρφĺĩ¢åţĩöⁿ ĩš яúņ ẁīτĥθũτ ąŉ èхĩśŧΐиġ śēŝśιόň, łíķę ƒřőм ťħë Şтăřт Мεⁿũ οŕ Ŕύп ðіαļоġ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ťђě ţэřмīηãĺ ǻφφℓï¢ǻтΐбň ŧђáт łáůйčĥēś ẅĥэп ā сöмmǻńđ-ľіŉэ ăρρĺįċāτΐôⁿ ϊš яųñ шíţћöυţ ªņ ĕхϊŝŧĭñğ şěŝѕïŏπ, ŀĩĸė ƒѓом ţћĕ Ŝτáґт Μęπü бг Яųņ ďīäℓöğ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
   <data name="Globals_ForceFullRepaint.Header" xml:space="preserve">
-    <value>Ŕеδřαω ēлŧįřê ѕćяéэи ώнęή ďîѕφļáÿ űрďåτêš !!! !!! !!! !!!</value>
+    <value>Ŗёδѓªŵ еñţιŗę šĉřέëŋ шн℮й đĩşρℓâў υρďάţëš !!! !!! !!! !!!</value>
     <comment>Header for a control to toggle the "force full repaint" setting. When enabled, the app renders new content between screen frames.</comment>
   </data>
   <data name="Globals_ForceFullRepaint.HelpText" xml:space="preserve">
-    <value>Ẅħëņ ďīѕάьℓĕď, тĥ℮ тєŗmίⁿάł ẃїĺĺ ř℮ńđèŗ σйłỳ τĥè ϋрđǻτєŝ ţσ тнë şċѓëεπ ъĕťẃээⁿ ƒřámêś. !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Щħ℮п đįѕāъĺèđ, ťђέ тèřмΐņäľ ωìľľ řεŉďęŗ όŉľŷ ŧђέ ŭρďăţзŝ τö ŧђë šсгèзņ вêţшзэŉ ƒяāméş. !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "force full repaint" setting does. Presented near "Globals_ForceFullRepaint.Header".</comment>
   </data>
   <data name="Globals_InitialCols.Text" xml:space="preserve">
-    <value>Çóļцмлš !!</value>
+    <value>Ċσŀùмñѕ !!</value>
     <comment>Header for a control to choose the number of columns in the terminal's text grid.</comment>
   </data>
   <data name="Globals_InitialRows.Text" xml:space="preserve">
-    <value>Ŕóẃś !</value>
+    <value>Ѓõшŝ !</value>
     <comment>Header for a control to choose the number of rows in the terminal's text grid.</comment>
   </data>
   <data name="Globals_InitialColsBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ĩñíŧĭąĺ €óľμмńš !!! !</value>
+    <value>Îйϊŧìãľ Çòłųмπş !!! !</value>
     <comment>Name for a control to choose the number of columns in the terminal's text grid.</comment>
   </data>
   <data name="Globals_InitialRowsBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ίņĭŧįáℓ Γǿшś !!! </value>
+    <value>İńìťîáℓ Ŕőώś !!! </value>
     <comment>Name for a control to choose the number of rows in the terminal's text grid.</comment>
   </data>
   <data name="Globals_InitialPosX.Text" xml:space="preserve">
-    <value>χ рòśίťιŏπ !!!</value>
+    <value>χ φόśΐтįóñ !!!</value>
     <comment>Header for a control to choose the X coordinate of the terminal's starting position.</comment>
   </data>
   <data name="Globals_InitialPosY.Text" xml:space="preserve">
-    <value>Ύ рǿѕіτìõи !!!</value>
+    <value>Ỳ φôѕΐтĩσп !!!</value>
     <comment>Header for a control to choose the Y coordinate of the terminal's starting position.</comment>
   </data>
   <data name="Globals_InitialPosXBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Х φõşїтĭőη !!!</value>
+    <value>χ φŏѕĭтϊόŋ !!!</value>
     <comment>Name for a control to choose the X coordinate of the terminal's starting position.</comment>
   </data>
   <data name="Globals_InitialPosXBox.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Εņţєŕ τħê νàłůè ƒøŗ ŧћє ж-čǿóґďïⁿат℮. !!! !!! !!! !!</value>
+    <value>Ëŉŧëř ţнę νáľυé ƒóŗ τђę х-čōóѓđΐήâтë. !!! !!! !!! !!</value>
     <comment>Tooltip for the control that allows the user to choose the X coordinate of the terminal's starting position.</comment>
   </data>
   <data name="Globals_InitialPosXBox.PlaceholderText" xml:space="preserve">
@@ -356,11 +356,11 @@
     <comment>The string to be displayed when there is no current value in the x-coordinate number box.</comment>
   </data>
   <data name="Globals_InitialPosYBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Υ φǿśіťίǿл !!!</value>
+    <value>Ỳ ρθŝìŧιοπ !!!</value>
     <comment>Name for a control to choose the Y coordinate of the terminal's starting position.</comment>
   </data>
   <data name="Globals_InitialPosYBox.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ĕņтэř ŧнэ νãļùе ƒθґ ŧħĕ ỳ-ĉőöŕδïπáţέ. !!! !!! !!! !!</value>
+    <value>Ёйŧëŕ ţћε νàłüέ ƒòŕ ťĥє ỳ-čоθґδĩπāтė. !!! !!! !!! !!</value>
     <comment>Tooltip for the control that allows the user to choose the Y coordinate of the terminal's starting position.</comment>
   </data>
   <data name="Globals_InitialPosYBox.PlaceholderText" xml:space="preserve">
@@ -368,538 +368,538 @@
     <comment>The string to be displayed when there is no current value in the y-coordinate number box.</comment>
   </data>
   <data name="Globals_DefaultLaunchPositionCheckbox.Content" xml:space="preserve">
-    <value>₤зτ Щΐиðøẃѕ ðèċįðз !!! !!</value>
+    <value>₤êτ Ẃĩиðōẁŝ ðē¢îðε !!! !!</value>
     <comment>A checkbox for the "launch position" setting. Toggling this control sets the launch position to whatever the Windows operating system decides.</comment>
   </data>
   <data name="Globals_DefaultLaunchPositionCheckbox.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Īƒ ėлªвĺёδ, ūѕè ţħė šŷşŧëm ďэƒāџľţ ļāύήсħ φöѕīтίθŋ. !!! !!! !!! !!! !!!</value>
+    <value>Іƒ éлдъłëđ, úśз тђé ѕýŝт℮m δέƒăµłŧ łäúηćћ φöšïţϊóň. !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "default launch position" checkbox does. Presented near "Globals_DefaultLaunchPositionCheckbox".</comment>
   </data>
   <data name="Globals_FirstWindowPreference.Header" xml:space="preserve">
-    <value>Ẃнēи Ťεřmιйàℓ šţдґτś !!! !!!</value>
+    <value>Ẃђéñ Ţëгмїńªĺ ѕťářтš !!! !!!</value>
     <comment>Header for a control to select how the terminal should load its first window.</comment>
   </data>
   <data name="Globals_FirstWindowPreference.HelpText" xml:space="preserve">
-    <value>Ẃђăť şħõύļð вэ şћöωń ώнėņ тћ℮ ƒϊяšŧ тĕřміŉªľ īš ςгęåťêđ. !!! !!! !!! !!! !!! !</value>
+    <value>Ẁђăт şĥõцĺð вε ѕнбшп ẁћёй ťђё ƒîŗŝт тěřмΐйåł їś сѓéąţзď. !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="Globals_FirstWindowPreferenceDefaultProfile.Content" xml:space="preserve">
-    <value>Όρεň å τâв ώΐţћ ŧђз ďĕƒάüļτ рřоƒīŀέ !!! !!! !!! !</value>
+    <value>Οрзη à ťáь ώΐţĥ ţђè δεƒāűĺţ ρяθƒίłё !!! !!! !!! !</value>
     <comment>An option to choose from for the "First window preference" setting. Open the default profile.</comment>
   </data>
   <data name="Globals_FirstWindowPreferencePersistedWindowLayout.Content" xml:space="preserve">
-    <value>Öρęņ ŵîиďόшѕ ƒřŏм а ргéνįóûş šęšŝĩбⁿ !!! !!! !!! !</value>
+    <value>Орéŋ ẅϊηďóωš ƒřōm ă φяèνιôùś şęŝśîőň !!! !!! !!! !</value>
     <comment>An option to choose from for the "First window preference" setting. Reopen the layouts from the last session.</comment>
   </data>
   <data name="Globals_LaunchMode.Header" xml:space="preserve">
-    <value>Ĺǻϋйċћ мōđ℮ !!!</value>
+    <value>₤дΰⁿçћ mοďè !!!</value>
     <comment>Header for a control to select what mode to launch the terminal in.</comment>
   </data>
   <data name="Globals_LaunchMode.HelpText" xml:space="preserve">
-    <value>Ĥοẃ ţнэ ťéяmīⁿåĺ ωïℓł ąφρзάř ŏñ ŀäũлčн. ₣õċűş шīľŀ ħΐδ℮ тħё тãъŝ άπð ţіŧŀě ьаг. !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ηóώ ţĥè ţěѓmϊиаľ ẁίĺĺ àρρ℮åг σⁿ łåŭⁿ¢ĥ. ₣οċύŝ ẁīłł ђїδė ţђê ťªьş āńð тιŧľ℮ вăŕ. !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>'Focus' must match &lt;Globals_LaunchModeFocus.Content&gt;.</comment>
   </data>
   <data name="Globals_LaunchParameters.Header" xml:space="preserve">
-    <value>Ĺåμŉćн ραѓämёťэřŝ !!! !!</value>
+    <value>£ăŭŉсн рąґăмěţеґŝ !!! !!</value>
     <comment>Header for a set of settings that determine how terminal launches. These settings include the launch mode, launch position and whether the terminal should center itself on launch.</comment>
   </data>
   <data name="Globals_LaunchParameters.HelpText" xml:space="preserve">
-    <value>Şётťΐήğѕ ţĥåτ ςоŋţґőł нθŵ ţĥė ŧëгмίŉàℓ ĺàύńċћёš !!! !!! !!! !!! !!</value>
+    <value>Ѕèттîŋĝś ŧħªŧ ςôňťѓσŀ ĥõщ ţнè ţĕŗmîйåℓ ℓăµňĉнэś !!! !!! !!! !!! !!</value>
     <comment>A description for what the "launch parameters" expander contains. Presented near "Globals_LaunchParameters.Header".</comment>
   </data>
   <data name="Globals_LaunchModeSetting.Text" xml:space="preserve">
-    <value>Ĺαüйςђ мŏðé !!!</value>
+    <value>Ŀäцñсн mőď℮ !!!</value>
     <comment>Header for a control to select what mode to launch the terminal in.</comment>
   </data>
   <data name="Globals_LaunchModeSetting.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ηöш ŧнё τэяmίйäļ ώιłł àρφєдя σⁿ łàŭηĉħ. ₣ő¢цş ẁιĺℓ нïďĕ ţнé тâвś äŉδ ţïţłê ъăѓ. !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ηōŵ ţнέ тěřmіηªĺ ẃΐŀľ ąρρëäґ öñ ļǻûй¢ћ. ₣όςµŝ ẅїļł ħĭďē τћε ŧªъš āηď ŧìťℓέ ьář. !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>'Focus' must match &lt;Globals_LaunchModeFocus.Content&gt;.</comment>
   </data>
   <data name="Globals_LaunchModeDefault.Content" xml:space="preserve">
-    <value>Đєƒάцĺŧ !!</value>
+    <value>Ďěƒάυŀţ !!</value>
     <comment>An option to choose from for the "launch mode" setting. Default option.</comment>
   </data>
   <data name="Globals_LaunchModeFullscreen.Content" xml:space="preserve">
-    <value>₣ùĺĺ şċяěêή !!!</value>
+    <value>₣ųľľ ѕ¢řέей !!!</value>
     <comment>An option to choose from for the "launch mode" setting. Opens the app in a full screen state.</comment>
   </data>
   <data name="Globals_LaunchModeMaximized.Content" xml:space="preserve">
-    <value>Мą×ímĭźέđ !!!</value>
+    <value>Μâ×įміźέď !!!</value>
     <comment>An option to choose from for the "launch mode" setting. Opens the app maximized (covers the whole screen).</comment>
   </data>
   <data name="Globals_WindowingBehavior.Header" xml:space="preserve">
-    <value>Ñέш їηśťдпčé ьέђäνíòř !!! !!!</value>
+    <value>Νēщ ίńѕţãиςé ьęĥâνΐог !!! !!!</value>
     <comment>Header for a control to select how new app instances are handled.</comment>
   </data>
   <data name="Globals_WindowingBehavior.HelpText" xml:space="preserve">
-    <value>Ĉŏηтřöļŝ ħŏщ пëω ťéřмïήдĺ įлѕţªⁿčзś ãŧτâ¢н το έ×ϊśŧϊπģ ωĩŋďöẃş. !!! !!! !!! !!! !!! !!! </value>
+    <value>Ĉöñтŕбℓš ћøш иēŵ τêгmîⁿàļ ĩπšţáπςεŝ άťţдčн тö є×ĭšτіņğ ώілđøẃş. !!! !!! !!! !!! !!! !!! </value>
     <comment>A description for what the "windowing behavior" setting does. Presented near "Globals_WindowingBehavior.Header".</comment>
   </data>
   <data name="Globals_WindowingBehaviorUseNew.Content" xml:space="preserve">
-    <value>Ĉŗзäţ℮ â иεш ώĩŋđбω !!! !!!</value>
+    <value>Ćяèàťέ д ήéẃ ẃĭлďőω !!! !!!</value>
     <comment>An option to choose from for the "windowing behavior" setting. When selected, new instances create a new window.</comment>
   </data>
   <data name="Globals_WindowingBehaviorUseAnyExisting.Content" xml:space="preserve">
-    <value>Άţţǻçħ ţò ťħê мбšŧ гęсėñţĺỳ ϋŝēð ẁîήďøώ !!! !!! !!! !!!</value>
+    <value>Ăţţăčĥ ŧó тħέ mõŝŧ řěçèпŧļý ŭśëď ẃįňδσω !!! !!! !!! !!!</value>
     <comment>An option to choose from for the "windowing behavior" setting. When selected, new instances open in the most recently used window.</comment>
   </data>
   <data name="Globals_WindowingBehaviorUseExisting.Content" xml:space="preserve">
-    <value>Âťťàçħ ţõ тĥе мōśτ řěсèйтĺγ ŭşėδ ŵīŋδθẃ őŉ ŧĥϊŝ ďēѕĸţóφ !!! !!! !!! !!! !!! !</value>
+    <value>Äţŧαĉђ τǿ τħе mοѕт ѓěςęńτļγ ûѕєď ŵíñðοω øи тћϊѕ ďёšкτǿφ !!! !!! !!! !!! !!! !</value>
     <comment>An option to choose from for the "windowing behavior" setting. When selected, new instances open in the most recently used window on this virtual desktop.</comment>
   </data>
   <data name="Globals_RenderingDisclaimer.Text" xml:space="preserve">
-    <value>Тħĕѕе ѕęťťíňģѕ мāý ъè ùѕзƒüļ ƒόѓ ŧгôύьļėşћόόťĩηġ âņ іśśűэ, ĥбωэνêř тĥєу ŵіľĺ ĩmρâćτ ŷôцг φĕґƒōґмªńčë. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Τћέŝė ѕëτтίņģš мâу ьê üѕēƒµľ ƒόґ τřóųьŀėѕĥбοτілġ ǻл іŝśü℮, нσώéνєŕ τĥêў ŵīŀł ΐmρåςť убŭя ρěгƒόґмåñĉę. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A disclaimer presented at the top of a page.</comment>
   </data>
   <data name="Globals_ShowTitlebar.Header" xml:space="preserve">
-    <value>Ήĭδë ŧћέ тïťłë вäѓ (ѓзqüïгєŝ ŗéℓâūň¢ħ) !!! !!! !!! !!</value>
+    <value>Ĥìđε тħê τīţĺё ъªř (ŗėqūΐŗêś яеľаϋŉčћ) !!! !!! !!! !!</value>
     <comment>Header for a control to toggle whether the title bar should be shown or not. Changing this setting requires the user to relaunch the app.</comment>
   </data>
   <data name="Globals_ShowTitlebar.HelpText" xml:space="preserve">
-    <value>Ẅħеñ δіѕªъĺєð, ŧнέ ţιťłê ъαя ẃīļļ аρφėαг авŏνé ŧћэ тāвś. !!! !!! !!! !!! !!! !</value>
+    <value>Ẃћèп ðϊŝαъłėð, тнė ťĭτłê вąѓ ẁιĺł ąφφёǻŕ äвöνė ŧħė ťãьś. !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "show titlebar" setting does. Presented near "Globals_ShowTitlebar.Header".</comment>
   </data>
   <data name="Globals_AcrylicTabRow.Header" xml:space="preserve">
-    <value>Ůѕε ăčѓÿℓїč mαтέѓįάł ĭń тħε ťàъ ѓσŵ !!! !!! !!! !</value>
+    <value>Ūŝē àςѓýłīć мãτęѓįάł ϊή ťнę ťāъ гоω !!! !!! !!! !</value>
     <comment>Header for a control to toggle whether "acrylic material" is used. "Acrylic material" is a Microsoft-specific term: https://docs.microsoft.com/en-us/windows/apps/design/style/acrylic</comment>
   </data>
   <data name="Globals_ShowTitleInTitlebar.Header" xml:space="preserve">
-    <value>Ûšĕ áсτĭνĕ τёŗмΐⁿàŀ τįţļë áś ăφφĺïĉªţįθň тіτĺє !!! !!! !!! !!! !</value>
+    <value>Ůŝě å¢ťįνέ τèґmĭŉαĺ τįτľé äš дρφℓīĉатĭǿŉ ţιţľē !!! !!! !!! !!! !</value>
     <comment>Header for a control to toggle whether the terminal's title is shown as the application title, or not.</comment>
   </data>
   <data name="Globals_ShowTitleInTitlebar.HelpText" xml:space="preserve">
-    <value>Ŵђęñ đīśåьļěð, ţнє тιťŀє ьãя ẃιłł вë 'Ťēřмϊиåł'. !!! !!! !!! !!! !!</value>
+    <value>Ŵћéή đíѕǻьļεď, тħè ťįτłе ьǻŗ ẁїℓł вє 'Ťěѓмĩⁿăĺ'. !!! !!! !!! !!! !!</value>
     <comment>A description for what the "show title in titlebar" setting does. Presented near "Globals_ShowTitleInTitlebar.Header".{Locked="Windows"}</comment>
   </data>
   <data name="Globals_SnapToGridOnResize.Header" xml:space="preserve">
-    <value>Śпâφ ẃϊиδбẅ řéѕíżíⁿĝ τō ċħªґªçţèѓ ğřįď !!! !!! !!! !!</value>
+    <value>Ŝиάρ щίйðõщ яēşΐžíпĝ тõ čħáѓä¢ťέѓ ģѓĩδ !!! !!! !!! !!</value>
     <comment>Header for a control to toggle whether the terminal snaps the window to the character grid when resizing, or not.</comment>
   </data>
   <data name="Globals_SnapToGridOnResize.HelpText" xml:space="preserve">
-    <value>Ŵнэπ δϊşåъłёδ, тнē ẁїπđõŵ ωіļŀ řεѕìżέ ѕmόοτнłγ. !!! !!! !!! !!! !!</value>
+    <value>Ẅн℮ñ ðìşāьļĕð, τĥė ŵΐņďòώ ẃíļĺ řėŝîżē šмõόтнłγ. !!! !!! !!! !!! !!</value>
     <comment>A description for what the "snap to grid on resize" setting does. Presented near "Globals_SnapToGridOnResize.Header".</comment>
   </data>
   <data name="Globals_SoftwareRendering.Header" xml:space="preserve">
-    <value>Ūŝэ ѕοƒтŵάгē ґèňďĕřιňģ !!! !!! </value>
+    <value>Ųѕε ŝόƒťщаřė яĕŋðεříлğ !!! !!! </value>
     <comment>Header for a control to toggle whether the terminal should use software to render content instead of the hardware.</comment>
   </data>
   <data name="Globals_SoftwareRendering.HelpText" xml:space="preserve">
-    <value>Ẃĥ℮π ěлàвļ℮đ, ťĥз ţèŕмïñąℓ ẃΐłł ůšê ŧћз ѕθƒťшăŗę ŗέŋδêŕěŗ (ǻ.ĸ.â. ШĂЃΡ) ΐпšτёǻð õƒ ţћė ħâгđщåг℮ òиэ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ẅнέⁿ éñâвĺĕď, ŧĥë тěřmϊñăľ шîľĺ ŭşē ŧнé šбƒţẅāяē ґэпδėѓεŕ (д.к.ă. ẀÅЃΡ) ĭñŝτéāđ оƒ тħё ĥάґđẃаяē οлε. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "software rendering" setting does. Presented near "Globals_SoftwareRendering.Header".</comment>
   </data>
   <data name="Globals_StartOnUserLogin.Header" xml:space="preserve">
-    <value>Łąüπçђ ôπ mªčћΐηз şτаяţυρ !!! !!! !</value>
+    <value>₤áϋпςħ ôл мαςĥĭñę ŝťąřťûρ !!! !!! !</value>
     <comment>Header for a control to toggle whether the app should launch when the user's machine starts up, or not.</comment>
   </data>
   <data name="Globals_StartOnUserLogin.HelpText" xml:space="preserve">
-    <value>Αũтθмǻтίςàℓľý ĺāũиćћ Тēřмįŉàŀ ŵĥэņ уõŭ ℓбğ ĩⁿ ŧő Windows. !!! !!! !!! !!! !!! !!</value>
+    <value>Āũŧοмªτĩčäĺļỳ ŀªūⁿ¢ћ Ťëŗmįŋāℓ ẃнęņ ўоű ŀóġ ìπ τσ Шĩņðоẁѕ. !!! !!! !!! !!! !!! !!</value>
     <comment>A description for what the "start on user login" setting does. Presented near "Globals_StartOnUserLogin.Header". {Locked="Windows"}</comment>
   </data>
   <data name="Globals_CenterOnLaunchCentered" xml:space="preserve">
-    <value>€êńтέя℮δ !!</value>
+    <value>Ćêŋťєŕеδ !!</value>
     <comment>Shorthand, explanatory text displayed when the user has enabled the feature indicated by "Globals_CenterOnLaunch.Text".</comment>
   </data>
   <data name="Globals_CenterOnLaunch.Text" xml:space="preserve">
-    <value>Ċ℮йť℮ŗ øň ľªűйсн !!! !</value>
+    <value>Ćēňτєѓ ŏŋ ľäūńçђ !!! !</value>
     <comment>Header for a control to toggle whether the app should launch in the center of the screen, or not.</comment>
   </data>
   <data name="Globals_CenterOnLaunch.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ẅнэй εйăъłèð, ťħê ẅιⁿđоŵ ẁíŀŀ ьē ρļàćёď ιп ťĥ℮ ĉ℮ňťέŕ òƒ ŧћê ščг℮ĕň ẅђзп łäůπснĕδ. !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Ẁђēи ėⁿąьĺëđ, ţħė ωīņďбώ ώїłľ ъė рℓªςέð ïⁿ ŧĥε сęⁿтєř ǿƒ ŧħè ŝćŕėęή ẁћêŉ ĺдűňĉĥεđ. !!! !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>A description for what the "center on launch" setting does. Presented near "Globals_CenterOnLaunch.Header".</comment>
   </data>
   <data name="Globals_AlwaysOnTop.Header" xml:space="preserve">
-    <value>Αĺẅάỳš ои τòр !!! </value>
+    <value>Аŀẅâγš ōп ŧбφ !!! </value>
     <comment>Header for a control to toggle if the app will always be presented on top of other windows, or is treated normally (when disabled).</comment>
   </data>
   <data name="Globals_AlwaysOnTop.HelpText" xml:space="preserve">
-    <value>Ŧęгмĭпåľ ẅΐℓľ äļщąγŝ в℮ τћē тόφmоšţ ώìŉδøẃ бŉ ţĥĕ ðęšкτőρ. !!! !!! !!! !!! !!! !!</value>
+    <value>Ťèřmĭήäľ ŵϊłļ àļщāÿş ъĕ ŧħє ţóрmόѕŧ шíñđθώ όи ŧħě δεşĸţбφ. !!! !!! !!! !!! !!! !!</value>
     <comment>A description for what the "always on top" setting does. Presented near "Globals_AlwaysOnTop.Header".</comment>
   </data>
   <data name="Globals_TabWidthMode.Header" xml:space="preserve">
-    <value>Ťáв ẁιðťђ mθδë !!! !</value>
+    <value>Ťâв ώΐđťн mбðě !!! !</value>
     <comment>Header for a control to choose how wide the tabs are.</comment>
   </data>
   <data name="Globals_TabWidthMode.HelpText" xml:space="preserve">
-    <value>Ćοмрǻсŧ щїŀł ѕħřĭńĸ īйªčŧĭνз τäьş ŧό ţĥє šϊżе õƒ ţĥе ιĉőπ. !!! !!! !!! !!! !!! !!</value>
+    <value>Ćôмрáçτ ώĭĺļ ŝнгíñк ïŋãċţïνе тâъѕ ťö тĥε ѕіźë ŏƒ ŧн℮ ĩćóň. !!! !!! !!! !!! !!! !!</value>
     <comment>A description for what the "tab width mode" setting does. Presented near "Globals_TabWidthMode.Header". 'Compact' must match the value for &lt;Globals_TabWidthModeCompact.Content&gt;.</comment>
   </data>
   <data name="Globals_TabWidthModeCompact.Content" xml:space="preserve">
-    <value>Čόмράсτ !!</value>
+    <value>Ċøмрªĉť !!</value>
     <comment>An option to choose from for the "tab width mode" setting. When selected, unselected tabs collapse to show only their icon. The selected tab adjusts to display the content within the tab.</comment>
   </data>
   <data name="Globals_TabWidthModeEqual.Content" xml:space="preserve">
-    <value>Εqυàł !</value>
+    <value>Εqüáł !</value>
     <comment>An option to choose from for the "tab width mode" setting. When selected, each tab has the same width.</comment>
   </data>
   <data name="Globals_TabWidthModeTitleLength.Content" xml:space="preserve">
-    <value>Тìŧℓэ ľэņġŧĥ !!! </value>
+    <value>Тīτľе ľεňĝτђ !!! </value>
     <comment>An option to choose from for the "tab width mode" setting. When selected, each tab adjusts its width to the content within the tab.</comment>
   </data>
   <data name="Globals_Theme.Header" xml:space="preserve">
-    <value>∆φρĺîςąтіøπ Ţћ℮мè !!! !!</value>
+    <value>Αрρłΐćàтīòñ Ŧнèм℮ !!! !!</value>
     <comment>Header for a control to choose the theme colors used in the app.</comment>
   </data>
   <data name="Globals_ThemeDark.Content" xml:space="preserve">
-    <value>Đâřĸ !</value>
+    <value>Đăгќ !</value>
     <comment>An option to choose from for the "theme" setting. When selected, the app is in dark theme and darker colors are used throughout the app.</comment>
   </data>
   <data name="Globals_ThemeSystem.Content" xml:space="preserve">
-    <value>Úѕё Ẃîήðòώѕ τђзмэ !!! !!</value>
+    <value>Űŝ℮ Щįņđоẃś тћěmе !!! !!</value>
     <comment>An option to choose from for the "theme" setting. When selected, the app uses the theme selected in the Windows operating system.</comment>
   </data>
   <data name="Globals_ThemeLight.Content" xml:space="preserve">
-    <value>Ľіġћт !</value>
+    <value>Ĺιģћť !</value>
     <comment>An option to choose from for the "theme" setting. When selected, the app is in light theme and lighter colors are used throughout the app.</comment>
   </data>
   <data name="Globals_ThemeDarkLegacy.Content" xml:space="preserve">
-    <value>Đάřκ (Ľзġªçŷ) !!! </value>
+    <value>Ďāґќ (₤єĝåçŷ) !!! </value>
     <comment>An option to choose from for the "theme" setting. When selected, the app is in dark theme and darker colors are used throughout the app. This is an older version of the "dark" theme</comment>
   </data>
   <data name="Globals_ThemeSystemLegacy.Content" xml:space="preserve">
-    <value>Ùşė Шìлďθŵѕ τћεmě (Ľēĝаçÿ) !!! !!! !</value>
+    <value>Ùśê Щΐŉδøщŝ ťħéмě (Łèĝąçу) !!! !!! !</value>
     <comment>An option to choose from for the "theme" setting. When selected, the app uses the theme selected in the Windows operating system. This is an older version of the "Use Windows theme" theme</comment>
   </data>
   <data name="Globals_ThemeLightLegacy.Content" xml:space="preserve">
-    <value>Ĺίğħť (Ļĕğâčÿ) !!! !</value>
+    <value>Ŀїģнţ (Łεĝäċÿ) !!! !</value>
     <comment>An option to choose from for the "theme" setting. When selected, the app is in light theme and lighter colors are used throughout the app. This is an older version of the "light" theme</comment>
   </data>
   <data name="Globals_WordDelimiters.Header" xml:space="preserve">
-    <value>Ẅθґď ďεľіmΐτзŗŝ !!! !</value>
+    <value>Щοґδ đэļιмϊŧеѓş !!! !</value>
     <comment>Header for a control to determine what delimiters to use to identify separate words during word selection.</comment>
   </data>
   <data name="Globals_WordDelimiters.HelpText" xml:space="preserve">
-    <value>Ţĥзśε şÿмвоłś ẅιℓĺ ьё џşєđ шĥèņ ỳòú ðσυвĺë-¢ľïčķ тзжт įπ τђэ тėгмίηåł όř дсţіνáţ℮ "Мåґк móδέ". !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ţћзŝ℮ ѕумвöŀѕ шιŀℓ вê ùŝеď ẃнёñ ỳõµ ďбùвŀэ-ċľϊčк ţε×ť ïⁿ ţћě τєґmїиаℓ ŏѓ αсτϊνãŧě "Мάřк mŏđë". !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "word delimiters" setting does. Presented near "Globals_WordDelimiters.Header". "Mark" is used in the sense of "choosing something to interact with."</comment>
   </data>
   <data name="Nav_Appearance.Content" xml:space="preserve">
-    <value>Λрρеąŕаиçє !!!</value>
+    <value>Λρρёªгąńсё !!!</value>
     <comment>Header for the "appearance" menu item. This navigates to a page that lets you see and modify settings related to the app's appearance.</comment>
   </data>
   <data name="Nav_ColorSchemes.Content" xml:space="preserve">
-    <value>Соŀőг ŝčħеmзś !!! </value>
+    <value>Ċōľøя š¢нēměѕ !!! </value>
     <comment>Header for the "color schemes" menu item. This navigates to a page that lets you see and modify schemes of colors that can be used by the terminal.</comment>
   </data>
   <data name="Nav_Interaction.Content" xml:space="preserve">
-    <value>Ίņŧεґäćťìόл !!!</value>
+    <value>Íŋт℮řâçτîöй !!!</value>
     <comment>Header for the "interaction" menu item. This navigates to a page that lets you see and modify settings related to the user's mouse and touch interactions with the app.</comment>
   </data>
   <data name="Nav_Launch.Content" xml:space="preserve">
-    <value>Śτāŕţūр !!</value>
+    <value>Ѕţâŕτűр !!</value>
     <comment>Header for the "startup" menu item. This navigates to a page that lets you see and modify settings related to the app's launch experience (i.e. screen position, mode, etc.)</comment>
   </data>
   <data name="Nav_OpenJSON.Content" xml:space="preserve">
-    <value>Ωφел ĴŜÖŊ ƒīĺé !!! !</value>
+    <value>Фφëņ ЈŞŐŅ ƒϊĺэ !!! !</value>
     <comment>Header for a menu item. This opens the JSON file that is used to log the app's settings.</comment>
   </data>
   <data name="Nav_ProfileDefaults.Content" xml:space="preserve">
-    <value>Ďėƒάüℓťś !!</value>
+    <value>Đэƒαűŀţş !!</value>
     <comment>Header for the "defaults" menu item. This navigates to a page that lets you see and modify settings that affect profiles. This is the lowest layer of profile settings that all other profile settings are based on. If a profile doesn't define a setting, this page is responsible for figuring out what that setting is supposed to be.</comment>
   </data>
   <data name="Nav_Rendering.Content" xml:space="preserve">
-    <value>Řěŉδєŕιńģ !!!</value>
+    <value>Ŕэⁿðэŕίńğ !!!</value>
     <comment>Header for the "rendering" menu item. This navigates to a page that lets you see and modify settings related to the app's rendering of text in the terminal.</comment>
   </data>
   <data name="Nav_Actions.Content" xml:space="preserve">
-    <value>Äćŧΐоήš !!</value>
+    <value>Ăςтιòñš !!</value>
     <comment>Header for the "actions" menu item. This navigates to a page that lets you see and modify commands, key bindings, and actions that can be done in the app.</comment>
   </data>
   <data name="Profile_OpacitySlider.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>βāçķğřόцлδ øрãсïţỳ !!! !!</value>
+    <value>βά¢ĸĝŕõúήđ ǿрãĉĩŧÿ !!! !!</value>
     <comment>Name for a control to determine the level of opacity for the background of the control. The user can choose to make the background of the app more or less opaque.</comment>
   </data>
   <data name="Profile_Opacity.Header" xml:space="preserve">
-    <value>βăĉĸģяōΰńď ōφā¢ίту !!! !!</value>
+    <value>βāĉκğřôμηď óρăĉїŧỳ !!! !!</value>
     <comment>Header for a control to determine the level of opacity for the background of the control. The user can choose to make the background of the app more or less opaque.</comment>
   </data>
   <data name="Profile_Opacity.HelpText" xml:space="preserve">
-    <value>Şёτś τђє θрαčїťý òƒ τћë ŵίηðǿш. !!! !!! !!!</value>
+    <value>Ŝεŧŝ ţђé ǿφąċϊτŷ ôƒ ťђé ẃіŋďοẁ. !!! !!! !!!</value>
     <comment>A description for what the "opacity" setting does. Presented near "Profile_Opacity.Header".</comment>
   </data>
   <data name="Profile_Advanced.Header" xml:space="preserve">
-    <value>∆δνάņсеδ !!</value>
+    <value>Дδναиċēδ !!</value>
     <comment>Header for a sub-page of profile settings focused on more advanced scenarios.</comment>
   </data>
   <data name="Profile_AltGrAliasing.Header" xml:space="preserve">
-    <value>AltGr åľįäѕιńġ !!! !</value>
+    <value>ΛŀţĢř ąĺîàśιⁿģ !!! !</value>
     <comment>Header for a control to toggle whether the app treats ctrl+alt as the AltGr (also known as the Alt Graph) modifier key found on keyboards. {Locked="AltGr"}</comment>
   </data>
   <data name="Profile_AltGrAliasing.HelpText" xml:space="preserve">
-    <value>βý đеƒäůľт, Windows τяęаťš Čтґℓ+Âŀţ ªś дй αŀįαś ƒοя ÄľτĜґ. Ŧħΐš šĕťтîηģ шìłľ óνèяґίđ℮ Windows' δéƒāцľт ьэћдνϊőř. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Βу ďёƒдџĺţ, Ŵϊńďŏшš τřεåτš Ċťґℓ+Аłτ åѕ αń àłĩάš ƒŏг ДŀŧĢř. Τħїś śёťтїлğ ŵíℓĺ õνёяřΐďё Ŵìŉďôщѕ' ďэƒâüŀт ьĕђāνïŏř. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>A description for what the "AltGr aliasing" setting does. Presented near "Profile_AltGrAliasing.Header". {Locked="Windows"}</comment>
   </data>
   <data name="Profile_AntialiasingMode.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ţежţ ąйŧĩдļíåśīйğ !!! !!</value>
+    <value>Ŧεжτ āпŧїåℓїášĩňģ !!! !!</value>
     <comment>Name for a control to select the graphical anti-aliasing format of text.</comment>
   </data>
   <data name="Profile_AntialiasingMode.Header" xml:space="preserve">
-    <value>Ţ℮хţ άлтīāļíдѕíпģ !!! !!</value>
+    <value>Ŧėжţ âлтίāℓïãšìņĝ !!! !!</value>
     <comment>Header for a control to select the graphical anti-aliasing format of text.</comment>
   </data>
   <data name="Profile_AntialiasingMode.HelpText" xml:space="preserve">
-    <value>Ċθŋтřŏℓѕ ħоẃ ťєжт ìš ãŋτîāŀìαŝеď ΐń τђз ř℮лđĕяεř. !!! !!! !!! !!! !!!</value>
+    <value>€σŋťгǿĺś ноώ τë×ţ ĭŝ āηтįāĺįäŝзđ ïⁿ тнê ŕëⁿðęг℮ř. !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "antialiasing mode" setting does. Presented near "Profile_AntialiasingMode.Header".</comment>
   </data>
   <data name="Profile_AntialiasingModeAliased.Content" xml:space="preserve">
-    <value>Δłΐäşеđ !!</value>
+    <value>Ǻłìдšèδ !!</value>
     <comment>An option to choose from for the "text antialiasing" setting. When selected, the app's text renderer does not use antialiasing techniques.</comment>
   </data>
   <data name="Profile_AntialiasingModeClearType.Content" xml:space="preserve">
-    <value>ClearType !!!</value>
+    <value>ĊłėāřŦўрε !!!</value>
     <comment>An option to choose from for the "text antialiasing" setting. When selected, the app's text renderer uses a "ClearType" antialiasing technique. {Locked="ClearType"}</comment>
   </data>
   <data name="Profile_AntialiasingModeGrayscale.Content" xml:space="preserve">
-    <value>Ğŕáŷŝčăĺĕ !!!</value>
+    <value>Ġѓǻỳşćãľ℮ !!!</value>
     <comment>An option to choose from for the "text antialiasing" setting. When selected, the app's text renderer uses a grayscale antialiasing technique.</comment>
   </data>
   <data name="Profile_Appearance.Header" xml:space="preserve">
-    <value>Λррєāгǻйςę !!!</value>
+    <value>Äррéâřăйςё !!!</value>
     <comment>Header for a sub-page of profile settings focused on customizing the appearance of the profile.</comment>
   </data>
   <data name="Profile_BackgroundImageBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Вàčκġřöυπđ ίмãġê φдŧħ !!! !!!</value>
+    <value>Вãćκĝґõцńð ιмăġέ ратĥ !!! !!!</value>
     <comment>Name for a control to determine the image presented on the background of the app.</comment>
   </data>
   <data name="Profile_BackgroundImage.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ъáčќģґøϋŋď ìmαğé φåτн !!! !!!</value>
+    <value>Βãĉķğѓθцňď ΐмάģ℮ φªţĥ !!! !!!</value>
     <comment>Name for a control to determine the image presented on the background of the app.</comment>
   </data>
   <data name="Profile_BackgroundImage.Header" xml:space="preserve">
-    <value>Ъāςķĝřόûņð ίmαğ℮ φâτħ !!! !!!</value>
+    <value>βäċκġяǿúпđ ĩмåĝё φατн !!! !!!</value>
     <comment>Header for a control to determine the image presented on the background of the app.</comment>
   </data>
   <data name="Profile_BackgroundImage.HelpText" xml:space="preserve">
-    <value>₣іļê ľõćąτïõή όƒ ťђё ιmāġê űѕеð ìⁿ тђé ъāçќġяōűňδ σƒ тнε ẃїπďóщ. !!! !!! !!! !!! !!! !!! !</value>
+    <value>₣įĺė łóςąтιǿŋ òƒ ŧħê íмάğз űšéδ їŉ ťĥ℮ вǻ¢κĝяőųиď őƒ ţĥė ώĭŋδбŵ. !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "background image path" setting does. Presented near "Profile_BackgroundImage".</comment>
   </data>
   <data name="Profile_BackgroundImageAlignment.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Βáскğѓōúⁿð імáğэ ąłιğπmėńт !!! !!! !</value>
+    <value>ßάсĸģŗǿџηδ ιmãģê αĺĭġήmēлť !!! !!! !</value>
     <comment>Name for a control to choose the visual alignment of the image presented on the background of the app.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignment.Header" xml:space="preserve">
-    <value>Βăçķğŗоūŋď іmäĝė аℓīġŉмēņţ !!! !!! !</value>
+    <value>Бαčĸğяōΰηđ їмåĝэ åłĭğŉмεлŧ !!! !!! !</value>
     <comment>Header for a control to choose the visual alignment of the image presented on the background of the app.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignment.HelpText" xml:space="preserve">
-    <value>Ѕēţѕ ĥош τнз ьǻćĸģŕöůŋđ ĭмâġē āľіģŉš тθ ţнê ъòūйðáґĭέѕ σƒ τнέ шīиđòŵ. !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ś℮ţŝ ћöẅ τĥę ва¢κğŗθŭйδ ìmдğē αŀíģņś то τħę вóµŉďăгĩěѕ öƒ τћз щĭńðǿẃ. !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "background image alignment" setting does. Presented near "Profile_BackgroundImageAlignment".</comment>
   </data>
   <data name="Profile_BackgroundImageAlignmentBottom.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ъőŧťσм !</value>
+    <value>Βŏτŧøм !</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignmentBottomLeft.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ьбτтõм ŀêƒţ !!!</value>
+    <value>Βòττōм łéƒŧ !!!</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignmentBottomRight.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ьσťтом ѓіģĥť !!! </value>
+    <value>Вбŧŧŏм ŗίģнť !!! </value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignmentCenter.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ćέήтęя !</value>
+    <value>Ĉêñť℮ř !</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignmentLeft.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>£ĕƒт !</value>
+    <value>Ŀèƒţ !</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignmentRight.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ґīğђŧ !</value>
+    <value>Ŗĭģħŧ !</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignmentTop.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Тǿρ </value>
+    <value>Ťθφ </value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignmentTopLeft.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Τбφ ļĕƒť !!</value>
+    <value>Ţθр ļέƒτ !!</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignmentTopRight.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ťóφ ґΐġнŧ !!!</value>
+    <value>Тøρ ŕĩġћт !!!</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
   <data name="Profile_BackgroundImageBrowse.Content" xml:space="preserve">
-    <value>Вяøωšє... !!!</value>
+    <value>Ьřоẅşé... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
   <data name="Profile_AddNewFontAxis.Text" xml:space="preserve">
-    <value>Ăđδ ņēẅ !!</value>
+    <value>Λďð ňéẁ !!</value>
     <comment>Button label that adds a new font axis for the current font.</comment>
   </data>
   <data name="Profile_AddNewFontFeature.Text" xml:space="preserve">
-    <value>Äδδ пéẁ !!</value>
+    <value>Άðδ ⁿэщ !!</value>
     <comment>Button label that adds a new font feature for the current font.</comment>
   </data>
   <data name="Profile_BackgroundImageOpacitySlider.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>βªçķģřǿűиď їмăĝë брāçίтў !!! !!! !</value>
+    <value>Βαċĸġґθũηď ϊmдġэ орάсιτу !!! !!! !</value>
     <comment>Name for a control to choose the opacity of the image presented on the background of the app.</comment>
   </data>
   <data name="Profile_BackgroundImageOpacity.Header" xml:space="preserve">
-    <value>βåĉкĝґóŭйδ įmäġē ōρàĉīτý !!! !!! !</value>
+    <value>Βàĉĸġгòΰлð ϊmąġє бφáĉΐţÿ !!! !!! !</value>
     <comment>Header for a control to choose the opacity of the image presented on the background of the app.</comment>
   </data>
   <data name="Profile_BackgroundImageOpacity.HelpText" xml:space="preserve">
-    <value>Şëţś τħè őφåсιτỳ őƒ ťĥę ьâ¢ķğгσυήδ ìmāģë. !!! !!! !!! !!!</value>
+    <value>Ŝέтŝ тĥě ōφâĉіţŷ θƒ ŧħë ъâćќğŕоŭńð ĩмαĝę. !!! !!! !!! !!!</value>
     <comment>A description for what the "background image opacity" setting does. Presented near "Profile_BackgroundImageOpacity".</comment>
   </data>
   <data name="Profile_BackgroundImageStretchMode.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Бâċќģгøųňð īмαğ℮ śтŗèţсн mόďé !!! !!! !!!</value>
+    <value>Вάĉĸġřόϋⁿð ĩмăğе şťŗ℮ŧĉђ мòδ℮ !!! !!! !!!</value>
     <comment>Name for a control to choose the stretch mode of the image presented on the background of the app. Stretch mode is how the image is resized to fill its allocated space.</comment>
   </data>
   <data name="Profile_BackgroundImageStretchMode.Header" xml:space="preserve">
-    <value>Ъăċķĝřόůŋď іmäġē ѕťřэţсħ моðè !!! !!! !!!</value>
+    <value>ßäскġŗǿůπď īмâġэ şтŗĕтсħ мőďè !!! !!! !!!</value>
     <comment>Header for a control to choose the stretch mode of the image presented on the background of the app. Stretch mode is how the image is resized to fill its allocated space.</comment>
   </data>
   <data name="Profile_BackgroundImageStretchMode.HelpText" xml:space="preserve">
-    <value>Şзťŝ ĥощ τĥє вąсķģřοųпđ їmάĝĕ îѕ ŗēŝΐžзð тǿ ƒίĺĺ τнę шιņðθω. !!! !!! !!! !!! !!! !!!</value>
+    <value>Šëτş ħσω ŧħё ьãćķĝгøµπð īмαğę ϊš řĕŝіżèď ţθ ƒĭŀł ťћέ ωїηđôẁ. !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "background image stretch mode" setting does. Presented near "Profile_BackgroundImageStretchMode".</comment>
   </data>
   <data name="Profile_BackgroundImageStretchModeFill.Content" xml:space="preserve">
-    <value>₣ίℓľ !</value>
+    <value>₣ίľļ !</value>
     <comment>An option to choose from for the "background image stretch mode" setting. When selected, the image is resized to fill the destination dimensions. The aspect ratio is not preserved.</comment>
   </data>
   <data name="Profile_BackgroundImageStretchModeNone.Content" xml:space="preserve">
-    <value>Йôйé !</value>
+    <value>Ŋŏⁿé !</value>
     <comment>An option to choose from for the "background image stretch mode" setting. When selected, the image preserves its original size.</comment>
   </data>
   <data name="Profile_BackgroundImageStretchModeUniform.Content" xml:space="preserve">
-    <value>Ûñΐƒøям !!</value>
+    <value>Üⁿĭƒòгm !!</value>
     <comment>An option to choose from for the "background image stretch mode" setting. When selected,the image is resized to fit in the destination dimensions while it preserves its native aspect ratio.</comment>
   </data>
   <data name="Profile_BackgroundImageStretchModeUniformToFill.Content" xml:space="preserve">
-    <value>Ųⁿιƒõŕm тō ƒϊļℓ !!! !</value>
+    <value>Úⁿîƒŏŕм τо ƒіļļ !!! !</value>
     <comment>An option to choose from for the "background image stretch mode" setting. When selected, the content is resized to fill the destination dimensions while it preserves its native aspect ratio. But if the aspect ratio of the destination differs, the image is clipped to fit in the space (to fill the space)</comment>
   </data>
   <data name="Profile_CloseOnExit.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ρѓσƒїℓє τэřmíňάтίõи ьêћǻνΐőґ !!! !!! !!</value>
+    <value>Рѓǿƒïłė ţέřmįпąťїоп ьэндνіõя !!! !!! !!</value>
     <comment>Name for a control to select the behavior of a terminal session (a profile) when it closes.</comment>
   </data>
   <data name="Profile_CloseOnExit.Header" xml:space="preserve">
-    <value>Ρŗοƒîℓ℮ ţєґmїйãτìоñ ьěнãνīõř !!! !!! !!</value>
+    <value>Рŗσƒīļє τеŗmíŋªťιοñ вěђâνίøя !!! !!! !!</value>
     <comment>Header for a control to select the behavior of a terminal session (a profile) when it closes.</comment>
   </data>
   <data name="Profile_CloseOnExitAlways.Content" xml:space="preserve">
-    <value>Ĉĺõѕê ẁнëň ρŗō¢ĕŝş э×ïťš, ƒāιℓŝ, οŕ ćřαŝħзѕ !!! !!! !!! !!! </value>
+    <value>Сĺöѕę ẃђèи φяô¢єśş êжîţš, ƒäιļš, оř ¢řąŝнéś !!! !!! !!! !!! </value>
     <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled (exit) or uncontrolled (fail or crash) scenario.</comment>
   </data>
   <data name="Profile_CloseOnExitGraceful.Content" xml:space="preserve">
-    <value>Čℓôşё øŋŀý ẃħзи φгöćêšŝ êхįτѕ śűςсєšśƒϋŀŀỳ !!! !!! !!! !!! </value>
+    <value>Сłбşê бńļγ ẅнēή рřόс℮śŝ ęжιτś ŝџçсĕšѕƒŭŀłў !!! !!! !!! !!! </value>
     <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully.</comment>
   </data>
   <data name="Profile_CloseOnExitNever.Content" xml:space="preserve">
-    <value>Иένèѓ ĉłőşě άŭτőmåŧĭ¢äľłў !!! !!! !</value>
+    <value>Ŋ℮νĕŗ ćļǿѕê äμτőмâťĩċªļŀў !!! !!! !</value>
     <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal never closes, even if the process exits in a controlled or uncontrolled scenario. The user would have to manually close the terminal.</comment>
   </data>
   <data name="Profile_CloseOnExitAutomatic.Content" xml:space="preserve">
-    <value>Δџτöмãτĩč !!!</value>
+    <value>Ãµťøмäтïč !!!</value>
     <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Windows Terminal.</comment>
   </data>
   <data name="Profile_ColorScheme.Header" xml:space="preserve">
-    <value>Ćŏłοř ŝċħёmē !!! </value>
+    <value>Çŏłőг ŝćнĕмε !!! </value>
     <comment>Header for a control to select the scheme (or set) of colors used in the session. This is selected from a list of options managed by the user.</comment>
   </data>
   <data name="Profile_Commandline.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ċомmâŉđ ŀïηë !!! </value>
+    <value>€οмmǻпδ łįŉε !!! </value>
     <comment>Name for a control to determine commandline executable (i.e. a .exe file) to run when a terminal session of this profile is launched.</comment>
   </data>
   <data name="Profile_Commandline.Header" xml:space="preserve">
-    <value>Ĉόмmªŋð ℓïňê !!! </value>
+    <value>Соммаňð ℓιπë !!! </value>
     <comment>Header for a control to determine commandline executable (i.e. a .exe file) to run when a terminal session of this profile is launched.</comment>
   </data>
   <data name="Profile_CommandlineBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Çõmмåηď ℓϊņė !!! </value>
+    <value>Çŏммǻиδ ŀϊňè !!! </value>
     <comment>Name for a control to determine commandline executable (i.e. a .exe file) to run when a terminal session of this profile is launched.</comment>
   </data>
   <data name="Profile_Commandline.HelpText" xml:space="preserve">
-    <value>Ε×èĉűţàъļé úšëδ ϊň ťћê рřοƒίļè. !!! !!! !!!</value>
+    <value>Эхĕçΰтдьłё ūśëď įñ ţħè рŕòƒĭŀз. !!! !!! !!!</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
   <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
-    <value>βяóώŝё... !!!</value>
+    <value>ßгθшşє... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
   <data name="Profile_CursorHeight.Header" xml:space="preserve">
-    <value>Čμŗšôѓ ħèіġнţ !!! </value>
+    <value>Сµгŝőґ ђēîĝħт !!! </value>
     <comment>Header for a control to determine the height of the text cursor.</comment>
   </data>
   <data name="Profile_CursorHeight.HelpText" xml:space="preserve">
-    <value>Šēтš τћэ φεгĉэņťáğе ћεїģнŧ öƒ тће ćúŕŝòř ѕţàѓτĩпĝ ƒгŏm ţћę ъøţтσm. Όŉłý ẃôřķş ẁîтħ τĥė νΐпŧǻğε сųгšöř šђäρè. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Šеτѕ тĥέ φегсеŋтåĝě ћēíġĥт öƒ ťĥέ ¢úґšόг ŝŧάřťīŉģ ƒŕõм τћ℮ воţŧōм. Φņľγ шбŕķş ωітĥ τђĕ νĭŋťάġз ¢ūґşσř ŝнāφē. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>A description for what the "cursor height" setting does. Presented near "Profile_CursorHeight".</comment>
   </data>
   <data name="Profile_CursorShape.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Çûřşθŗ śĥąφĕ !!! </value>
+    <value>Ćũяšòѓ ŝђàρĕ !!! </value>
     <comment>Name for a control to select the shape of the text cursor.</comment>
   </data>
   <data name="Profile_CursorShape.Header" xml:space="preserve">
-    <value>Ĉϋŕŝőŗ śћàρē !!! </value>
+    <value>Ĉϋřšǿг śнâρε !!! </value>
     <comment>Header for a control to select the shape of the text cursor.</comment>
   </data>
   <data name="Profile_AdjustIndistinguishableColorsNever.Content" xml:space="preserve">
-    <value>Ņзνэř !</value>
+    <value>Ñèνêř !</value>
     <comment>An option to choose from for the "adjust indistinguishable colors" setting. When selected, we will never adjust the text colors.</comment>
   </data>
   <data name="Profile_AdjustIndistinguishableColorsIndexed.Content" xml:space="preserve">
-    <value>Òņłỳ ƒőř čθĺοŕś ίņ τнę çóℓбг ѕсћĕmє !!! !!! !!! !</value>
+    <value>Òňľỳ ƒθг çöłőґš ΐл ťħé сøłθґ ŝĉћ℮мё !!! !!! !!! !</value>
     <comment>An option to choose from for the "adjust indistinguishable colors" setting. When selected, we will adjust the text colors for visibility only when the colors are part of this profile's color scheme's color table.</comment>
   </data>
   <data name="Profile_AdjustIndistinguishableColorsAlways.Content" xml:space="preserve">
-    <value>Дľŵдỳš !</value>
+    <value>Åļωάỳš !</value>
     <comment>An option to choose from for the "adjust indistinguishable colors" setting. When selected, we will adjust the text colors for visibility.</comment>
   </data>
   <data name="Profile_CursorShapeBar.Content" xml:space="preserve">
-    <value>βаř ( ┃ ) !!!</value>
+    <value>Ъâг ( ┃ ) !!!</value>
     <comment>{Locked="┃"} An option to choose from for the "cursor shape" setting. When selected, the cursor will look like a vertical bar. The character in the parentheses is used to show what it looks like.</comment>
   </data>
   <data name="Profile_CursorShapeEmptyBox.Content" xml:space="preserve">
-    <value>Εмρťŷ ьο× ( ▯ ) !!! !</value>
+    <value>Емρţý ьǿ× ( ▯ ) !!! !</value>
     <comment>{Locked="▯"} An option to choose from for the "cursor shape" setting. When selected, the cursor will look like an empty box. The character in the parentheses is used to show what it looks like.</comment>
   </data>
   <data name="Profile_CursorShapeFilledBox.Content" xml:space="preserve">
-    <value>₣ĭℓŀеď вǿх ( █ ) !!! !</value>
+    <value>₣ιŀłęđ вσж ( █ ) !!! !</value>
     <comment>{Locked="█"} An option to choose from for the "cursor shape" setting. When selected, the cursor will look like a filled box. The character in the parentheses is used to show what it looks like.</comment>
   </data>
   <data name="Profile_CursorShapeUnderscore.Content" xml:space="preserve">
-    <value>Ùŋðэŕśςǿřε ( ▁ ) !!! !</value>
+    <value>Ùήđĕřŝċогё ( ▁ ) !!! !</value>
     <comment>{Locked="▁"} An option to choose from for the "cursor shape" setting. When selected, the cursor will look like an underscore. The character in the parentheses is used to show what it looks like.</comment>
   </data>
   <data name="Profile_CursorShapeVintage.Content" xml:space="preserve">
-    <value>Vįйťąğё ( ▃ ) !!! </value>
+    <value>Vίпτâĝĕ ( ▃ ) !!! </value>
     <comment>{Locked="▃"} An option to choose from for the "cursor shape" setting. When selected, the cursor will look like a thick underscore. This is the vintage and classic look of a cursor for terminals. The character in the parentheses is used to show what it looks like.</comment>
   </data>
   <data name="Profile_CursorShapeDoubleUnderscore.Content" xml:space="preserve">
-    <value>Ðθŭъľе ũиđēгşçöř℮ ( ‗ ) !!! !!! </value>
+    <value>Ďòûьĺē ύηđεґşćбяĕ ( ‗ ) !!! !!! </value>
     <comment>{Locked="‗"} An option to choose from for the "cursor shape" setting. When selected, the cursor will look like a stacked set of two underscores. The character in the parentheses is used to show what it looks like.</comment>
   </data>
   <data name="Profile_FontFace.Header" xml:space="preserve">
-    <value>₣øŋŧ ƒäĉε !!!</value>
+    <value>₣øñт ƒâςę !!!</value>
     <comment>Header for a control to select the font for text in the app.</comment>
   </data>
   <data name="Profile_FontFaceBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>₣ŏπт ƒª¢з !!!</value>
+    <value>₣øñŧ ƒдсέ !!!</value>
     <comment>Name for a control to select the font for text in the app.</comment>
   </data>
   <data name="Profile_FontSize.Header" xml:space="preserve">
-    <value>₣ǿηŧ ѕîžė !!!</value>
+    <value>₣ŏňτ şίźε !!!</value>
     <comment>Header for a control to determine the size of the text in the app.</comment>
   </data>
   <data name="Profile_FontSizeBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>₣óⁿτ ŝīżе !!!</value>
+    <value>₣оňť şίżє !!!</value>
     <comment>Name for a control to determine the size of the text in the app.</comment>
   </data>
   <data name="Profile_FontSize.HelpText" xml:space="preserve">
-    <value>Ѕιžè σƒ тђę ƒôñť ĭŋ рôΐŋťѕ. !!! !!! !!</value>
+    <value>Šіžё ǿƒ тнé ƒõņτ їņ φσîйτş. !!! !!! !!</value>
     <comment>A description for what the "font size" setting does. Presented near "Profile_FontSize".</comment>
   </data>
   <data name="Profile_LineHeight.Header" xml:space="preserve">
-    <value>Ļíŋĕ н℮іĝћť !!!</value>
+    <value>Ŀīйĕ ĥĕΐĝђŧ !!!</value>
     <comment>Header for a control that sets the text line height.</comment>
   </data>
   <data name="Profile_LineHeightBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>£іňê нèìĝћт !!!</value>
+    <value>₤ìŋè ħέίģћť !!!</value>
     <comment>Header for a control that sets the text line height.</comment>
   </data>
   <data name="Profile_LineHeight.HelpText" xml:space="preserve">
-    <value>Ονэŕŕíðê ŧћę ľïŋē нéιĝĥţ оƒ ŧĥê ŧĕямíňâľ. Μĕàšũяёđ āś α мųłтїрļè όƒ тħė ƒǿηт ѕїżе. Ťђё δęƒäϋļŧ νǻłůέ đęρеŉđş οп уόμя ƒбŋŧ ăлď ϊś μŝϋдļľŷ āґσůпδ 1.2. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Ονëřŗíďĕ тђэ ℓìŉё ћëîğнτ оƒ ŧнè τёґмįņªļ. Мēáśυґ℮đ аś ª mϋłţìρℓè õƒ тне ƒõήτ ѕΐżë. Тђê ďέƒāųŀţ νâŀüē δέρěņđš ǿň ỳőυя ƒôŉт ąŉď ΐş υşūäľŀÿ àŗôüŋđ 1.2. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>A description for what the "line height" setting does. Presented near "Profile_LineHeight".</comment>
   </data>
   <data name="Profile_LineHeightBox.PlaceholderText" xml:space="preserve">
@@ -907,854 +907,886 @@
     <comment>"1.2" is a decimal number.</comment>
   </data>
   <data name="Profile_EnableBuiltinGlyphs.Header" xml:space="preserve">
-    <value>βúïłтіⁿ Ğĺỳφђš !!! !</value>
+    <value>Ьùïľŧïň Ģłуφĥś !!! !</value>
     <comment>The main label of a toggle. When enabled, certain characters (glyphs) are replaced with better looking ones.</comment>
   </data>
   <data name="Profile_EnableBuiltinGlyphs.HelpText" xml:space="preserve">
-    <value>Шнєй εйαъľëδ, тħè ťєřmĭлªŀ δřаωş ĉΰšτőm ğļỳрнś ƒŏŗ ъℓøск ёℓεмεňτ αňδ ьõх đяªщįπģ ςђāŕά¢ţёřѕ іиśŧєāδ õƒ ϋŝίήģ ťħέ ƒóйť. Ŧђìѕ ƒěăтűґè биĺγ ωбгќś ώнеη ĞΡŬ Δĉċėŀєřäţìоŋ ΐş âνàïłåъℓê. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Ẅħĕň еņªъℓёð, тћз τēгмïπдℓ ðѓáшş çύšτом ģļўφħѕ ƒǿя ъĺôсĸ éℓêm℮ήŧ àñð ъο× ðгдωΐπĝ čћдŗąςŧέѓś ìπŝţėãđ ŏƒ ũŝіⁿğ ťћę ƒбηŧ. Ţћιş ƒзаτџŕè οŉĺŷ ωóгκŝ ẁĥéŋ ĢΡŬ Àςĉеŀèѓдτισñ ĩѕ ǻνãîļåвłę. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>A longer description of the "Profile_EnableBuiltinGlyphs" toggle. "glyphs", "block element" and "box drawing characters" are technical terms from the Unicode specification.</comment>
   </data>
   <data name="Profile_EnableColorGlyphs.Header" xml:space="preserve">
-    <value>₣μĺℓ-ςбļŏя Εмојì !!! !</value>
+    <value>₣џłŀ-сθℓøґ Έmόјї !!! !</value>
     <comment>The main label of a toggle. When enabled, certain characters (emoji in this case) are displayed with multiple colors.</comment>
   </data>
   <data name="Profile_EnableColorGlyphs.HelpText" xml:space="preserve">
-    <value>Шħêņ επáвℓзđ, Éмőĵί дґэ ðїşρłåγєđ ïп ƒΰłŀ сθŀόř. !!! !!! !!! !!! !!</value>
+    <value>Ẅнзп έňåвłёδ, Эмöĵī ãŕě ďíşρľǻỳęð ίñ ƒμŀℓ ćоļöŕ. !!! !!! !!! !!! !!</value>
     <comment>A longer description of the "Profile_EnableColorGlyphs" toggle.</comment>
   </data>
   <data name="Profile_FontWeightComboBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>₣бήт ωĕїĝћť !!!</value>
+    <value>₣οиτ ẅэíğħť !!!</value>
     <comment>Name for a control to select the weight (i.e. bold, thin, etc.) of the text in the app.</comment>
   </data>
   <data name="Profile_FontWeightSlider.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>₣οⁿт ώêϊģħť !!!</value>
+    <value>₣õиτ ŵėíğĥŧ !!!</value>
     <comment>Name for a control to select the weight (i.e. bold, thin, etc.) of the text in the app.</comment>
   </data>
   <data name="Profile_FontWeight.Header" xml:space="preserve">
-    <value>₣őņт щ℮ìğнτ !!!</value>
+    <value>₣оňτ ŵειġнт !!!</value>
     <comment>Header for a control to select the weight (i.e. bold, thin, etc.) of the text in the app.</comment>
   </data>
   <data name="Profile_FontWeight.HelpText" xml:space="preserve">
-    <value>Ŝèťŝ ŧħę шēĭġħţ (ļīģћтπėśś õя ĥзäνīпēşѕ бƒ тħз ŝţґöκ℮ѕ) ƒōř ŧђé ĝìνеп ƒόⁿŧ. !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ŝéŧѕ ţђέ ẁèϊģнť (łϊğħţⁿéşś όř ђзâνĩηзśş óƒ ŧĥė śťгόќęŝ) ƒθґ тħέ ġįνэи ƒőňţ. !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "font weight" setting does. Presented near "Profile_FontWeight".</comment>
   </data>
   <data name="Profile_FontAxes.Header" xml:space="preserve">
-    <value>Vагíдвĺё ƒŏηŧ ахĕѕ !!! !!</value>
+    <value>Vαгįдвłз ƒôηŧ á×ęś !!! !!</value>
     <comment>Header for a control to allow editing the font axes.</comment>
   </data>
   <data name="Profile_FontAxesAvailable.Text" xml:space="preserve">
-    <value>Δďď оř яèmőνé ƒοпŧ ªхеѕ ƒǿŗ τћε ĝĩνэπ ƒόņť. !!! !!! !!! !!! </value>
+    <value>Āðδ θѓ ŗēмôνε ƒŏŋτ āжеŝ ƒóř ťћè ġīνęŋ ƒóήτ. !!! !!! !!! !!! </value>
     <comment>A description for what the "font axes" setting does. Presented near "Profile_FontAxes".</comment>
   </data>
   <data name="Profile_FontAxesUnavailable.Text" xml:space="preserve">
-    <value>Тђę šзĺзсŧеð ƒóňт нαŝ ňô νăгϊàвļê ƒôйť ά×ěѕ. !!! !!! !!! !!! !</value>
+    <value>Тђέ šěļεċťєď ƒŏηŧ ћάś πø νäѓїдвłз ƒōπт αжęš. !!! !!! !!! !!! !</value>
     <comment>A description provided when the font axes setting is disabled. Presented near "Profile_FontAxes".</comment>
   </data>
   <data name="Profile_FontFeatures.Header" xml:space="preserve">
-    <value>₣σňτ ƒèąтűřзş !!! </value>
+    <value>₣оŉτ ƒзåŧŭŕέś !!! </value>
     <comment>Header for a control to allow editing the font features.</comment>
   </data>
   <data name="Profile_FontFeaturesAvailable.Text" xml:space="preserve">
-    <value>Аđđ θř ѓέmбν℮ ƒθňτ ƒέάтцřēš ƒŏŕ тћэ ģïνėń ƒőηţ. !!! !!! !!! !!! !!</value>
+    <value>Ǻďð όŗ řěmòνě ƒóńт ƒєãťüгęś ƒθг тнĕ ĝĩνёŋ ƒόŋţ. !!! !!! !!! !!! !!</value>
     <comment>A description for what the "font features" setting does. Presented near "Profile_FontFeatures".</comment>
   </data>
   <data name="Profile_FontFeaturesUnavailable.Text" xml:space="preserve">
-    <value>Ťħе śёℓєçтěď ƒōňţ ĥâѕ ņō ƒбńт ƒéåτüŗěŝ. !!! !!! !!! !!!</value>
+    <value>Τћē ŝэŀëсŧзð ƒőйť нâŝ иο ƒòиŧ ƒėäţцŕэś. !!! !!! !!! !!!</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
   <data name="Profile_General.Header" xml:space="preserve">
-    <value>Ģęпеŗàľ !!</value>
+    <value>Ġеŉėяâĺ !!</value>
     <comment>Header for a sub-page of profile settings focused on more general scenarios.</comment>
   </data>
   <data name="Profile_Hidden.Header" xml:space="preserve">
-    <value>Нīďë ρяоƒĭĺĕ ƒґθm đяσрδόщи !!! !!! !</value>
+    <value>Ήîď℮ φябƒίļĕ ƒѓòm ďřóφδόшπ !!! !!! !</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
   <data name="Profile_Hidden.HelpText" xml:space="preserve">
-    <value>Іƒ эиäъľėδ, ţĥє φŕόƒīŀέ ẅιℓℓ ŉøτ ǻрφėâг ĩп ŧћę ľīşţ σƒ φяóƒίłěş. Ťĥίŝ ςǻл ъε üşĕď тō нιđé đэƒдџĺŧ ρяõƒíļέš дńδ δγñãміćāļℓŷ ĝеήэѓаŧêð ρяōƒϊŀèś, ώђįℓё łёàνĩпğ τнем ïп γôùѓ ѕęтŧîηĝš ƒîłë. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Їƒ ĕηάъℓěđ, ťĥэ φѓóƒїłę щíĺŀ иǿτ āφрĕдґ ΐŋ ŧћ℮ ŀīѕţ ǿƒ ρřŏƒīłėѕ. Ţђіş ςǻⁿ ъê ūšέð ťŏ ђĩðė δëƒǻūļт φґøƒíļέş аņð ďγñăмïĉâļℓÿ ģěиēяāŧεð ρřòƒίļзŝ, ẁĥιľє łэăνīⁿĝ ťĥèм ϊŉ ỳôцг śэťŧιйğŝ ƒιľë. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
   </data>
   <data name="Profile_Elevate.Header" xml:space="preserve">
-    <value>Ŗűπ ŧħìѕ ряőƒіŀê ǻš Λďміиϊśţŕãŧõř !!! !!! !!! </value>
+    <value>Гµл тђįş φѓöƒιļэ åş Λđmįňίšтŕàтоя !!! !!! !!! </value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
   </data>
   <data name="Profile_Elevate.HelpText" xml:space="preserve">
-    <value>Ĩƒ êηāвļêδ, тнě φŗóƒΐℓэ ẃïℓĺ ôрêή īⁿ äи Ąďмîŉ тēŕмįňàľ шīŉđòẃ áũŧōмãτΐċãℓłу. Īƒ ţђĕ ςũřґэйť шїņđοώ їŝ åļґзàðỳ ŗµņņìňģ ǻş åďmίņ, įŧ'ľľ óφěŋ ïи тђĭş ωîйδõω. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ìƒ éņãвļзδ, ŧĥĕ рŗоƒīľё ẅιľł óрėŋ ΐή åň Ąďmįŋ теѓmίидŀ шïпδσώ аůţòмăтìсаļļγ. Ĭƒ ŧĥе čцѓґ℮ⁿť ẁįлđόŵ їŝ áŀřėãďу ŕύŋņïπġ āš αðмīŉ, ϊţ'ŀℓ σрèń ĩй тħїŝ ẅīйδõẁ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
-    <value>Ĥĩšťòѓў śïźê !!! </value>
+    <value>Нíşŧôŗỳ ѕιźë !!! </value>
     <comment>Header for a control to determine how many lines of text can be saved in a session. In terminals, the "history" is the output generated within your session.</comment>
   </data>
   <data name="Profile_HistorySizeBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Нïѕтояγ śіżē !!! </value>
+    <value>Ĥіśţόѓÿ šιžё !!! </value>
     <comment>Name for a control to determine how many lines of text can be saved in a session. In terminals, the "history" is the output generated within your session.</comment>
   </data>
   <data name="Profile_HistorySize.HelpText" xml:space="preserve">
-    <value>Τћё иümьēř őƒ ľįⁿěś äьόνе тђé όŋέş δίšρłаγĕđ ìⁿ ţћэ ŵίņδòẁ ÿöù ĉàи şсгσļľ ъàĉк τо. !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Тђě ņůмвέґ όƒ ļïлèѕ àьόνэ τнέ ôиεŝ ďίşрℓâýèď ΐη ŧћз ẃΐлđóẃ ŷòц сåп şçřбŀľ вªćķ ťσ. !!! !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>A description for what the "history size" setting does. Presented near "Profile_HistorySize".</comment>
   </data>
   <data name="Profile_Icon.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>İčόл !</value>
+    <value>Îčόŋ !</value>
     <comment>Name for a control to determine what icon can be used to represent this profile. This is not necessarily a file path, but can be one.</comment>
   </data>
   <data name="Profile_Icon.Header" xml:space="preserve">
-    <value>İĉöη !</value>
+    <value>İ¢оń !</value>
     <comment>Header for a control to determine what icon can be used to represent this profile. This is not necessarily a file path, but can be one.</comment>
   </data>
   <data name="Profile_IconBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ίčθл !</value>
+    <value>Į¢òп !</value>
     <comment>Name for a control to determine what icon can be used to represent this profile. This is not necessarily a file path, but can be one.</comment>
   </data>
   <data name="Profile_Icon.HelpText" xml:space="preserve">
-    <value>Ęмǿјî őѓ īmάğё ƒіł℮ ļőĉäтΐôπ θƒ τћê ίćǿñ ΰŝęđ ΐñ тĥĕ ρгōƒϊłе. !!! !!! !!! !!! !!! !!!</value>
+    <value>Ęmőĵì õř îmаĝė ƒìĺĕ ļöĉǻтïòπ ǿƒ ŧђē ісǿⁿ ùšεð іń τĥε φřôƒιľê. !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "icon" setting does. Presented near "Profile_Icon".</comment>
   </data>
   <data name="Profile_IconBrowse.Content" xml:space="preserve">
-    <value>βřõώşē... !!!</value>
+    <value>Ьřòẁśз... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
   <data name="Profile_PaddingSlider.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ρǻďδíŋģ !!</value>
+    <value>Рáðđĩñġ !!</value>
     <comment>Name for a control to determine the amount of space between text in a terminal and the edge of the window.</comment>
   </data>
   <data name="Profile_Padding.Header" xml:space="preserve">
-    <value>Ράďďϊŉġ !!</value>
+    <value>Ρáððìŉğ !!</value>
     <comment>Header for a control to determine the amount of space between text in a terminal and the edge of the window. The space can be any combination of the top, bottom, left, and right side of the window.</comment>
   </data>
   <data name="Profile_Padding.HelpText" xml:space="preserve">
-    <value>Ŝĕťş ŧħе ρãδδĩŋĝ άřóųπď тћê т℮жť ŵίťђïŋ ťнé ẅίņďοẅ. !!! !!! !!! !!! !!!</value>
+    <value>Śěтš тђ℮ ρªđδїлğ ăѓоūńđ ŧћέ τεжт ẃĭтħϊп τħέ ẃίņδθẁ. !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "padding" setting does. Presented near "Profile_Padding".</comment>
   </data>
   <data name="Profile_RetroTerminalEffect.Header" xml:space="preserve">
-    <value>Яěţґò τęяmіпåł έƒƒёċтş !!! !!! </value>
+    <value>Яęтѓō тéѓmιйăĺ ëƒƒέсŧŝ !!! !!! </value>
     <comment>Header for a control to toggle classic CRT display effects, which gives the terminal a retro look.</comment>
   </data>
   <data name="Profile_RetroTerminalEffect.HelpText" xml:space="preserve">
-    <value>Šђбẁ яεŧґø-şтýłэ ťεřmїηąļ èƒƒęċтš ѕμ¢н ªš ğŀøώīлģ ţ℮жť ǻňð şĉăņ ļΐňзš. !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Śĥбẅ гзτřō-şтγłе τëѓmīⁿдĺ еƒƒέсτś şúćђ αş ğℓōώĩиġ ţέхť άηδ šςаи ľìиėš. !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "retro terminal effects" setting does. Presented near "Profile_RetroTerminalEffect". "Retro" is a common English prefix that suggests a nostalgic, dated appearance.</comment>
   </data>
   <data name="Profile_AdjustIndistinguishableColors.Header" xml:space="preserve">
-    <value>Λџţόмǻŧіčǻℓℓý ăδјūѕţ ĺïġћтņėŝŝ ŏƒ ìⁿđιşťĩηĝŭïśндъľę тё×т !!! !!! !!! !!! !!! !</value>
+    <value>Аŭťοмäтĩčāĺłỳ ăδјΰѕť ļϊģђτπ℮şѕ ǿƒ їиδιšťΐņğűīşћāвłэ тêжť !!! !!! !!! !!! !!! !</value>
     <comment>Header for a control to toggle if we should adjust the foreground color's lightness to make it more visible when necessary, based on the background color.</comment>
   </data>
   <data name="Profile_AdjustIndistinguishableColors.HelpText" xml:space="preserve">
-    <value>Ãΰτοmáťìĉåļľγ ьґīğĥŧëŋѕ σг ðàгķēŋş ŧĕ×т τό mãķè ĭτ мòгè νìšìъļэ. Éνэŋ щĥėл ёήªъĺĕδ, ţћīѕ äðĵµѕтmèηţ ώіŀľ øлľў оċçύг ẁĥзп ά čőмвιйαтιŏⁿ òƒ ƒǿŕęġяöυйď åŋδ ьąćкģгőųпð çбļŏѓş шбŭłď ŕэѕüŀŧ ìи ρôŏя сοⁿŧŕąŝŧ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>∆ųţοmäţιċãℓľў ьŗϊġĥťëñś ǿŗ δåřķēиѕ ťěжŧ ťò mäќε ĭŧ mόґз νίşìъŀĕ. Зνёŋ ẃћéŋ ęηāьℓёδ, τћιѕ äđјυšŧměйŧ ẃìℓŀ õñℓў ôćčцг ŵђěи ǻ çøмъĩⁿãτĩθñ øƒ ƒбřεġґòϋňδ áηď вāсκģřŏŭпδ čółοřş ẁóΰłđ я℮şŭľτ ìñ ρőόŗ сõŉтгáѕт. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "adjust indistinguishable colors" setting does. Presented near "Profile_AdjustIndistinguishableColors".</comment>
   </data>
   <data name="Profile_ScrollbarVisibility.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ѕсгбľľъάŗ νīśîьĭŀίŧÿ !!! !!!</value>
+    <value>Šсґσļľвąя νĩѕìъįłіťу !!! !!!</value>
     <comment>Name for a control to select the visibility of the scrollbar in a session.</comment>
   </data>
   <data name="Profile_ScrollbarVisibility.Header" xml:space="preserve">
-    <value>Şċѓόℓłьäř νìşĩвîłĩţỳ !!! !!!</value>
+    <value>Ščяòľŀвåŕ νίšιъįŀιτÿ !!! !!!</value>
     <comment>Header for a control to select the visibility of the scrollbar in a session.</comment>
   </data>
   <data name="Profile_ScrollbarVisibilityHidden.Content" xml:space="preserve">
-    <value>Ηíďď℮ñ !</value>
+    <value>Ĥΐδđēⁿ !</value>
     <comment>An option to choose from for the "scrollbar visibility" setting. When selected, the scrollbar is hidden.</comment>
   </data>
   <data name="Profile_ScrollbarVisibilityVisible.Content" xml:space="preserve">
-    <value>Vιşĩвĺέ !!</value>
+    <value>Vїşівłε !!</value>
     <comment>An option to choose from for the "scrollbar visibility" setting. When selected, the scrollbar is visible but may dynamically shrink.</comment>
   </data>
   <data name="Profile_ScrollbarVisibilityAlways.Content" xml:space="preserve">
-    <value>Λŀώдуś !</value>
+    <value>Âℓώãýѕ !</value>
     <comment>An option to choose from for the "scrollbar visibility" setting. When selected, the scrollbar is always visible.</comment>
   </data>
   <data name="Profile_SnapOnInput.Header" xml:space="preserve">
-    <value>Śςŗθĺĺ ŧó îирμт ωнзń ţуφιňĝ !!! !!! !!</value>
+    <value>Śсгόľĺ ťσ їŋрυт ẃħęπ ţỳφįⁿģ !!! !!! !!</value>
     <comment>Header for a control to toggle if keyboard input should automatically scroll to where the input was placed.</comment>
   </data>
   <data name="Profile_StartingDirectory.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ŝťàгτïŋĝ ðïґëçŧǿŕγ !!! !!</value>
+    <value>Ŝταяτìлĝ ðĩѓ℮ćτоŗỳ !!! !!</value>
     <comment>Name for a control to determine the directory the session opens it at launch. This is on a text box that accepts folder paths.</comment>
   </data>
   <data name="Profile_StartingDirectory.Header" xml:space="preserve">
-    <value>Šταґŧĩήģ ðΐřê¢τōřỳ !!! !!</value>
+    <value>Ѕťåřťіπġ đíгëĉţöґγ !!! !!</value>
     <comment>Header for a control to determine the directory the session opens it at launch. This is on a text box that accepts folder paths.</comment>
   </data>
   <data name="Profile_StartingDirectoryBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Šτдŗτїⁿĝ διŗэćťόŗγ !!! !!</value>
+    <value>Šтдřтíⁿģ đϊŕёςŧôŗў !!! !!</value>
     <comment>Name for a control to determine the directory the session opens it at launch. This is on a text box that accepts folder paths.</comment>
   </data>
   <data name="Profile_StartingDirectory.HelpText" xml:space="preserve">
-    <value>Ŧђз đїřесτöřу ţнē ряόƒíļë šŧăѓτŝ ìň ẁħèń ïŧ ĭś ℓоãďзđ. !!! !!! !!! !!! !!! !</value>
+    <value>Ţћé đĭŗéçťòŕу τħе рѓøƒĩŀе śťªřťş ïή ẅћĕл îţ ίѕ ŀбдδėď. !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
   </data>
   <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
-    <value>βŗθωšé... !!!</value>
+    <value>Ьŕōωŝē... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
   <data name="Profile_StartingDirectoryUseParentCheckbox.Content" xml:space="preserve">
-    <value>Ųѕέ φáŗéπт ρŗōсэѕѕ δīř℮ĉťояỳ !!! !!! !!</value>
+    <value>Üŝè φαŗèńŧ рřоĉěѕѕ đĭřё¢τоґý !!! !!! !!</value>
     <comment>A supplementary setting to the "starting directory" setting. "Parent" refers to the parent process of the current process.</comment>
   </data>
   <data name="Profile_StartingDirectoryUseParentCheckbox.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Іƒ ëⁿåьľĕδ, тĥιś ρŕøƒïŀέ ẅιℓĺ ѕρāẃй ιη тĥë ďΐřêċτόŕỳ ƒѓòм ẅħįćĥ Ť℮řmĩлăĺ ŵąŝ ļåûηсĥèď. !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Îƒ έпãьłëď, тђìš ρѓòƒìĺè ωιĺℓ ŝρǻẁň іň ţћę ðіяеçţбгγ ƒřőм щћįςђ Теямĭņàł ẃªş ŀáцⁿĉħёđ. !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the supplementary "use parent process directory" setting does. Presented near "Profile_StartingDirectoryUseParentCheckbox".</comment>
   </data>
   <data name="Profile_HideIconCheckbox.Content" xml:space="preserve">
-    <value>Нιđє ісθή !!!</value>
+    <value>Ηϊðё îçǿй !!!</value>
     <comment>A supplementary setting to the "icon" setting.</comment>
   </data>
   <data name="Profile_HideIconCheckbox.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>İƒ εηăьľέď, ťĥίѕ ρяόƒϊŀέ ώįĺł ħàνė ηò íćōň. !!! !!! !!! !!! </value>
+    <value>Íƒ ёηдъļэδ, ŧĥϊŝ φгōƒιℓз шіℓŀ ђдνê ňö ΐĉôй. !!! !!! !!! !!! </value>
     <comment>A description for what the supplementary "Hide icon" setting does. Presented near "Profile_HideIconCheckbox".</comment>
   </data>
   <data name="Profile_SuppressApplicationTitle.Header" xml:space="preserve">
-    <value>Šűρφґзšѕ ţįтľε ĉħªņĝēŝ !!! !!! </value>
+    <value>Ѕΰφφřэśš τíťļė čħªŉĝèѕ !!! !!! </value>
     <comment>Header for a control to toggle changes in the app title.</comment>
   </data>
   <data name="Profile_SuppressApplicationTitle.HelpText" xml:space="preserve">
-    <value>Ìĝηоřę дφрļîсâţίбл ŕéqυέѕťş тǿ ĉĥáηğè ţĥе τΐτłë (OSC 2). !!! !!! !!! !!! !!! !</value>
+    <value>Íġπόŗэ áρρĺіćâţìǿŋ ŗέqúёśţś ťò çђâηğě ťђê тįтŀé (ΘЅĆ 2). !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "suppress application title" setting does. Presented near "Profile_SuppressApplicationTitle". "OSC 2" is a technical term that is understood in the industry. {Locked="OSC 2"}</comment>
   </data>
   <data name="Profile_TabTitle.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Таъ тĩţļε !!!</value>
+    <value>Τάъ ŧїŧļê !!!</value>
     <comment>Name for a control to determine the title of the tab. This is represented using a text box.</comment>
   </data>
   <data name="Profile_TabTitle.Header" xml:space="preserve">
-    <value>Τâъ τΐŧłė !!!</value>
+    <value>Ťǻв τįťłэ !!!</value>
     <comment>Header for a control to determine the title of the tab. This is represented using a text box.</comment>
   </data>
   <data name="Profile_TabTitle.HelpText" xml:space="preserve">
-    <value>Ґèрľдςэş ţĥе φřǿƒĭļ℮ ňǻmě áѕ τђē тιτĺέ ťö рдѕŝ ťò тĥ℮ śнéļℓ õп şţαŕťũр. !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ŕèφłǻčèş ţће рřöƒîℓέ иάмз äş τне тíŧŀë ŧŏ φāѕş ŧό ţĥë şђëℓł öņ śťâгŧûρ. !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "tab title" setting does. Presented near "Profile_TabTitle".</comment>
   </data>
   <data name="Profile_UnfocusedAppearanceTextBlock.Text" xml:space="preserve">
-    <value>Ũŉƒσ¢ύŝéð αφрèάřąňсє !!! !!!</value>
+    <value>Ûηƒŏċμşεď äррėāŕαńćё !!! !!!</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
   <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Čŕéăτė Αρφзάŗаņçė !!! !!</value>
+    <value>Ĉřêάŧэ Δрφзάŕãñςε !!! !!</value>
     <comment>Button label that adds an unfocused appearance for this profile.</comment>
   </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
-    <value>Ďéľ℮ŧě !</value>
+    <value>Ðéľėŧê !</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
   </data>
   <data name="Profile_UseAcrylic.Header" xml:space="preserve">
-    <value>Èήâвℓë ąĉѓýļįč мâťěŗīåļ !!! !!! </value>
+    <value>Єňάьłē дсѓŷĺĭс mąτěřìªŀ !!! !!! </value>
     <comment>Header for a control to toggle the use of acrylic material for the background. "Acrylic material" is a Microsoft-specific term: https://docs.microsoft.com/en-us/windows/apps/design/style/acrylic</comment>
   </data>
   <data name="Profile_UseAcrylic.HelpText" xml:space="preserve">
-    <value>Ãρρļïзŝ ā ŧřаπśℓΰćęπŧ τёхτμřэ ťô ţћê ьдćќĝґбύпď бƒ τнê шіńðòẃ. !!! !!! !!! !!! !!! !!! </value>
+    <value>Àφρļįëś ã ţґάήŝℓűсэиŧ тēжτυŗэ ťό тĥ℮ ъάćĸĝґõυήď õƒ ţћ℮ щϊηðǿщ. !!! !!! !!! !!! !!! !!! </value>
     <comment>A description for what the "Profile_UseAcrylic" setting does.</comment>
   </data>
   <data name="Profile_UseDesktopImage.Content" xml:space="preserve">
-    <value>Џѕę đёѕќťőφ ώаļľρаφέѓ !!! !!!</value>
+    <value>Ŭŝē đεśķτòр ẃąℓłραрĕя !!! !!!</value>
     <comment>A supplementary setting to the "background image" setting. When enabled, the OS desktop wallpaper is used as the background image. Presented near "Profile_BackgroundImage".</comment>
   </data>
   <data name="Profile_UseDesktopImage.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ūѕê ŧћę δěŝκŧőφ щãŀļрàρèŗ įмàġé åś τће вåċķġřόũňð ίмªġē ƒбг ťĥè ţεřmīπáļ. !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Ůšê тнè ďєśķťōρ ŵªĺļраφēř ímǻğё αś тħэ ъąĉκġřōůлđ іmãġè ƒόґ ŧн℮ ţэґмϊлªļ. !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>A description for what the supplementary "use desktop image" setting does. Presented near "Profile_UseDesktopImage".</comment>
   </data>
   <data name="Settings_ResetSettingsButton.Content" xml:space="preserve">
-    <value>Ďĭşςαяđ ςĥαñĝєѕ !!! !</value>
+    <value>Ďìš¢αŗð ĉђăŉġęѕ !!! !</value>
     <comment>Text label for a destructive button that discards the changes made to the settings.</comment>
   </data>
   <data name="Settings_ResetSettingsButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Đίšсäřδ āļľ űņšανêď šέтťιйģś. !!! !!! !!!</value>
+    <value>Ðĭŝĉäŕð дĺľ цŋşåνёď ѕεťŧīńġś. !!! !!! !!!</value>
     <comment>A description for what the "discard changes" button does. Presented near "Settings_ResetSettingsButton".</comment>
   </data>
   <data name="Settings_SaveSettingsButton.Content" xml:space="preserve">
-    <value>Ŝăν℮ !</value>
+    <value>Śāνэ !</value>
     <comment>Text label for the confirmation button that saves the changes made to the settings.</comment>
   </data>
   <data name="Settings_UnsavedSettingsWarning.Text" xml:space="preserve">
-    <value>⚠ Ўöџ ħăνе ûńšάνэð ¢ħáńģεš. !!! !!! !!</value>
+    <value>⚠ Υŏű нâνě цπśąνêδ ¢ђãпġēš. !!! !!! !!</value>
     <comment>{Locked="⚠"} A disclaimer that appears when the unsaved changes to the settings are present.</comment>
   </data>
   <data name="Nav_AddNewProfile.Content" xml:space="preserve">
-    <value>Ąðđ α пêщ φѓôƒīŀė !!! !!</value>
+    <value>Ãđδ α ηèŵ ряоƒіľэ !!! !!</value>
     <comment>Header for the "add new" menu item. This navigates to the page where users can add a new profile.</comment>
   </data>
   <data name="Nav_Profiles.Content" xml:space="preserve">
-    <value>Ρѓŏƒíŀзѕ !!</value>
+    <value>Ρґőƒϊłеѕ !!</value>
     <comment>Header for the "profiles" menu items. This acts as a divider to introduce profile-related menu items.</comment>
   </data>
   <data name="Globals_LaunchModeFocus.Content" xml:space="preserve">
-    <value>₣оĉũş !</value>
+    <value>₣őćџŝ !</value>
     <comment>An option to choose from for the "launch mode" setting. Focus mode is a mode designed to help you focus.</comment>
   </data>
   <data name="Globals_LaunchModeMaximizedFocus.Content" xml:space="preserve">
-    <value>Μā×ίмϊžęď ƒōçųś !!! !</value>
+    <value>Μãхîмížęď ƒòćύŝ !!! !</value>
     <comment>An option to choose from for the "launch mode" setting. Opens the app maximized and in focus mode.</comment>
   </data>
   <data name="Globals_LaunchModeMaximizedFullscreen.Content" xml:space="preserve">
-    <value>Μªжΐmĩžзđ ƒũłℓ śčŕёėи !!! !!!</value>
+    <value>Мª×įmίźėδ ƒύļĺ šсґèэη !!! !!!</value>
     <comment>An option to choose from for the "launch mode" setting. Opens the app maximized and in full screen.</comment>
   </data>
   <data name="Globals_LaunchModeFullscreenFocus.Content" xml:space="preserve">
-    <value>₣űŀŀ şçґєзŋ ƒó¢ůş !!! !!</value>
+    <value>₣üĺℓ śčřèéη ƒŏćŭś !!! !!</value>
     <comment>An option to choose from for the "launch mode" setting. Opens the app in full screen and in focus mode.</comment>
   </data>
   <data name="Globals_LaunchModeMaximizedFullscreenFocus.Content" xml:space="preserve">
-    <value>Мǻ×іmΐžéđ ƒūℓł ѕčŗеèⁿ ƒσčůŝ !!! !!! !!</value>
+    <value>Μąжįмīźēď ƒµĺļ śсяé℮ⁿ ƒθčϋš !!! !!! !!</value>
     <comment>An option to choose from for the "launch mode" setting. Opens the app maximized in full screen and in focus mode.</comment>
   </data>
   <data name="Profile_BellStyle.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ьέŀℓ иοŧïƒĭćªţїóи šŧỳļë !!! !!! </value>
+    <value>Бэĺł иőťíƒΐćªŧίøл ѕţуĺз !!! !!! </value>
     <comment>Name for a control to select the how the app notifies the user. "Bell" is the common term in terminals for the BEL character (like the metal device used to chime).</comment>
   </data>
   <data name="Profile_BellStyle.Header" xml:space="preserve">
-    <value>ß℮ĺļ ņŏţіƒї¢âтΐόή šţÿłé !!! !!! </value>
+    <value>Веĺł йθŧϊƒīçǻťΐθп ŝťỳℓé !!! !!! </value>
     <comment>Header for a control to select the how the app notifies the user. "Bell" is the common term in terminals for the BEL character (like the metal device used to chime).</comment>
   </data>
   <data name="Profile_BellStyle.HelpText" xml:space="preserve">
-    <value>Ċöήτŗоℓś ωħαť ĥăрρепś шħєń ťђê дρρℓĩčäţιοń έмιţѕ ä BEL čħагä¢тëг. !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ĉøήτѓōℓѕ ẅнǻτ ђдρφéпš шђĕñ тнē ąρрĺιčάτĩоň емìťś а ЬΕ£ ćђãяд¢ţĕř. !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "bell style" setting does. Presented near "Profile_BellStyle".{Locked="BEL"}</comment>
   </data>
   <data name="Profile_ReloadEnvVars.Header" xml:space="preserve">
-    <value>£ãϋňčĥ тĥіş ąφрļΐςаţїóň шĩτн д иэώ έпνіѓσиmэŋŧ ъŀǿčķ !!! !!! !!! !!! !!! </value>
+    <value>£αüņ¢ħ ŧћΐš аρφℓîсäŧïōп ŵìţн α йéω ёňνΐѓõлmĕπţ ъłосќ !!! !!! !!! !!! !!! </value>
     <comment>"environment variables" are user-definable values that can affect the way running processes will behave on a computer</comment>
   </data>
   <data name="Profile_ReloadEnvVars.HelpText" xml:space="preserve">
-    <value>Шћéŋ зήдвĺэđ, тĥĕ Τêгмĩлàľ ώįℓŀ ģêηėřąτё â лэŵ ęйνĭґοиmėņť вℓǿċκ ẅђęη ςřέαŧϊņģ пēŵ ŧáъŝ õг ρąņěš ωĩтħ ŧнíŝ рřόƒîĺέ. Ẁђэŋ ðϊśăъĺêđ, ťћē ťάв/φáⁿз ώïļł ìήѕτёąð ιпћεгīţ ţћë νãгіǻьĺэş ţђĕ Τεґмïňął ẅäş şτãѓτэđ ẃìŧћ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ẁћέл εņаьŀèď, τħё Ŧëгmĩňªľ ẅīŀℓ ğεлěяαте å ŉэщ еńνîřόńмęñт ьŀøĉĸ ŵħ℮л čґēãťîņğ ŉεώ τâвѕ όя рªлёѕ щĭτћ тĥĭѕ ρŗòƒΐℓė. Ẅђêй ðìšąвļėđ, τћë ťąь/рáňε шîŀĺ íñśτėáđ īήђзŕίτ τђė νăяϊаьℓĕŝ ţђε Ťęřmíŋаŀ ẁαŝ śťäřťέδ ωįтħ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "Reload environment variables" setting does. Presented near "Profile_ReloadEnvVars".</comment>
   </data>
   <data name="Profile_VtPassthrough.Header" xml:space="preserve">
-    <value>Êñåвľ℮ ёжφęŗīмéŋţàľ νΐřтϋåĺ ťéяміпаł рāѕśťħгòùĝĥ !!! !!! !!! !!! !!</value>
+    <value>Зńăьℓē эхφзґímėпτªŀ νіѓтűǻļ τ℮ґмϊñāļ φаśşтнґöúģн !!! !!! !!! !!! !!</value>
     <comment>An option to enable experimental virtual terminal passthrough connectivity option with the underlying ConPTY</comment>
   </data>
+  <data name="Profile_RightClickContextMenu.Header" xml:space="preserve">
+    <value>Ðįşφłąÿ ǻ мèηΰ όή řïĝĥť-ćľїçķ !!! !!! !!!</value>
+    <comment>This controls how a right-click behaves in the terminal</comment>
+  </data>
+  <data name="Profile_RightClickContextMenu.HelpText" xml:space="preserve">
+    <value>Ẁђéŋ êπäвĺεð, ţĥё Τéŕмįⁿął ẃìļŀ ďïśρĺąỳ ã мέиц öη ŕìğĥţ-сℓĩ¢ķ. Ŵћëŉ đϊśªьŀèð, řιġћţ-čℓî¢ķιñĝ ẁĩłℓ ĉσрÿ тħē şèłэĉţĕđ ŧэжτ (ŏя рâŝтé ΐƒ ťћзяę'ś йб śзľĕćţîбñ). !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <comment>A description for what the "Display a menu on right-click" setting does. Presented near "Profile_RightClickContextMenu".</comment>
+  </data>
+  <data name="Profile_ShowMarks.Header" xml:space="preserve">
+    <value>Ďιşрĺąŷ мǻŕĸş θй ţĥě ŝćřбŀŀъáŕ !!! !!! !!!</value>
+    <comment>"Marks" are small visual indicators that can help the user identify the position of useful info in the scrollbar</comment>
+  </data>
+  <data name="Profile_ShowMarks.HelpText" xml:space="preserve">
+    <value>Ẅĥέň ёпдъļêď, τĥ℮ Τëгmįиªł ẃĩľļ ðΐśρℓăỳ мāѓκś ιñ ţħє şĉѓòℓľьªŗ ŵħëⁿ ŝēãѓçђιŋĝ ƒθř ťèжт, σѓ ŵћзп šђêļŀ ίπтέğґãťîόи іś εŋäьłёđ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <comment>A description for what the "Display marks on the scrollbar" setting does. Presented near "Profile_ShowMarks".</comment>
+  </data>
+  <data name="Profile_AutoMarkPrompts.Header" xml:space="preserve">
+    <value>∆űŧòмåťĩċǻłļγ маѓķ ρřǿmρŧş óй φґěѕşіиğ Еŋŧєř !!! !!! !!! !!! !</value>
+    <comment>"Enter" is the enter/return key on the keyboard. This will add a mark indicating the position of a shell prompt when the user presses enter.</comment>
+  </data>
+  <data name="Profile_AutoMarkPrompts.HelpText" xml:space="preserve">
+    <value>Ẃћеⁿ эņáвļēď, тħè Тěřмíиãŀ ǻµтοмăťìςǻℓľу åδď ã мâŕĸ іиđιςåŧïⁿġ тħé рσŝĩţίол öƒ ţђé ęņð øƒ τĥę ςбmмǻйδ ẃћéи ýθů φŕэѕѕ ēиŧęѓ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <comment>A description for what the "Automatically mark prompts on pressing Enter" setting does. Presented near "Profile_AutoMarkPrompts".</comment>
+  </data>
+  <data name="Profile_RepositionCursorWithMouse.Header" xml:space="preserve">
+    <value>Ê×рэґїmзŉτâļ: Гэрŏśΐťĩőⁿ τћέ ćũŕšσŕ ẁіτн mσůśё ċℓīċĸѕ !!! !!! !!! !!! !!! </value>
+    <comment>This allows the user to move the text cursor just by clicking with the mouse.</comment>
+  </data>
+  <data name="Profile_RepositionCursorWithMouse.HelpText" xml:space="preserve">
+    <value>Ẅћзή ℮йăъļэð, ĉľīćкїηġ ιňśīðè ŧĥё ρŕσmρŧ ωïŀļ мσνэ ţћё čúřšŏѓ тő ţħάŧ рōŝΐτíôⁿ. Ŧђΐŝ ŕéqűїřέѕ šћėľľ іñţεģřãţīǿň тø ъē зŋāвłêð ιπ убųѓ ѕћєľĺ τó ẃθѓκ ăѕ зжφĕčτēď. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <comment>A description for what the "Reload environment variables" setting does. Presented near "Profile_RepositionCursorWithMouse".</comment>
+  </data>
   <data name="Profile_BellStyleAudible.Content" xml:space="preserve">
-    <value>Ãüđīъłě !!</value>
+    <value>∆ůðĭъĺę !!</value>
     <comment>An option to choose from for the "bell style" setting. When selected, an audible cue is used to notify the user.</comment>
   </data>
   <data name="Profile_BellStyleNone.Content" xml:space="preserve">
-    <value>Ňőηė !</value>
+    <value>Ñбŉĕ !</value>
     <comment>An option to choose from for the "bell style" setting. When selected, notifications are silenced.</comment>
   </data>
   <data name="Globals_DisableAnimations.Header" xml:space="preserve">
-    <value>Ðïśαъłĕ рåйĕ ăŉίmдтíόŋŝ !!! !!! </value>
+    <value>Đїŝâвŀè рăŋě ǻйįmąтіǿňŝ !!! !!! </value>
     <comment>Header for a control to toggle animations on panes. "Enabled" value disables the animations.</comment>
   </data>
   <data name="Profile_FontWeightBlack.Content" xml:space="preserve">
-    <value>Ьłáςќ !</value>
+    <value>Вĺåčќ !</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightBold.Content" xml:space="preserve">
-    <value>Ъσĺď !</value>
+    <value>Ъθĺď !</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightCustom.Content" xml:space="preserve">
-    <value>€ūŝŧôм !</value>
+    <value>Ćцѕτσm !</value>
     <comment>This is an entry that allows the user to select their own font weight value outside of the simplified list of options.</comment>
   </data>
   <data name="Profile_FontWeightExtra-black.Content" xml:space="preserve">
-    <value>Êхŧřǻ-ßŀдςк !!!</value>
+    <value>Ĕжťŗā-Βļаċк !!!</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightExtra-bold.Content" xml:space="preserve">
-    <value>Ёжŧгą-ßǿŀð !!!</value>
+    <value>Ёжţгд-Боļδ !!!</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightExtra-light.Content" xml:space="preserve">
-    <value>Σхтřà-£ιġĥţ !!!</value>
+    <value>Ę×тяā-£ïĝћţ !!!</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightLight.Content" xml:space="preserve">
-    <value>₤īğнτ !</value>
+    <value>Ŀιğĥŧ !</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightMedium.Content" xml:space="preserve">
-    <value>Мęđϊüм !</value>
+    <value>Μєđιϋм !</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightNormal.Content" xml:space="preserve">
-    <value>Ñόřmàℓ !</value>
+    <value>Ňŏŗmªĺ !</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightSemi-bold.Content" xml:space="preserve">
-    <value>Śēмι-Вοľđ !!!</value>
+    <value>Şèмï-Вōłđ !!!</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightSemi-light.Content" xml:space="preserve">
-    <value>Šĕmĩ-₤ìġнт !!!</value>
+    <value>Ѕėmį-₤іģħŧ !!!</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightThin.Content" xml:space="preserve">
-    <value>Тħĭπ !</value>
+    <value>Ŧħīň !</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontFeature_rlig" xml:space="preserve">
-    <value>Ґèqûίŕęð ŀіġάţüѓęş !!! !!</value>
+    <value>Ŗéqùїяëď ľîģąτüřеŝ !!! !!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_locl" xml:space="preserve">
-    <value>Ľōсаℓϊżèď ƒõямš !!! !</value>
+    <value>£ǿčãłϊźэď ƒŏгмş !!! !</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_ccmp" xml:space="preserve">
-    <value>Ĉǿмρøŝĭţĭôй/ðêčσmρőśíťįőη !!! !!! !</value>
+    <value>Ćóмρőśĭťϊοņ/ðέċömφóšίτìøη !!! !!! !</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_calt" xml:space="preserve">
-    <value>Ċóήťē×ťύдℓ ãℓŧёŗлдťэѕ !!! !!!</value>
+    <value>Сθⁿте×тüáŀ ǻℓţėŗпαтēŝ !!! !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_liga" xml:space="preserve">
-    <value>Šтăŉďàŗđ ľĭġάťùřëѕ !!! !!</value>
+    <value>Ѕτάлďάґð ℓíġąтŭѓεѕ !!! !!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_clig" xml:space="preserve">
-    <value>Ćǿⁿтĕ×ťŭάℓ ℓĩģàţűřёѕ !!! !!!</value>
+    <value>Ċоňťêжţũāł łіġăŧµѓèś !!! !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_rvrn" xml:space="preserve">
-    <value>Γеqцíŕěď νäѓίãτΐōň āłτęґпåŧēŝ !!! !!! !!!</value>
+    <value>Ŕëqџìґêð νãяìâтïöп ªļтĕгñąţëš !!! !!! !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_kern" xml:space="preserve">
-    <value>Κęřήïήğ !!</value>
+    <value>Ќεřпĩńģ !!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_mark" xml:space="preserve">
-    <value>Μǻŕĸ рõşїτіθлįйğ !!! !</value>
+    <value>Мăґĸ φбśїτìõйίήģ !!! !</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_mkmk" xml:space="preserve">
-    <value>Μäѓк ţö мâŗĸ рσśìţїöйΐήğ !!! !!! !</value>
+    <value>Мªяκ ŧθ máгķ φбşίţīōпîņĝ !!! !!! !</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_dist" xml:space="preserve">
-    <value>Ðĩѕŧãń¢ě !!</value>
+    <value>Ďïşťªпčє !!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_aalt" xml:space="preserve">
-    <value>Ǻĉčëśš дℓľ ãĺťęгйαŧēš !!! !!!</value>
+    <value>Âĉċēśş αłł ǻĺтэяńáťėş !!! !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_case" xml:space="preserve">
-    <value>Ċаşè şейśìтîνе ƒόґмś !!! !!!</value>
+    <value>€αŝē śεⁿŝιţіνé ƒǿŗmŝ !!! !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_dnom" xml:space="preserve">
-    <value>Ďêиómіŋαţǿя !!!</value>
+    <value>Đēñômĭņąţόя !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_fina" xml:space="preserve">
-    <value>Ťзŕmιηăℓ ƒôѓмѕ !!! !</value>
+    <value>Ŧēгмιπáļ ƒόŕmś !!! !</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_frac" xml:space="preserve">
-    <value>₣ŕãĉŧįόлŝ !!!</value>
+    <value>₣ŕãçŧїõήŝ !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_init" xml:space="preserve">
-    <value>Ίйíтīаł ƒόѓmѕ !!! </value>
+    <value>Īήíťĭàľ ƒõяmŝ !!! </value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_medi" xml:space="preserve">
-    <value>Мзðідļ ƒόямš !!! </value>
+    <value>Μеďìαℓ ƒбřмš !!! </value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_numr" xml:space="preserve">
-    <value>Ņümзѓåŧŏŕ !!!</value>
+    <value>Ňϋмēгªţőř !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_ordn" xml:space="preserve">
-    <value>Øřðΐŋаĺѕ !!</value>
+    <value>Οřďĩŋäℓѕ !!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_rclt" xml:space="preserve">
-    <value>Ŗēqůїґéð çóńŧĕхŧύǻĺ дŀťэŗňãţêş !!! !!! !!!</value>
+    <value>Ŗèqŭīŗеð ĉοйτęхťüàĺ áľţėřŉãŧεŝ !!! !!! !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_sinf" xml:space="preserve">
-    <value>Šсïзйţĭƒîċ ìηƒéгĭǿřś !!! !!!</value>
+    <value>Śсϊèⁿťίƒιč ΐñƒєřīōŗŝ !!! !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_subs" xml:space="preserve">
-    <value>Şцвşсřĩрτ !!!</value>
+    <value>Śûвś¢řîρţ !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_sups" xml:space="preserve">
-    <value>Šűφєѓѕćяїрť !!!</value>
+    <value>Ŝùρεřśčřîφŧ !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_zero" xml:space="preserve">
-    <value>Śĺаѕĥêď żêŗо !!! </value>
+    <value>Ѕĺáѕħëď żêґø !!! </value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_abvm" xml:space="preserve">
-    <value>Авθνέ-ъãşэ мâгκ рōŝΐŧіōńíńĝ !!! !!! !!</value>
+    <value>Λъŏνє-ъåѕέ мǻяќ φōśīτΐóņīлĝ !!! !!! !!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Globals_LaunchSize.Header" xml:space="preserve">
-    <value>Ļдűⁿčн šϊżë !!!</value>
+    <value>Łáцηсħ šіžē !!!</value>
     <comment>Header for a group of settings that control the size of the app. Presented near "Globals_InitialCols" and "Globals_InitialRows".</comment>
   </data>
   <data name="Globals_LaunchSize.HelpText" xml:space="preserve">
-    <value>Ŧђ℮ ŋúмвęґ οƒ řøẅš аήδ ćǿļύмŋŝ đîśрľаγĕď íη ťĥĕ ωĩйďòŵ µροή ƒířŝτ ĺоàδ. Мέåšυřёď ìи сħăřąçŧèяѕ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Τĥé ήυмвēŕ θƒ гόωş äйđ ςôľũмņś đΐşφĺąŷęđ îй ŧĥê ẃįňďŏώ ųрбŋ ƒїяšţ ļŏăď. Μêάşµřēď īй ςħαŕāçτέřś. !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "rows" and "columns" settings do. Presented near "Globals_LaunchSize.Header".</comment>
   </data>
   <data name="Globals_LaunchPosition.Text" xml:space="preserve">
-    <value>Łâµηčĥ ρθśιťĩōπ !!! !</value>
+    <value>Ľâűπçћ φσѕíţįбŉ !!! !</value>
     <comment>Header for a group of settings that control the launch position of the app. Presented near "Globals_InitialPosX" and "Globals_InitialPosY".</comment>
   </data>
   <data name="Globals_LaunchPosition.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ŧћё īήíťιдŀ рôśϊťîôñ ōƒ ţħέ тĕґміпäł щїлδθш ùρöπ śťåгŧύρ. Ẁђěπ ℓªüйçђìňĝ āŝ ма×ĩmіżєð, ƒúℓĺ ś¢ŕ℮℮п, ôř ẅĩτђ "€ёņŧèг ôñ łąűηçћ" єлáьĺєð, ťĥíѕ ïš ύŝэδ ŧσ ŧàŕģēţ ŧђè mŏηίτóѓ òƒ įⁿт℮ґеşτ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Ťнέ īηĭţϊąĺ φǿšĩтīòл őƒ ŧђę τĕѓмīηäł ωĭиđŏщ ϋρőŉ śτåřťϋр. Ŵнέη ľãцпçђìŋģ άŝ mã×ĩмιż℮ď, ƒµļľ ŝ¢ґэ℮ň, øř ẃĩτħ "Çĕпτеґ ои łåúŋ¢ђ" ĕņǻвℓėδ, ŧĥíŝ íś џşĕď ţö ţάřĝēŧ тħē моŋітòя σƒ įпťēґēśŧ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>A description for what the "X position" and "Y position" settings do. Presented near "Globals_LaunchPosition.Header".</comment>
   </data>
   <data name="Profile_BellStyleAll.Content" xml:space="preserve">
-    <value>Δℓľ </value>
+    <value>Äŀℓ </value>
     <comment>An option to choose from for the "bell style" setting. When selected, a combination of the other bell styles is used to notify the user.</comment>
   </data>
   <data name="Profile_BellStyleVisual.Content" xml:space="preserve">
-    <value>Vίѕцдℓ (ƒŀǻşђ ťāšќъăѓ) !!! !!! </value>
+    <value>Vĭśũάŀ (ƒĺāşђ ţąşκвдѓ) !!! !!! </value>
   </data>
   <data name="Profile_BellStyleTaskbar.Content" xml:space="preserve">
-    <value>₣ŀαŝħ τâŝќьåя !!! </value>
+    <value>₣ŀªśћ τâśќъäѓ !!! </value>
     <comment>An option to choose from for the "bell style" setting. When selected, a visual notification is used to notify the user. In this case, the taskbar is flashed.</comment>
   </data>
   <data name="Profile_BellStyleWindow.Content" xml:space="preserve">
-    <value>₣ľãşћ шįńđоẅ !!! </value>
+    <value>₣łāŝћ ẅїňďŏщ !!! </value>
     <comment>An option to choose from for the "bell style" setting. When selected, a visual notification is used to notify the user. In this case, the window is flashed.</comment>
   </data>
   <data name="ColorScheme_AddNewButton.Text" xml:space="preserve">
-    <value>Ăδđ пëẁ !!</value>
+    <value>Äδď ⁿĕш !!</value>
     <comment>Button label that creates a new color scheme.</comment>
   </data>
   <data name="ColorScheme_DeleteButton.Text" xml:space="preserve">
-    <value>Ð℮łéтε çóĺøŕ ѕċĥêmĕ !!! !!!</value>
+    <value>Ðєĺèŧĕ ¢оľōѓ ѕснεмė !!! !!!</value>
     <comment>Button label that deletes the selected color scheme.</comment>
   </data>
   <data name="ColorScheme_EditButton.Text" xml:space="preserve">
-    <value>Ëďìт !</value>
+    <value>Σδϊт !</value>
     <comment>Button label that edits the currently selected color scheme.</comment>
   </data>
   <data name="ColorScheme_DeleteButton2.Text" xml:space="preserve">
-    <value>Ðέľèтė !</value>
+    <value>Đеļėŧę !</value>
     <comment>Button label that deletes the selected color scheme.</comment>
   </data>
   <data name="ColorScheme_Name.Header" xml:space="preserve">
-    <value>Йåме !</value>
+    <value>Ŋām℮ !</value>
     <comment>The name of the color scheme. Used as a label on the name control.</comment>
   </data>
   <data name="ColorScheme_Name.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ŧĥε ŉάмē öƒ ţнέ ¢őℓòґ ѕçнęмê. !!! !!! !!!</value>
+    <value>Ŧħё ŋąмэ őƒ τћě ¢ǿℓôѓ śçђéмē. !!! !!! !!!</value>
     <comment>Supplementary text (tooltip) for the control used to select a color scheme that is under view.</comment>
   </data>
   <data name="Profile_DeleteButton.Text" xml:space="preserve">
-    <value>Đєļĕţè φѓσƒιŀέ !!! !</value>
+    <value>Đёľĕŧз рŗõƒιŀê !!! !</value>
     <comment>Button label that deletes the current profile that is being viewed.</comment>
   </data>
   <data name="Profile_Name.HelpText" xml:space="preserve">
-    <value>Ţħė ηªмέ бƒ τнз φřσƒîĺē ŧђαţ åρφēąѓš ìπ тħэ ďяόρđōωп. !!! !!! !!! !!! !!! </value>
+    <value>Ťћє ηǻмэ бƒ тнέ рřоƒïľé ţĥāτ άрρеαяѕ ĭπ ťћê đŕøφđóẃи. !!! !!! !!! !!! !!! </value>
     <comment>A description for what the "name" setting does. Presented near "Profile_Name".</comment>
   </data>
   <data name="Profile_Name.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ńάmè !</value>
+    <value>∏ãmê !</value>
     <comment>Name for a control to determine the name of the profile. This is a text box.</comment>
   </data>
   <data name="Profile_Name.Header" xml:space="preserve">
-    <value>Ñăмě !</value>
+    <value>Ņàmě !</value>
     <comment>Header for a control to determine the name of the profile. This is a text box.</comment>
   </data>
   <data name="Profile_TransparencyHeader.Text" xml:space="preserve">
-    <value>Ŧяáņśφаŕ℮ńςŷ !!! </value>
+    <value>Ţřąηѕρªґěňçÿ !!! </value>
     <comment>Header for a group of settings related to transparency, including the acrylic material background of the app.</comment>
   </data>
   <data name="Profile_BackgroundHeader.Text" xml:space="preserve">
-    <value>Ъą¢ķġřõűήđ ιmąğз !!! !</value>
+    <value>Βдĉкġřöûⁿď ìmąĝέ !!! !</value>
     <comment>Header for a group of settings that control the image presented on the background of the app. Presented near "Profile_BackgroundImage" and other keys starting with "Profile_BackgroundImage".</comment>
   </data>
   <data name="Profile_CursorHeader.Text" xml:space="preserve">
-    <value>Čµŗśóř !</value>
+    <value>Čυřŝóґ !</value>
     <comment>Header for a group of settings that control the appearance of the cursor. Presented near "Profile_CursorHeight" and other keys starting with "Profile_Cursor".</comment>
   </data>
   <data name="Profile_AdditionalSettingsHeader.Text" xml:space="preserve">
-    <value>Åđðϊτіõήąŀ šěтτįņğŝ !!! !!!</value>
+    <value>∆ďδΐţіõпаľ śєτťΐņĝŝ !!! !!!</value>
     <comment>Header for the buttons that navigate to additional settings for the profile.</comment>
   </data>
   <data name="Profile_TextHeader.Text" xml:space="preserve">
-    <value>Ţĕ×ţ !</value>
+    <value>Ţέхţ !</value>
     <comment>Header for a group of settings that control the appearance of text in the app.</comment>
   </data>
   <data name="Profile_WindowHeader.Text" xml:space="preserve">
-    <value>Ẃιйðόώ !</value>
+    <value>Щіňďош !</value>
     <comment>Header for a group of settings that control the appearance of the window frame of the app.</comment>
   </data>
   <data name="Nav_OpenJSON.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Öφёή ỳŏüŕ settings.json ƒïℓê. Дĺт+Çłįск ťò όрèň ỳøύř defaults.json ƒιĺз. !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Ώр℮п ỳõμѓ settings.json ƒιĺ℮. Áŀţ+Ċĺι¢ќ тθ ôφ℮л уοųѓ δěƒåџĺţş.јśŏл ƒïłе. !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>{Locked="settings.json"}, {Locked="defaults.json"}</comment>
   </data>
   <data name="Rename.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ŗέŉåмĕ !</value>
+    <value>Γ℮иάмê !</value>
     <comment>Text label for a button that can be used to begin the renaming process.</comment>
   </data>
   <data name="ColorScheme_DeleteButtonDisclaimerInBox.Text" xml:space="preserve">
-    <value>Ŧнįś ĉбľòŗ ѕςнëmэ çäñπòτ ъē δεļéţ℮ď öř гěⁿаmεď вėсâùŝè ĭţ їš ïŋ¢ŀΰđēđ ьý δĕƒαŭŀτ. !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Τћîŝ čŏļòя şċĥěмε ćâňñǿτ ьё đĕļ℮ťèδ ōŕ ґĕňãmėð ьēĉаūśё ĭţ îś їńċľůðзď ъγ đэƒāûŀŧ. !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>Disclaimer presented next to the delete button when it is disabled.</comment>
   </data>
   <data name="ColorScheme_DeleteConfirmationButton.Content" xml:space="preserve">
-    <value>Ϋєś, đёŀĕτз čôľőг śçђèmē !!! !!! !</value>
+    <value>Ýëѕ, ðěĺέŧε çółöг śċћэмέ !!! !!! !</value>
     <comment>Button label for positive confirmation of deleting a color scheme (presented with "ColorScheme_DeleteConfirmationMessage")</comment>
   </data>
   <data name="ColorScheme_DeleteConfirmationMessage.Text" xml:space="preserve">
-    <value>Âřе ўόù ŝûŕέ ŷσϋ ώάⁿτ ťŏ ďёℓетé ťђĩš ¢øłòř ѕсĥěмε? !!! !!! !!! !!! !!!</value>
+    <value>Аŕë уоû şύŗê γǿџ ẃаηť ŧθ ðέłēтε тнíѕ çσľòř ѕćĥεмέ? !!! !!! !!! !!! !!!</value>
     <comment>A confirmation message displayed when the user intends to delete a color scheme.</comment>
   </data>
   <data name="RenameAccept.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Āçċėρŧ ґēиάmε !!! </value>
+    <value>Àćĉêрŧ ŕεηáмĕ !!! </value>
     <comment>Text label for a button that can be used to confirm a rename operation during the renaming process.</comment>
   </data>
   <data name="RenameCancel.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Čàηçëł ѓęлаmэ !!! </value>
+    <value>Čªⁿςęℓ гëήдмέ !!! </value>
     <comment>Text label for a button that can be used to cancel a rename operation during the renaming process.</comment>
   </data>
   <data name="ColorSchemesDisclaimer.Text" xml:space="preserve">
-    <value>Ŝċћęмэś ďēƒїńėď нεґе ćàň ъē арρŀïэđ ŧŏ ỳσûг рřσƒίĺĕѕ ûŋδ℮ř тђě "Άφφěãґăлć℮ŝ" ѕĕĉτϊôń оƒ ţħě ρяŏƒїŀё šèτтїńğѕ ρàġęѕ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Šсћěмěš đèƒιñèđ ћėřė ċдŋ ъę αрφŀĩ℮ð ŧö ỳóцř ρґοƒįℓэŝ цйðĕř ŧћ℮ "Άρφêäгăήςεѕ" šєĉťΐόη θƒ τћę φґôƒіℓē şĕŧŧιⁿĝѕ рǻĝêѕ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A disclaimer presented at the top of a page. "Appearances" should match Profile_Appearance.Header.</comment>
   </data>
   <data name="Profile_BaseLayerDisclaimer.Text" xml:space="preserve">
-    <value>Ѕєτťϊйĝѕ δêƒĭπеđ ĥєřе щίℓļ ªρρĺŷ ŧò ąłŀ ρгǿƒíĺєş µйℓēşş тђεỳ àř℮ óνέѓŕíδđĕň ьỳ а ргόƒιℓ℮'š şєťτїйĝş. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Śéţţĩñģš ďėƒįňеδ ђеŗ℮ ẃίľĺ áφρℓý ŧō ªļł ряöƒíŀєš ūлĺèŝŝ ťħęу àгë σνэřřїδδέй ьγ а рŗőƒįŀé'ś ŝëтţіиġš. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A disclaimer presented at the top of a page. See "Nav_ProfileDefaults.Content" for a description on what the defaults layer does in the app.</comment>
   </data>
   <data name="Profile_DeleteConfirmationButton.Content" xml:space="preserve">
-    <value>Ỳēş, đёľèťê φřǿƒιľė !!! !!!</value>
+    <value>Ỳěŝ, ďзľетè ρřöƒīľé !!! !!!</value>
     <comment>Button label for positive confirmation of deleting a profile (presented with "Profile_DeleteConfirmationMessage")</comment>
   </data>
   <data name="Profile_DeleteConfirmationMessage.Text" xml:space="preserve">
-    <value>Ǻѓе ýòũ śúŕ℮ γбû ẅáиτ ţő ďэℓêť℮ ŧĥίś φŕǿƒΐļē? !!! !!! !!! !!! !</value>
+    <value>Дгè уøџ ѕŭřз ỳθū шдŋт ťö đěĺэţè ţћιś φгòƒίŀ℮? !!! !!! !!! !!! !</value>
     <comment>A confirmation message displayed when the user intends to delete a profile.</comment>
   </data>
   <data name="Settings_SaveSettingsButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ŝªνě áľŀ цŋśàνзδ śёţтīηğŝ. !!! !!! !</value>
+    <value>Ѕąνε āľŀ ΰŉşаν℮ð šέťτϊŋģŝ. !!! !!! !</value>
     <comment>A description for what the "save" button does. Presented near "Settings_SaveSettingsButton".</comment>
   </data>
   <data name="Globals_TabSwitcherMode.Header" xml:space="preserve">
-    <value>Ťąв şŵìτčнêґ їņτеřƒăćĕ şтŷℓе !!! !!! !!</value>
+    <value>Τãь ŝẃιťςђęř įⁿтëяƒā¢ĕ şтγℓε !!! !!! !!</value>
     <comment>Header for a control to choose how the tab switcher operates.</comment>
   </data>
   <data name="Globals_TabSwitcherMode.HelpText" xml:space="preserve">
-    <value>Ŝèľеċτѕ ẃĥісн ϊпŧêŗƒдċè ωĩĺļ ьє ûśзď ώħёŉ ýøµ śщìтċђ тăьŝ ύśîпğ ťћè кĕγъǿåґð. !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Śėℓĕčţś ẃħĩçћ īиŧēгƒаςэ ωīℓℓ вè цŝëδ шħёл ŷόџ şщīťĉђ ŧáвš ùśīлġ τнз ќèŷьóâяð. !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>A description for what the "tab switcher mode" setting does. Presented near "Globals_TabSwitcherMode.Header".</comment>
   </data>
   <data name="Globals_TabSwitcherModeMru.Content" xml:space="preserve">
-    <value>Şέφдяāτë щīηðοш, ïń мőşт ґêς℮йтľý űśёđ öяďēя !!! !!! !!! !!! !</value>
+    <value>Şéράŗâт℮ ŵĩñðōω, ïл mθŝť ŗĕčєπťℓу ūŝěď оŗδêґ !!! !!! !!! !!! !</value>
     <comment>An option to choose from for the "tab switcher mode" setting. The tab switcher overlay is shown in most recently used order.</comment>
   </data>
   <data name="Globals_TabSwitcherModeInOrder.Content" xml:space="preserve">
-    <value>Ѕєφåřάтє щīпðǿẅ, ĩи тāв ѕťгιφ όґďеř !!! !!! !!! !</value>
+    <value>Šєρãѓªτе ẅійđòẁ, îń ťāъ śŧґір σяðєŗ !!! !!! !!! !</value>
     <comment>An option to choose from for the "tab switcher mode" setting. The tab switcher overlay is shown in the order of the tabs at the top of the app.</comment>
   </data>
   <data name="Globals_TabSwitcherModeDisabled.Content" xml:space="preserve">
-    <value>Тŗаðîťϊôηǻļ ñàνĭĝдτîōη, ήб ŝεφάŗàτĕ ώĩŉδõш !!! !!! !!! !!! </value>
+    <value>Ţřàðίţίöлàľ ήдνΐĝãťįθⁿ, ⁿô šэράŕăť℮ ẃĩηďøω !!! !!! !!! !!! </value>
     <comment>An option to choose from for the "tab switcher mode" setting. The tab switcher overlay is hidden and does not appear in a separate window.</comment>
   </data>
   <data name="Globals_CopyFormat.Header" xml:space="preserve">
-    <value>Ţехτ ƒöгмǻťŝ ťó сбφÿ ŧø ťћę ¢ŀįφъøдґď !!! !!! !!! !!</value>
+    <value>Ţęхţ ƒόřмâтš ťσ ċορў ţő ťнё ĉĺїρвσагδ !!! !!! !!! !!</value>
     <comment>Header for a control to select the format of copied text.</comment>
   </data>
   <data name="Globals_CopyFormatNone.Content" xml:space="preserve">
-    <value>Рļǻїи ŧєхţ ôⁿℓỳ !!! !</value>
+    <value>Ρĺαΐñ ŧëжť όиĺÿ !!! !</value>
     <comment>An option to choose from for the "copy formatting" setting. Store only plain text data.</comment>
   </data>
   <data name="Globals_CopyFormatHtml.Content" xml:space="preserve">
-    <value>ĦТΜ₤ !</value>
+    <value>ΉТМ£ !</value>
     <comment>An option to choose from for the "copy formatting" setting. Store only HTML data.</comment>
   </data>
   <data name="Globals_CopyFormatRtf.Content" xml:space="preserve">
-    <value>ŘŢ₣ </value>
+    <value>ЯŢ₣ </value>
     <comment>An option to choose from for the "copy formatting" setting. Store only RTF data.</comment>
   </data>
   <data name="Globals_CopyFormatAll.Content" xml:space="preserve">
-    <value>βŏţћ ΗŦМ£ аήď ГŢ₣ !!! !!</value>
+    <value>βôτђ ΉŢΜŁ àήδ ГТ₣ !!! !!</value>
     <comment>An option to choose from for the "copy formatting" setting. Store both HTML and RTF data.</comment>
   </data>
   <data name="ColorScheme_RenameErrorTip.Subtitle" xml:space="preserve">
-    <value>Рĺėаšе ĉћôòşέ ã ðίƒƒэřέŉť лªmě. !!! !!! !!!</value>
+    <value>Ρłęāѕë ċнǿőŝê å ðíƒƒ℮яēйţ ņãмέ. !!! !!! !!!</value>
     <comment>An error message that appears when the user attempts to rename a color scheme to something invalid. This appears as the subtitle and provides guidance to fix the issue.</comment>
   </data>
   <data name="ColorScheme_RenameErrorTip.Title" xml:space="preserve">
-    <value>Τћιѕ čöłǿґ ščĥęmε ńâмē íŝ ǻľřέåðγ îπ ύŝε. !!! !!! !!! !!!</value>
+    <value>Τħīѕ çôŀóř ѕčћємє ŋдmë ĩѕ άĺŕėãďý ĭп ύšє. !!! !!! !!! !!!</value>
     <comment>An error message that appears when the user attempts to rename a color scheme to something invalid. This appears as the title, and explains the issue.</comment>
   </data>
   <data name="Globals_FocusFollowMouse.Header" xml:space="preserve">
-    <value>Ăµτómãţιĉāłļỳ ƒŏςûš φǻйë бп мôüśĕ ћöνēя !!! !!! !!! !!!</value>
+    <value>Áϋτомàţīćąłłý ƒόćŭś рåπę öń мõùšě ђöνëŗ !!! !!! !!! !!!</value>
     <comment>Header for a control to toggle the "focus follow mouse" setting. When enabled, hovering over a pane puts it in focus.</comment>
   </data>
   <data name="Globals_DisableAnimationsReversed.Header" xml:space="preserve">
-    <value>Рäŋě αņîmαţϊσňš !!! !</value>
+    <value>Ρǻйě ǻйϊмäţіőηş !!! !</value>
     <comment>Header for a control to toggle animations on panes. "Enabled" value enables the animations.</comment>
   </data>
   <data name="Globals_AlwaysShowNotificationIcon.Header" xml:space="preserve">
-    <value>Άŀẅåγѕ đîśφľãý дπ ιćőñ īη ţĥе лοŧιƒϊċªŧĩοŉ άгέą !!! !!! !!! !!! !!</value>
+    <value>Äľŵαŷś ďιśφĺαу дⁿ ìčǿи їň ţнē ŋöťϊƒĭćåţιøй αřεд !!! !!! !!! !!! !!</value>
     <comment>Header for a control to toggle whether the notification icon should always be shown.</comment>
   </data>
   <data name="Globals_MinimizeToNotificationArea.Header" xml:space="preserve">
-    <value>Нϊďε Ţέѓmìлаļ ιπ ťнę ⁿöтíƒіćǻťіόπ ăřęд ώнєŋ ĭŧ ίš mιлїmīźэð !!! !!! !!! !!! !!! !!!</value>
+    <value>Ήïδė Ŧěŗмìπàł ïň τħз ⁿøтíƒĩçąтіοй âŕéă ẁћēή ΐť ίś mìлїmïźєđ !!! !!! !!! !!! !!! !!!</value>
     <comment>Header for a control to toggle whether the terminal should hide itself in the notification area instead of the taskbar when minimized.</comment>
   </data>
   <data name="SettingContainer_OverrideMessageBaseLayer" xml:space="preserve">
-    <value>Яěşεŧ ţθ ΐŋђеřіŧēď νãℓųε. !!! !!! !</value>
+    <value>Яėşĕт ťо ίлћėŕίťеď νãľΰę. !!! !!! !</value>
     <comment>This button will remove a user's customization from a given setting, restoring it to the value that the profile inherited. This is a text label on a button.</comment>
   </data>
   <data name="ColorScheme_TerminalColorsHeader.Text" xml:space="preserve">
-    <value>Тёґмιйąľ ćθłόřś !!! !</value>
+    <value>Тêѓmíņäľ ¢бŀòгŝ !!! !</value>
     <comment>A header for a grouping of colors in the color scheme. These colors are used for basic parts of the terminal.</comment>
   </data>
   <data name="ColorScheme_SystemColorsHeader.Text" xml:space="preserve">
-    <value>Şỳŝтĕм ςοŀбŕş !!! </value>
+    <value>Ŝўѕţèm čøĺøгѕ !!! </value>
     <comment>A header for a grouping of colors in the color scheme. These colors are used for functional parts of the terminal.</comment>
   </data>
   <data name="ColorScheme_ColorsHeader.Header" xml:space="preserve">
-    <value>Ćθľöŕś !</value>
+    <value>Ċôŀŏŕŝ !</value>
     <comment>A header for the grouping of colors in the color scheme.</comment>
   </data>
   <data name="SettingContainer_OverrideMessageFragmentExtension" xml:space="preserve">
-    <value>Яęŝёт τǿ νãŀΰз ƒŗőm: {} !!! !!! </value>
+    <value>Γ℮šĕţ τǿ νăļϋè ƒяŏm: {} !!! !!! </value>
     <comment>{} is replaced by the name of another profile or generator. This is a text label on a button that is dynamically generated and provides more context in the {}.</comment>
   </data>
   <data name="Profile_FontFaceShowAllFonts.Content" xml:space="preserve">
-    <value>Šћощ ăłł ƒóņтś !!! !</value>
+    <value>Şħбω ąłļ ƒőňŧś !!! !</value>
     <comment>A supplementary setting to the "font face" setting. Toggling this control updates the font face control to show all of the fonts installed.</comment>
   </data>
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Їƒ èñаьļ℮δ, ѕђоẅ äŀľ ΐņśтªℓĺёď ƒőņτš ίⁿ τћè ŀĭѕţ âъσνê. Φţнëŗшĭşе, óйĺў ŝнøŵ τĥє ĺιśť øƒ мöńоšρäςè ƒòпŧŝ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Įƒ ěлåвℓεď, šħöω ăℓŀ їήšτаļľêð ƒõņŧŝ ίл τне ľíşť ªвσνє. Öťĥέŕωíŝě, ôπľγ ŝĥσẃ ţĥэ ľíѕτ θƒ mōйǿѕφâčз ƒоņτŝ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
   </data>
   <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ċŗέăτэ Λφφёàřāņ¢è !!! !!</value>
+    <value>Çřëаţë Ăφрзαѓăŉ¢έ !!! !!</value>
     <comment>Name for a control which creates an the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
   </data>
   <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>€ř℮àŧë άŋ úņƒоćùŝєð αφрéāґäлčê ƒσґ тћіš ρгŏƒϊļę. Τнΐŝ ŵїĺľ вê τħë дρρěаřªŋçě όƒ тħě ρřоƒΐľė ŵћéл ϊţ ĭŝ įпãċţîνэ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Ċґêâŧέ āл ûηƒοćüšεð аφрěąґªŋčέ ƒòř тнìş φřòƒîľέ. Ţнīѕ ωïĺľ вé ťнē αррêãřªήç℮ οƒ ŧћê ρґőƒίļė ŵħėņ īŧ ίš ïńαčτîν℮. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ď℮ļέŧэ Äφφέăřдπĉę !!! !!</value>
+    <value>Ďєľéтę Āρρєαяâп¢ė !!! !!</value>
     <comment>Name for a control which deletes an the unfocused appearance settings for this profile.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Đέļ℮ťё ţђę цñƒόćũŝĕď ãφрзαŗåŉ¢ē ƒőř ţђїš ρгøƒϊłē. !!! !!! !!! !!! !!!</value>
+    <value>Ðěłêţэ ŧђέ џпƒоćΰѕēď ǻρрέāяāηĉé ƒŏѓ τђįś φřōƒĭŀĕ. !!! !!! !!! !!! !!!</value>
     <comment>A description for what the delete unfocused appearance button does.</comment>
   </data>
   <data name="Actions_DeleteConfirmationButton.Content" xml:space="preserve">
-    <value>¥еš, δέłëţε кéÿ ъіňðīηġ !!! !!! </value>
+    <value>Ýęѕ, ďэļěŧέ ќêý ьïⁿďїňĝ !!! !!! </value>
     <comment>Button label that confirms deletion of a key binding entry.</comment>
   </data>
   <data name="Actions_DeleteConfirmationMessage.Text" xml:space="preserve">
-    <value>Λяз γǿű šůřέ ýόű шåňţ ţο ðēĺĕтё ţнîś кеу вìŋδîлĝ? !!! !!! !!! !!! !!!</value>
+    <value>Άѓє ŷøü şΰŗė ŷóц ẁаńт ťб ðеℓ℮тè ŧђįś κëÿ вΐπðϊńġ? !!! !!! !!! !!! !!!</value>
     <comment>Confirmation message displayed when the user attempts to delete a key binding entry.</comment>
   </data>
   <data name="Actions_InvalidKeyChordMessage" xml:space="preserve">
-    <value>Īņνãŀίδ κєŷ ¢нòгď. Ρłêªѕ℮ зňŧëř à νāŀίđ ķéÿ ċђόґď. !!! !!! !!! !!! !!!</value>
+    <value>Іпνáŀįδ κέу ¢ђòřď. Ρľеαşέ ëπŧзŕ ā νāŀϊđ ķэў čђθґð. !!! !!! !!! !!! !!!</value>
     <comment>Error message displayed when an invalid key chord is input by the user.</comment>
   </data>
   <data name="Actions_RenameConflictConfirmationAcceptButton" xml:space="preserve">
-    <value>Ỳęš </value>
+    <value>Υэŝ </value>
     <comment>Button label that confirms the deletion of a conflicting key binding to allow the current key binding to be registered.</comment>
   </data>
   <data name="Actions_RenameConflictConfirmationMessage" xml:space="preserve">
-    <value>Тђê ρŕόνíđêď ĸęу сĥояð ìś ǻľѓзąδŷ вěϊñğ ùšěð вý ţђě ƒŏŀℓόщíńģ αčŧίôή: !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ţнз рŕǿνĭđêδ κęγ ĉноřď ΐś аŀгèαďý ьеїńġ úśέð ьу ţĥē ƒбľĺõẅΐňĝ ăćŧìôň: !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>Error message displayed when a key chord that is already in use is input by the user. The name of the conflicting key chord is displayed after this message.</comment>
   </data>
   <data name="Actions_RenameConflictConfirmationQuestion" xml:space="preserve">
-    <value>Ẁόŭℓð ýôŭ ľїĸê ťô őνêŗẁґìтé їť? !!! !!! !!!</value>
+    <value>Шőűľđ ỳŏυ ĺïķэ тō όνēѓщřΐтê ιţ? !!! !!! !!!</value>
     <comment>Confirmation message displayed when a key chord that is already in use is input by the user. This is intended to ask the user if they wish to delete the conflicting key binding, and assign the current key chord (or binding) instead. This is presented in the context of Actions_RenameConflictConfirmationMessage. The subject of this sentence is the object of that one.</comment>
   </data>
   <data name="Actions_UnnamedCommandName" xml:space="preserve">
-    <value>&lt;ũήηаmэď čòmмăйđ&gt; !!! !!</value>
+    <value>&lt;цŉňαmеδ ĉŏmмάŋð&gt; !!! !!</value>
     <comment>{Locked="&lt;"} {Locked="&gt;"} The text shown when referring to a command that is unnamed.</comment>
   </data>
   <data name="Actions_AcceptButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ăс¢ēрť !</value>
+    <value>Ăç¢еρт !</value>
     <comment>Text label for a button that can be used to accept changes to a key binding entry.</comment>
   </data>
   <data name="Actions_CancelButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ĉάήĉĕľ !</value>
+    <value>Çäňçèĺ !</value>
     <comment>Text label for a button that can be used to cancel changes to a key binding entry</comment>
   </data>
   <data name="Actions_DeleteButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ðзľęτе !</value>
+    <value>Đēŀéт℮ !</value>
     <comment>Text label for a button that can be used to delete a key binding entry.</comment>
   </data>
   <data name="Actions_EditButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Έđΐŧ !</value>
+    <value>Σδĩţ !</value>
     <comment>Text label for a button that can be used to begin making changes to a key binding entry.</comment>
   </data>
   <data name="Actions_AddNewTextBlock.Text" xml:space="preserve">
-    <value>Άďð ŋзш !!</value>
+    <value>Дδđ ñėώ !!</value>
     <comment>Button label that creates a new action on the actions page.</comment>
   </data>
   <data name="Actions_ActionComboBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Åсţїòη !</value>
+    <value>Α¢тίōй !</value>
     <comment>Label for a control that sets the action of a key binding.</comment>
   </data>
   <data name="KeyChordListener.[using:Windows.UI.Xaml.Automation]AutomationProperties.HelpText" xml:space="preserve">
-    <value>Ĩñφΰţ ўθűř ðέšιѓĕđ κ℮ýьόαŗđ śĥōřŧčŭŧ. !!! !!! !!! !!</value>
+    <value>Ійрûť ýőџѓ ďеśîґеδ кĕÿьôǻґđ ŝнόґŧĉüτ. !!! !!! !!! !!</value>
     <comment>Help text directing users how to use the "KeyChordListener" control. Pressing a keyboard shortcut will be recorded by this control.</comment>
   </data>
   <data name="KeyChordListener.[using:Windows.UI.Xaml.Automation]AutomationProperties.LocalizedControlType" xml:space="preserve">
-    <value>şћσяŧçűт łīѕŧзлëя !!! !!</value>
+    <value>ŝћøŕтςųţ ℓįŝтèŉêŗ !!! !!</value>
     <comment>The control type for a control that awaits keyboard input and records it.</comment>
   </data>
   <data name="KeyChordListener.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Śћôŗτċύŧ !!</value>
+    <value>Şħōяŧ¢цτ !!</value>
     <comment>The label for a "key chord listener" control that sets the keys a key binding is bound to.</comment>
   </data>
   <data name="Appearance_TextFormattingHeader.Text" xml:space="preserve">
-    <value>Τěхţ ₣θŗmάţŧΐŋģ !!! !</value>
+    <value>Ťĕхτ ₣ôямåτţίŉğ !!! !</value>
     <comment>Header for a control to how text is formatted</comment>
   </data>
   <data name="Appearance_IntenseTextStyle.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Íήťêŉŝē τε×т śтўŀë !!! !!</value>
+    <value>Ϊηŧэйšè ŧзжт şťÿĺë !!! !!</value>
     <comment>Name for a control to select how "intense" text is formatted (bold, bright, both or none)</comment>
   </data>
   <data name="Appearance_IntenseTextStyle.Header" xml:space="preserve">
-    <value>Ίŋтēņšе ŧєжť ŝτỳłē !!! !!</value>
+    <value>Ĭиτзиśě τёжт şτўĺє !!! !!</value>
     <comment>Header for a control to select how "intense" text is formatted (bold, bright, both or none)</comment>
   </data>
   <data name="Appearance_IntenseTextStyleNone.Content" xml:space="preserve">
-    <value>Νõńё !</value>
+    <value>∏őйě !</value>
     <comment>An option to choose from for the "intense text format" setting. When selected, "intense" text will not be rendered differently</comment>
   </data>
   <data name="Appearance_IntenseTextStyleBold.Content" xml:space="preserve">
-    <value>Бσłđ ƒòŉŧ !!!</value>
+    <value>Ьθℓď ƒσŉŧ !!!</value>
     <comment>An option to choose from for the "intense text format" setting. When selected, "intense" text will be rendered as bold text</comment>
   </data>
   <data name="Appearance_IntenseTextStyleBright.Content" xml:space="preserve">
-    <value>ßŗΐğћŧ ĉοĺσŗŝ !!! </value>
+    <value>βгïĝĥт çőĺǿгş !!! </value>
     <comment>An option to choose from for the "intense text format" setting. When selected, "intense" text will be rendered in a brighter color</comment>
   </data>
   <data name="Appearance_IntenseTextStyleAll.Content" xml:space="preserve">
-    <value>Ьоľð ƒθиτ ώίŧћ вгĩĝĥť ¢σĺöřѕ !!! !!! !!</value>
+    <value>Βοŀð ƒόπť ωіŧĥ вгϊģћţ čõĺόřş !!! !!! !!</value>
     <comment>An option to choose from for the "intense text format" setting. When selected, "intense" text will be rendered as both bold text and in a brighter color</comment>
   </data>
   <data name="Globals_AutoHideWindow.Header" xml:space="preserve">
-    <value>Δύτômáťї¢äℓĺŷ ћįďэ ŵîηđøш !!! !!! !</value>
+    <value>Ǻùţόmǻŧіĉąĺĺỳ ħíďз ώìñδǿẅ !!! !!! !</value>
     <comment>Header for a control to toggle the "Automatically hide window" setting. If enabled, the terminal will be hidden as soon as you switch to another window.</comment>
   </data>
   <data name="Globals_AutoHideWindow.HelpText" xml:space="preserve">
-    <value>Іƒ ėπąьľéđ, ťћë ťëřmíπăŀ ẁїļł ь℮ ћιðð℮ñ āŝ ѕбóň ăŝ γöŭ ѕщĭť¢ĥ τò áйόтĥзґ ẅіňδóш. !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Įƒ εⁿàъļêď, тђĕ ťέґmιпäļ щìℓŀ ъэ нîďδзñ ąś ѕõθŋ âş γôù śшίτċн ťø àпøťнзř шíήðόщ. !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "Automatically hide window" setting does.</comment>
   </data>
   <data name="ColorScheme_DeleteDisclaimerInBox" xml:space="preserve">
-    <value>Ŧћϊš ĉбļōг ŝ¢ħęмé ¢ăňņöţ ъє δěłèť℮đ ьєçªúšё īŧ íş ίⁿςłůđėđ ъÿ ðéƒãμℓт. !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ťĥíŝ ćσľõѓ şсħéмэ ĉãйпόŧ в℮ δεĺёт℮ð ьèċàцśě îţ ìš іŋçļųďĕđ вý đ℮ƒдџļť. !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>Disclaimer presented near the controls to delete the selected color scheme when that functionality is disabled.</comment>
   </data>
   <data name="ColorScheme_RenameDisclaimerInBox" xml:space="preserve">
-    <value>Ťћΐš ċôŀöŕ ŝĉħēmê ċαήπǿţ вê ѓёñåmеď ъēсάµšé įţ îŝ īπçℓŭđêδ ьу δěƒаūŀť. !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ŧĥιѕ сбĺθѓ ś¢ĥěмэ ĉαлήôť вė ŕ℮ňąmëđ ь℮ςăΰśĕ ĩт ìš ϊņċĺμďĕđ ъỳ đέƒãüłτ. !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>Disclaimer presented near the controls to rename the color scheme when that functionality is disabled.</comment>
   </data>
   <data name="ColorScheme_DefaultTag.Text" xml:space="preserve">
-    <value>ðεƒáΰŀτ !!</value>
+    <value>ðéƒαųŀť !!</value>
     <comment>Text label displayed adjacent to a "color scheme" entry signifying that it is currently set as the default color scheme to be used.</comment>
   </data>
   <data name="ColorScheme_SetAsDefaultButton.Content" xml:space="preserve">
-    <value>Śėŧ áŝ ďĕƒâųłτ !!! !</value>
+    <value>Şëť åѕ ďзƒªџŀτ !!! !</value>
     <comment>Text label for a button that, when invoked, sets the selected color scheme as the default scheme to use.</comment>
   </data>
   <data name="Globals_ConfirmCloseAllTabs.Header" xml:space="preserve">
-    <value>Ẅąřп ώнêń сłόšίлģ mŏяé τћăŉ òлэ τªь !!! !!! !!! !</value>
+    <value>Ẃářй ẅђëπ ĉľôśĩήĝ mǿѓĕ тĥąπ òπё τάь !!! !!! !!! !</value>
     <comment>Header for a control to toggle whether to show a confirm dialog box when closing the application with multiple tabs open.</comment>
   </data>
   <data name="Settings_PortableModeNote.Text" xml:space="preserve">
-    <value>Ẁïηðоẁѕ Тĕřмĭиαľ ίş ѓùņŋїŉġ їŋ ρоřţäъĺэ mőðе. !!! !!! !!! !!! !</value>
+    <value>Ẅїηðσшѕ Ţеřmíńăľ īѕ ґϋййïŉģ ĭņ рόѓťáъℓė mōďе. !!! !!! !!! !!! !</value>
     <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder.</comment>
   </data>
   <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve">
@@ -1762,15 +1794,15 @@
     <comment>{Locked}</comment>
   </data>
   <data name="Settings_PortableModeInfoLinkTextRun.Text" xml:space="preserve">
-    <value>₤ěªѓл mŏřе. !!!</value>
+    <value>Ļĕдŗⁿ мõгĕ. !!!</value>
     <comment>A hyperlink displayed near Settings_PortableModeNote.Text that the user can follow for more information.</comment>
   </data>
   <data name="Profile_FontFace_ProportionalFontWarning.Title" xml:space="preserve">
-    <value>Ẃåяņĭηğ: !!</value>
+    <value>Ẃãялíŉĝ: !!</value>
     <comment>Title for the warning info bar used when a non monospace font face is chosen to indicate that there may be visual artifacts</comment>
   </data>
   <data name="Profile_FontFace_ProportionalFontWarning.Message" xml:space="preserve">
-    <value>Čћōбŝїпģ ā ⁿбņ-móήǿŝрąċеď ƒσиŧ ωίľℓ ľїĸєľў ŕēŝџĺţ íñ νіšΰâŀ ªгтΐƒãςτš. Ųѕе ąτ ỳóũѓ όẃň ðĭѕĉѓēτĭõń. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>€ħσõśïŉğ ą ñой-мõποşφãĉєδ ƒŏŋţ ẅіľľ łîķέℓў ŕєŝùłţ íй νΐşūαℓ āѓťīƒдςţŝ. Џŝè àţ ÿοùŗ øẁη δíśčґ℮ťîбņ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>Warning info bar used when a non monospace font face is chosen to indicate that there may be visual artifacts</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
@@ -118,788 +118,788 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AddProfile_AddNewButton.Tag" xml:space="preserve">
-    <value>Čяёατé Νêŵ Ъũťτøή !!! !!</value>
+    <value>Čгéªţë Ŋещ Бϋτţбⁿ !!! !!</value>
   </data>
   <data name="AddProfile_AddNewTextBlock.Text" xml:space="preserve">
-    <value>Νěω éмρтŷ рřøƒįĺé !!! !!</value>
+    <value>Ŋ℮ω ĕmρŧý рŗőƒîļё !!! !!</value>
     <comment>Button label that creates a new profile with default settings.</comment>
   </data>
   <data name="AddProfile_Duplicate.Header" xml:space="preserve">
-    <value>Ðũрļìćατé ª ряσƒīℓ℮ !!! !!!</value>
+    <value>Ďύφľίċåте ã φґǿƒïłē !!! !!!</value>
     <comment>This is the header for a control that lets the user duplicate one of their existing profiles.</comment>
   </data>
   <data name="AddProfile_DuplicateButton.Tag" xml:space="preserve">
-    <value>Ðџφłįĉǻţе Βμтťθñ !!! !</value>
+    <value>Ðùρłīĉāţз Вµτŧσň !!! !</value>
   </data>
   <data name="AddProfile_DuplicateTextBlock.Text" xml:space="preserve">
-    <value>Ðџρĺĭĉãţε !!!</value>
+    <value>Đŭρŀī¢ατê !!!</value>
     <comment>Button label that duplicates the selected profile and navigates to the duplicate's page.</comment>
   </data>
   <data name="ColorScheme_InboxSchemeDuplicate.Header" xml:space="preserve">
-    <value>Τĥìѕ ςõļōř şснэmё їś φäřт оƒ ţђĕ ъϋīľŧ-ìŉ şéŧťΐлğѕ ŏř ай īйѕτáľľэδ ёжťзŉѕĭŏи !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ţħīѕ ċøłǿґ ŝςħèм℮ îś рăŗţ õƒ тнè ъûĩľт-íπ śéţťΐлĝś õř дŋ íńşťªłĺèð èжťęлşίοη !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment></comment>
   </data>
   <data name="ColorScheme_InboxSchemeDuplicate.HelpText" xml:space="preserve">
-    <value>Ŧб мǻκë ćнàŉģěş τθ ţнïś ¢õĺòŕ ščĥêmë, γòũ mŭšť мăκę ą ćοφŷ öƒ īт. !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ţό màќз ¢ћдņĝзş тő ťђїš ĉǿℓöř śсђзmė, ÿŏú мũŝт măĸę α сòφў σƒ ΐť. !!! !!! !!! !!! !!! !!! !</value>
     <comment></comment>
   </data>
   <data name="ColorScheme_DuplicateButton.Content" xml:space="preserve">
-    <value>Μåκę α ċθрỳ !!!</value>
+    <value>Маĸέ α ċōρý !!!</value>
     <comment>This is a call to action; the user can click the button to make a copy of the current color scheme.</comment>
   </data>
   <data name="ColorScheme_SetAsDefault.Header" xml:space="preserve">
-    <value>Šéţ ¢θļǿŗ šĉђєме ąş đёƒдųľţ !!! !!! !!</value>
+    <value>Śèţ ćŏŀθґ šςħëmĕ âŝ δĕƒдϋŀţ !!! !!! !!</value>
     <comment>This is the header for a control that allows the user to set the currently selected color scheme as their default.</comment>
   </data>
   <data name="ColorScheme_SetAsDefault.HelpText" xml:space="preserve">
-    <value>∆ρрĺγ тћїš ċбłøř şĉħēmĕ τō áŀł ỳǿüг ρґôƒíľέś, вŷ ďėƒªüłт. Ĩⁿðĩνϊďùãľ ρŗōƒìľèş сαп ŝтΐľĺ šзℓëĉт тћέįŗ ŏώñ сöłòŗ ščнëмěş. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Áφρļу τђìš čǿℓóѓ ѕςĥеmё ţò âļℓ ўσùґ φѓôƒίļеš, ъÿ ðεƒăŭļŧ. Īиðїνιďμäĺ φяöƒíłĕš çǻп şťíĺļ ŝзĺëĉτ тнĕιř ǿшŋ сόļöѓ şčĥêмέѕ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A description explaining how this control changes the user's default color scheme.</comment>
   </data>
   <data name="ColorScheme_Rename.Header" xml:space="preserve">
-    <value>Яэńдmê ¢òłŏŗ śςнęмê !!! !!!</value>
+    <value>Ŕêпªmè сθłόя ŝçħémë !!! !!!</value>
     <comment>This is the header for a control that allows the user to rename the currently selected color scheme.</comment>
   </data>
   <data name="ColorScheme_Background.Text" xml:space="preserve">
-    <value>Вâċĸģŕòůñδ !!!</value>
+    <value>Ъāċкġřőůņð !!!</value>
     <comment>This is the header for a control that lets the user select the background color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_Black.Text" xml:space="preserve">
-    <value>Вľäčќ !</value>
+    <value>Вľд¢κ !</value>
     <comment>This is the header for a control that lets the user select the black color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_Blue.Text" xml:space="preserve">
-    <value>Ьℓů℮ !</value>
+    <value>Ьĺųε !</value>
     <comment>This is the header for a control that lets the user select the blue color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_BrightBlack.Text" xml:space="preserve">
-    <value>Βѓïĝнť вļàčķ !!! </value>
+    <value>Ьŗίĝħť ьľā¢к !!! </value>
     <comment>This is the header for a control that lets the user select the bright black color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_BrightBlue.Text" xml:space="preserve">
-    <value>Ьяìğћτ ъļΰэ !!!</value>
+    <value>βґίġнť вŀµё !!!</value>
     <comment>This is the header for a control that lets the user select the bright blue color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_BrightCyan.Text" xml:space="preserve">
-    <value>Ъѓīğнŧ ĉỳâп !!!</value>
+    <value>Вяίģћŧ ĉуǻл !!!</value>
     <comment>This is the header for a control that lets the user select the bright cyan color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_BrightGreen.Text" xml:space="preserve">
-    <value>Βŕίġнť ĝŗèεň !!! </value>
+    <value>ßѓΐĝђŧ ğґęêп !!! </value>
     <comment>This is the header for a control that lets the user select the bright green color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_BrightPurple.Text" xml:space="preserve">
-    <value>Бґїĝĥť рџŗрŀ℮ !!! </value>
+    <value>Бяīğнŧ ρùŗрľĕ !!! </value>
     <comment>This is the header for a control that lets the user select the bright purple color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_BrightRed.Text" xml:space="preserve">
-    <value>Бѓíģћт ґёđ !!!</value>
+    <value>Ъŕίğћт гėđ !!!</value>
     <comment>This is the header for a control that lets the user select the bright red color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_BrightWhite.Text" xml:space="preserve">
-    <value>Бяìġђŧ ẃнįτë !!! </value>
+    <value>Ьгīģђţ ωђĭτê !!! </value>
     <comment>This is the header for a control that lets the user select the bright white color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_BrightYellow.Text" xml:space="preserve">
-    <value>Бŗιģнť ŷëľłòщ !!! </value>
+    <value>Вříĝħŧ ÿéĺĺóẃ !!! </value>
     <comment>This is the header for a control that lets the user select the bright yellow color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_CursorColor.Text" xml:space="preserve">
-    <value>Ĉúґšŏř ċôľθŗ !!! </value>
+    <value>Ćμŕšσґ ćθŀθя !!! </value>
     <comment>This is the header for a control that lets the user select the text cursor's color displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_Cyan.Text" xml:space="preserve">
-    <value>€ŷαп !</value>
+    <value>Сÿāⁿ !</value>
     <comment>This is the header for a control that lets the user select the cyan color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_Foreground.Text" xml:space="preserve">
-    <value>₣ǿŕέġŕōцņδ !!!</value>
+    <value>₣οŕėĝřσűлđ !!!</value>
     <comment>This is the header for a control that lets the user select the foreground color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_Green.Text" xml:space="preserve">
-    <value>Ğяĕεή !</value>
+    <value>Ġязêή !</value>
     <comment>This is the header for a control that lets the user select the green color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_Purple.Text" xml:space="preserve">
-    <value>Ρϋгрŀέ !</value>
+    <value>Рµгρļě !</value>
     <comment>This is the header for a control that lets the user select the purple color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_SelectionBackground.Text" xml:space="preserve">
-    <value>Śέľéςτїóи ъāčķĝřøüπđ !!! !!!</value>
+    <value>Š℮ŀзςŧίθл ьâĉĸġřōŭńδ !!! !!!</value>
     <comment>This is the header for a control that lets the user select the background color for selected text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_Red.Text" xml:space="preserve">
-    <value>Гēð </value>
+    <value>Ŗ℮ď </value>
     <comment>This is the header for a control that lets the user select the red color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_White.Text" xml:space="preserve">
-    <value>Ŵħΐťě !</value>
+    <value>Щнϊтè !</value>
     <comment>This is the header for a control that lets the user select the white color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_Yellow.Text" xml:space="preserve">
-    <value>Ỳεľĺŏώ !</value>
+    <value>Υéĺľоŵ !</value>
     <comment>This is the header for a control that lets the user select the yellow color for text displayed on the screen.</comment>
   </data>
   <data name="Globals_Language.Header" xml:space="preserve">
-    <value>Łáпġŭǻğέ (геqúіґēѕ ŗэŀāūńćĥ) !!! !!! !!</value>
+    <value>Ŀąŉģüǻğз (řêqџĭŗэś яёłдũⁿ¢ħ) !!! !!! !!</value>
     <comment>The header for a control allowing users to choose the app's language.</comment>
   </data>
   <data name="Globals_Language.HelpText" xml:space="preserve">
-    <value>Ŝëĺё¢ţş ă đΐŝφłдў łąйğűäĝė ƒбř τћз ąφрľíςāťΐöη. Ťĥįš шΐłļ öν℮ŗŗϊδė ỳθϋŗ ď℮ƒдύłт Windows ϊиţěґƒдçē ľăŉģúåğê. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Ѕęļéćŧѕ ā ďįŝρℓду łàйģцâğέ ƒǿř ťћз ǻρрľïčдŧíòŉ. Ťħϊş ωіŀľ όνëґŗίďē уǿüř ďèƒăμľţ Ẃïñďбŵś įñτéŗƒαсэ ŀåŋġύдğé. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>A description explaining how this control changes the app's language. {Locked="Windows"}</comment>
   </data>
   <data name="Globals_LanguageDefault" xml:space="preserve">
-    <value>Ųšέ ѕŷşτėm ðêƒåųℓτ !!! !!</value>
+    <value>Ůŝê ѕŷŝτėм đєƒāùľŧ !!! !!</value>
     <comment>The app contains a control allowing users to choose the app's language. If this value is chosen, the language preference list of the system settings is used instead.</comment>
   </data>
   <data name="Globals_AlwaysShowTabs.Header" xml:space="preserve">
-    <value>Ãĺωáÿś şĥοш тáвѕ !!! !</value>
+    <value>Άľώāŷš şђǿŵ тãвŝ !!! !</value>
     <comment>Header for a control to toggle if the app should always show the tabs (similar to a website browser).</comment>
   </data>
   <data name="Globals_AlwaysShowTabs.HelpText" xml:space="preserve">
-    <value>Ŵђěη ðΐśàьľėð, ŧћ℮ τаъ ьáг ŵïĺℓ ąρρêαґ щħěи á ñзш ţăв ιѕ сŕёάť℮đ. Çăññбτ вέ đĭѕдьłєδ ẅћιłэ "Ήįđё ŧнĕ тїτĺĕ вǻř" ĩş Óη. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Шħεń ďίѕªъľеð, ţĥё ŧāъ ъаŕ ώіļℓ аρρëâř ẃн℮ŋ ª ŋëẁ ťаъ ιš сгęǻţеď. Ćâиňбŧ ьε ďîśαъŀ℮đ ωħϊŀē "Ĥίδē τђę ţĭτľέ ъάѓ" įś Ωń. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>A description for what the "always show tabs" setting does. Presented near "Globals_AlwaysShowTabs.Header". This setting cannot be disabled while "Globals_ShowTitlebar.Header" is enabled.</comment>
   </data>
   <data name="Globals_NewTabPosition.Header" xml:space="preserve">
-    <value>Рøšįтíóñ бƒ ňêẁĺў ċŕėâŧêδ τąъѕ !!! !!! !!!</value>
+    <value>Ρόšîŧϊøņ őƒ йĕŵℓу ĉřēάţεđ τдьš !!! !!! !!!</value>
     <comment>Header for a control to select position of newly created tabs.</comment>
   </data>
   <data name="Globals_NewTabPosition.HelpText" xml:space="preserve">
-    <value>Ѕφéсίƒįêś ẁнэґε пέώ τàьŝ âρφзаŗ įπ τћē τàь гθω. !!! !!! !!! !!! !!</value>
+    <value>Śφзćїƒíеş шĥëřē ⁿêŵ τâъś ªρρёáґ ĭп тћé τåв яøш. !!! !!! !!! !!! !!</value>
     <comment>A description for what the "Position of newly created tabs" setting does.</comment>
   </data>
   <data name="Globals_NewTabPositionAfterLastTab.Content" xml:space="preserve">
-    <value>Ǻƒŧέŕ ţĥè ŀąŝŧ ταь !!! !!</value>
+    <value>Äƒτёř ţнė ĺąśţ τаъ !!! !!</value>
     <comment>An option to choose from for the "Position of newly created tabs" setting. When selected new tab appears after the last tab.</comment>
   </data>
   <data name="Globals_NewTabPositionAfterCurrentTab.Content" xml:space="preserve">
-    <value>Åƒŧеř тћë ¢ϋřřēⁿτ ťāь !!! !!!</value>
+    <value>Αƒŧëѓ ťнė сúѓŗėπτ τăъ !!! !!!</value>
     <comment>An option to choose from for the "Position of newly created tabs" setting. When selected new tab appears after the current tab.</comment>
   </data>
   <data name="Globals_CopyOnSelect.Header" xml:space="preserve">
-    <value>Ãûτθмáτìςãŀļỳ ¢ǿрŷ ѕзĺэçтíοŉ τó сłìρъбäґđ !!! !!! !!! !!!</value>
+    <value>Āúтǿmаţιĉąľľў сοφý şèℓэċтïøñ ţō ĉļĩρьóąґď !!! !!! !!! !!!</value>
     <comment>Header for a control to toggle whether selected text should be copied to the clipboard automatically, or not.</comment>
   </data>
   <data name="Globals_DetectURLs.Header" xml:space="preserve">
-    <value>Ăΰťóмªťίčдļĺγ δ℮ťĕčţ ÜЃĻš āηð mâĸέ тћêm ςĺι¢ķáьŀ℮ !!! !!! !!! !!! !!!</value>
+    <value>Λυτοмдτìćăŀŀÿ đзťēćτ ЦŖĿš аňđ máĸë ţнэм сŀĭçќάвłĕ !!! !!! !!! !!! !!!</value>
     <comment>Header for a control to toggle whether the terminal should automatically detect URLs and make them clickable, or not.</comment>
   </data>
   <data name="Globals_TrimBlockSelection.Header" xml:space="preserve">
-    <value>Ґěmøνë ţяâīľìйġ ẃнιтê-ŝφáĉз ĭŋ геćταņĝűĺдѓ šēĺéçŧĩоñ !!! !!! !!! !!! !!! </value>
+    <value>Ѓëmονĕ тŕáìĺїŉġ ẃђϊτë-ѕρá¢ę ĭл ѓеċτåηğцĺăŗ ş℮ŀěčŧĭõň !!! !!! !!! !!! !!! </value>
     <comment>Header for a control to toggle whether a text selected with block selection should be trimmed of white spaces when copied to the clipboard, or not.</comment>
   </data>
   <data name="Globals_TrimPaste.Header" xml:space="preserve">
-    <value>Гęмőνĕ ťŕąιℓíŋģ шнîŧέ-ѕрăċ℮ ŵђεл φªşţíήĝ !!! !!! !!! !!!</value>
+    <value>Ґεmθνе ťѓªįŀíŉĝ шĥіťе-šрäčė ẃнзň φâśťίņġ !!! !!! !!! !!!</value>
     <comment>Header for a control to toggle whether pasted text should be trimmed of white spaces, or not.</comment>
   </data>
   <data name="Globals_KeybindingsDisclaimer.Text" xml:space="preserve">
-    <value>βєłōщ ãŕ℮ ŧђė ςũѓґэñτĺý вǿµήď кëỳѕ, ŵђΐĉђ ¢ąή вé mǿđíƒίєď ьў éđīţĩņğ тħз ЈŚÖŅ şêŧŧĩήĝş ƒιłē. !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Вêļσώ áяэ τĥє сûѓгεπтľý ъόůηð κєÿş, ώĥīćн čāñ ъз мοðïƒīěð ьý зðїŧįńģ τћė ЈŜÖΝ şзťŧίñğѕ ƒΐłέ. !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>A disclaimer located at the top of the actions page that presents the list of keybindings.</comment>
   </data>
   <data name="Globals_DefaultProfile.Header" xml:space="preserve">
-    <value>Ďєƒαΰľτ φѓŏƒїĺē !!! !</value>
+    <value>Đėƒªûľť рґøƒϊľê !!! !</value>
     <comment>Header for a control to select your default profile from the list of profiles you've created.</comment>
   </data>
   <data name="Globals_DefaultProfile.HelpText" xml:space="preserve">
-    <value>Ргôƒïļέ ŧћǻţ öφéńş ẃћėи ¢łιĉĸĭπĝ τђё '+' įĉóŋ ôř ьγ ťўφíήġ ŧħε ηзщ τāв ķзÿ ъíňδįňġ. !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Ρŗσƒιℓê тнǻт ōреŋś ώнèи ¢ļíčкïñğ ťћέ '+' ίçôи ŏґ ьў ţýрϊńğ тĥє ņěẁ тªв ќèý ъϊήðїńġ. !!! !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>A description for what the default profile is and when it's used.</comment>
   </data>
   <data name="Globals_DefaultTerminal.Header" xml:space="preserve">
-    <value>Đеƒдûľť ťĕřmìηáł αφрŀіćàţīθñ !!! !!! !!</value>
+    <value>Ðêƒάϋℓτ ŧέřmìпάℓ аρφĺΐςàţїōŋ !!! !!! !!</value>
     <comment>Header for a drop down that permits the user to select which installed Terminal application will launch when command line tools like CMD are run from the Windows Explorer run box or start menu or anywhere else that they do not already have a graphical window assigned.</comment>
   </data>
   <data name="Globals_DefaultTerminal.HelpText" xml:space="preserve">
-    <value>Ţнė τěŗmĭηдŀ äρφłïćāτíøи тħąţ ℓдũŋčħèś шћэņ ā çσmмάⁿđ-ľĭйé ǻρрłί¢ąţìŏл īś ґūⁿ ώîτĥöυţ āή ēхîśтίηģ ŝëśѕïοή, ĺікè ƒřбм ŧĥė Ŝтªгт Μëпū σя Ŕùŉ đίдľôġ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ťђě ţэřмīηãĺ ǻφφℓï¢ǻтΐбň ŧђáт łáůйčĥēś ẅĥэп ā сöмmǻńđ-ľіŉэ ăρρĺįċāτΐôⁿ ϊš яųñ шíţћöυţ ªņ ĕхϊŝŧĭñğ şěŝѕïŏπ, ŀĩĸė ƒѓом ţћĕ Ŝτáґт Μęπü бг Яųņ ďīäℓöğ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
   <data name="Globals_ForceFullRepaint.Header" xml:space="preserve">
-    <value>Ŕεðŕåŵ эηťĩřё śċяеёπ ωћęñ ðіşрŀâŷ υφđãŧēş !!! !!! !!! !!!</value>
+    <value>Ŗёδѓªŵ еñţιŗę šĉřέëŋ шн℮й đĩşρℓâў υρďάţëš !!! !!! !!! !!!</value>
     <comment>Header for a control to toggle the "force full repaint" setting. When enabled, the app renders new content between screen frames.</comment>
   </data>
   <data name="Globals_ForceFullRepaint.HelpText" xml:space="preserve">
-    <value>Ẁĥĕŋ ďιśàвłèđ, ŧђ℮ ŧēяmíπäŀ ẁįłļ ѓēŉďεř ǿиłý ťħё цφđατèѕ ťǿ ŧħє ŝçŗēěń ьеŧщєęⁿ ƒŗăмéş. !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Щħ℮п đįѕāъĺèđ, ťђέ тèřмΐņäľ ωìľľ řεŉďęŗ όŉľŷ ŧђέ ŭρďăţзŝ τö ŧђë šсгèзņ вêţшзэŉ ƒяāméş. !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "force full repaint" setting does. Presented near "Globals_ForceFullRepaint.Header".</comment>
   </data>
   <data name="Globals_InitialCols.Text" xml:space="preserve">
-    <value>€õľümŋѕ !!</value>
+    <value>Ċσŀùмñѕ !!</value>
     <comment>Header for a control to choose the number of columns in the terminal's text grid.</comment>
   </data>
   <data name="Globals_InitialRows.Text" xml:space="preserve">
-    <value>Ŕőŵš !</value>
+    <value>Ѓõшŝ !</value>
     <comment>Header for a control to choose the number of rows in the terminal's text grid.</comment>
   </data>
   <data name="Globals_InitialColsBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ίŉįτĩáł Сõľџмⁿŝ !!! !</value>
+    <value>Îйϊŧìãľ Çòłųмπş !!! !</value>
     <comment>Name for a control to choose the number of columns in the terminal's text grid.</comment>
   </data>
   <data name="Globals_InitialRowsBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Īиįťϊâľ Ґбώѕ !!! </value>
+    <value>İńìťîáℓ Ŕőώś !!! </value>
     <comment>Name for a control to choose the number of rows in the terminal's text grid.</comment>
   </data>
   <data name="Globals_InitialPosX.Text" xml:space="preserve">
-    <value>Ж рǿşіŧіση !!!</value>
+    <value>χ φόśΐтįóñ !!!</value>
     <comment>Header for a control to choose the X coordinate of the terminal's starting position.</comment>
   </data>
   <data name="Globals_InitialPosY.Text" xml:space="preserve">
-    <value>Ỳ рθѕîţїõŉ !!!</value>
+    <value>Ỳ φôѕΐтĩσп !!!</value>
     <comment>Header for a control to choose the Y coordinate of the terminal's starting position.</comment>
   </data>
   <data name="Globals_InitialPosXBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Χ φοśїтіôŉ !!!</value>
+    <value>χ φŏѕĭтϊόŋ !!!</value>
     <comment>Name for a control to choose the X coordinate of the terminal's starting position.</comment>
   </data>
   <data name="Globals_InitialPosXBox.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ёŉŧзг ťĥė ναľŭє ƒбґ ŧħê ж-¢όøŗδїпªтэ. !!! !!! !!! !!</value>
+    <value>Ëŉŧëř ţнę νáľυé ƒóŗ τђę х-čōóѓđΐήâтë. !!! !!! !!! !!</value>
     <comment>Tooltip for the control that allows the user to choose the X coordinate of the terminal's starting position.</comment>
   </data>
   <data name="Globals_InitialPosXBox.PlaceholderText" xml:space="preserve">
-    <value>Ж</value>
+    <value>Χ</value>
     <comment>The string to be displayed when there is no current value in the x-coordinate number box.</comment>
   </data>
   <data name="Globals_InitialPosYBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Υ роśїтΐóń !!!</value>
+    <value>Ỳ ρθŝìŧιοπ !!!</value>
     <comment>Name for a control to choose the Y coordinate of the terminal's starting position.</comment>
   </data>
   <data name="Globals_InitialPosYBox.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Еňτéг ŧħз νäľűε ƒόŕ ŧнэ ý-ςбοřδϊňªţé. !!! !!! !!! !!</value>
+    <value>Ёйŧëŕ ţћε νàłüέ ƒòŕ ťĥє ỳ-čоθґδĩπāтė. !!! !!! !!! !!</value>
     <comment>Tooltip for the control that allows the user to choose the Y coordinate of the terminal's starting position.</comment>
   </data>
   <data name="Globals_InitialPosYBox.PlaceholderText" xml:space="preserve">
-    <value>Ỳ</value>
+    <value>Ў</value>
     <comment>The string to be displayed when there is no current value in the y-coordinate number box.</comment>
   </data>
   <data name="Globals_DefaultLaunchPositionCheckbox.Content" xml:space="preserve">
-    <value>Ľēŧ Шĩŋďöщş ďėĉįďэ !!! !!</value>
+    <value>₤êτ Ẃĩиðōẁŝ ðē¢îðε !!! !!</value>
     <comment>A checkbox for the "launch position" setting. Toggling this control sets the launch position to whatever the Windows operating system decides.</comment>
   </data>
   <data name="Globals_DefaultLaunchPositionCheckbox.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Īƒ éπāъĺеđ, ûşë ţћē šγşтēm ðėƒâúľŧ ŀăúŉĉћ ρθšιťίôŉ. !!! !!! !!! !!! !!!</value>
+    <value>Іƒ éлдъłëđ, úśз тђé ѕýŝт℮m δέƒăµłŧ łäúηćћ φöšïţϊóň. !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "default launch position" checkbox does. Presented near "Globals_DefaultLaunchPositionCheckbox".</comment>
   </data>
   <data name="Globals_FirstWindowPreference.Header" xml:space="preserve">
-    <value>Ẁĥěи Ţ℮řміŋąĺ šťǻřţŝ !!! !!!</value>
+    <value>Ẃђéñ Ţëгмїńªĺ ѕťářтš !!! !!!</value>
     <comment>Header for a control to select how the terminal should load its first window.</comment>
   </data>
   <data name="Globals_FirstWindowPreference.HelpText" xml:space="preserve">
-    <value>Ẁћáţ śћόũļď ъ℮ ŝħóωη ώћêñ ŧĥè ƒïŗŝт ţëřмїйāł īś сř℮ăтέδ. !!! !!! !!! !!! !!! !</value>
+    <value>Ẁђăт şĥõцĺð вε ѕнбшп ẁћёй ťђё ƒîŗŝт тěřмΐйåł їś сѓéąţзď. !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="Globals_FirstWindowPreferenceDefaultProfile.Content" xml:space="preserve">
-    <value>Όρèń α ŧãв ώΐŧĥ ŧђę ďėƒáџľť φѓőƒïł℮ !!! !!! !!! !</value>
+    <value>Οрзη à ťáь ώΐţĥ ţђè δεƒāűĺţ ρяθƒίłё !!! !!! !!! !</value>
     <comment>An option to choose from for the "First window preference" setting. Open the default profile.</comment>
   </data>
   <data name="Globals_FirstWindowPreferencePersistedWindowLayout.Content" xml:space="preserve">
-    <value>Ôрêή ẃιŉďøωѕ ƒяőm а ρřëνΐŏũѕ şέśśĭóň !!! !!! !!! !</value>
+    <value>Орéŋ ẅϊηďóωš ƒřōm ă φяèνιôùś şęŝśîőň !!! !!! !!! !</value>
     <comment>An option to choose from for the "First window preference" setting. Reopen the layouts from the last session.</comment>
   </data>
   <data name="Globals_LaunchMode.Header" xml:space="preserve">
-    <value>£ăûⁿςн мσðε !!!</value>
+    <value>₤дΰⁿçћ mοďè !!!</value>
     <comment>Header for a control to select what mode to launch the terminal in.</comment>
   </data>
   <data name="Globals_LaunchMode.HelpText" xml:space="preserve">
-    <value>Ĥòŵ ŧħз тéґмíйäℓ щιľℓ áρр℮âя οй ļãúήςħ. ₣оςůś ώïłľ ĥϊðε ţħĕ τãвѕ åńδ ťіτłē ьāř. !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ηóώ ţĥè ţěѓmϊиаľ ẁίĺĺ àρρ℮åг σⁿ łåŭⁿ¢ĥ. ₣οċύŝ ẁīłł ђїδė ţђê ťªьş āńð тιŧľ℮ вăŕ. !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>'Focus' must match &lt;Globals_LaunchModeFocus.Content&gt;.</comment>
   </data>
   <data name="Globals_LaunchParameters.Header" xml:space="preserve">
-    <value>Ĺдϋиċђ φāŕąмéτéŕš !!! !!</value>
+    <value>£ăŭŉсн рąґăмěţеґŝ !!! !!</value>
     <comment>Header for a set of settings that determine how terminal launches. These settings include the launch mode, launch position and whether the terminal should center itself on launch.</comment>
   </data>
   <data name="Globals_LaunchParameters.HelpText" xml:space="preserve">
-    <value>Ş℮тτіήĝš ŧђǻτ ċŏñţřóŀ ĥθŵ τħę тэŕмįⁿàł ℓâŭńсĥєѕ !!! !!! !!! !!! !!</value>
+    <value>Ѕèттîŋĝś ŧħªŧ ςôňťѓσŀ ĥõщ ţнè ţĕŗmîйåℓ ℓăµňĉнэś !!! !!! !!! !!! !!</value>
     <comment>A description for what the "launch parameters" expander contains. Presented near "Globals_LaunchParameters.Header".</comment>
   </data>
   <data name="Globals_LaunchModeSetting.Text" xml:space="preserve">
-    <value>Łăυпċђ мσďë !!!</value>
+    <value>Ŀäцñсн mőď℮ !!!</value>
     <comment>Header for a control to select what mode to launch the terminal in.</comment>
   </data>
   <data name="Globals_LaunchModeSetting.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ήőẅ тнê τēŕmíиаŀ щΐŀļ ăρφèάř óπ ĺªμŉĉн. ₣øčųѕ ẅιļĺ нìďе тћé τăьŝ àñð ŧϊτℓê вăř. !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ηōŵ ţнέ тěřmіηªĺ ẃΐŀľ ąρρëäґ öñ ļǻûй¢ћ. ₣όςµŝ ẅїļł ħĭďē τћε ŧªъš āηď ŧìťℓέ ьář. !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>'Focus' must match &lt;Globals_LaunchModeFocus.Content&gt;.</comment>
   </data>
   <data name="Globals_LaunchModeDefault.Content" xml:space="preserve">
-    <value>Ðéƒăųℓт !!</value>
+    <value>Ďěƒάυŀţ !!</value>
     <comment>An option to choose from for the "launch mode" setting. Default option.</comment>
   </data>
   <data name="Globals_LaunchModeFullscreen.Content" xml:space="preserve">
-    <value>₣υŀļ şċřěеⁿ !!!</value>
+    <value>₣ųľľ ѕ¢řέей !!!</value>
     <comment>An option to choose from for the "launch mode" setting. Opens the app in a full screen state.</comment>
   </data>
   <data name="Globals_LaunchModeMaximized.Content" xml:space="preserve">
-    <value>Мд×īмìżěð !!!</value>
+    <value>Μâ×įміźέď !!!</value>
     <comment>An option to choose from for the "launch mode" setting. Opens the app maximized (covers the whole screen).</comment>
   </data>
   <data name="Globals_WindowingBehavior.Header" xml:space="preserve">
-    <value>Ń℮ŵ íηŝŧâŋçэ вéĥάνιог !!! !!!</value>
+    <value>Νēщ ίńѕţãиςé ьęĥâνΐог !!! !!!</value>
     <comment>Header for a control to select how new app instances are handled.</comment>
   </data>
   <data name="Globals_WindowingBehavior.HelpText" xml:space="preserve">
-    <value>Ċοηťřοľś ħбẁ иĕŵ ťёŕmίиàℓ ïйŝτдńсěś αťŧаċн ŧõ ę×íśťîлġ ωϊπđôŵѕ. !!! !!! !!! !!! !!! !!! </value>
+    <value>Ĉöñтŕбℓš ћøш иēŵ τêгmîⁿàļ ĩπšţáπςεŝ άťţдčн тö є×ĭšτіņğ ώілđøẃş. !!! !!! !!! !!! !!! !!! </value>
     <comment>A description for what the "windowing behavior" setting does. Presented near "Globals_WindowingBehavior.Header".</comment>
   </data>
   <data name="Globals_WindowingBehaviorUseNew.Content" xml:space="preserve">
-    <value>Сѓėāţë ą ňĕẁ ẅіňδôẃ !!! !!!</value>
+    <value>Ćяèàťέ д ήéẃ ẃĭлďőω !!! !!!</value>
     <comment>An option to choose from for the "windowing behavior" setting. When selected, new instances create a new window.</comment>
   </data>
   <data name="Globals_WindowingBehaviorUseAnyExisting.Content" xml:space="preserve">
-    <value>Âŧтáсђ тθ тĥè мθŝт řєċєпťĺγ џšęδ шīπďθŵ !!! !!! !!! !!!</value>
+    <value>Ăţţăčĥ ŧó тħέ mõŝŧ řěçèпŧļý ŭśëď ẃįňδσω !!! !!! !!! !!!</value>
     <comment>An option to choose from for the "windowing behavior" setting. When selected, new instances open in the most recently used window.</comment>
   </data>
   <data name="Globals_WindowingBehaviorUseExisting.Content" xml:space="preserve">
-    <value>Аťţâςђ τό ŧнэ mǿšт řэ¢ëñτŀý џšēď ωīηđοω όñ ţћιš đèşќŧοр !!! !!! !!! !!! !!! !</value>
+    <value>Äţŧαĉђ τǿ τħе mοѕт ѓěςęńτļγ ûѕєď ŵíñðοω øи тћϊѕ ďёšкτǿφ !!! !!! !!! !!! !!! !</value>
     <comment>An option to choose from for the "windowing behavior" setting. When selected, new instances open in the most recently used window on this virtual desktop.</comment>
   </data>
   <data name="Globals_RenderingDisclaimer.Text" xml:space="preserve">
-    <value>Ţн℮şę ŝēтťīⁿĝŝ мāγ ьз µŝèƒцℓ ƒøŕ ŧřõϋьľêŝђøǿţîпĝ åń іşŝũê, нõẅěν℮ř τĥĕý ώϊĺĺ ίмрáĉτ ÿőцг рєґƒòґмάпĉэ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Τћέŝė ѕëτтίņģš мâу ьê üѕēƒµľ ƒόґ τřóųьŀėѕĥбοτілġ ǻл іŝśü℮, нσώéνєŕ τĥêў ŵīŀł ΐmρåςť убŭя ρěгƒόґмåñĉę. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A disclaimer presented at the top of a page.</comment>
   </data>
   <data name="Globals_ShowTitlebar.Header" xml:space="preserve">
-    <value>Нΐðē ťĥĕ ŧΐтŀë ьдŕ (ґēqμįřеś ґĕĺãŭñċĥ) !!! !!! !!! !!</value>
+    <value>Ĥìđε тħê τīţĺё ъªř (ŗėqūΐŗêś яеľаϋŉčћ) !!! !!! !!! !!</value>
     <comment>Header for a control to toggle whether the title bar should be shown or not. Changing this setting requires the user to relaunch the app.</comment>
   </data>
   <data name="Globals_ShowTitlebar.HelpText" xml:space="preserve">
-    <value>Щħεй đїѕавľ℮ð, тђė ŧïťℓé ъαг ŵĩℓļ άφрёäř αьõνē ťĥ℮ ťαвş. !!! !!! !!! !!! !!! !</value>
+    <value>Ẃћèп ðϊŝαъłėð, тнė ťĭτłê вąѓ ẁιĺł ąφφёǻŕ äвöνė ŧħė ťãьś. !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "show titlebar" setting does. Presented near "Globals_ShowTitlebar.Header".</comment>
   </data>
   <data name="Globals_AcrylicTabRow.Header" xml:space="preserve">
-    <value>Ůśё дċŕýℓĭĉ мăŧєřίªŀ îņ ŧĥè ŧáъ řóẃ !!! !!! !!! !</value>
+    <value>Ūŝē àςѓýłīć мãτęѓįάł ϊή ťнę ťāъ гоω !!! !!! !!! !</value>
     <comment>Header for a control to toggle whether "acrylic material" is used. "Acrylic material" is a Microsoft-specific term: https://docs.microsoft.com/en-us/windows/apps/design/style/acrylic</comment>
   </data>
   <data name="Globals_ShowTitleInTitlebar.Header" xml:space="preserve">
-    <value>Üŝè ǻčτινє τ℮ґmīпαŀ ţįťŀє ǻѕ åрρĺïсăţìôⁿ ţįтℓè !!! !!! !!! !!! !</value>
+    <value>Ůŝě å¢ťįνέ τèґmĭŉαĺ τįτľé äš дρφℓīĉатĭǿŉ ţιţľē !!! !!! !!! !!! !</value>
     <comment>Header for a control to toggle whether the terminal's title is shown as the application title, or not.</comment>
   </data>
   <data name="Globals_ShowTitleInTitlebar.HelpText" xml:space="preserve">
-    <value>Шђēñ ďìśάъŀěδ, ŧћē ŧίŧļе вăř ẅíłŀ вê 'Ťĕґmĭйăŀ'. !!! !!! !!! !!! !!</value>
+    <value>Ŵћéή đíѕǻьļεď, тħè ťįτłе ьǻŗ ẁїℓł вє 'Ťěѓмĩⁿăĺ'. !!! !!! !!! !!! !!</value>
     <comment>A description for what the "show title in titlebar" setting does. Presented near "Globals_ShowTitleInTitlebar.Header".{Locked="Windows"}</comment>
   </data>
   <data name="Globals_SnapToGridOnResize.Header" xml:space="preserve">
-    <value>Ѕпåр щīńďоẁ ř℮ѕįźιлġ τσ ćђăяаċŧĕг ġřίđ !!! !!! !!! !!</value>
+    <value>Ŝиάρ щίйðõщ яēşΐžíпĝ тõ čħáѓä¢ťέѓ ģѓĩδ !!! !!! !!! !!</value>
     <comment>Header for a control to toggle whether the terminal snaps the window to the character grid when resizing, or not.</comment>
   </data>
   <data name="Globals_SnapToGridOnResize.HelpText" xml:space="preserve">
-    <value>Ẅђéŉ διśάъļéď, ťне ωìйδŏẅ ώΐłĺ řèšïżē ѕмôǿτђℓŷ. !!! !!! !!! !!! !!</value>
+    <value>Ẅн℮ñ ðìşāьļĕð, τĥė ŵΐņďòώ ẃíļĺ řėŝîżē šмõόтнłγ. !!! !!! !!! !!! !!</value>
     <comment>A description for what the "snap to grid on resize" setting does. Presented near "Globals_SnapToGridOnResize.Header".</comment>
   </data>
   <data name="Globals_SoftwareRendering.Header" xml:space="preserve">
-    <value>Цş℮ şőƒţщâгé ґęлðєґїпģ !!! !!! </value>
+    <value>Ųѕε ŝόƒťщаřė яĕŋðεříлğ !!! !!! </value>
     <comment>Header for a control to toggle whether the terminal should use software to render content instead of the hardware.</comment>
   </data>
   <data name="Globals_SoftwareRendering.HelpText" xml:space="preserve">
-    <value>Ẅћēη êиåьļέδ, ťĥё τэŕмīпдľ ẃìĺł ϋşέ ťħ℮ ѕóƒťωäяę ŕęпđзřέґ (ä.ķ.ǻ. ẄĄŔР) ĭŋŝťėãδ óƒ ťĥέ ĥâѓđẁãřĕ őйê. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ẅнέⁿ éñâвĺĕď, ŧĥë тěřmϊñăľ шîľĺ ŭşē ŧнé šбƒţẅāяē ґэпδėѓεŕ (д.к.ă. ẀÅЃΡ) ĭñŝτéāđ оƒ тħё ĥάґđẃаяē οлε. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "software rendering" setting does. Presented near "Globals_SoftwareRendering.Header".</comment>
   </data>
   <data name="Globals_StartOnUserLogin.Header" xml:space="preserve">
-    <value>£âüиçħ οп mąćђīñэ śţáяŧũр !!! !!! !</value>
+    <value>₤áϋпςħ ôл мαςĥĭñę ŝťąřťûρ !!! !!! !</value>
     <comment>Header for a control to toggle whether the app should launch when the user's machine starts up, or not.</comment>
   </data>
   <data name="Globals_StartOnUserLogin.HelpText" xml:space="preserve">
-    <value>Åůŧǿmдτįčãľłý ĺàüņčħ Ţёřмïйάł ωћêй ўǿũ ℓоġ ĩŋ τσ Windows. !!! !!! !!! !!! !!! !!</value>
+    <value>Āũŧοмªτĩčäĺļỳ ŀªūⁿ¢ћ Ťëŗmįŋāℓ ẃнęņ ўоű ŀóġ ìπ τσ Шĩņðоẁѕ. !!! !!! !!! !!! !!! !!</value>
     <comment>A description for what the "start on user login" setting does. Presented near "Globals_StartOnUserLogin.Header". {Locked="Windows"}</comment>
   </data>
   <data name="Globals_CenterOnLaunchCentered" xml:space="preserve">
-    <value>Сзñŧεř℮δ !!</value>
+    <value>Ćêŋťєŕеδ !!</value>
     <comment>Shorthand, explanatory text displayed when the user has enabled the feature indicated by "Globals_CenterOnLaunch.Text".</comment>
   </data>
   <data name="Globals_CenterOnLaunch.Text" xml:space="preserve">
-    <value>€ěņţēŕ ōņ ļǻυⁿĉћ !!! !</value>
+    <value>Ćēňτєѓ ŏŋ ľäūńçђ !!! !</value>
     <comment>Header for a control to toggle whether the app should launch in the center of the screen, or not.</comment>
   </data>
   <data name="Globals_CenterOnLaunch.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ẁĥёñ єлãъľєđ, ťђè ẃιηδθώ ẃιľŀ ьë ρĺäċëď ïи ťђ℮ čéņτēŕ ǿƒ тĥė šĉŗ℮ĕл ẅђел ľăυлćђεď. !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Ẁђēи ėⁿąьĺëđ, ţħė ωīņďбώ ώїłľ ъė рℓªςέð ïⁿ ŧĥε сęⁿтєř ǿƒ ŧħè ŝćŕėęή ẁћêŉ ĺдűňĉĥεđ. !!! !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>A description for what the "center on launch" setting does. Presented near "Globals_CenterOnLaunch.Header".</comment>
   </data>
   <data name="Globals_AlwaysOnTop.Header" xml:space="preserve">
-    <value>Âℓẁдỳš ол τορ !!! </value>
+    <value>Аŀẅâγš ōп ŧбφ !!! </value>
     <comment>Header for a control to toggle if the app will always be presented on top of other windows, or is treated normally (when disabled).</comment>
   </data>
   <data name="Globals_AlwaysOnTop.HelpText" xml:space="preserve">
-    <value>Τêѓmíⁿаľ ώìĺĺ åĺẁãγś ьэ ťħê τôрмσŝţ ωįпďóŵ оή ŧђė ďēŝķтöр. !!! !!! !!! !!! !!! !!</value>
+    <value>Ťèřmĭήäľ ŵϊłļ àļщāÿş ъĕ ŧħє ţóрmόѕŧ шíñđθώ όи ŧħě δεşĸţбφ. !!! !!! !!! !!! !!! !!</value>
     <comment>A description for what the "always on top" setting does. Presented near "Globals_AlwaysOnTop.Header".</comment>
   </data>
   <data name="Globals_TabWidthMode.Header" xml:space="preserve">
-    <value>Ţăв ωîđťħ мǿδė !!! !</value>
+    <value>Ťâв ώΐđťн mбðě !!! !</value>
     <comment>Header for a control to choose how wide the tabs are.</comment>
   </data>
   <data name="Globals_TabWidthMode.HelpText" xml:space="preserve">
-    <value>Ĉõmφаĉτ ŵìłľ śняίňќ їņãĉţįν℮ тäъś τò тнë şîżè øƒ ţħє ī¢õň. !!! !!! !!! !!! !!! !!</value>
+    <value>Ćôмрáçτ ώĭĺļ ŝнгíñк ïŋãċţïνе тâъѕ ťö тĥε ѕіźë ŏƒ ŧн℮ ĩćóň. !!! !!! !!! !!! !!! !!</value>
     <comment>A description for what the "tab width mode" setting does. Presented near "Globals_TabWidthMode.Header". 'Compact' must match the value for &lt;Globals_TabWidthModeCompact.Content&gt;.</comment>
   </data>
   <data name="Globals_TabWidthModeCompact.Content" xml:space="preserve">
-    <value>Čòмρàçτ !!</value>
+    <value>Ċøмрªĉť !!</value>
     <comment>An option to choose from for the "tab width mode" setting. When selected, unselected tabs collapse to show only their icon. The selected tab adjusts to display the content within the tab.</comment>
   </data>
   <data name="Globals_TabWidthModeEqual.Content" xml:space="preserve">
-    <value>Зqũǻļ !</value>
+    <value>Εqüáł !</value>
     <comment>An option to choose from for the "tab width mode" setting. When selected, each tab has the same width.</comment>
   </data>
   <data name="Globals_TabWidthModeTitleLength.Content" xml:space="preserve">
-    <value>Ŧїţℓè ľеηġťђ !!! </value>
+    <value>Тīτľе ľεňĝτђ !!! </value>
     <comment>An option to choose from for the "tab width mode" setting. When selected, each tab adjusts its width to the content within the tab.</comment>
   </data>
   <data name="Globals_Theme.Header" xml:space="preserve">
-    <value>Ăφрŀì¢ãťîσń Ťћеmĕ !!! !!</value>
+    <value>Αрρłΐćàтīòñ Ŧнèм℮ !!! !!</value>
     <comment>Header for a control to choose the theme colors used in the app.</comment>
   </data>
   <data name="Globals_ThemeDark.Content" xml:space="preserve">
-    <value>Đάгĸ !</value>
+    <value>Đăгќ !</value>
     <comment>An option to choose from for the "theme" setting. When selected, the app is in dark theme and darker colors are used throughout the app.</comment>
   </data>
   <data name="Globals_ThemeSystem.Content" xml:space="preserve">
-    <value>Üşë Ẁĭήðõшѕ ŧћěмε !!! !!</value>
+    <value>Űŝ℮ Щįņđоẃś тћěmе !!! !!</value>
     <comment>An option to choose from for the "theme" setting. When selected, the app uses the theme selected in the Windows operating system.</comment>
   </data>
   <data name="Globals_ThemeLight.Content" xml:space="preserve">
-    <value>Ĺĭġĥŧ !</value>
+    <value>Ĺιģћť !</value>
     <comment>An option to choose from for the "theme" setting. When selected, the app is in light theme and lighter colors are used throughout the app.</comment>
   </data>
   <data name="Globals_ThemeDarkLegacy.Content" xml:space="preserve">
-    <value>Ďªѓκ (Łеğãċý) !!! </value>
+    <value>Ďāґќ (₤єĝåçŷ) !!! </value>
     <comment>An option to choose from for the "theme" setting. When selected, the app is in dark theme and darker colors are used throughout the app. This is an older version of the "dark" theme</comment>
   </data>
   <data name="Globals_ThemeSystemLegacy.Content" xml:space="preserve">
-    <value>Űѕё Ẅίŋðöŵѕ тĥ℮mé (₤ёģªćỳ) !!! !!! !</value>
+    <value>Ùśê Щΐŉδøщŝ ťħéмě (Łèĝąçу) !!! !!! !</value>
     <comment>An option to choose from for the "theme" setting. When selected, the app uses the theme selected in the Windows operating system. This is an older version of the "Use Windows theme" theme</comment>
   </data>
   <data name="Globals_ThemeLightLegacy.Content" xml:space="preserve">
-    <value>Ľιğћť (₤еģάςу) !!! !</value>
+    <value>Ŀїģнţ (Łεĝäċÿ) !!! !</value>
     <comment>An option to choose from for the "theme" setting. When selected, the app is in light theme and lighter colors are used throughout the app. This is an older version of the "light" theme</comment>
   </data>
   <data name="Globals_WordDelimiters.Header" xml:space="preserve">
-    <value>Ẃōŕδ δέĺιmîŧěґş !!! !</value>
+    <value>Щοґδ đэļιмϊŧеѓş !!! !</value>
     <comment>Header for a control to determine what delimiters to use to identify separate words during word selection.</comment>
   </data>
   <data name="Globals_WordDelimiters.HelpText" xml:space="preserve">
-    <value>Ţĥęѕз ѕÿmвöĺş ώīℓľ ьē ΰśĕď шħéл ỳøú đбúьĺê-ςļìсĸ ŧě×τ ιπ ťћё τєŗмίⁿąŀ ôґ ǻстìνãţ℮ "Μâŕĸ mōðę". !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ţћзŝ℮ ѕумвöŀѕ шιŀℓ вê ùŝеď ẃнёñ ỳõµ ďбùвŀэ-ċľϊčк ţε×ť ïⁿ ţћě τєґmїиаℓ ŏѓ αсτϊνãŧě "Мάřк mŏđë". !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "word delimiters" setting does. Presented near "Globals_WordDelimiters.Header". "Mark" is used in the sense of "choosing something to interact with."</comment>
   </data>
   <data name="Nav_Appearance.Content" xml:space="preserve">
-    <value>Λφреǻřдηĉ℮ !!!</value>
+    <value>Λρρёªгąńсё !!!</value>
     <comment>Header for the "appearance" menu item. This navigates to a page that lets you see and modify settings related to the app's appearance.</comment>
   </data>
   <data name="Nav_ColorSchemes.Content" xml:space="preserve">
-    <value>Сõĺθя ŝ¢ħêмεş !!! </value>
+    <value>Ċōľøя š¢нēměѕ !!! </value>
     <comment>Header for the "color schemes" menu item. This navigates to a page that lets you see and modify schemes of colors that can be used by the terminal.</comment>
   </data>
   <data name="Nav_Interaction.Content" xml:space="preserve">
-    <value>Įπτěŗāčŧīόņ !!!</value>
+    <value>Íŋт℮řâçτîöй !!!</value>
     <comment>Header for the "interaction" menu item. This navigates to a page that lets you see and modify settings related to the user's mouse and touch interactions with the app.</comment>
   </data>
   <data name="Nav_Launch.Content" xml:space="preserve">
-    <value>Śťäřŧџр !!</value>
+    <value>Ѕţâŕτűр !!</value>
     <comment>Header for the "startup" menu item. This navigates to a page that lets you see and modify settings related to the app's launch experience (i.e. screen position, mode, etc.)</comment>
   </data>
   <data name="Nav_OpenJSON.Content" xml:space="preserve">
-    <value>Ωρέň ĴЅОŅ ƒϊļè !!! !</value>
+    <value>Фφëņ ЈŞŐŅ ƒϊĺэ !!! !</value>
     <comment>Header for a menu item. This opens the JSON file that is used to log the app's settings.</comment>
   </data>
   <data name="Nav_ProfileDefaults.Content" xml:space="preserve">
-    <value>Ðёƒåϋļţś !!</value>
+    <value>Đэƒαűŀţş !!</value>
     <comment>Header for the "defaults" menu item. This navigates to a page that lets you see and modify settings that affect profiles. This is the lowest layer of profile settings that all other profile settings are based on. If a profile doesn't define a setting, this page is responsible for figuring out what that setting is supposed to be.</comment>
   </data>
   <data name="Nav_Rendering.Content" xml:space="preserve">
-    <value>Ґęŉðęŕίŋġ !!!</value>
+    <value>Ŕэⁿðэŕίńğ !!!</value>
     <comment>Header for the "rendering" menu item. This navigates to a page that lets you see and modify settings related to the app's rendering of text in the terminal.</comment>
   </data>
   <data name="Nav_Actions.Content" xml:space="preserve">
-    <value>Âĉτīøńŝ !!</value>
+    <value>Ăςтιòñš !!</value>
     <comment>Header for the "actions" menu item. This navigates to a page that lets you see and modify commands, key bindings, and actions that can be done in the app.</comment>
   </data>
   <data name="Profile_OpacitySlider.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ьαςќġřόџⁿď ōрãςίŧγ !!! !!</value>
+    <value>βά¢ĸĝŕõúήđ ǿрãĉĩŧÿ !!! !!</value>
     <comment>Name for a control to determine the level of opacity for the background of the control. The user can choose to make the background of the app more or less opaque.</comment>
   </data>
   <data name="Profile_Opacity.Header" xml:space="preserve">
-    <value>Ьªĉκğřōûŋđ σφăčΐţў !!! !!</value>
+    <value>βāĉκğřôμηď óρăĉїŧỳ !!! !!</value>
     <comment>Header for a control to determine the level of opacity for the background of the control. The user can choose to make the background of the app more or less opaque.</comment>
   </data>
   <data name="Profile_Opacity.HelpText" xml:space="preserve">
-    <value>Ѕзťś ŧђе ǿрàčίτў őƒ ţнē ωίπđőẁ. !!! !!! !!!</value>
+    <value>Ŝεŧŝ ţђé ǿφąċϊτŷ ôƒ ťђé ẃіŋďοẁ. !!! !!! !!!</value>
     <comment>A description for what the "opacity" setting does. Presented near "Profile_Opacity.Header".</comment>
   </data>
   <data name="Profile_Advanced.Header" xml:space="preserve">
-    <value>Δďνǻņčęδ !!</value>
+    <value>Дδναиċēδ !!</value>
     <comment>Header for a sub-page of profile settings focused on more advanced scenarios.</comment>
   </data>
   <data name="Profile_AltGrAliasing.Header" xml:space="preserve">
-    <value>AltGr ǻļιâŝĩⁿģ !!! !</value>
+    <value>ΛŀţĢř ąĺîàśιⁿģ !!! !</value>
     <comment>Header for a control to toggle whether the app treats ctrl+alt as the AltGr (also known as the Alt Graph) modifier key found on keyboards. {Locked="AltGr"}</comment>
   </data>
   <data name="Profile_AltGrAliasing.HelpText" xml:space="preserve">
-    <value>Ьў ðёƒãџĺŧ, Windows ťŕёдтŝ Ĉтяł+Ǻŀţ àŝ áŉ аľіăš ƒòя АłťĢŕ. Ŧħìś ŝετтϊиğ шіŀł ôνέřѓϊďε Windows' ďзƒαυŀţ ьèĥäνïοř. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Βу ďёƒдџĺţ, Ŵϊńďŏшš τřεåτš Ċťґℓ+Аłτ åѕ αń àłĩάš ƒŏг ДŀŧĢř. Τħїś śёťтїлğ ŵíℓĺ õνёяřΐďё Ŵìŉďôщѕ' ďэƒâüŀт ьĕђāνïŏř. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>A description for what the "AltGr aliasing" setting does. Presented near "Profile_AltGrAliasing.Header". {Locked="Windows"}</comment>
   </data>
   <data name="Profile_AntialiasingMode.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Τехт áпŧîàŀĩâŝíήĝ !!! !!</value>
+    <value>Ŧεжτ āпŧїåℓїášĩňģ !!! !!</value>
     <comment>Name for a control to select the graphical anti-aliasing format of text.</comment>
   </data>
   <data name="Profile_AntialiasingMode.Header" xml:space="preserve">
-    <value>Ťêжτ âŉтìãŀĭãŝīήğ !!! !!</value>
+    <value>Ŧėжţ âлтίāℓïãšìņĝ !!! !!</value>
     <comment>Header for a control to select the graphical anti-aliasing format of text.</comment>
   </data>
   <data name="Profile_AntialiasingMode.HelpText" xml:space="preserve">
-    <value>Ċοňţŕоĺŝ ћόш ţė×τ ĭş άиţίαłΐаşеđ їл τћë řеňďēŗέŕ. !!! !!! !!! !!! !!!</value>
+    <value>€σŋťгǿĺś ноώ τë×ţ ĭŝ āηтįāĺįäŝзđ ïⁿ тнê ŕëⁿðęг℮ř. !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "antialiasing mode" setting does. Presented near "Profile_AntialiasingMode.Header".</comment>
   </data>
   <data name="Profile_AntialiasingModeAliased.Content" xml:space="preserve">
-    <value>Ăℓįåѕεδ !!</value>
+    <value>Ǻłìдšèδ !!</value>
     <comment>An option to choose from for the "text antialiasing" setting. When selected, the app's text renderer does not use antialiasing techniques.</comment>
   </data>
   <data name="Profile_AntialiasingModeClearType.Content" xml:space="preserve">
-    <value>ClearType !!!</value>
+    <value>ĊłėāřŦўрε !!!</value>
     <comment>An option to choose from for the "text antialiasing" setting. When selected, the app's text renderer uses a "ClearType" antialiasing technique. {Locked="ClearType"}</comment>
   </data>
   <data name="Profile_AntialiasingModeGrayscale.Content" xml:space="preserve">
-    <value>Ģŕǻўşĉαł℮ !!!</value>
+    <value>Ġѓǻỳşćãľ℮ !!!</value>
     <comment>An option to choose from for the "text antialiasing" setting. When selected, the app's text renderer uses a grayscale antialiasing technique.</comment>
   </data>
   <data name="Profile_Appearance.Header" xml:space="preserve">
-    <value>Δφρêąřąñčз !!!</value>
+    <value>Äррéâřăйςё !!!</value>
     <comment>Header for a sub-page of profile settings focused on customizing the appearance of the profile.</comment>
   </data>
   <data name="Profile_BackgroundImageBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Вą¢ķğѓŏµлδ ïмâģе ρаŧĥ !!! !!!</value>
+    <value>Вãćκĝґõцńð ιмăġέ ратĥ !!! !!!</value>
     <comment>Name for a control to determine the image presented on the background of the app.</comment>
   </data>
   <data name="Profile_BackgroundImage.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>ßά¢ќģѓбűήď ìmăġё φäтђ !!! !!!</value>
+    <value>Βãĉķğѓθцňď ΐмάģ℮ φªţĥ !!! !!!</value>
     <comment>Name for a control to determine the image presented on the background of the app.</comment>
   </data>
   <data name="Profile_BackgroundImage.Header" xml:space="preserve">
-    <value>βªςκġгοüйδ ĭmāĝє ρáŧћ !!! !!!</value>
+    <value>βäċκġяǿúпđ ĩмåĝё φατн !!! !!!</value>
     <comment>Header for a control to determine the image presented on the background of the app.</comment>
   </data>
   <data name="Profile_BackgroundImage.HelpText" xml:space="preserve">
-    <value>₣įľé ĺσ¢āτϊŏň öƒ тĥê ĩmåĝĕ üšёδ ĩń ţћĕ ьǻčкğŕθџňđ øƒ ŧнé ωĩηðσω. !!! !!! !!! !!! !!! !!! !</value>
+    <value>₣įĺė łóςąтιǿŋ òƒ ŧħê íмάğз űšéδ їŉ ťĥ℮ вǻ¢κĝяőųиď őƒ ţĥė ώĭŋδбŵ. !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "background image path" setting does. Presented near "Profile_BackgroundImage".</comment>
   </data>
   <data name="Profile_BackgroundImageAlignment.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ьªċќğяøµпđ īмāģè ăℓίģⁿmεŉτ !!! !!! !</value>
+    <value>ßάсĸģŗǿџηδ ιmãģê αĺĭġήmēлť !!! !!! !</value>
     <comment>Name for a control to choose the visual alignment of the image presented on the background of the app.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignment.Header" xml:space="preserve">
-    <value>βάćкģŕóµиð імáģè ąŀїğимэиτ !!! !!! !</value>
+    <value>Бαčĸğяōΰηđ їмåĝэ åłĭğŉмεлŧ !!! !!! !</value>
     <comment>Header for a control to choose the visual alignment of the image presented on the background of the app.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignment.HelpText" xml:space="preserve">
-    <value>Śεŧš ħŏẃ ţĥё ьāçкğřŏūŋď ímåģέ ãłĭĝňš ŧо τћê ьôύńďąяīέş őƒ τĥε щìņđσω. !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ś℮ţŝ ћöẅ τĥę ва¢κğŗθŭйδ ìmдğē αŀíģņś то τħę вóµŉďăгĩěѕ öƒ τћз щĭńðǿẃ. !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "background image alignment" setting does. Presented near "Profile_BackgroundImageAlignment".</comment>
   </data>
   <data name="Profile_BackgroundImageAlignmentBottom.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Вöтτøm !</value>
+    <value>Βŏτŧøм !</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignmentBottomLeft.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>βθтτŏm ĺёƒŧ !!!</value>
+    <value>Βòττōм łéƒŧ !!!</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignmentBottomRight.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>βбŧтбm ŕіģђт !!! </value>
+    <value>Вбŧŧŏм ŗίģнť !!! </value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignmentCenter.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ćēπţèŕ !</value>
+    <value>Ĉêñť℮ř !</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignmentLeft.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>₤êƒт !</value>
+    <value>Ŀèƒţ !</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignmentRight.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ґìġĥŧ !</value>
+    <value>Ŗĭģħŧ !</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignmentTop.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ŧоφ </value>
+    <value>Ťθφ </value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignmentTopLeft.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Τőρ ľèƒτ !!</value>
+    <value>Ţθр ļέƒτ !!</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignmentTopRight.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ţόφ ŕïĝђŧ !!!</value>
+    <value>Тøρ ŕĩġћт !!!</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
   <data name="Profile_BackgroundImageBrowse.Content" xml:space="preserve">
-    <value>Βŗσщѕę... !!!</value>
+    <value>Ьřоẅşé... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
   <data name="Profile_AddNewFontAxis.Text" xml:space="preserve">
-    <value>Áðđ πеш !!</value>
+    <value>Λďð ňéẁ !!</value>
     <comment>Button label that adds a new font axis for the current font.</comment>
   </data>
   <data name="Profile_AddNewFontFeature.Text" xml:space="preserve">
-    <value>Аδδ ή℮ω !!</value>
+    <value>Άðδ ⁿэщ !!</value>
     <comment>Button label that adds a new font feature for the current font.</comment>
   </data>
   <data name="Profile_BackgroundImageOpacitySlider.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ьªćκģŗσūŋď ϊmăģз őρасΐţγ !!! !!! !</value>
+    <value>Βαċĸġґθũηď ϊmдġэ орάсιτу !!! !!! !</value>
     <comment>Name for a control to choose the opacity of the image presented on the background of the app.</comment>
   </data>
   <data name="Profile_BackgroundImageOpacity.Header" xml:space="preserve">
-    <value>Ъäсќğřǿüŋđ îmâģë ŏρåςĩŧỳ !!! !!! !</value>
+    <value>Βàĉĸġгòΰлð ϊmąġє бφáĉΐţÿ !!! !!! !</value>
     <comment>Header for a control to choose the opacity of the image presented on the background of the app.</comment>
   </data>
   <data name="Profile_BackgroundImageOpacity.HelpText" xml:space="preserve">
-    <value>Ŝěтš ŧħė бρа¢ïťу όƒ тħě ъä¢ќġѓòũиď īмαģз. !!! !!! !!! !!!</value>
+    <value>Ŝέтŝ тĥě ōφâĉіţŷ θƒ ŧħë ъâćќğŕоŭńð ĩмαĝę. !!! !!! !!! !!!</value>
     <comment>A description for what the "background image opacity" setting does. Presented near "Profile_BackgroundImageOpacity".</comment>
   </data>
   <data name="Profile_BackgroundImageStretchMode.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Βäçκģяǿџиď ΐмāğё şŧґєтĉħ мöðě !!! !!! !!!</value>
+    <value>Вάĉĸġřόϋⁿð ĩмăğе şťŗ℮ŧĉђ мòδ℮ !!! !!! !!!</value>
     <comment>Name for a control to choose the stretch mode of the image presented on the background of the app. Stretch mode is how the image is resized to fill its allocated space.</comment>
   </data>
   <data name="Profile_BackgroundImageStretchMode.Header" xml:space="preserve">
-    <value>Βäĉĸģŗöŭŋď ϊmăģ℮ ŝтѓέτċĥ mθδĕ !!! !!! !!!</value>
+    <value>ßäскġŗǿůπď īмâġэ şтŗĕтсħ мőďè !!! !!! !!!</value>
     <comment>Header for a control to choose the stretch mode of the image presented on the background of the app. Stretch mode is how the image is resized to fill its allocated space.</comment>
   </data>
   <data name="Profile_BackgroundImageStretchMode.HelpText" xml:space="preserve">
-    <value>Śêŧѕ ћǿώ ťнě ьάćкġŕōūŉð ìмªĝĕ ΐѕ ѓэśíżęđ ţô ƒïŀℓ ţħέ ώїⁿďоẅ. !!! !!! !!! !!! !!! !!!</value>
+    <value>Šëτş ħσω ŧħё ьãćķĝгøµπð īмαğę ϊš řĕŝіżèď ţθ ƒĭŀł ťћέ ωїηđôẁ. !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "background image stretch mode" setting does. Presented near "Profile_BackgroundImageStretchMode".</comment>
   </data>
   <data name="Profile_BackgroundImageStretchModeFill.Content" xml:space="preserve">
-    <value>₣ίℓĺ !</value>
+    <value>₣ίľļ !</value>
     <comment>An option to choose from for the "background image stretch mode" setting. When selected, the image is resized to fill the destination dimensions. The aspect ratio is not preserved.</comment>
   </data>
   <data name="Profile_BackgroundImageStretchModeNone.Content" xml:space="preserve">
-    <value>Иöⁿé !</value>
+    <value>Ŋŏⁿé !</value>
     <comment>An option to choose from for the "background image stretch mode" setting. When selected, the image preserves its original size.</comment>
   </data>
   <data name="Profile_BackgroundImageStretchModeUniform.Content" xml:space="preserve">
-    <value>Ũпϊƒόřm !!</value>
+    <value>Üⁿĭƒòгm !!</value>
     <comment>An option to choose from for the "background image stretch mode" setting. When selected,the image is resized to fit in the destination dimensions while it preserves its native aspect ratio.</comment>
   </data>
   <data name="Profile_BackgroundImageStretchModeUniformToFill.Content" xml:space="preserve">
-    <value>Ũñĩƒοяm ţо ƒîłļ !!! !</value>
+    <value>Úⁿîƒŏŕм τо ƒіļļ !!! !</value>
     <comment>An option to choose from for the "background image stretch mode" setting. When selected, the content is resized to fill the destination dimensions while it preserves its native aspect ratio. But if the aspect ratio of the destination differs, the image is clipped to fit in the space (to fill the space)</comment>
   </data>
   <data name="Profile_CloseOnExit.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Рŗôƒїŀě ŧëямĩñàŧїǿň ьèĥдνїőŗ !!! !!! !!</value>
+    <value>Рѓǿƒïłė ţέřmįпąťїоп ьэндνіõя !!! !!! !!</value>
     <comment>Name for a control to select the behavior of a terminal session (a profile) when it closes.</comment>
   </data>
   <data name="Profile_CloseOnExit.Header" xml:space="preserve">
-    <value>Ρřōƒïľě тėŗmìⁿàτΐôη ьęћåνïθŗ !!! !!! !!</value>
+    <value>Рŗσƒīļє τеŗmíŋªťιοñ вěђâνίøя !!! !!! !!</value>
     <comment>Header for a control to select the behavior of a terminal session (a profile) when it closes.</comment>
   </data>
   <data name="Profile_CloseOnExitAlways.Content" xml:space="preserve">
-    <value>Сłôѕĕ ωħёл φŕôçėšś ёхιτş, ƒâíłŝ, ŏŕ ċŕαśĥèѕ !!! !!! !!! !!! </value>
+    <value>Сĺöѕę ẃђèи φяô¢єśş êжîţš, ƒäιļš, оř ¢řąŝнéś !!! !!! !!! !!! </value>
     <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled (exit) or uncontrolled (fail or crash) scenario.</comment>
   </data>
   <data name="Profile_CloseOnExitGraceful.Content" xml:space="preserve">
-    <value>Сłοšэ ǿήℓў ẅĥėи ρѓσçέśѕ έхìтš ѕúç¢ėššƒύĺļý !!! !!! !!! !!! </value>
+    <value>Сłбşê бńļγ ẅнēή рřόс℮śŝ ęжιτś ŝџçсĕšѕƒŭŀłў !!! !!! !!! !!! </value>
     <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully.</comment>
   </data>
   <data name="Profile_CloseOnExitNever.Content" xml:space="preserve">
-    <value>Νёνèř čļоšė āμťσмªťìćǻŀℓÿ !!! !!! !</value>
+    <value>Ŋ℮νĕŗ ćļǿѕê äμτőмâťĩċªļŀў !!! !!! !</value>
     <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal never closes, even if the process exits in a controlled or uncontrolled scenario. The user would have to manually close the terminal.</comment>
   </data>
   <data name="Profile_CloseOnExitAutomatic.Content" xml:space="preserve">
-    <value>∆ũтõmàťïċ !!!</value>
+    <value>Ãµťøмäтïč !!!</value>
     <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Windows Terminal.</comment>
   </data>
   <data name="Profile_ColorScheme.Header" xml:space="preserve">
-    <value>Ĉοłǿŗ ѕćђ℮mэ !!! </value>
+    <value>Çŏłőг ŝćнĕмε !!! </value>
     <comment>Header for a control to select the scheme (or set) of colors used in the session. This is selected from a list of options managed by the user.</comment>
   </data>
   <data name="Profile_Commandline.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ĉοmмάπδ łϊŉέ !!! </value>
+    <value>€οмmǻпδ łįŉε !!! </value>
     <comment>Name for a control to determine commandline executable (i.e. a .exe file) to run when a terminal session of this profile is launched.</comment>
   </data>
   <data name="Profile_Commandline.Header" xml:space="preserve">
-    <value>Ċőмmάήď ļιňê !!! </value>
+    <value>Соммаňð ℓιπë !!! </value>
     <comment>Header for a control to determine commandline executable (i.e. a .exe file) to run when a terminal session of this profile is launched.</comment>
   </data>
   <data name="Profile_CommandlineBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Çοммǻŉδ łĭŉě !!! </value>
+    <value>Çŏммǻиδ ŀϊňè !!! </value>
     <comment>Name for a control to determine commandline executable (i.e. a .exe file) to run when a terminal session of this profile is launched.</comment>
   </data>
   <data name="Profile_Commandline.HelpText" xml:space="preserve">
-    <value>Эжê¢ûŧąвŀέ υѕéð ïи тђė ряõƒίł℮. !!! !!! !!!</value>
+    <value>Эхĕçΰтдьłё ūśëď įñ ţħè рŕòƒĭŀз. !!! !!! !!!</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
   <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
-    <value>Ьґóẅšĕ... !!!</value>
+    <value>ßгθшşє... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
   <data name="Profile_CursorHeight.Header" xml:space="preserve">
-    <value>Čџѓѕòґ ħэįġħŧ !!! </value>
+    <value>Сµгŝőґ ђēîĝħт !!! </value>
     <comment>Header for a control to determine the height of the text cursor.</comment>
   </data>
   <data name="Profile_CursorHeight.HelpText" xml:space="preserve">
-    <value>Ŝєτš ŧћз рéŗςєηŧäğе ĥèίġħţ ôƒ ŧђê ċŭŗšбґ ŝтářţĩиģ ƒѓбм ťнė ъöŧŧσm. Ωņŀÿ ŵǿґκѕ ŵìτђ ťнê νіňŧąĝέ çцŗşоѓ śћāρе. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Šеτѕ тĥέ φегсеŋтåĝě ћēíġĥт öƒ ťĥέ ¢úґšόг ŝŧάřťīŉģ ƒŕõм τћ℮ воţŧōм. Φņľγ шбŕķş ωітĥ τђĕ νĭŋťάġз ¢ūґşσř ŝнāφē. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>A description for what the "cursor height" setting does. Presented near "Profile_CursorHeight".</comment>
   </data>
   <data name="Profile_CursorShape.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ĉüѓѕôѓ ŝнąρэ !!! </value>
+    <value>Ćũяšòѓ ŝђàρĕ !!! </value>
     <comment>Name for a control to select the shape of the text cursor.</comment>
   </data>
   <data name="Profile_CursorShape.Header" xml:space="preserve">
-    <value>€ůŗšоѓ ѕћàρ℮ !!! </value>
+    <value>Ĉϋřšǿг śнâρε !!! </value>
     <comment>Header for a control to select the shape of the text cursor.</comment>
   </data>
   <data name="Profile_AdjustIndistinguishableColorsNever.Content" xml:space="preserve">
-    <value>Ńęν℮ř !</value>
+    <value>Ñèνêř !</value>
     <comment>An option to choose from for the "adjust indistinguishable colors" setting. When selected, we will never adjust the text colors.</comment>
   </data>
   <data name="Profile_AdjustIndistinguishableColorsIndexed.Content" xml:space="preserve">
-    <value>Ώŉŀŷ ƒŏŗ ςôŀбґŝ ïй ŧĥë ςόļǿг şςћëmέ !!! !!! !!! !</value>
+    <value>Òňľỳ ƒθг çöłőґš ΐл ťħé сøłθґ ŝĉћ℮мё !!! !!! !!! !</value>
     <comment>An option to choose from for the "adjust indistinguishable colors" setting. When selected, we will adjust the text colors for visibility only when the colors are part of this profile's color scheme's color table.</comment>
   </data>
   <data name="Profile_AdjustIndistinguishableColorsAlways.Content" xml:space="preserve">
-    <value>Áĺшãÿŝ !</value>
+    <value>Åļωάỳš !</value>
     <comment>An option to choose from for the "adjust indistinguishable colors" setting. When selected, we will adjust the text colors for visibility.</comment>
   </data>
   <data name="Profile_CursorShapeBar.Content" xml:space="preserve">
-    <value>Ъàŕ ( ┃ ) !!!</value>
+    <value>Ъâг ( ┃ ) !!!</value>
     <comment>{Locked="┃"} An option to choose from for the "cursor shape" setting. When selected, the cursor will look like a vertical bar. The character in the parentheses is used to show what it looks like.</comment>
   </data>
   <data name="Profile_CursorShapeEmptyBox.Content" xml:space="preserve">
-    <value>Ęмφťỳ вο× ( ▯ ) !!! !</value>
+    <value>Емρţý ьǿ× ( ▯ ) !!! !</value>
     <comment>{Locked="▯"} An option to choose from for the "cursor shape" setting. When selected, the cursor will look like an empty box. The character in the parentheses is used to show what it looks like.</comment>
   </data>
   <data name="Profile_CursorShapeFilledBox.Content" xml:space="preserve">
-    <value>₣їļľéð ьô× ( █ ) !!! !</value>
+    <value>₣ιŀłęđ вσж ( █ ) !!! !</value>
     <comment>{Locked="█"} An option to choose from for the "cursor shape" setting. When selected, the cursor will look like a filled box. The character in the parentheses is used to show what it looks like.</comment>
   </data>
   <data name="Profile_CursorShapeUnderscore.Content" xml:space="preserve">
-    <value>Úйδęгŝςøŕę ( ▁ ) !!! !</value>
+    <value>Ùήđĕřŝċогё ( ▁ ) !!! !</value>
     <comment>{Locked="▁"} An option to choose from for the "cursor shape" setting. When selected, the cursor will look like an underscore. The character in the parentheses is used to show what it looks like.</comment>
   </data>
   <data name="Profile_CursorShapeVintage.Content" xml:space="preserve">
-    <value>Vįπţαğė ( ▃ ) !!! </value>
+    <value>Vίпτâĝĕ ( ▃ ) !!! </value>
     <comment>{Locked="▃"} An option to choose from for the "cursor shape" setting. When selected, the cursor will look like a thick underscore. This is the vintage and classic look of a cursor for terminals. The character in the parentheses is used to show what it looks like.</comment>
   </data>
   <data name="Profile_CursorShapeDoubleUnderscore.Content" xml:space="preserve">
-    <value>Đоŭьℓè űñδêřšçòřэ ( ‗ ) !!! !!! </value>
+    <value>Ďòûьĺē ύηđεґşćбяĕ ( ‗ ) !!! !!! </value>
     <comment>{Locked="‗"} An option to choose from for the "cursor shape" setting. When selected, the cursor will look like a stacked set of two underscores. The character in the parentheses is used to show what it looks like.</comment>
   </data>
   <data name="Profile_FontFace.Header" xml:space="preserve">
-    <value>₣òлτ ƒąċē !!!</value>
+    <value>₣øñт ƒâςę !!!</value>
     <comment>Header for a control to select the font for text in the app.</comment>
   </data>
   <data name="Profile_FontFaceBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>₣òņτ ƒǻĉè !!!</value>
+    <value>₣øñŧ ƒдсέ !!!</value>
     <comment>Name for a control to select the font for text in the app.</comment>
   </data>
   <data name="Profile_FontSize.Header" xml:space="preserve">
-    <value>₣θлŧ śϊźé !!!</value>
+    <value>₣ŏňτ şίźε !!!</value>
     <comment>Header for a control to determine the size of the text in the app.</comment>
   </data>
   <data name="Profile_FontSizeBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>₣бητ šїźé !!!</value>
+    <value>₣оňť şίżє !!!</value>
     <comment>Name for a control to determine the size of the text in the app.</comment>
   </data>
   <data name="Profile_FontSize.HelpText" xml:space="preserve">
-    <value>Şįźè σƒ ťħē ƒòŉť ϊŋ φσĩиťš. !!! !!! !!</value>
+    <value>Šіžё ǿƒ тнé ƒõņτ їņ φσîйτş. !!! !!! !!</value>
     <comment>A description for what the "font size" setting does. Presented near "Profile_FontSize".</comment>
   </data>
   <data name="Profile_LineHeight.Header" xml:space="preserve">
-    <value>Ľїπё ĥéíĝђť !!!</value>
+    <value>Ŀīйĕ ĥĕΐĝђŧ !!!</value>
     <comment>Header for a control that sets the text line height.</comment>
   </data>
   <data name="Profile_LineHeightBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ľїńë нęĭğĥτ !!!</value>
+    <value>₤ìŋè ħέίģћť !!!</value>
     <comment>Header for a control that sets the text line height.</comment>
   </data>
   <data name="Profile_LineHeight.HelpText" xml:space="preserve">
-    <value>Ωνэґяϊδê ťĥε ℓїⁿê ћ℮ĩġћţ ôƒ τнэ τěřмïŋаŀ. Мēдѕũřĕð άš ά мџľţΐρĺ℮ ŏƒ τћē ƒŏиť šįžе. Тħĕ δеƒдûľţ νąℓцэ ďėφêйðş óл γόŭř ƒòлť ªйđ ϊś üŝŭáŀĺŷ äŗøūήđ 1.2. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Ονëřŗíďĕ тђэ ℓìŉё ћëîğнτ оƒ ŧнè τёґмįņªļ. Мēáśυґ℮đ аś ª mϋłţìρℓè õƒ тне ƒõήτ ѕΐżë. Тђê ďέƒāųŀţ νâŀüē δέρěņđš ǿň ỳőυя ƒôŉт ąŉď ΐş υşūäľŀÿ àŗôüŋđ 1.2. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>A description for what the "line height" setting does. Presented near "Profile_LineHeight".</comment>
   </data>
   <data name="Profile_LineHeightBox.PlaceholderText" xml:space="preserve">
@@ -907,854 +907,886 @@
     <comment>"1.2" is a decimal number.</comment>
   </data>
   <data name="Profile_EnableBuiltinGlyphs.Header" xml:space="preserve">
-    <value>Бűīłτĭл Ĝľурĥš !!! !</value>
+    <value>Ьùïľŧïň Ģłуφĥś !!! !</value>
     <comment>The main label of a toggle. When enabled, certain characters (glyphs) are replaced with better looking ones.</comment>
   </data>
   <data name="Profile_EnableBuiltinGlyphs.HelpText" xml:space="preserve">
-    <value>Щђëń ℮йãвļэđ, тнė τєřmìήąļ đгäшŝ ċцšťσm ġłγφнş ƒôř ъŀσсķ èľėmέňτ âлď ьõх δґåώίиģ čћãѓαςτēřş íйşťëàď ǿƒ џşįηĝ τħé ƒŏñť. Тћїş ƒêάťųřė θņĺÿ ẁôѓκš щћéπ ĜΡÚ Λċсĕłėŕâŧιǿŉ ΐѕ ăνдìŀαвŀε. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Ẅħĕň еņªъℓёð, тћз τēгмïπдℓ ðѓáшş çύšτом ģļўφħѕ ƒǿя ъĺôсĸ éℓêm℮ήŧ àñð ъο× ðгдωΐπĝ čћдŗąςŧέѓś ìπŝţėãđ ŏƒ ũŝіⁿğ ťћę ƒбηŧ. Ţћιş ƒзаτџŕè οŉĺŷ ωóгκŝ ẁĥéŋ ĢΡŬ Àςĉеŀèѓдτισñ ĩѕ ǻνãîļåвłę. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>A longer description of the "Profile_EnableBuiltinGlyphs" toggle. "glyphs", "block element" and "box drawing characters" are technical terms from the Unicode specification.</comment>
   </data>
   <data name="Profile_EnableColorGlyphs.Header" xml:space="preserve">
-    <value>₣ύℓℓ-сôŀőŗ Ēmθјϊ !!! !</value>
+    <value>₣џłŀ-сθℓøґ Έmόјї !!! !</value>
     <comment>The main label of a toggle. When enabled, certain characters (emoji in this case) are displayed with multiple colors.</comment>
   </data>
   <data name="Profile_EnableColorGlyphs.HelpText" xml:space="preserve">
-    <value>Ẁћέń зňªвłεð, Ємóĵί äŕė δΐşрľâýзð ίņ ƒύℓŀ ĉōĺõŕ. !!! !!! !!! !!! !!</value>
+    <value>Ẅнзп έňåвłёδ, Эмöĵī ãŕě ďíşρľǻỳęð ίñ ƒμŀℓ ćоļöŕ. !!! !!! !!! !!! !!</value>
     <comment>A longer description of the "Profile_EnableColorGlyphs" toggle.</comment>
   </data>
   <data name="Profile_FontWeightComboBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>₣οńţ ώєїġнţ !!!</value>
+    <value>₣οиτ ẅэíğħť !!!</value>
     <comment>Name for a control to select the weight (i.e. bold, thin, etc.) of the text in the app.</comment>
   </data>
   <data name="Profile_FontWeightSlider.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>₣ǿиŧ ẃєíģĥť !!!</value>
+    <value>₣õиτ ŵėíğĥŧ !!!</value>
     <comment>Name for a control to select the weight (i.e. bold, thin, etc.) of the text in the app.</comment>
   </data>
   <data name="Profile_FontWeight.Header" xml:space="preserve">
-    <value>₣ǿŋτ ŵёīĝĥτ !!!</value>
+    <value>₣оňτ ŵειġнт !!!</value>
     <comment>Header for a control to select the weight (i.e. bold, thin, etc.) of the text in the app.</comment>
   </data>
   <data name="Profile_FontWeight.HelpText" xml:space="preserve">
-    <value>Šεţš τħē шείğнŧ (ℓΐģђťиеŝѕ ǿř ħзάνΐηėšѕ оƒ ţћé šŧѓσķέš) ƒōř τħ℮ ĝìνęⁿ ƒõńτ. !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ŝéŧѕ ţђέ ẁèϊģнť (łϊğħţⁿéşś όř ђзâνĩηзśş óƒ ŧĥė śťгόќęŝ) ƒθґ тħέ ġįνэи ƒőňţ. !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "font weight" setting does. Presented near "Profile_FontWeight".</comment>
   </data>
   <data name="Profile_FontAxes.Header" xml:space="preserve">
-    <value>Vāřĭªвľ℮ ƒоñţ αхęś !!! !!</value>
+    <value>Vαгįдвłз ƒôηŧ á×ęś !!! !!</value>
     <comment>Header for a control to allow editing the font axes.</comment>
   </data>
   <data name="Profile_FontAxesAvailable.Text" xml:space="preserve">
-    <value>Ǻđď θř я℮mσνë ƒöпт ãхęś ƒôŗ ţħě ġϊνєп ƒоņţ. !!! !!! !!! !!! </value>
+    <value>Āðδ θѓ ŗēмôνε ƒŏŋτ āжеŝ ƒóř ťћè ġīνęŋ ƒóήτ. !!! !!! !!! !!! </value>
     <comment>A description for what the "font axes" setting does. Presented near "Profile_FontAxes".</comment>
   </data>
   <data name="Profile_FontAxesUnavailable.Text" xml:space="preserve">
-    <value>Тћę ŝеļеçτėð ƒőпт ћåŝ йø νäяΐäьłё ƒøńŧ á×ěś. !!! !!! !!! !!! !</value>
+    <value>Тђέ šěļεċťєď ƒŏηŧ ћάś πø νäѓїдвłз ƒōπт αжęš. !!! !!! !!! !!! !</value>
     <comment>A description provided when the font axes setting is disabled. Presented near "Profile_FontAxes".</comment>
   </data>
   <data name="Profile_FontFeatures.Header" xml:space="preserve">
-    <value>₣öňт ƒзåτũгэŝ !!! </value>
+    <value>₣оŉτ ƒзåŧŭŕέś !!! </value>
     <comment>Header for a control to allow editing the font features.</comment>
   </data>
   <data name="Profile_FontFeaturesAvailable.Text" xml:space="preserve">
-    <value>Äðδ σґ řéмōνз ƒŏñт ƒєăŧūгёš ƒσŗ тĥз ġινęπ ƒõήт. !!! !!! !!! !!! !!</value>
+    <value>Ǻďð όŗ řěmòνě ƒóńт ƒєãťüгęś ƒθг тнĕ ĝĩνёŋ ƒόŋţ. !!! !!! !!! !!! !!</value>
     <comment>A description for what the "font features" setting does. Presented near "Profile_FontFeatures".</comment>
   </data>
   <data name="Profile_FontFeaturesUnavailable.Text" xml:space="preserve">
-    <value>Τђê šёľėĉŧěð ƒбņť ћăş пσ ƒŏήт ƒёάťϋŕěѕ. !!! !!! !!! !!!</value>
+    <value>Τћē ŝэŀëсŧзð ƒőйť нâŝ иο ƒòиŧ ƒėäţцŕэś. !!! !!! !!! !!!</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
   <data name="Profile_General.Header" xml:space="preserve">
-    <value>Ģєŉеŗαℓ !!</value>
+    <value>Ġеŉėяâĺ !!</value>
     <comment>Header for a sub-page of profile settings focused on more general scenarios.</comment>
   </data>
   <data name="Profile_Hidden.Header" xml:space="preserve">
-    <value>Ήіðе ρŕθƒΐļ℮ ƒгθм δřōφďòẁñ !!! !!! !</value>
+    <value>Ήîď℮ φябƒίļĕ ƒѓòm ďřóφδόшπ !!! !!! !</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
   <data name="Profile_Hidden.HelpText" xml:space="preserve">
-    <value>Ίƒ эήªвℓεď, τћз ргоƒїłэ ẃíℓļ ņόţ аρφèåř ϊŉ ŧħę ŀїşţ οƒ φŗòƒíŀėŝ. Τĥїš сâⁿ ъ℮ üŝĕď ťό ĥΐďě đĕƒäΰŀŧ φяόƒіℓзѕ αŉδ δўиáмìćǻļĺу ğ℮иεŕαтєđ φřöƒіĺεş, шнίľз ļэάνīήģ ţђĕм îñ ỳôûř śєţţίņğš ƒїľз. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Їƒ ĕηάъℓěđ, ťĥэ φѓóƒїłę щíĺŀ иǿτ āφрĕдґ ΐŋ ŧћ℮ ŀīѕţ ǿƒ ρřŏƒīłėѕ. Ţђіş ςǻⁿ ъê ūšέð ťŏ ђĩðė δëƒǻūļт φґøƒíļέş аņð ďγñăмïĉâļℓÿ ģěиēяāŧεð ρřòƒίļзŝ, ẁĥιľє łэăνīⁿĝ ťĥèм ϊŉ ỳôцг śэťŧιйğŝ ƒιľë. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
   </data>
   <data name="Profile_Elevate.Header" xml:space="preserve">
-    <value>Řύπ ŧћίś рѓŏƒìŀē дѕ Аδmĭⁿĭŝтяǻτöя !!! !!! !!! </value>
+    <value>Гµл тђįş φѓöƒιļэ åş Λđmįňίšтŕàтоя !!! !!! !!! </value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
   </data>
   <data name="Profile_Elevate.HelpText" xml:space="preserve">
-    <value>Įƒ έпàьŀêδ, ťħê φяοƒΐŀĕ ẁιĺŀ όреŋ īη ªŋ Дđmìή теямĭńáľ ẅĩñðǿщ åúťσмăŧїĉāłĺў. Ίƒ ťħз ĉùяřéņť ŵіиδοẁ іş ªŀгеàđγ řµпñїпģ åś ąδmίņ, íţ'ĺŀ ōреή íŉ τђίş ωιńďõẅ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ìƒ éņãвļзδ, ŧĥĕ рŗоƒīľё ẅιľł óрėŋ ΐή åň Ąďmįŋ теѓmίидŀ шïпδσώ аůţòмăтìсаļļγ. Ĭƒ ŧĥе čцѓґ℮ⁿť ẁįлđόŵ їŝ áŀřėãďу ŕύŋņïπġ āš αðмīŉ, ϊţ'ŀℓ σрèń ĩй тħїŝ ẅīйδõẁ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
-    <value>Ĥĩšţоřý şΐźε !!! </value>
+    <value>Нíşŧôŗỳ ѕιźë !!! </value>
     <comment>Header for a control to determine how many lines of text can be saved in a session. In terminals, the "history" is the output generated within your session.</comment>
   </data>
   <data name="Profile_HistorySizeBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ηïšтōґý ѕΐžě !!! </value>
+    <value>Ĥіśţόѓÿ šιžё !!! </value>
     <comment>Name for a control to determine how many lines of text can be saved in a session. In terminals, the "history" is the output generated within your session.</comment>
   </data>
   <data name="Profile_HistorySize.HelpText" xml:space="preserve">
-    <value>Тнë иϋmвĕŕ σƒ łίňêš αьονě тĥé σņёѕ δίşφĺąγěδ іл τħе ŵΐŉđöŵ ÿоû çäη šςřôļĺ ьāćκ ţο. !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Тђě ņůмвέґ όƒ ļïлèѕ àьόνэ τнέ ôиεŝ ďίşрℓâýèď ΐη ŧћз ẃΐлđóẃ ŷòц сåп şçřбŀľ вªćķ ťσ. !!! !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>A description for what the "history size" setting does. Presented near "Profile_HistorySize".</comment>
   </data>
   <data name="Profile_Icon.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Įςøņ !</value>
+    <value>Îčόŋ !</value>
     <comment>Name for a control to determine what icon can be used to represent this profile. This is not necessarily a file path, but can be one.</comment>
   </data>
   <data name="Profile_Icon.Header" xml:space="preserve">
-    <value>Ì¢öŋ !</value>
+    <value>İ¢оń !</value>
     <comment>Header for a control to determine what icon can be used to represent this profile. This is not necessarily a file path, but can be one.</comment>
   </data>
   <data name="Profile_IconBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ìсθл !</value>
+    <value>Į¢òп !</value>
     <comment>Name for a control to determine what icon can be used to represent this profile. This is not necessarily a file path, but can be one.</comment>
   </data>
   <data name="Profile_Icon.HelpText" xml:space="preserve">
-    <value>Ēmōјĭ ôř ĩмąġě ƒϊľê ĺόćąтïбп όƒ τĥэ įĉõи úšêđ ìи ţĥє рřöƒįļέ. !!! !!! !!! !!! !!! !!!</value>
+    <value>Ęmőĵì õř îmаĝė ƒìĺĕ ļöĉǻтïòπ ǿƒ ŧђē ісǿⁿ ùšεð іń τĥε φřôƒιľê. !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "icon" setting does. Presented near "Profile_Icon".</comment>
   </data>
   <data name="Profile_IconBrowse.Content" xml:space="preserve">
-    <value>Βгøшŝė... !!!</value>
+    <value>Ьřòẁśз... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
   <data name="Profile_PaddingSlider.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Рâðδїπĝ !!</value>
+    <value>Рáðđĩñġ !!</value>
     <comment>Name for a control to determine the amount of space between text in a terminal and the edge of the window.</comment>
   </data>
   <data name="Profile_Padding.Header" xml:space="preserve">
-    <value>Ρäðďįиģ !!</value>
+    <value>Ρáððìŉğ !!</value>
     <comment>Header for a control to determine the amount of space between text in a terminal and the edge of the window. The space can be any combination of the top, bottom, left, and right side of the window.</comment>
   </data>
   <data name="Profile_Padding.HelpText" xml:space="preserve">
-    <value>Ŝέţѕ ţнé ρªðδìπġ аґôϋňδ тђě ţêжт шĩτђĩη ŧħě ẁιⁿđöш. !!! !!! !!! !!! !!!</value>
+    <value>Śěтš тђ℮ ρªđδїлğ ăѓоūńđ ŧћέ τεжт ẃĭтħϊп τħέ ẃίņδθẁ. !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "padding" setting does. Presented near "Profile_Padding".</comment>
   </data>
   <data name="Profile_RetroTerminalEffect.Header" xml:space="preserve">
-    <value>Ŗèтгб ŧěѓmϊňâℓ ėƒƒέĉτѕ !!! !!! </value>
+    <value>Яęтѓō тéѓmιйăĺ ëƒƒέсŧŝ !!! !!! </value>
     <comment>Header for a control to toggle classic CRT display effects, which gives the terminal a retro look.</comment>
   </data>
   <data name="Profile_RetroTerminalEffect.HelpText" xml:space="preserve">
-    <value>Ŝħõщ ѓэťřò-şŧýľě τěŗmϊπдł єƒƒēċтş ѕùсĥ ąś ģłøώìлĝ ŧě×τ άήđ şčãņ ļϊηěś. !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Śĥбẅ гзτřō-şтγłе τëѓmīⁿдĺ еƒƒέсτś şúćђ αş ğℓōώĩиġ ţέхť άηδ šςаи ľìиėš. !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "retro terminal effects" setting does. Presented near "Profile_RetroTerminalEffect". "Retro" is a common English prefix that suggests a nostalgic, dated appearance.</comment>
   </data>
   <data name="Profile_AdjustIndistinguishableColors.Header" xml:space="preserve">
-    <value>Àũŧŏмâťί¢αļℓў αδјûšţ ļіģнţⁿ℮śš õƒ їńďιŝţίňĝūíѕћавłз тēжţ !!! !!! !!! !!! !!! !</value>
+    <value>Аŭťοмäтĩčāĺłỳ ăδјΰѕť ļϊģђτπ℮şѕ ǿƒ їиδιšťΐņğűīşћāвłэ тêжť !!! !!! !!! !!! !!! !</value>
     <comment>Header for a control to toggle if we should adjust the foreground color's lightness to make it more visible when necessary, based on the background color.</comment>
   </data>
   <data name="Profile_AdjustIndistinguishableColors.HelpText" xml:space="preserve">
-    <value>Аŭťömάťî¢áŀľÿ ъґĭģнтéήş оŗ ðãґќέñś ŧēжţ ťõ mâĸē įţ mοřė νĭŝїьļ℮. Еνεй ŵћêή ейдвĺέδ, ŧħίŝ ǻδјůşŧмзņŧ ωìℓļ ōиłў óćĉúг ẃĥëη à сòмвĩиăтϊǿй őƒ ƒŏřęĝŗǿϋηð алð ъą¢ķğřòύиđ ċôłǿѓş ώǿűŀð ѓеѕŭℓţ ιπ ρоóř ¢ôñтґåѕŧ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>∆ųţοmäţιċãℓľў ьŗϊġĥťëñś ǿŗ δåřķēиѕ ťěжŧ ťò mäќε ĭŧ mόґз νίşìъŀĕ. Зνёŋ ẃћéŋ ęηāьℓёδ, τћιѕ äđјυšŧměйŧ ẃìℓŀ õñℓў ôćčцг ŵђěи ǻ çøмъĩⁿãτĩθñ øƒ ƒбřεġґòϋňδ áηď вāсκģřŏŭпδ čółοřş ẁóΰłđ я℮şŭľτ ìñ ρőόŗ сõŉтгáѕт. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "adjust indistinguishable colors" setting does. Presented near "Profile_AdjustIndistinguishableColors".</comment>
   </data>
   <data name="Profile_ScrollbarVisibility.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ŝсгŏļľьâř νīŝίвĩℓïτγ !!! !!!</value>
+    <value>Šсґσļľвąя νĩѕìъįłіťу !!! !!!</value>
     <comment>Name for a control to select the visibility of the scrollbar in a session.</comment>
   </data>
   <data name="Profile_ScrollbarVisibility.Header" xml:space="preserve">
-    <value>Ŝćяόℓľвăґ νįѕīъìℓιтŷ !!! !!!</value>
+    <value>Ščяòľŀвåŕ νίšιъįŀιτÿ !!! !!!</value>
     <comment>Header for a control to select the visibility of the scrollbar in a session.</comment>
   </data>
   <data name="Profile_ScrollbarVisibilityHidden.Content" xml:space="preserve">
-    <value>Ĥĭđďéй !</value>
+    <value>Ĥΐδđēⁿ !</value>
     <comment>An option to choose from for the "scrollbar visibility" setting. When selected, the scrollbar is hidden.</comment>
   </data>
   <data name="Profile_ScrollbarVisibilityVisible.Content" xml:space="preserve">
-    <value>Vīѕïвłè !!</value>
+    <value>Vїşівłε !!</value>
     <comment>An option to choose from for the "scrollbar visibility" setting. When selected, the scrollbar is visible but may dynamically shrink.</comment>
   </data>
   <data name="Profile_ScrollbarVisibilityAlways.Content" xml:space="preserve">
-    <value>Άĺẅäÿš !</value>
+    <value>Âℓώãýѕ !</value>
     <comment>An option to choose from for the "scrollbar visibility" setting. When selected, the scrollbar is always visible.</comment>
   </data>
   <data name="Profile_SnapOnInput.Header" xml:space="preserve">
-    <value>Śςŕбℓŀ ŧό įñρųť ẁĥэή ţўрīηğ !!! !!! !!</value>
+    <value>Śсгόľĺ ťσ їŋрυт ẃħęπ ţỳφįⁿģ !!! !!! !!</value>
     <comment>Header for a control to toggle if keyboard input should automatically scroll to where the input was placed.</comment>
   </data>
   <data name="Profile_StartingDirectory.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ѕтāřŧΐņğ ďіřěсťôѓý !!! !!</value>
+    <value>Ŝταяτìлĝ ðĩѓ℮ćτоŗỳ !!! !!</value>
     <comment>Name for a control to determine the directory the session opens it at launch. This is on a text box that accepts folder paths.</comment>
   </data>
   <data name="Profile_StartingDirectory.Header" xml:space="preserve">
-    <value>Šťąяţιŉĝ διѓ℮čťőѓγ !!! !!</value>
+    <value>Ѕťåřťіπġ đíгëĉţöґγ !!! !!</value>
     <comment>Header for a control to determine the directory the session opens it at launch. This is on a text box that accepts folder paths.</comment>
   </data>
   <data name="Profile_StartingDirectoryBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ŝтäгţϊŋġ ðϊŗëçτöяў !!! !!</value>
+    <value>Šтдřтíⁿģ đϊŕёςŧôŗў !!! !!</value>
     <comment>Name for a control to determine the directory the session opens it at launch. This is on a text box that accepts folder paths.</comment>
   </data>
   <data name="Profile_StartingDirectory.HelpText" xml:space="preserve">
-    <value>Тђэ ðιřесτöŗў τнę рřбƒîļ℮ şτаřтş їņ ẅħėл īŧ ίş ŀόǻδėď. !!! !!! !!! !!! !!! !</value>
+    <value>Ţћé đĭŗéçťòŕу τħе рѓøƒĩŀе śťªřťş ïή ẅћĕл îţ ίѕ ŀбдδėď. !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
   </data>
   <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
-    <value>Ьřŏωѕē... !!!</value>
+    <value>Ьŕōωŝē... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
   <data name="Profile_StartingDirectoryUseParentCheckbox.Content" xml:space="preserve">
-    <value>Џѕé φãŕėⁿţ рřóςзŝš ðįŕзćтøяγ !!! !!! !!</value>
+    <value>Üŝè φαŗèńŧ рřоĉěѕѕ đĭřё¢τоґý !!! !!! !!</value>
     <comment>A supplementary setting to the "starting directory" setting. "Parent" refers to the parent process of the current process.</comment>
   </data>
   <data name="Profile_StartingDirectoryUseParentCheckbox.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ĩƒ éидьłєđ, τħîś рřôƒīℓĕ щìľĺ šрдŵŋ ìй ťћє δίřëçťσřŷ ƒŕόm ẁђісн Ťêřmìñáļ шăš ŀǻцηćђёδ. !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Îƒ έпãьłëď, тђìš ρѓòƒìĺè ωιĺℓ ŝρǻẁň іň ţћę ðіяеçţбгγ ƒřőм щћįςђ Теямĭņàł ẃªş ŀáцⁿĉħёđ. !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the supplementary "use parent process directory" setting does. Presented near "Profile_StartingDirectoryUseParentCheckbox".</comment>
   </data>
   <data name="Profile_HideIconCheckbox.Content" xml:space="preserve">
-    <value>Ħïđе ĩсöи !!!</value>
+    <value>Ηϊðё îçǿй !!!</value>
     <comment>A supplementary setting to the "icon" setting.</comment>
   </data>
   <data name="Profile_HideIconCheckbox.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Íƒ ĕпàвłèď, тћįŝ φřоƒīłę ωîłł ĥдνë ņŏ įċόŋ. !!! !!! !!! !!! </value>
+    <value>Íƒ ёηдъļэδ, ŧĥϊŝ φгōƒιℓз шіℓŀ ђдνê ňö ΐĉôй. !!! !!! !!! !!! </value>
     <comment>A description for what the supplementary "Hide icon" setting does. Presented near "Profile_HideIconCheckbox".</comment>
   </data>
   <data name="Profile_SuppressApplicationTitle.Header" xml:space="preserve">
-    <value>Śųφφгęśš ţĭţļě çħаńģéš !!! !!! </value>
+    <value>Ѕΰφφřэśš τíťļė čħªŉĝèѕ !!! !!! </value>
     <comment>Header for a control to toggle changes in the app title.</comment>
   </data>
   <data name="Profile_SuppressApplicationTitle.HelpText" xml:space="preserve">
-    <value>Іģŋŏŗê āρφℓīçάŧΐøη гέqüęŝţŝ τθ ĉнаňģέ ŧђé ţιτĺе (OSC 2). !!! !!! !!! !!! !!! !</value>
+    <value>Íġπόŗэ áρρĺіćâţìǿŋ ŗέqúёśţś ťò çђâηğě ťђê тįтŀé (ΘЅĆ 2). !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "suppress application title" setting does. Presented near "Profile_SuppressApplicationTitle". "OSC 2" is a technical term that is understood in the industry. {Locked="OSC 2"}</comment>
   </data>
   <data name="Profile_TabTitle.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Тăь ţíтľé !!!</value>
+    <value>Τάъ ŧїŧļê !!!</value>
     <comment>Name for a control to determine the title of the tab. This is represented using a text box.</comment>
   </data>
   <data name="Profile_TabTitle.Header" xml:space="preserve">
-    <value>Ťаь тīтľę !!!</value>
+    <value>Ťǻв τįťłэ !!!</value>
     <comment>Header for a control to determine the title of the tab. This is represented using a text box.</comment>
   </data>
   <data name="Profile_TabTitle.HelpText" xml:space="preserve">
-    <value>Гεрľǻ¢έş ţћё рřǿƒїłз пам℮ áѕ ŧħë тīţļε ŧο φªšѕ тǿ ţђê ŝħěłľ öή śŧāѓτùρ. !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ŕèφłǻčèş ţће рřöƒîℓέ иάмз äş τне тíŧŀë ŧŏ φāѕş ŧό ţĥë şђëℓł öņ śťâгŧûρ. !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "tab title" setting does. Presented near "Profile_TabTitle".</comment>
   </data>
   <data name="Profile_UnfocusedAppearanceTextBlock.Text" xml:space="preserve">
-    <value>Ûŋƒǿċûšεð äрρεªŕаήςз !!! !!!</value>
+    <value>Ûηƒŏċμşεď äррėāŕαńćё !!! !!!</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
   <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Čřęдτє ∆рреářдйċе !!! !!</value>
+    <value>Ĉřêάŧэ Δрφзάŕãñςε !!! !!</value>
     <comment>Button label that adds an unfocused appearance for this profile.</comment>
   </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
-    <value>Đёĺęτê !</value>
+    <value>Ðéľėŧê !</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
   </data>
   <data name="Profile_UseAcrylic.Header" xml:space="preserve">
-    <value>Елáъłε āçѓýŀϊĉ мάтεŕіâĺ !!! !!! </value>
+    <value>Єňάьłē дсѓŷĺĭс mąτěřìªŀ !!! !!! </value>
     <comment>Header for a control to toggle the use of acrylic material for the background. "Acrylic material" is a Microsoft-specific term: https://docs.microsoft.com/en-us/windows/apps/design/style/acrylic</comment>
   </data>
   <data name="Profile_UseAcrylic.HelpText" xml:space="preserve">
-    <value>Дрρłĭèŝ á ťяåйşļüсеиţ ŧє×ţūřё ţθ тĥз ьā¢кĝгöũńð бƒ ŧĥε ẃĩήðбŵ. !!! !!! !!! !!! !!! !!! </value>
+    <value>Àφρļįëś ã ţґάήŝℓűсэиŧ тēжτυŗэ ťό тĥ℮ ъάćĸĝґõυήď õƒ ţћ℮ щϊηðǿщ. !!! !!! !!! !!! !!! !!! </value>
     <comment>A description for what the "Profile_UseAcrylic" setting does.</comment>
   </data>
   <data name="Profile_UseDesktopImage.Content" xml:space="preserve">
-    <value>Űšē δєśκτθρ ώàŀłρåρèŕ !!! !!!</value>
+    <value>Ŭŝē đεśķτòр ẃąℓłραрĕя !!! !!!</value>
     <comment>A supplementary setting to the "background image" setting. When enabled, the OS desktop wallpaper is used as the background image. Presented near "Profile_BackgroundImage".</comment>
   </data>
   <data name="Profile_UseDesktopImage.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ũѕě ťђе đëѕќτōр ŵαℓŀрαρёг įмάġē ªş тнє ьªċĸĝѓŏûⁿδ імáģě ƒσг тће τĕѓmіηáľ. !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Ůšê тнè ďєśķťōρ ŵªĺļраφēř ímǻğё αś тħэ ъąĉκġřōůлđ іmãġè ƒόґ ŧн℮ ţэґмϊлªļ. !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>A description for what the supplementary "use desktop image" setting does. Presented near "Profile_UseDesktopImage".</comment>
   </data>
   <data name="Settings_ResetSettingsButton.Content" xml:space="preserve">
-    <value>Ďϊѕĉªřđ ċнάиğеś !!! !</value>
+    <value>Ďìš¢αŗð ĉђăŉġęѕ !!! !</value>
     <comment>Text label for a destructive button that discards the changes made to the settings.</comment>
   </data>
   <data name="Settings_ResetSettingsButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Đΐѕċάŗď äŀĺ ϋйšǻνëď śēττìйğś. !!! !!! !!!</value>
+    <value>Ðĭŝĉäŕð дĺľ цŋşåνёď ѕεťŧīńġś. !!! !!! !!!</value>
     <comment>A description for what the "discard changes" button does. Presented near "Settings_ResetSettingsButton".</comment>
   </data>
   <data name="Settings_SaveSettingsButton.Content" xml:space="preserve">
-    <value>Śάνê !</value>
+    <value>Śāνэ !</value>
     <comment>Text label for the confirmation button that saves the changes made to the settings.</comment>
   </data>
   <data name="Settings_UnsavedSettingsWarning.Text" xml:space="preserve">
-    <value>⚠ ¥θũ ђāνε űпѕªνêð čћалĝεŝ. !!! !!! !!</value>
+    <value>⚠ Υŏű нâνě цπśąνêδ ¢ђãпġēš. !!! !!! !!</value>
     <comment>{Locked="⚠"} A disclaimer that appears when the unsaved changes to the settings are present.</comment>
   </data>
   <data name="Nav_AddNewProfile.Content" xml:space="preserve">
-    <value>Āδð а π℮ẅ φяόƒіļę !!! !!</value>
+    <value>Ãđδ α ηèŵ ряоƒіľэ !!! !!</value>
     <comment>Header for the "add new" menu item. This navigates to the page where users can add a new profile.</comment>
   </data>
   <data name="Nav_Profiles.Content" xml:space="preserve">
-    <value>Ρяóƒĩļеś !!</value>
+    <value>Ρґőƒϊłеѕ !!</value>
     <comment>Header for the "profiles" menu items. This acts as a divider to introduce profile-related menu items.</comment>
   </data>
   <data name="Globals_LaunchModeFocus.Content" xml:space="preserve">
-    <value>₣öċΰš !</value>
+    <value>₣őćџŝ !</value>
     <comment>An option to choose from for the "launch mode" setting. Focus mode is a mode designed to help you focus.</comment>
   </data>
   <data name="Globals_LaunchModeMaximizedFocus.Content" xml:space="preserve">
-    <value>Μǻ×імϊžеδ ƒó¢űѕ !!! !</value>
+    <value>Μãхîмížęď ƒòćύŝ !!! !</value>
     <comment>An option to choose from for the "launch mode" setting. Opens the app maximized and in focus mode.</comment>
   </data>
   <data name="Globals_LaunchModeMaximizedFullscreen.Content" xml:space="preserve">
-    <value>Μа×ίmїžęð ƒцłľ ѕćґєĕň !!! !!!</value>
+    <value>Мª×įmίźėδ ƒύļĺ šсґèэη !!! !!!</value>
     <comment>An option to choose from for the "launch mode" setting. Opens the app maximized and in full screen.</comment>
   </data>
   <data name="Globals_LaunchModeFullscreenFocus.Content" xml:space="preserve">
-    <value>₣ŭŀĺ ščŕėёп ƒòçϋş !!! !!</value>
+    <value>₣üĺℓ śčřèéη ƒŏćŭś !!! !!</value>
     <comment>An option to choose from for the "launch mode" setting. Opens the app in full screen and in focus mode.</comment>
   </data>
   <data name="Globals_LaunchModeMaximizedFullscreenFocus.Content" xml:space="preserve">
-    <value>Μà×ιmιźèď ƒџĺľ śćŗěёп ƒøčύś !!! !!! !!</value>
+    <value>Μąжįмīźēď ƒµĺļ śсяé℮ⁿ ƒθčϋš !!! !!! !!</value>
     <comment>An option to choose from for the "launch mode" setting. Opens the app maximized in full screen and in focus mode.</comment>
   </data>
   <data name="Profile_BellStyle.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Бēŀĺ лòτιƒϊçâŧíóй šťÿŀэ !!! !!! </value>
+    <value>Бэĺł иőťíƒΐćªŧίøл ѕţуĺз !!! !!! </value>
     <comment>Name for a control to select the how the app notifies the user. "Bell" is the common term in terminals for the BEL character (like the metal device used to chime).</comment>
   </data>
   <data name="Profile_BellStyle.Header" xml:space="preserve">
-    <value>Ъεļľ йόťїƒïсäţιòл śтŷłĕ !!! !!! </value>
+    <value>Веĺł йθŧϊƒīçǻťΐθп ŝťỳℓé !!! !!! </value>
     <comment>Header for a control to select the how the app notifies the user. "Bell" is the common term in terminals for the BEL character (like the metal device used to chime).</comment>
   </data>
   <data name="Profile_BellStyle.HelpText" xml:space="preserve">
-    <value>Çσñţгøłŝ щђāţ ĥäρφεиŝ шћёη ŧђë åφрℓįčаτίбⁿ ēmīτѕ ǻ BEL ćħâŕäćтęг. !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ĉøήτѓōℓѕ ẅнǻτ ђдρφéпš шђĕñ тнē ąρрĺιčάτĩоň емìťś а ЬΕ£ ćђãяд¢ţĕř. !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "bell style" setting does. Presented near "Profile_BellStyle".{Locked="BEL"}</comment>
   </data>
   <data name="Profile_ReloadEnvVars.Header" xml:space="preserve">
-    <value>£ãűп¢н ťнΐѕ äρρłîĉάτìøň ẅіţĥ ã йεω èņνĭґοńmĕŉт ъłŏ¢ĸ !!! !!! !!! !!! !!! </value>
+    <value>£αüņ¢ħ ŧћΐš аρφℓîсäŧïōп ŵìţн α йéω ёňνΐѓõлmĕπţ ъłосќ !!! !!! !!! !!! !!! </value>
     <comment>"environment variables" are user-definable values that can affect the way running processes will behave on a computer</comment>
   </data>
   <data name="Profile_ReloadEnvVars.HelpText" xml:space="preserve">
-    <value>Ŵђέи έńąъĺèð, ŧħë Тĕґmїŋâļ ẁíŀľ ğ℮ⁿėřåτ℮ ª ήέщ εήνĩřσπmёиţ ьļōċķ ŵђêή ĉŗêάŧϊйģ ņěω ťάвѕ ŏг рαñёş щīтћ ţнїѕ рŕöƒíľē. Шћεń đīŝαъłëđ, ţħé ţáъ/φąňз ẃίŀℓ ìňśţедď îηħëяíţ ťнê νагϊåъĺêŝ ţђě Ťэŕmϊπāł ẁдŝ şтǻгтєđ ẅïťћ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ẁћέл εņаьŀèď, τħё Ŧëгmĩňªľ ẅīŀℓ ğεлěяαте å ŉэщ еńνîřόńмęñт ьŀøĉĸ ŵħ℮л čґēãťîņğ ŉεώ τâвѕ όя рªлёѕ щĭτћ тĥĭѕ ρŗòƒΐℓė. Ẅђêй ðìšąвļėđ, τћë ťąь/рáňε шîŀĺ íñśτėáđ īήђзŕίτ τђė νăяϊаьℓĕŝ ţђε Ťęřmíŋаŀ ẁαŝ śťäřťέδ ωįтħ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "Reload environment variables" setting does. Presented near "Profile_ReloadEnvVars".</comment>
   </data>
   <data name="Profile_VtPassthrough.Header" xml:space="preserve">
-    <value>Еņǻвŀè èжρ℮яιmëлťäł νіѓţυåł τ℮ŗmιлăļ ρäŝŝŧђѓόϋġħ !!! !!! !!! !!! !!</value>
+    <value>Зńăьℓē эхφзґímėпτªŀ νіѓтűǻļ τ℮ґмϊñāļ φаśşтнґöúģн !!! !!! !!! !!! !!</value>
     <comment>An option to enable experimental virtual terminal passthrough connectivity option with the underlying ConPTY</comment>
   </data>
+  <data name="Profile_RightClickContextMenu.Header" xml:space="preserve">
+    <value>Ðįşφłąÿ ǻ мèηΰ όή řïĝĥť-ćľїçķ !!! !!! !!!</value>
+    <comment>This controls how a right-click behaves in the terminal</comment>
+  </data>
+  <data name="Profile_RightClickContextMenu.HelpText" xml:space="preserve">
+    <value>Ẁђéŋ êπäвĺεð, ţĥё Τéŕмįⁿął ẃìļŀ ďïśρĺąỳ ã мέиц öη ŕìğĥţ-сℓĩ¢ķ. Ŵћëŉ đϊśªьŀèð, řιġћţ-čℓî¢ķιñĝ ẁĩłℓ ĉσрÿ тħē şèłэĉţĕđ ŧэжτ (ŏя рâŝтé ΐƒ ťћзяę'ś йб śзľĕćţîбñ). !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <comment>A description for what the "Display a menu on right-click" setting does. Presented near "Profile_RightClickContextMenu".</comment>
+  </data>
+  <data name="Profile_ShowMarks.Header" xml:space="preserve">
+    <value>Ďιşрĺąŷ мǻŕĸş θй ţĥě ŝćřбŀŀъáŕ !!! !!! !!!</value>
+    <comment>"Marks" are small visual indicators that can help the user identify the position of useful info in the scrollbar</comment>
+  </data>
+  <data name="Profile_ShowMarks.HelpText" xml:space="preserve">
+    <value>Ẅĥέň ёпдъļêď, τĥ℮ Τëгmįиªł ẃĩľļ ðΐśρℓăỳ мāѓκś ιñ ţħє şĉѓòℓľьªŗ ŵħëⁿ ŝēãѓçђιŋĝ ƒθř ťèжт, σѓ ŵћзп šђêļŀ ίπтέğґãťîόи іś εŋäьłёđ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <comment>A description for what the "Display marks on the scrollbar" setting does. Presented near "Profile_ShowMarks".</comment>
+  </data>
+  <data name="Profile_AutoMarkPrompts.Header" xml:space="preserve">
+    <value>∆űŧòмåťĩċǻłļγ маѓķ ρřǿmρŧş óй φґěѕşіиğ Еŋŧєř !!! !!! !!! !!! !</value>
+    <comment>"Enter" is the enter/return key on the keyboard. This will add a mark indicating the position of a shell prompt when the user presses enter.</comment>
+  </data>
+  <data name="Profile_AutoMarkPrompts.HelpText" xml:space="preserve">
+    <value>Ẃћеⁿ эņáвļēď, тħè Тěřмíиãŀ ǻµтοмăťìςǻℓľу åδď ã мâŕĸ іиđιςåŧïⁿġ тħé рσŝĩţίол öƒ ţђé ęņð øƒ τĥę ςбmмǻйδ ẃћéи ýθů φŕэѕѕ ēиŧęѓ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <comment>A description for what the "Automatically mark prompts on pressing Enter" setting does. Presented near "Profile_AutoMarkPrompts".</comment>
+  </data>
+  <data name="Profile_RepositionCursorWithMouse.Header" xml:space="preserve">
+    <value>Ê×рэґїmзŉτâļ: Гэрŏśΐťĩőⁿ τћέ ćũŕšσŕ ẁіτн mσůśё ċℓīċĸѕ !!! !!! !!! !!! !!! </value>
+    <comment>This allows the user to move the text cursor just by clicking with the mouse.</comment>
+  </data>
+  <data name="Profile_RepositionCursorWithMouse.HelpText" xml:space="preserve">
+    <value>Ẅћзή ℮йăъļэð, ĉľīćкїηġ ιňśīðè ŧĥё ρŕσmρŧ ωïŀļ мσνэ ţћё čúřšŏѓ тő ţħάŧ рōŝΐτíôⁿ. Ŧђΐŝ ŕéqűїřέѕ šћėľľ іñţεģřãţīǿň тø ъē зŋāвłêð ιπ убųѓ ѕћєľĺ τó ẃθѓκ ăѕ зжφĕčτēď. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <comment>A description for what the "Reload environment variables" setting does. Presented near "Profile_RepositionCursorWithMouse".</comment>
+  </data>
   <data name="Profile_BellStyleAudible.Content" xml:space="preserve">
-    <value>Àũđιьľē !!</value>
+    <value>∆ůðĭъĺę !!</value>
     <comment>An option to choose from for the "bell style" setting. When selected, an audible cue is used to notify the user.</comment>
   </data>
   <data name="Profile_BellStyleNone.Content" xml:space="preserve">
-    <value>Ňōπë !</value>
+    <value>Ñбŉĕ !</value>
     <comment>An option to choose from for the "bell style" setting. When selected, notifications are silenced.</comment>
   </data>
   <data name="Globals_DisableAnimations.Header" xml:space="preserve">
-    <value>Ďΐŝäъĺє ρǻņ℮ äηімдтіøйѕ !!! !!! </value>
+    <value>Đїŝâвŀè рăŋě ǻйįmąтіǿňŝ !!! !!! </value>
     <comment>Header for a control to toggle animations on panes. "Enabled" value disables the animations.</comment>
   </data>
   <data name="Profile_FontWeightBlack.Content" xml:space="preserve">
-    <value>Вľåĉĸ !</value>
+    <value>Вĺåčќ !</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightBold.Content" xml:space="preserve">
-    <value>ßοℓď !</value>
+    <value>Ъθĺď !</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightCustom.Content" xml:space="preserve">
-    <value>€úšŧǿm !</value>
+    <value>Ćцѕτσm !</value>
     <comment>This is an entry that allows the user to select their own font weight value outside of the simplified list of options.</comment>
   </data>
   <data name="Profile_FontWeightExtra-black.Content" xml:space="preserve">
-    <value>Ê×ţřа-ßℓąçќ !!!</value>
+    <value>Ĕжťŗā-Βļаċк !!!</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightExtra-bold.Content" xml:space="preserve">
-    <value>Эжτяå-Вóļď !!!</value>
+    <value>Ёжţгд-Боļδ !!!</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightExtra-light.Content" xml:space="preserve">
-    <value>Єхтгā-₤ïġħт !!!</value>
+    <value>Ę×тяā-£ïĝћţ !!!</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightLight.Content" xml:space="preserve">
-    <value>Ŀįĝђŧ !</value>
+    <value>Ŀιğĥŧ !</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightMedium.Content" xml:space="preserve">
-    <value>Мέδΐüm !</value>
+    <value>Μєđιϋм !</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightNormal.Content" xml:space="preserve">
-    <value>Йоřмãľ !</value>
+    <value>Ňŏŗmªĺ !</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightSemi-bold.Content" xml:space="preserve">
-    <value>Ѕěмĭ-Βοℓδ !!!</value>
+    <value>Şèмï-Вōłđ !!!</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightSemi-light.Content" xml:space="preserve">
-    <value>Ѕēmį-Ļίġћτ !!!</value>
+    <value>Ѕėmį-₤іģħŧ !!!</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightThin.Content" xml:space="preserve">
-    <value>Ŧħіŉ !</value>
+    <value>Ŧħīň !</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontFeature_rlig" xml:space="preserve">
-    <value>Řεqцιŕèδ ļіġãťųяéŝ !!! !!</value>
+    <value>Ŗéqùїяëď ľîģąτüřеŝ !!! !!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_locl" xml:space="preserve">
-    <value>Ļοςâĺϊżêð ƒσгmš !!! !</value>
+    <value>£ǿčãłϊźэď ƒŏгмş !!! !</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_ccmp" xml:space="preserve">
-    <value>Сõmρőšíτìοñ/đэčómрôşĩŧіŏņ !!! !!! !</value>
+    <value>Ćóмρőśĭťϊοņ/ðέċömφóšίτìøη !!! !!! !</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_calt" xml:space="preserve">
-    <value>Сőиτęхťûâł άĺτèřⁿáτεŝ !!! !!!</value>
+    <value>Сθⁿте×тüáŀ ǻℓţėŗпαтēŝ !!! !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_liga" xml:space="preserve">
-    <value>Ŝťάŋðαгđ ļιġдτύґэѕ !!! !!</value>
+    <value>Ѕτάлďάґð ℓíġąтŭѓεѕ !!! !!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_clig" xml:space="preserve">
-    <value>Ĉöηťёхţџªŀ łîğáтüŕėş !!! !!!</value>
+    <value>Ċоňťêжţũāł łіġăŧµѓèś !!! !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_rvrn" xml:space="preserve">
-    <value>Ґëqΰίґ℮δ νâгĩдťΐŏň ãĺţěřńаţēś !!! !!! !!!</value>
+    <value>Ŕëqџìґêð νãяìâтïöп ªļтĕгñąţëš !!! !!! !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_kern" xml:space="preserve">
-    <value>Κзяňϊņğ !!</value>
+    <value>Ќεřпĩńģ !!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_mark" xml:space="preserve">
-    <value>Μâѓк рǿŝϊтїôňίήĝ !!! !</value>
+    <value>Мăґĸ φбśїτìõйίήģ !!! !</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_mkmk" xml:space="preserve">
-    <value>Мåѓķ тǿ mářк φοşíţĭòņįñģ !!! !!! !</value>
+    <value>Мªяκ ŧθ máгķ φбşίţīōпîņĝ !!! !!! !</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_dist" xml:space="preserve">
-    <value>Đìşťάňçе !!</value>
+    <value>Ďïşťªпčє !!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_aalt" xml:space="preserve">
-    <value>∆ćčεśś àļŀ ǻŀтèřйäť℮ѕ !!! !!!</value>
+    <value>Âĉċēśş αłł ǻĺтэяńáťėş !!! !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_case" xml:space="preserve">
-    <value>Čåśé śęπšīтΐνé ƒŏѓmѕ !!! !!!</value>
+    <value>€αŝē śεⁿŝιţіνé ƒǿŗmŝ !!! !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_dnom" xml:space="preserve">
-    <value>Đĕиòmĭñдţόґ !!!</value>
+    <value>Đēñômĭņąţόя !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_fina" xml:space="preserve">
-    <value>Тëřмìήâŀ ƒοŗмś !!! !</value>
+    <value>Ŧēгмιπáļ ƒόŕmś !!! !</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_frac" xml:space="preserve">
-    <value>₣řąċŧίοňѕ !!!</value>
+    <value>₣ŕãçŧїõήŝ !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_init" xml:space="preserve">
-    <value>Ίпįτιâł ƒóřмŝ !!! </value>
+    <value>Īήíťĭàľ ƒõяmŝ !!! </value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_medi" xml:space="preserve">
-    <value>Μеðïªł ƒθŗmš !!! </value>
+    <value>Μеďìαℓ ƒбřмš !!! </value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_numr" xml:space="preserve">
-    <value>Νμm℮гåŧŏŗ !!!</value>
+    <value>Ňϋмēгªţőř !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_ordn" xml:space="preserve">
-    <value>Фŗďίпåłš !!</value>
+    <value>Οřďĩŋäℓѕ !!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_rclt" xml:space="preserve">
-    <value>Гéqűіŗєð čοⁿťєхтűǻľ ªłťęгņăтěş !!! !!! !!!</value>
+    <value>Ŗèqŭīŗеð ĉοйτęхťüàĺ áľţėřŉãŧεŝ !!! !!! !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_sinf" xml:space="preserve">
-    <value>Ŝçīэņтïƒìċ ìпƒéŗïôŗѕ !!! !!!</value>
+    <value>Śсϊèⁿťίƒιč ΐñƒєřīōŗŝ !!! !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_subs" xml:space="preserve">
-    <value>Ѕùьšçřιρŧ !!!</value>
+    <value>Śûвś¢řîρţ !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_sups" xml:space="preserve">
-    <value>Śŭрзґŝςяîφτ !!!</value>
+    <value>Ŝùρεřśčřîφŧ !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_zero" xml:space="preserve">
-    <value>Šĺαşĥęđ żëřő !!! </value>
+    <value>Ѕĺáѕħëď żêґø !!! </value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_abvm" xml:space="preserve">
-    <value>Ąьõνė-ьäŝе мāґќ ροśίτíόйїπģ !!! !!! !!</value>
+    <value>Λъŏνє-ъåѕέ мǻяќ φōśīτΐóņīлĝ !!! !!! !!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Globals_LaunchSize.Header" xml:space="preserve">
-    <value>Ŀâûņčн śĩźε !!!</value>
+    <value>Łáцηсħ šіžē !!!</value>
     <comment>Header for a group of settings that control the size of the app. Presented near "Globals_InitialCols" and "Globals_InitialRows".</comment>
   </data>
   <data name="Globals_LaunchSize.HelpText" xml:space="preserve">
-    <value>Тне иµmвэѓ оƒ ябẃş äйδ ¢őľųmпś ðīѕρĺαÿĕď ϊй ŧћё ẁίйďοщ úφøл ƒīřŝτ ļøåď. Мздŝůязð îņ ¢ħаѓàćтĕřş. !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Τĥé ήυмвēŕ θƒ гόωş äйđ ςôľũмņś đΐşφĺąŷęđ îй ŧĥê ẃįňďŏώ ųрбŋ ƒїяšţ ļŏăď. Μêάşµřēď īй ςħαŕāçτέřś. !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "rows" and "columns" settings do. Presented near "Globals_LaunchSize.Header".</comment>
   </data>
   <data name="Globals_LaunchPosition.Text" xml:space="preserve">
-    <value>Łдϋйċĥ рοšįţīσи !!! !</value>
+    <value>Ľâűπçћ φσѕíţįбŉ !!! !</value>
     <comment>Header for a group of settings that control the launch position of the app. Presented near "Globals_InitialPosX" and "Globals_InitialPosY".</comment>
   </data>
   <data name="Globals_LaunchPosition.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Τћє ïņіτīдŀ φоşїţїθŋ бƒ ŧĥê т℮řмĩлąŀ ẁιŋδøщ ΰρőň şтáгτυр. Щĥеⁿ ľǻűņċђĭπĝ ãś mªхíмìžĕď, ƒůļĺ ś¢ŕêέŋ, θŗ ẅīťĥ "Ĉëňτëř ŏή ļąùⁿċĥ" єńάьĺэď, ŧћίš ĩš ûŝèď τø ţâгĝεţ тĥє мøñіŧōŕ øƒ įπťέřέśт. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Ťнέ īηĭţϊąĺ φǿšĩтīòл őƒ ŧђę τĕѓмīηäł ωĭиđŏщ ϋρőŉ śτåřťϋр. Ŵнέη ľãцпçђìŋģ άŝ mã×ĩмιż℮ď, ƒµļľ ŝ¢ґэ℮ň, øř ẃĩτħ "Çĕпτеґ ои łåúŋ¢ђ" ĕņǻвℓėδ, ŧĥíŝ íś џşĕď ţö ţάřĝēŧ тħē моŋітòя σƒ įпťēґēśŧ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>A description for what the "X position" and "Y position" settings do. Presented near "Globals_LaunchPosition.Header".</comment>
   </data>
   <data name="Profile_BellStyleAll.Content" xml:space="preserve">
-    <value>Аľļ </value>
+    <value>Äŀℓ </value>
     <comment>An option to choose from for the "bell style" setting. When selected, a combination of the other bell styles is used to notify the user.</comment>
   </data>
   <data name="Profile_BellStyleVisual.Content" xml:space="preserve">
-    <value>Vìŝüåℓ (ƒℓдşĥ ťªšкьãґ) !!! !!! </value>
+    <value>Vĭśũάŀ (ƒĺāşђ ţąşκвдѓ) !!! !!! </value>
   </data>
   <data name="Profile_BellStyleTaskbar.Content" xml:space="preserve">
-    <value>₣łäśĥ ταŝķьãř !!! </value>
+    <value>₣ŀªśћ τâśќъäѓ !!! </value>
     <comment>An option to choose from for the "bell style" setting. When selected, a visual notification is used to notify the user. In this case, the taskbar is flashed.</comment>
   </data>
   <data name="Profile_BellStyleWindow.Content" xml:space="preserve">
-    <value>₣łáşћ ẁįйđǿŵ !!! </value>
+    <value>₣łāŝћ ẅїňďŏщ !!! </value>
     <comment>An option to choose from for the "bell style" setting. When selected, a visual notification is used to notify the user. In this case, the window is flashed.</comment>
   </data>
   <data name="ColorScheme_AddNewButton.Text" xml:space="preserve">
-    <value>Ąðδ ⁿëώ !!</value>
+    <value>Äδď ⁿĕш !!</value>
     <comment>Button label that creates a new color scheme.</comment>
   </data>
   <data name="ColorScheme_DeleteButton.Text" xml:space="preserve">
-    <value>Ď℮ļēŧ℮ çòļбґ ş¢ђèме !!! !!!</value>
+    <value>Ðєĺèŧĕ ¢оľōѓ ѕснεмė !!! !!!</value>
     <comment>Button label that deletes the selected color scheme.</comment>
   </data>
   <data name="ColorScheme_EditButton.Text" xml:space="preserve">
-    <value>Εďîŧ !</value>
+    <value>Σδϊт !</value>
     <comment>Button label that edits the currently selected color scheme.</comment>
   </data>
   <data name="ColorScheme_DeleteButton2.Text" xml:space="preserve">
-    <value>Ðэĺëţê !</value>
+    <value>Đеļėŧę !</value>
     <comment>Button label that deletes the selected color scheme.</comment>
   </data>
   <data name="ColorScheme_Name.Header" xml:space="preserve">
-    <value>Ламē !</value>
+    <value>Ŋām℮ !</value>
     <comment>The name of the color scheme. Used as a label on the name control.</comment>
   </data>
   <data name="ColorScheme_Name.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ťћè ńǻmè őƒ ţнέ čθłōř śςнēмэ. !!! !!! !!!</value>
+    <value>Ŧħё ŋąмэ őƒ τћě ¢ǿℓôѓ śçђéмē. !!! !!! !!!</value>
     <comment>Supplementary text (tooltip) for the control used to select a color scheme that is under view.</comment>
   </data>
   <data name="Profile_DeleteButton.Text" xml:space="preserve">
-    <value>Đēℓëţĕ ρяôƒϊļё !!! !</value>
+    <value>Đёľĕŧз рŗõƒιŀê !!! !</value>
     <comment>Button label that deletes the current profile that is being viewed.</comment>
   </data>
   <data name="Profile_Name.HelpText" xml:space="preserve">
-    <value>Ţħĕ ńąmė õƒ ŧħë ρґõƒΐľэ ŧћâť αррëãѓŝ ĩñ τђĕ đґöрðőẃņ. !!! !!! !!! !!! !!! </value>
+    <value>Ťћє ηǻмэ бƒ тнέ рřоƒïľé ţĥāτ άрρеαяѕ ĭπ ťћê đŕøφđóẃи. !!! !!! !!! !!! !!! </value>
     <comment>A description for what the "name" setting does. Presented near "Profile_Name".</comment>
   </data>
   <data name="Profile_Name.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Йămε !</value>
+    <value>∏ãmê !</value>
     <comment>Name for a control to determine the name of the profile. This is a text box.</comment>
   </data>
   <data name="Profile_Name.Header" xml:space="preserve">
-    <value>Иåмë !</value>
+    <value>Ņàmě !</value>
     <comment>Header for a control to determine the name of the profile. This is a text box.</comment>
   </data>
   <data name="Profile_TransparencyHeader.Text" xml:space="preserve">
-    <value>Тґαиšрāгеŉ¢ў !!! </value>
+    <value>Ţřąηѕρªґěňçÿ !!! </value>
     <comment>Header for a group of settings related to transparency, including the acrylic material background of the app.</comment>
   </data>
   <data name="Profile_BackgroundHeader.Text" xml:space="preserve">
-    <value>Ьãćκġяοùņđ ϊмаġе !!! !</value>
+    <value>Βдĉкġřöûⁿď ìmąĝέ !!! !</value>
     <comment>Header for a group of settings that control the image presented on the background of the app. Presented near "Profile_BackgroundImage" and other keys starting with "Profile_BackgroundImage".</comment>
   </data>
   <data name="Profile_CursorHeader.Text" xml:space="preserve">
-    <value>Ćϋřşθř !</value>
+    <value>Čυřŝóґ !</value>
     <comment>Header for a group of settings that control the appearance of the cursor. Presented near "Profile_CursorHeight" and other keys starting with "Profile_Cursor".</comment>
   </data>
   <data name="Profile_AdditionalSettingsHeader.Text" xml:space="preserve">
-    <value>Áďďітĭόйāĺ şęţтīпğś !!! !!!</value>
+    <value>∆ďδΐţіõпаľ śєτťΐņĝŝ !!! !!!</value>
     <comment>Header for the buttons that navigate to additional settings for the profile.</comment>
   </data>
   <data name="Profile_TextHeader.Text" xml:space="preserve">
-    <value>Ţєхŧ !</value>
+    <value>Ţέхţ !</value>
     <comment>Header for a group of settings that control the appearance of text in the app.</comment>
   </data>
   <data name="Profile_WindowHeader.Text" xml:space="preserve">
-    <value>Шΐñðöω !</value>
+    <value>Щіňďош !</value>
     <comment>Header for a group of settings that control the appearance of the window frame of the app.</comment>
   </data>
   <data name="Nav_OpenJSON.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Øφĕⁿ ÿόυг settings.json ƒϊłз. Аℓť+Ċľĭčк ťб öφėй ŷοüř defaults.json ƒιĺę. !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Ώр℮п ỳõμѓ settings.json ƒιĺ℮. Áŀţ+Ċĺι¢ќ тθ ôφ℮л уοųѓ δěƒåџĺţş.јśŏл ƒïłе. !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>{Locked="settings.json"}, {Locked="defaults.json"}</comment>
   </data>
   <data name="Rename.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ґęŉámě !</value>
+    <value>Γ℮иάмê !</value>
     <comment>Text label for a button that can be used to begin the renaming process.</comment>
   </data>
   <data name="ColorScheme_DeleteButtonDisclaimerInBox.Text" xml:space="preserve">
-    <value>Ţнïѕ ćöℓσř ѕčнěмз ćάиŉôŧ вέ δзĺєŧéδ οŗ ŗëήάмέð вëċäůѕĕ îŧ įş ιŉćĺùðèď ъÿ ďėƒāûľť. !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Τћîŝ čŏļòя şċĥěмε ćâňñǿτ ьё đĕļ℮ťèδ ōŕ ґĕňãmėð ьēĉаūśё ĭţ îś їńċľůðзď ъγ đэƒāûŀŧ. !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>Disclaimer presented next to the delete button when it is disabled.</comment>
   </data>
   <data name="ColorScheme_DeleteConfirmationButton.Content" xml:space="preserve">
-    <value>Ŷêś, đëℓетє čóĺοг ŝςнéмє !!! !!! !</value>
+    <value>Ýëѕ, ðěĺέŧε çółöг śċћэмέ !!! !!! !</value>
     <comment>Button label for positive confirmation of deleting a color scheme (presented with "ColorScheme_DeleteConfirmationMessage")</comment>
   </data>
   <data name="ColorScheme_DeleteConfirmationMessage.Text" xml:space="preserve">
-    <value>Âŕĕ ỳõυ ѕΰгè ỳöû ŵаπť тŏ δеĺĕŧэ ťħīŝ ĉòľōґ śçђęmέ? !!! !!! !!! !!! !!!</value>
+    <value>Аŕë уоû şύŗê γǿџ ẃаηť ŧθ ðέłēтε тнíѕ çσľòř ѕćĥεмέ? !!! !!! !!! !!! !!!</value>
     <comment>A confirmation message displayed when the user intends to delete a color scheme.</comment>
   </data>
   <data name="RenameAccept.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ã¢¢єрτ řέñαмё !!! </value>
+    <value>Àćĉêрŧ ŕεηáмĕ !!! </value>
     <comment>Text label for a button that can be used to confirm a rename operation during the renaming process.</comment>
   </data>
   <data name="RenameCancel.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Čдл¢єℓ г℮ήämė !!! </value>
+    <value>Čªⁿςęℓ гëήдмέ !!! </value>
     <comment>Text label for a button that can be used to cancel a rename operation during the renaming process.</comment>
   </data>
   <data name="ColorSchemesDisclaimer.Text" xml:space="preserve">
-    <value>Śĉђέмёş δėƒίńéđ нëяё ĉåŉ вє åρφľїеđ ţθ ўσϋя ряοƒïłėѕ ũηδēř ŧнё "Λрρёąяªŋćеś" ѕ℮стīол øƒ ţħë φřóƒΐĺé şêţťΐņĝś рäğёš. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Šсћěмěš đèƒιñèđ ћėřė ċдŋ ъę αрφŀĩ℮ð ŧö ỳóцř ρґοƒįℓэŝ цйðĕř ŧћ℮ "Άρφêäгăήςεѕ" šєĉťΐόη θƒ τћę φґôƒіℓē şĕŧŧιⁿĝѕ рǻĝêѕ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A disclaimer presented at the top of a page. "Appearances" should match Profile_Appearance.Header.</comment>
   </data>
   <data name="Profile_BaseLayerDisclaimer.Text" xml:space="preserve">
-    <value>Şέŧтįηġş ðëƒίņєđ ђέřé ẁïĺĺ ąρрļŷ τō дłľ φґŏƒïŀęş űπℓёšŝ тнêÿ ªřэ σνέřяіððєŉ вỳ á ρŗóƒĩłε'ś ѕєţтιπğѕ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Śéţţĩñģš ďėƒįňеδ ђеŗ℮ ẃίľĺ áφρℓý ŧō ªļł ряöƒíŀєš ūлĺèŝŝ ťħęу àгë σνэřřїδδέй ьγ а рŗőƒįŀé'ś ŝëтţіиġš. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A disclaimer presented at the top of a page. See "Nav_ProfileDefaults.Content" for a description on what the defaults layer does in the app.</comment>
   </data>
   <data name="Profile_DeleteConfirmationButton.Content" xml:space="preserve">
-    <value>Υêš, ďęłēтė ргõƒϊŀε !!! !!!</value>
+    <value>Ỳěŝ, ďзľетè ρřöƒīľé !!! !!!</value>
     <comment>Button label for positive confirmation of deleting a profile (presented with "Profile_DeleteConfirmationMessage")</comment>
   </data>
   <data name="Profile_DeleteConfirmationMessage.Text" xml:space="preserve">
-    <value>Àґэ ỳŏų šüґє уοū ŵǻπт ŧõ đēľеτ℮ ţĥĭś ρгòƒįℓэ? !!! !!! !!! !!! !</value>
+    <value>Дгè уøџ ѕŭřз ỳθū шдŋт ťö đěĺэţè ţћιś φгòƒίŀ℮? !!! !!! !!! !!! !</value>
     <comment>A confirmation message displayed when the user intends to delete a profile.</comment>
   </data>
   <data name="Settings_SaveSettingsButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Şąνè âłł ΰňѕăνêď şзŧтĩņģŝ. !!! !!! !</value>
+    <value>Ѕąνε āľŀ ΰŉşаν℮ð šέťτϊŋģŝ. !!! !!! !</value>
     <comment>A description for what the "save" button does. Presented near "Settings_SaveSettingsButton".</comment>
   </data>
   <data name="Globals_TabSwitcherMode.Header" xml:space="preserve">
-    <value>Тãь şωïţςħ℮ŗ ϊŋţêŗƒăċè šţўłē !!! !!! !!</value>
+    <value>Τãь ŝẃιťςђęř įⁿтëяƒā¢ĕ şтγℓε !!! !!! !!</value>
     <comment>Header for a control to choose how the tab switcher operates.</comment>
   </data>
   <data name="Globals_TabSwitcherMode.HelpText" xml:space="preserve">
-    <value>Ѕэℓęćţś ẅĥϊςћ ϊηŧεгƒǻçę шïłľ ьє ùšĕđ ẁнëη ÿóŭ śẁΐτčħ ţāьś úŝìŋģ τђë кêýъøàŕδ. !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Śėℓĕčţś ẃħĩçћ īиŧēгƒаςэ ωīℓℓ вè цŝëδ шħёл ŷόџ şщīťĉђ ŧáвš ùśīлġ τнз ќèŷьóâяð. !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>A description for what the "tab switcher mode" setting does. Presented near "Globals_TabSwitcherMode.Header".</comment>
   </data>
   <data name="Globals_TabSwitcherModeMru.Content" xml:space="preserve">
-    <value>Śēφăřâŧę ωΐⁿđόẃ, ίŋ моšτ řєсзпťŀу ūŝėδ όřďзя !!! !!! !!! !!! !</value>
+    <value>Şéράŗâт℮ ŵĩñðōω, ïл mθŝť ŗĕčєπťℓу ūŝěď оŗδêґ !!! !!! !!! !!! !</value>
     <comment>An option to choose from for the "tab switcher mode" setting. The tab switcher overlay is shown in most recently used order.</comment>
   </data>
   <data name="Globals_TabSwitcherModeInOrder.Content" xml:space="preserve">
-    <value>Śèрαґąтę ωĭŋđõẃ, įй ŧăв şţŗίр σŕδέř !!! !!! !!! !</value>
+    <value>Šєρãѓªτе ẅійđòẁ, îń ťāъ śŧґір σяðєŗ !!! !!! !!! !</value>
     <comment>An option to choose from for the "tab switcher mode" setting. The tab switcher overlay is shown in the order of the tabs at the top of the app.</comment>
   </data>
   <data name="Globals_TabSwitcherModeDisabled.Content" xml:space="preserve">
-    <value>Тгăđĭтϊóŉąĺ ŋāνїġäţįǿň, пø śěφαяáţέ ẃīиðσώ !!! !!! !!! !!! </value>
+    <value>Ţřàðίţίöлàľ ήдνΐĝãťįθⁿ, ⁿô šэράŕăť℮ ẃĩηďøω !!! !!! !!! !!! </value>
     <comment>An option to choose from for the "tab switcher mode" setting. The tab switcher overlay is hidden and does not appear in a separate window.</comment>
   </data>
   <data name="Globals_CopyFormat.Header" xml:space="preserve">
-    <value>Тєжτ ƒοřmăτś τò ćбρỳ τσ ŧнê çĺīрьóäяď !!! !!! !!! !!</value>
+    <value>Ţęхţ ƒόřмâтš ťσ ċορў ţő ťнё ĉĺїρвσагδ !!! !!! !!! !!</value>
     <comment>Header for a control to select the format of copied text.</comment>
   </data>
   <data name="Globals_CopyFormatNone.Content" xml:space="preserve">
-    <value>Рļãĭп τèхτ ŏŋℓў !!! !</value>
+    <value>Ρĺαΐñ ŧëжť όиĺÿ !!! !</value>
     <comment>An option to choose from for the "copy formatting" setting. Store only plain text data.</comment>
   </data>
   <data name="Globals_CopyFormatHtml.Content" xml:space="preserve">
-    <value>ΗΤΜ₤ !</value>
+    <value>ΉТМ£ !</value>
     <comment>An option to choose from for the "copy formatting" setting. Store only HTML data.</comment>
   </data>
   <data name="Globals_CopyFormatRtf.Content" xml:space="preserve">
-    <value>ΓŦ₣ </value>
+    <value>ЯŢ₣ </value>
     <comment>An option to choose from for the "copy formatting" setting. Store only RTF data.</comment>
   </data>
   <data name="Globals_CopyFormatAll.Content" xml:space="preserve">
-    <value>Вőťђ ΗΤМĻ áиδ ҐŢ₣ !!! !!</value>
+    <value>βôτђ ΉŢΜŁ àήδ ГТ₣ !!! !!</value>
     <comment>An option to choose from for the "copy formatting" setting. Store both HTML and RTF data.</comment>
   </data>
   <data name="ColorScheme_RenameErrorTip.Subtitle" xml:space="preserve">
-    <value>Ρŀёαѕё čђбòşë ă ďϊƒƒěř℮ñť ñāме. !!! !!! !!!</value>
+    <value>Ρłęāѕë ċнǿőŝê å ðíƒƒ℮яēйţ ņãмέ. !!! !!! !!!</value>
     <comment>An error message that appears when the user attempts to rename a color scheme to something invalid. This appears as the subtitle and provides guidance to fix the issue.</comment>
   </data>
   <data name="ColorScheme_RenameErrorTip.Title" xml:space="preserve">
-    <value>Τћĭѕ ċôℓōѓ śĉĥэмэ ήămē įś ǻŀяĕäδÿ ïň ųŝé. !!! !!! !!! !!!</value>
+    <value>Τħīѕ çôŀóř ѕčћємє ŋдmë ĩѕ άĺŕėãďý ĭп ύšє. !!! !!! !!! !!!</value>
     <comment>An error message that appears when the user attempts to rename a color scheme to something invalid. This appears as the title, and explains the issue.</comment>
   </data>
   <data name="Globals_FocusFollowMouse.Header" xml:space="preserve">
-    <value>Дµţőmäŧïçąłľў ƒõςűš рâлε òи møüŝе ĥǿνêř !!! !!! !!! !!!</value>
+    <value>Áϋτомàţīćąłłý ƒόćŭś рåπę öń мõùšě ђöνëŗ !!! !!! !!! !!!</value>
     <comment>Header for a control to toggle the "focus follow mouse" setting. When enabled, hovering over a pane puts it in focus.</comment>
   </data>
   <data name="Globals_DisableAnimationsReversed.Header" xml:space="preserve">
-    <value>Ρǻŋэ âŉіmаţїóňš !!! !</value>
+    <value>Ρǻйě ǻйϊмäţіőηş !!! !</value>
     <comment>Header for a control to toggle animations on panes. "Enabled" value enables the animations.</comment>
   </data>
   <data name="Globals_AlwaysShowNotificationIcon.Header" xml:space="preserve">
-    <value>Ǻľẁаỳś δīśφŀдý àń ΐсöⁿ ίή ŧђέ ńòŧіƒΐçаτīоп āřεà !!! !!! !!! !!! !!</value>
+    <value>Äľŵαŷś ďιśφĺαу дⁿ ìčǿи їň ţнē ŋöťϊƒĭćåţιøй αřεд !!! !!! !!! !!! !!</value>
     <comment>Header for a control to toggle whether the notification icon should always be shown.</comment>
   </data>
   <data name="Globals_MinimizeToNotificationArea.Header" xml:space="preserve">
-    <value>Ĥιđз Ŧēґмιñâŀ їй ťĥė йöτίƒι¢ατīόп âѓ℮ą ŵћєŋ íţ īŝ мíňϊмìżèđ !!! !!! !!! !!! !!! !!!</value>
+    <value>Ήïδė Ŧěŗмìπàł ïň τħз ⁿøтíƒĩçąтіοй âŕéă ẁћēή ΐť ίś mìлїmïźєđ !!! !!! !!! !!! !!! !!!</value>
     <comment>Header for a control to toggle whether the terminal should hide itself in the notification area instead of the taskbar when minimized.</comment>
   </data>
   <data name="SettingContainer_OverrideMessageBaseLayer" xml:space="preserve">
-    <value>Гėѕ℮ŧ тб ίиђзřīŧęď νάľųé. !!! !!! !</value>
+    <value>Яėşĕт ťо ίлћėŕίťеď νãľΰę. !!! !!! !</value>
     <comment>This button will remove a user's customization from a given setting, restoring it to the value that the profile inherited. This is a text label on a button.</comment>
   </data>
   <data name="ColorScheme_TerminalColorsHeader.Text" xml:space="preserve">
-    <value>Ťэřmїñдļ ćοłόѓŝ !!! !</value>
+    <value>Тêѓmíņäľ ¢бŀòгŝ !!! !</value>
     <comment>A header for a grouping of colors in the color scheme. These colors are used for basic parts of the terminal.</comment>
   </data>
   <data name="ColorScheme_SystemColorsHeader.Text" xml:space="preserve">
-    <value>Śÿšτем ćóļŏяŝ !!! </value>
+    <value>Ŝўѕţèm čøĺøгѕ !!! </value>
     <comment>A header for a grouping of colors in the color scheme. These colors are used for functional parts of the terminal.</comment>
   </data>
   <data name="ColorScheme_ColorsHeader.Header" xml:space="preserve">
-    <value>Čöľσřś !</value>
+    <value>Ċôŀŏŕŝ !</value>
     <comment>A header for the grouping of colors in the color scheme.</comment>
   </data>
   <data name="SettingContainer_OverrideMessageFragmentExtension" xml:space="preserve">
-    <value>Яεѕėτ ťο νдľϋē ƒřоm: {} !!! !!! </value>
+    <value>Γ℮šĕţ τǿ νăļϋè ƒяŏm: {} !!! !!! </value>
     <comment>{} is replaced by the name of another profile or generator. This is a text label on a button that is dynamically generated and provides more context in the {}.</comment>
   </data>
   <data name="Profile_FontFaceShowAllFonts.Content" xml:space="preserve">
-    <value>Ŝĥóω άłł ƒσήţş !!! !</value>
+    <value>Şħбω ąłļ ƒőňŧś !!! !</value>
     <comment>A supplementary setting to the "font face" setting. Toggling this control updates the font face control to show all of the fonts installed.</comment>
   </data>
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ĩƒ ℮ńãъļэđ, ѕнōŵ ǻℓℓ ĩиşţāŀĺĕđ ƒöňтş ϊⁿ ťĥе ļįśт ãвǿνέ. Ǿτĥéгẃїѕè, θйłў şђõщ ŧĥé ĺĩśт òƒ móйôśрªĉ℮ ƒòлтś. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Įƒ ěлåвℓεď, šħöω ăℓŀ їήšτаļľêð ƒõņŧŝ ίл τне ľíşť ªвσνє. Öťĥέŕωíŝě, ôπľγ ŝĥσẃ ţĥэ ľíѕτ θƒ mōйǿѕφâčз ƒоņτŝ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
   </data>
   <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Čŕēäтэ Ǻφφёάѓǻπċë !!! !!</value>
+    <value>Çřëаţë Ăφрзαѓăŉ¢έ !!! !!</value>
     <comment>Name for a control which creates an the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
   </data>
   <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Čŗèâťё āŋ цπƒõčùśĕđ àρрéǻŕàиĉз ƒōѓ ţнΐѕ φřôƒιℓέ. Ťнįŝ ώīĺŀ ьэ τђέ àрφэářαлĉē ōƒ ťĥє φŗθƒίľе ŵнєņ ìт іš ίπąĉŧīνë. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Ċґêâŧέ āл ûηƒοćüšεð аφрěąґªŋčέ ƒòř тнìş φřòƒîľέ. Ţнīѕ ωïĺľ вé ťнē αррêãřªήç℮ οƒ ŧћê ρґőƒίļė ŵħėņ īŧ ίš ïńαčτîν℮. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ďєĺėтē Âφφėãřãйçĕ !!! !!</value>
+    <value>Ďєľéтę Āρρєαяâп¢ė !!! !!</value>
     <comment>Name for a control which deletes an the unfocused appearance settings for this profile.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ðęłέţέ тĥė űņƒŏсůŝěδ äρρэαгäņċе ƒőґ ŧĥĩŝ φѓöƒΐℓè. !!! !!! !!! !!! !!!</value>
+    <value>Ðěłêţэ ŧђέ џпƒоćΰѕēď ǻρрέāяāηĉé ƒŏѓ τђįś φřōƒĭŀĕ. !!! !!! !!! !!! !!!</value>
     <comment>A description for what the delete unfocused appearance button does.</comment>
   </data>
   <data name="Actions_DeleteConfirmationButton.Content" xml:space="preserve">
-    <value>¥ėş, ðεļзтє ĸеў ъîńδîήĝ !!! !!! </value>
+    <value>Ýęѕ, ďэļěŧέ ќêý ьïⁿďїňĝ !!! !!! </value>
     <comment>Button label that confirms deletion of a key binding entry.</comment>
   </data>
   <data name="Actions_DeleteConfirmationMessage.Text" xml:space="preserve">
-    <value>Âѓ℮ уôύ śΰяє ÿθů щăñŧ ťô ðēłέτĕ тнįś κεý ьΐŉđîήğ? !!! !!! !!! !!! !!!</value>
+    <value>Άѓє ŷøü şΰŗė ŷóц ẁаńт ťб ðеℓ℮тè ŧђįś κëÿ вΐπðϊńġ? !!! !!! !!! !!! !!!</value>
     <comment>Confirmation message displayed when the user attempts to delete a key binding entry.</comment>
   </data>
   <data name="Actions_InvalidKeyChordMessage" xml:space="preserve">
-    <value>Īήνāĺίď ĸéÿ çĥόŕď. Рľэàşĕ ĕńτ℮ŗ á νāłìδ ќєỳ ċћöяð. !!! !!! !!! !!! !!!</value>
+    <value>Іпνáŀįδ κέу ¢ђòřď. Ρľеαşέ ëπŧзŕ ā νāŀϊđ ķэў čђθґð. !!! !!! !!! !!! !!!</value>
     <comment>Error message displayed when an invalid key chord is input by the user.</comment>
   </data>
   <data name="Actions_RenameConflictConfirmationAcceptButton" xml:space="preserve">
-    <value>Ўεş </value>
+    <value>Υэŝ </value>
     <comment>Button label that confirms the deletion of a conflicting key binding to allow the current key binding to be registered.</comment>
   </data>
   <data name="Actions_RenameConflictConfirmationMessage" xml:space="preserve">
-    <value>Ťћĕ рŕöνĭđéδ ķèу ςћбяð ϊŝ âľŗзâδý вέїņģ μŝ℮đ вý тħĕ ƒσĺłоẁιńğ ǻčтíôп: !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ţнз рŕǿνĭđêδ κęγ ĉноřď ΐś аŀгèαďý ьеїńġ úśέð ьу ţĥē ƒбľĺõẅΐňĝ ăćŧìôň: !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>Error message displayed when a key chord that is already in use is input by the user. The name of the conflicting key chord is displayed after this message.</comment>
   </data>
   <data name="Actions_RenameConflictConfirmationQuestion" xml:space="preserve">
-    <value>Шòϋŀð ŷòû ļĩķε ţó оνēяẅгіţê ĭţ? !!! !!! !!!</value>
+    <value>Шőűľđ ỳŏυ ĺïķэ тō όνēѓщřΐтê ιţ? !!! !!! !!!</value>
     <comment>Confirmation message displayed when a key chord that is already in use is input by the user. This is intended to ask the user if they wish to delete the conflicting key binding, and assign the current key chord (or binding) instead. This is presented in the context of Actions_RenameConflictConfirmationMessage. The subject of this sentence is the object of that one.</comment>
   </data>
   <data name="Actions_UnnamedCommandName" xml:space="preserve">
-    <value>&lt;ũήлâmзδ çőmmäήð&gt; !!! !!</value>
+    <value>&lt;цŉňαmеδ ĉŏmмάŋð&gt; !!! !!</value>
     <comment>{Locked="&lt;"} {Locked="&gt;"} The text shown when referring to a command that is unnamed.</comment>
   </data>
   <data name="Actions_AcceptButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Дĉĉєρτ !</value>
+    <value>Ăç¢еρт !</value>
     <comment>Text label for a button that can be used to accept changes to a key binding entry.</comment>
   </data>
   <data name="Actions_CancelButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ćăηčėľ !</value>
+    <value>Çäňçèĺ !</value>
     <comment>Text label for a button that can be used to cancel changes to a key binding entry</comment>
   </data>
   <data name="Actions_DeleteButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ďêľęţ℮ !</value>
+    <value>Đēŀéт℮ !</value>
     <comment>Text label for a button that can be used to delete a key binding entry.</comment>
   </data>
   <data name="Actions_EditButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ĕďїт !</value>
+    <value>Σδĩţ !</value>
     <comment>Text label for a button that can be used to begin making changes to a key binding entry.</comment>
   </data>
   <data name="Actions_AddNewTextBlock.Text" xml:space="preserve">
-    <value>Λδð πĕш !!</value>
+    <value>Дδđ ñėώ !!</value>
     <comment>Button label that creates a new action on the actions page.</comment>
   </data>
   <data name="Actions_ActionComboBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ǻčŧΐǿπ !</value>
+    <value>Α¢тίōй !</value>
     <comment>Label for a control that sets the action of a key binding.</comment>
   </data>
   <data name="KeyChordListener.[using:Windows.UI.Xaml.Automation]AutomationProperties.HelpText" xml:space="preserve">
-    <value>Їпρũτ ỳθϋř đєѕĭґёð ĸĕýъõàѓď şĥøґţсµŧ. !!! !!! !!! !!</value>
+    <value>Ійрûť ýőџѓ ďеśîґеδ кĕÿьôǻґđ ŝнόґŧĉüτ. !!! !!! !!! !!</value>
     <comment>Help text directing users how to use the "KeyChordListener" control. Pressing a keyboard shortcut will be recorded by this control.</comment>
   </data>
   <data name="KeyChordListener.[using:Windows.UI.Xaml.Automation]AutomationProperties.LocalizedControlType" xml:space="preserve">
-    <value>şĥôŕţсúŧ ŀíšťëņзґ !!! !!</value>
+    <value>ŝћøŕтςųţ ℓįŝтèŉêŗ !!! !!</value>
     <comment>The control type for a control that awaits keyboard input and records it.</comment>
   </data>
   <data name="KeyChordListener.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ѕнŏřтςûт !!</value>
+    <value>Şħōяŧ¢цτ !!</value>
     <comment>The label for a "key chord listener" control that sets the keys a key binding is bound to.</comment>
   </data>
   <data name="Appearance_TextFormattingHeader.Text" xml:space="preserve">
-    <value>Τзжτ ₣õґmāťţĭήġ !!! !</value>
+    <value>Ťĕхτ ₣ôямåτţίŉğ !!! !</value>
     <comment>Header for a control to how text is formatted</comment>
   </data>
   <data name="Appearance_IntenseTextStyle.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ìηţепśê ťēжţ ѕтγľє !!! !!</value>
+    <value>Ϊηŧэйšè ŧзжт şťÿĺë !!! !!</value>
     <comment>Name for a control to select how "intense" text is formatted (bold, bright, both or none)</comment>
   </data>
   <data name="Appearance_IntenseTextStyle.Header" xml:space="preserve">
-    <value>Įņтēпśè ŧзхŧ šтỳŀę !!! !!</value>
+    <value>Ĭиτзиśě τёжт şτўĺє !!! !!</value>
     <comment>Header for a control to select how "intense" text is formatted (bold, bright, both or none)</comment>
   </data>
   <data name="Appearance_IntenseTextStyleNone.Content" xml:space="preserve">
-    <value>Ņòήз !</value>
+    <value>∏őйě !</value>
     <comment>An option to choose from for the "intense text format" setting. When selected, "intense" text will not be rendered differently</comment>
   </data>
   <data name="Appearance_IntenseTextStyleBold.Content" xml:space="preserve">
-    <value>Βõŀð ƒŏńт !!!</value>
+    <value>Ьθℓď ƒσŉŧ !!!</value>
     <comment>An option to choose from for the "intense text format" setting. When selected, "intense" text will be rendered as bold text</comment>
   </data>
   <data name="Appearance_IntenseTextStyleBright.Content" xml:space="preserve">
-    <value>Ъřîĝћτ сøŀôřš !!! </value>
+    <value>βгïĝĥт çőĺǿгş !!! </value>
     <comment>An option to choose from for the "intense text format" setting. When selected, "intense" text will be rendered in a brighter color</comment>
   </data>
   <data name="Appearance_IntenseTextStyleAll.Content" xml:space="preserve">
-    <value>Вόłδ ƒöπŧ ώιťђ вяιğĥτ ċθŀôřš !!! !!! !!</value>
+    <value>Βοŀð ƒόπť ωіŧĥ вгϊģћţ čõĺόřş !!! !!! !!</value>
     <comment>An option to choose from for the "intense text format" setting. When selected, "intense" text will be rendered as both bold text and in a brighter color</comment>
   </data>
   <data name="Globals_AutoHideWindow.Header" xml:space="preserve">
-    <value>Ãũţõmãτíčąľľγ ћĭďè ωįŋđõŵ !!! !!! !</value>
+    <value>Ǻùţόmǻŧіĉąĺĺỳ ħíďз ώìñδǿẅ !!! !!! !</value>
     <comment>Header for a control to toggle the "Automatically hide window" setting. If enabled, the terminal will be hidden as soon as you switch to another window.</comment>
   </data>
   <data name="Globals_AutoHideWindow.HelpText" xml:space="preserve">
-    <value>Ĩƒ ęлдьľēď, τће ťëŗmΐñãļ шíļℓ ьē ĥіďđèπ дŝ ѕõσй αş ÿōџ şẁΐţćђ тő дпθŧĥεѓ щιńđǿẃ. !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Įƒ εⁿàъļêď, тђĕ ťέґmιпäļ щìℓŀ ъэ нîďδзñ ąś ѕõθŋ âş γôù śшίτċн ťø àпøťнзř шíήðόщ. !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "Automatically hide window" setting does.</comment>
   </data>
   <data name="ColorScheme_DeleteDisclaimerInBox" xml:space="preserve">
-    <value>Τħιś ĉбłǿŗ š¢ĥêмë ċáŉñοţ вê ðёŀέţěð ъεċâύŝë ΐт їś ιŉĉłůðзď вγ δεƒǻυļτ. !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ťĥíŝ ćσľõѓ şсħéмэ ĉãйпόŧ в℮ δεĺёт℮ð ьèċàцśě îţ ìš іŋçļųďĕđ вý đ℮ƒдџļť. !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>Disclaimer presented near the controls to delete the selected color scheme when that functionality is disabled.</comment>
   </data>
   <data name="ColorScheme_RenameDisclaimerInBox" xml:space="preserve">
-    <value>Ŧђīş ćòℓőѓ šςђėmэ çåπⁿσť вě ґзήămэð ьê¢ąųšę įť ϊş ĩŋçĺūđĕδ ьỳ ďęƒäúľτ. !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ŧĥιѕ сбĺθѓ ś¢ĥěмэ ĉαлήôť вė ŕ℮ňąmëđ ь℮ςăΰśĕ ĩт ìš ϊņċĺμďĕđ ъỳ đέƒãüłτ. !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>Disclaimer presented near the controls to rename the color scheme when that functionality is disabled.</comment>
   </data>
   <data name="ColorScheme_DefaultTag.Text" xml:space="preserve">
-    <value>đ℮ƒаűľť !!</value>
+    <value>ðéƒαųŀť !!</value>
     <comment>Text label displayed adjacent to a "color scheme" entry signifying that it is currently set as the default color scheme to be used.</comment>
   </data>
   <data name="ColorScheme_SetAsDefaultButton.Content" xml:space="preserve">
-    <value>Ѕ℮τ ąś đзƒāúℓŧ !!! !</value>
+    <value>Şëť åѕ ďзƒªџŀτ !!! !</value>
     <comment>Text label for a button that, when invoked, sets the selected color scheme as the default scheme to use.</comment>
   </data>
   <data name="Globals_ConfirmCloseAllTabs.Header" xml:space="preserve">
-    <value>Щąѓŉ ώħęπ ćłŏŝīηġ мŏřε τнάⁿ ŏŋе ταъ !!! !!! !!! !</value>
+    <value>Ẃářй ẅђëπ ĉľôśĩήĝ mǿѓĕ тĥąπ òπё τάь !!! !!! !!! !</value>
     <comment>Header for a control to toggle whether to show a confirm dialog box when closing the application with multiple tabs open.</comment>
   </data>
   <data name="Settings_PortableModeNote.Text" xml:space="preserve">
-    <value>Шїήďόŵś Ţèŗмíиàĺ īş ŗűñиίлġ îŋ ρōŕтąьŀę mоδё. !!! !!! !!! !!! !</value>
+    <value>Ẅїηðσшѕ Ţеřmíńăľ īѕ ґϋййïŉģ ĭņ рόѓťáъℓė mōďе. !!! !!! !!! !!! !</value>
     <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder.</comment>
   </data>
   <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve">
@@ -1762,15 +1794,15 @@
     <comment>{Locked}</comment>
   </data>
   <data name="Settings_PortableModeInfoLinkTextRun.Text" xml:space="preserve">
-    <value>Ŀěąґή mбґę. !!!</value>
+    <value>Ļĕдŗⁿ мõгĕ. !!!</value>
     <comment>A hyperlink displayed near Settings_PortableModeNote.Text that the user can follow for more information.</comment>
   </data>
   <data name="Profile_FontFace_ProportionalFontWarning.Title" xml:space="preserve">
-    <value>Ẃáŕпīлģ: !!</value>
+    <value>Ẃãялíŉĝ: !!</value>
     <comment>Title for the warning info bar used when a non monospace font face is chosen to indicate that there may be visual artifacts</comment>
   </data>
   <data name="Profile_FontFace_ProportionalFontWarning.Message" xml:space="preserve">
-    <value>€ћόбŝіήġ à йőл-mοñöşрă¢ēď ƒòηŧ шїļℓ ŀîĸеŀγ ŕэşцĺт ιπ νϊśцǻℓ ąѓтíƒăĉτş. Ųŝε åţ γøμг òщⁿ ďĩѕ¢řеτĭоп. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>€ħσõśïŉğ ą ñой-мõποşφãĉєδ ƒŏŋţ ẅіľľ łîķέℓў ŕєŝùłţ íй νΐşūαℓ āѓťīƒдςţŝ. Џŝè àţ ÿοùŗ øẁη δíśčґ℮ťîбņ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>Warning info bar used when a non monospace font face is chosen to indicate that there may be visual artifacts</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
@@ -118,237 +118,237 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AddProfile_AddNewButton.Tag" xml:space="preserve">
-    <value>Čяєáť℮ Ñέω Ьϋττøп !!! !!</value>
+    <value>Čгéªţë Ŋещ Бϋτţбⁿ !!! !!</value>
   </data>
   <data name="AddProfile_AddNewTextBlock.Text" xml:space="preserve">
-    <value>Иèẁ ℮мрτỳ φŗòƒіĺє !!! !!</value>
+    <value>Ŋ℮ω ĕmρŧý рŗőƒîļё !!! !!</value>
     <comment>Button label that creates a new profile with default settings.</comment>
   </data>
   <data name="AddProfile_Duplicate.Header" xml:space="preserve">
-    <value>Ďΰρĺīċãŧё а φѓōƒįℓє !!! !!!</value>
+    <value>Ďύφľίċåте ã φґǿƒïłē !!! !!!</value>
     <comment>This is the header for a control that lets the user duplicate one of their existing profiles.</comment>
   </data>
   <data name="AddProfile_DuplicateButton.Tag" xml:space="preserve">
-    <value>Đūφℓĭсåţз Ъųтťоⁿ !!! !</value>
+    <value>Ðùρłīĉāţз Вµτŧσň !!! !</value>
   </data>
   <data name="AddProfile_DuplicateTextBlock.Text" xml:space="preserve">
-    <value>Ďūρĺïčаτë !!!</value>
+    <value>Đŭρŀī¢ατê !!!</value>
     <comment>Button label that duplicates the selected profile and navigates to the duplicate's page.</comment>
   </data>
   <data name="ColorScheme_InboxSchemeDuplicate.Header" xml:space="preserve">
-    <value>Τђΐѕ ĉöℓσř ŝćнємз їś рāřτ ŏƒ ţћê вŭĭŀţ-іń śēŧтіňġѕ бѓ áή ϊńşτâĺłėδ ě×ŧ℮ŉŝïŏл !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ţħīѕ ċøłǿґ ŝςħèм℮ îś рăŗţ õƒ тнè ъûĩľт-íπ śéţťΐлĝś õř дŋ íńşťªłĺèð èжťęлşίοη !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment></comment>
   </data>
   <data name="ColorScheme_InboxSchemeDuplicate.HelpText" xml:space="preserve">
-    <value>Τó маке ćĥãйģëѕ тô τĥįş сõľøя ѕċĥэмэ, γøũ мцśт маќē á сσρў όƒ īť. !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ţό màќз ¢ћдņĝзş тő ťђїš ĉǿℓöř śсђзmė, ÿŏú мũŝт măĸę α сòφў σƒ ΐť. !!! !!! !!! !!! !!! !!! !</value>
     <comment></comment>
   </data>
   <data name="ColorScheme_DuplicateButton.Content" xml:space="preserve">
-    <value>Мǻкε д ćоφý !!!</value>
+    <value>Маĸέ α ċōρý !!!</value>
     <comment>This is a call to action; the user can click the button to make a copy of the current color scheme.</comment>
   </data>
   <data name="ColorScheme_SetAsDefault.Header" xml:space="preserve">
-    <value>Śέť ¢øŀőř ś¢ĥеmε άş ðеƒаúℓτ !!! !!! !!</value>
+    <value>Śèţ ćŏŀθґ šςħëmĕ âŝ δĕƒдϋŀţ !!! !!! !!</value>
     <comment>This is the header for a control that allows the user to set the currently selected color scheme as their default.</comment>
   </data>
   <data name="ColorScheme_SetAsDefault.HelpText" xml:space="preserve">
-    <value>Άрφłў τћįŝ соłõř śĉĥэме ťö ăłĺ уôμґ φŗбƒіłėś, ъу ðēƒαύļт. Įηðîνΐďúåļ φяόƒįℓзś ċαή ŝťιļļ śěľєĉτ ťħėįř ŏщп ċôľōř ѕ¢ĥеmέѕ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Áφρļу τђìš čǿℓóѓ ѕςĥеmё ţò âļℓ ўσùґ φѓôƒίļеš, ъÿ ðεƒăŭļŧ. Īиðїνιďμäĺ φяöƒíłĕš çǻп şťíĺļ ŝзĺëĉτ тнĕιř ǿшŋ сόļöѓ şčĥêмέѕ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A description explaining how this control changes the user's default color scheme.</comment>
   </data>
   <data name="ColorScheme_Rename.Header" xml:space="preserve">
-    <value>Ŗęπámĕ ςöℓθґ ѕςħémė !!! !!!</value>
+    <value>Ŕêпªmè сθłόя ŝçħémë !!! !!!</value>
     <comment>This is the header for a control that allows the user to rename the currently selected color scheme.</comment>
   </data>
   <data name="ColorScheme_Background.Text" xml:space="preserve">
-    <value>Бдĉкğřöµŉď !!!</value>
+    <value>Ъāċкġřőůņð !!!</value>
     <comment>This is the header for a control that lets the user select the background color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_Black.Text" xml:space="preserve">
-    <value>Ъļдсķ !</value>
+    <value>Вľд¢κ !</value>
     <comment>This is the header for a control that lets the user select the black color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_Blue.Text" xml:space="preserve">
-    <value>ßłųэ !</value>
+    <value>Ьĺųε !</value>
     <comment>This is the header for a control that lets the user select the blue color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_BrightBlack.Text" xml:space="preserve">
-    <value>Бŗîġнť ьŀåčκ !!! </value>
+    <value>Ьŗίĝħť ьľā¢к !!! </value>
     <comment>This is the header for a control that lets the user select the bright black color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_BrightBlue.Text" xml:space="preserve">
-    <value>Бѓιġћŧ вℓμê !!!</value>
+    <value>βґίġнť вŀµё !!!</value>
     <comment>This is the header for a control that lets the user select the bright blue color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_BrightCyan.Text" xml:space="preserve">
-    <value>Βŕįģħţ сýάπ !!!</value>
+    <value>Вяίģћŧ ĉуǻл !!!</value>
     <comment>This is the header for a control that lets the user select the bright cyan color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_BrightGreen.Text" xml:space="preserve">
-    <value>Βгîğĥτ ğřę℮ņ !!! </value>
+    <value>ßѓΐĝђŧ ğґęêп !!! </value>
     <comment>This is the header for a control that lets the user select the bright green color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_BrightPurple.Text" xml:space="preserve">
-    <value>Бřïğĥŧ φúѓφłе !!! </value>
+    <value>Бяīğнŧ ρùŗрľĕ !!! </value>
     <comment>This is the header for a control that lets the user select the bright purple color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_BrightRed.Text" xml:space="preserve">
-    <value>Ьгíġћť ŗέđ !!!</value>
+    <value>Ъŕίğћт гėđ !!!</value>
     <comment>This is the header for a control that lets the user select the bright red color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_BrightWhite.Text" xml:space="preserve">
-    <value>Ъřĭĝнť щђìţέ !!! </value>
+    <value>Ьгīģђţ ωђĭτê !!! </value>
     <comment>This is the header for a control that lets the user select the bright white color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_BrightYellow.Text" xml:space="preserve">
-    <value>Βяîģħŧ ÿέŀℓôώ !!! </value>
+    <value>Вříĝħŧ ÿéĺĺóẃ !!! </value>
     <comment>This is the header for a control that lets the user select the bright yellow color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_CursorColor.Text" xml:space="preserve">
-    <value>Ćùřѕòŗ сοļöŕ !!! </value>
+    <value>Ćμŕšσґ ćθŀθя !!! </value>
     <comment>This is the header for a control that lets the user select the text cursor's color displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_Cyan.Text" xml:space="preserve">
-    <value>Ćýαπ !</value>
+    <value>Сÿāⁿ !</value>
     <comment>This is the header for a control that lets the user select the cyan color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_Foreground.Text" xml:space="preserve">
-    <value>₣öґëġřöΰπđ !!!</value>
+    <value>₣οŕėĝřσűлđ !!!</value>
     <comment>This is the header for a control that lets the user select the foreground color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_Green.Text" xml:space="preserve">
-    <value>Ğřëéη !</value>
+    <value>Ġязêή !</value>
     <comment>This is the header for a control that lets the user select the green color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_Purple.Text" xml:space="preserve">
-    <value>Рυѓφļè !</value>
+    <value>Рµгρļě !</value>
     <comment>This is the header for a control that lets the user select the purple color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_SelectionBackground.Text" xml:space="preserve">
-    <value>Śέŀєçŧïоπ ъαĉķġřòϋńď !!! !!!</value>
+    <value>Š℮ŀзςŧίθл ьâĉĸġřōŭńδ !!! !!!</value>
     <comment>This is the header for a control that lets the user select the background color for selected text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_Red.Text" xml:space="preserve">
-    <value>Гęδ </value>
+    <value>Ŗ℮ď </value>
     <comment>This is the header for a control that lets the user select the red color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_White.Text" xml:space="preserve">
-    <value>Ẅћϊŧě !</value>
+    <value>Щнϊтè !</value>
     <comment>This is the header for a control that lets the user select the white color for text displayed on the screen.</comment>
   </data>
   <data name="ColorScheme_Yellow.Text" xml:space="preserve">
-    <value>Ỳĕľłбщ !</value>
+    <value>Υéĺľоŵ !</value>
     <comment>This is the header for a control that lets the user select the yellow color for text displayed on the screen.</comment>
   </data>
   <data name="Globals_Language.Header" xml:space="preserve">
-    <value>Ļāňĝūãğэ (řэqϋĭřêş řзℓаϋⁿċĥ) !!! !!! !!</value>
+    <value>Ŀąŉģüǻğз (řêqџĭŗэś яёłдũⁿ¢ħ) !!! !!! !!</value>
     <comment>The header for a control allowing users to choose the app's language.</comment>
   </data>
   <data name="Globals_Language.HelpText" xml:space="preserve">
-    <value>Ş℮ĺе¢ŧş д ðіšрĺāу ľâŉĝųдĝē ƒŏŕ ŧħě αφρłĩçâťιōή. Ŧĥįѕ ẅīļł òνеřŗìðė ўôûř ðèƒäųľт Windows іпτèѓƒăçэ łăŋĝϋǻğз. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Ѕęļéćŧѕ ā ďįŝρℓду łàйģцâğέ ƒǿř ťћз ǻρрľïčдŧíòŉ. Ťħϊş ωіŀľ όνëґŗίďē уǿüř ďèƒăμľţ Ẃïñďбŵś įñτéŗƒαсэ ŀåŋġύдğé. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>A description explaining how this control changes the app's language. {Locked="Windows"}</comment>
   </data>
   <data name="Globals_LanguageDefault" xml:space="preserve">
-    <value>Úŝë ѕýšτëm ďęƒāûĺŧ !!! !!</value>
+    <value>Ůŝê ѕŷŝτėм đєƒāùľŧ !!! !!</value>
     <comment>The app contains a control allowing users to choose the app's language. If this value is chosen, the language preference list of the system settings is used instead.</comment>
   </data>
   <data name="Globals_AlwaysShowTabs.Header" xml:space="preserve">
-    <value>Āľшãγś şћǿω τдвś !!! !</value>
+    <value>Άľώāŷš şђǿŵ тãвŝ !!! !</value>
     <comment>Header for a control to toggle if the app should always show the tabs (similar to a website browser).</comment>
   </data>
   <data name="Globals_AlwaysShowTabs.HelpText" xml:space="preserve">
-    <value>Шħеń ðîŝâъŀèδ, ţĥé τåь ьåґ ώĩĺľ àрρ℮аŗ ẁђėⁿ à ňзẅ тáв ϊš ćґэäŧêδ. Ćāŉήǿţ ьê ðĩšäъľĕδ ẁђΐℓέ "Ήίðě τнё τíŧℓё вдŗ" íš Ōй. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Шħεń ďίѕªъľеð, ţĥё ŧāъ ъаŕ ώіļℓ аρρëâř ẃн℮ŋ ª ŋëẁ ťаъ ιš сгęǻţеď. Ćâиňбŧ ьε ďîśαъŀ℮đ ωħϊŀē "Ĥίδē τђę ţĭτľέ ъάѓ" įś Ωń. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>A description for what the "always show tabs" setting does. Presented near "Globals_AlwaysShowTabs.Header". This setting cannot be disabled while "Globals_ShowTitlebar.Header" is enabled.</comment>
   </data>
   <data name="Globals_NewTabPosition.Header" xml:space="preserve">
-    <value>Ρоšίťіθή òƒ ⁿέщļÿ čгεдťεδ ťªъš !!! !!! !!!</value>
+    <value>Ρόšîŧϊøņ őƒ йĕŵℓу ĉřēάţεđ τдьš !!! !!! !!!</value>
     <comment>Header for a control to select position of newly created tabs.</comment>
   </data>
   <data name="Globals_NewTabPosition.HelpText" xml:space="preserve">
-    <value>Ѕрę¢іƒĭзš ẃћèге ņэẁ ţаъş āрφĕāř íη ťħє тăв ŗòẅ. !!! !!! !!! !!! !!</value>
+    <value>Śφзćїƒíеş шĥëřē ⁿêŵ τâъś ªρρёáґ ĭп тћé τåв яøш. !!! !!! !!! !!! !!</value>
     <comment>A description for what the "Position of newly created tabs" setting does.</comment>
   </data>
   <data name="Globals_NewTabPositionAfterLastTab.Content" xml:space="preserve">
-    <value>Аƒţеř ŧђ℮ łâşτ ţäв !!! !!</value>
+    <value>Äƒτёř ţнė ĺąśţ τаъ !!! !!</value>
     <comment>An option to choose from for the "Position of newly created tabs" setting. When selected new tab appears after the last tab.</comment>
   </data>
   <data name="Globals_NewTabPositionAfterCurrentTab.Content" xml:space="preserve">
-    <value>Δƒţєŗ τħ℮ ćŭѓя℮лť ŧāъ !!! !!!</value>
+    <value>Αƒŧëѓ ťнė сúѓŗėπτ τăъ !!! !!!</value>
     <comment>An option to choose from for the "Position of newly created tabs" setting. When selected new tab appears after the current tab.</comment>
   </data>
   <data name="Globals_CopyOnSelect.Header" xml:space="preserve">
-    <value>Λúŧǿмáŧïĉǻłŀỳ ¢òрý śéľ℮¢ŧίоⁿ тò çłĭрвόãŗđ !!! !!! !!! !!!</value>
+    <value>Āúтǿmаţιĉąľľў сοφý şèℓэċтïøñ ţō ĉļĩρьóąґď !!! !!! !!! !!!</value>
     <comment>Header for a control to toggle whether selected text should be copied to the clipboard automatically, or not.</comment>
   </data>
   <data name="Globals_DetectURLs.Header" xml:space="preserve">
-    <value>Дυтøмãτíсăľľÿ ðëŧé¢τ ŬҐ£ş äπð мâќě ţђєм ¢ľî¢ќάъľз !!! !!! !!! !!! !!!</value>
+    <value>Λυτοмдτìćăŀŀÿ đзťēćτ ЦŖĿš аňđ máĸë ţнэм сŀĭçќάвłĕ !!! !!! !!! !!! !!!</value>
     <comment>Header for a control to toggle whether the terminal should automatically detect URLs and make them clickable, or not.</comment>
   </data>
   <data name="Globals_TrimBlockSelection.Header" xml:space="preserve">
-    <value>Ѓėмбνē ťřǻįłіñĝ щђϊŧę-śρåčέ îй гēςţдńğúłдґ śēℓеċŧïóл !!! !!! !!! !!! !!! </value>
+    <value>Ѓëmονĕ тŕáìĺїŉġ ẃђϊτë-ѕρá¢ę ĭл ѓеċτåηğцĺăŗ ş℮ŀěčŧĭõň !!! !!! !!! !!! !!! </value>
     <comment>Header for a control to toggle whether a text selected with block selection should be trimmed of white spaces when copied to the clipboard, or not.</comment>
   </data>
   <data name="Globals_TrimPaste.Header" xml:space="preserve">
-    <value>Ŕĕмôνē ŧяăïłíňğ щĥΐŧέ-śράćέ ωнēή ραšťĭиĝ !!! !!! !!! !!!</value>
+    <value>Ґεmθνе ťѓªįŀíŉĝ шĥіťе-šрäčė ẃнзň φâśťίņġ !!! !!! !!! !!!</value>
     <comment>Header for a control to toggle whether pasted text should be trimmed of white spaces, or not.</comment>
   </data>
   <data name="Globals_KeybindingsDisclaimer.Text" xml:space="preserve">
-    <value>Веłбẁ àŕε ŧħε ĉцяѓέŋτĺỳ вбµñđ ќèуѕ, ώħίсħ ¢åл ь℮ мōðϊƒįëď вỳ ĕðιťïņğ τђė ЈŚÓ∏ ŝзтτĭπĝŝ ƒіļĕ. !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Вêļσώ áяэ τĥє сûѓгεπтľý ъόůηð κєÿş, ώĥīćн čāñ ъз мοðïƒīěð ьý зðїŧįńģ τћė ЈŜÖΝ şзťŧίñğѕ ƒΐłέ. !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>A disclaimer located at the top of the actions page that presents the list of keybindings.</comment>
   </data>
   <data name="Globals_DefaultProfile.Header" xml:space="preserve">
-    <value>Ðëƒåŭŀţ φяôƒïľе !!! !</value>
+    <value>Đėƒªûľť рґøƒϊľê !!! !</value>
     <comment>Header for a control to select your default profile from the list of profiles you've created.</comment>
   </data>
   <data name="Globals_DefaultProfile.HelpText" xml:space="preserve">
-    <value>Ргøƒíℓė ťнåŧ őрεńš ẃђëñ ċļΐćķíиģ ŧĥë '+' ϊçǿŉ ŏŕ вў ťуріⁿģ тћė ήęш τªь ķĕỳ ъîñδĭňğ. !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Ρŗσƒιℓê тнǻт ōреŋś ώнèи ¢ļíčкïñğ ťћέ '+' ίçôи ŏґ ьў ţýрϊńğ тĥє ņěẁ тªв ќèý ъϊήðїńġ. !!! !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>A description for what the default profile is and when it's used.</comment>
   </data>
   <data name="Globals_DefaultTerminal.Header" xml:space="preserve">
-    <value>Ðєƒàцļт ŧëřmϊήǻľ áρρľíčåτίόή !!! !!! !!</value>
+    <value>Ðêƒάϋℓτ ŧέřmìпάℓ аρφĺΐςàţїōŋ !!! !!! !!</value>
     <comment>Header for a drop down that permits the user to select which installed Terminal application will launch when command line tools like CMD are run from the Windows Explorer run box or start menu or anywhere else that they do not already have a graphical window assigned.</comment>
   </data>
   <data name="Globals_DefaultTerminal.HelpText" xml:space="preserve">
-    <value>Τĥè τěѓmįиàľ ąρφŀіċáŧĩθй ŧĥăţ ĺąűňçћĕŝ щђέή ä ċσммåņδ-ĺíηз аρφľίċăţíøη ĭś řџň ώîτћöùτ ªń эхíŝтíŋĝ şзşѕїоñ, ļįĸé ƒŗθm ŧђę Šťαґτ Мéŉų ôя Ѓüⁿ đĩåľøĝ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ťђě ţэřмīηãĺ ǻφφℓï¢ǻтΐбň ŧђáт łáůйčĥēś ẅĥэп ā сöмmǻńđ-ľіŉэ ăρρĺįċāτΐôⁿ ϊš яųñ шíţћöυţ ªņ ĕхϊŝŧĭñğ şěŝѕïŏπ, ŀĩĸė ƒѓом ţћĕ Ŝτáґт Μęπü бг Яųņ ďīäℓöğ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
   <data name="Globals_ForceFullRepaint.Header" xml:space="preserve">
-    <value>Яėδяǻẁ еиťìŕε şĉŗěēñ ŵђέй ðіšрĺαŷ μρδàτèş !!! !!! !!! !!!</value>
+    <value>Ŗёδѓªŵ еñţιŗę šĉřέëŋ шн℮й đĩşρℓâў υρďάţëš !!! !!! !!! !!!</value>
     <comment>Header for a control to toggle the "force full repaint" setting. When enabled, the app renders new content between screen frames.</comment>
   </data>
   <data name="Globals_ForceFullRepaint.HelpText" xml:space="preserve">
-    <value>Ẁнэи ðìşăвłëδ, ţĥé ŧĕѓмĩлªŀ ẃίℓŀ яέйđеř οñłу ţћέ υρđªτëѕ ťǿ ţћέ ŝčяěзй ьēťẅэèⁿ ƒѓāmĕş. !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Щħ℮п đįѕāъĺèđ, ťђέ тèřмΐņäľ ωìľľ řεŉďęŗ όŉľŷ ŧђέ ŭρďăţзŝ τö ŧђë šсгèзņ вêţшзэŉ ƒяāméş. !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "force full repaint" setting does. Presented near "Globals_ForceFullRepaint.Header".</comment>
   </data>
   <data name="Globals_InitialCols.Text" xml:space="preserve">
-    <value>Ćоĺΰмπş !!</value>
+    <value>Ċσŀùмñѕ !!</value>
     <comment>Header for a control to choose the number of columns in the terminal's text grid.</comment>
   </data>
   <data name="Globals_InitialRows.Text" xml:space="preserve">
-    <value>Ŗōŵŝ !</value>
+    <value>Ѓõшŝ !</value>
     <comment>Header for a control to choose the number of rows in the terminal's text grid.</comment>
   </data>
   <data name="Globals_InitialColsBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ίńīтĭąļ Ċǿℓųмлѕ !!! !</value>
+    <value>Îйϊŧìãľ Çòłųмπş !!! !</value>
     <comment>Name for a control to choose the number of columns in the terminal's text grid.</comment>
   </data>
   <data name="Globals_InitialRowsBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ίńіţιãĺ Γőшѕ !!! </value>
+    <value>İńìťîáℓ Ŕőώś !!! </value>
     <comment>Name for a control to choose the number of rows in the terminal's text grid.</comment>
   </data>
   <data name="Globals_InitialPosX.Text" xml:space="preserve">
-    <value>Χ φθśĭтìõñ !!!</value>
+    <value>χ φόśΐтįóñ !!!</value>
     <comment>Header for a control to choose the X coordinate of the terminal's starting position.</comment>
   </data>
   <data name="Globals_InitialPosY.Text" xml:space="preserve">
-    <value>Ý ρσŝìтĩσή !!!</value>
+    <value>Ỳ φôѕΐтĩσп !!!</value>
     <comment>Header for a control to choose the Y coordinate of the terminal's starting position.</comment>
   </data>
   <data name="Globals_InitialPosXBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Х ρöšїτϊσñ !!!</value>
+    <value>χ φŏѕĭтϊόŋ !!!</value>
     <comment>Name for a control to choose the X coordinate of the terminal's starting position.</comment>
   </data>
   <data name="Globals_InitialPosXBox.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>∑ņťêŕ тĥē νâľūз ƒöŗ ŧħэ х-çόòѓðΐŉāťê. !!! !!! !!! !!</value>
+    <value>Ëŉŧëř ţнę νáľυé ƒóŗ τђę х-čōóѓđΐήâтë. !!! !!! !!! !!</value>
     <comment>Tooltip for the control that allows the user to choose the X coordinate of the terminal's starting position.</comment>
   </data>
   <data name="Globals_InitialPosXBox.PlaceholderText" xml:space="preserve">
@@ -356,550 +356,550 @@
     <comment>The string to be displayed when there is no current value in the x-coordinate number box.</comment>
   </data>
   <data name="Globals_InitialPosYBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ŷ рбŝĭτíøņ !!!</value>
+    <value>Ỳ ρθŝìŧιοπ !!!</value>
     <comment>Name for a control to choose the Y coordinate of the terminal's starting position.</comment>
   </data>
   <data name="Globals_InitialPosYBox.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Éŉťèř ţћé νǻľůє ƒоŕ τћé ý-çσθяðΐńдťє. !!! !!! !!! !!</value>
+    <value>Ёйŧëŕ ţћε νàłüέ ƒòŕ ťĥє ỳ-čоθґδĩπāтė. !!! !!! !!! !!</value>
     <comment>Tooltip for the control that allows the user to choose the Y coordinate of the terminal's starting position.</comment>
   </data>
   <data name="Globals_InitialPosYBox.PlaceholderText" xml:space="preserve">
-    <value>Ύ</value>
+    <value>Ў</value>
     <comment>The string to be displayed when there is no current value in the y-coordinate number box.</comment>
   </data>
   <data name="Globals_DefaultLaunchPositionCheckbox.Content" xml:space="preserve">
-    <value>Ļèť Щīπδõŵŝ đěčϊđέ !!! !!</value>
+    <value>₤êτ Ẃĩиðōẁŝ ðē¢îðε !!! !!</value>
     <comment>A checkbox for the "launch position" setting. Toggling this control sets the launch position to whatever the Windows operating system decides.</comment>
   </data>
   <data name="Globals_DefaultLaunchPositionCheckbox.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ίƒ ĕŉªъļěď, μšз ťнё šÿŝţęm đęƒǻůĺт ľáüňĉн рόšΐťīǿŉ. !!! !!! !!! !!! !!!</value>
+    <value>Іƒ éлдъłëđ, úśз тђé ѕýŝт℮m δέƒăµłŧ łäúηćћ φöšïţϊóň. !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "default launch position" checkbox does. Presented near "Globals_DefaultLaunchPositionCheckbox".</comment>
   </data>
   <data name="Globals_FirstWindowPreference.Header" xml:space="preserve">
-    <value>Ŵнęй Тěѓмĩпǻļ śтάґţş !!! !!!</value>
+    <value>Ẃђéñ Ţëгмїńªĺ ѕťářтš !!! !!!</value>
     <comment>Header for a control to select how the terminal should load its first window.</comment>
   </data>
   <data name="Globals_FirstWindowPreference.HelpText" xml:space="preserve">
-    <value>Ẅħªť ѕĥōцŀδ ъë šнσẁņ ẅĥεη ŧħέ ƒїŕŝť тэŗміηāł ϊѕ ćґéаŧ℮ð. !!! !!! !!! !!! !!! !</value>
+    <value>Ẁђăт şĥõцĺð вε ѕнбшп ẁћёй ťђё ƒîŗŝт тěřмΐйåł їś сѓéąţзď. !!! !!! !!! !!! !!! !</value>
   </data>
   <data name="Globals_FirstWindowPreferenceDefaultProfile.Content" xml:space="preserve">
-    <value>Ŏφέπ â тāь ŵĩţн ŧђê ðέƒªύļţ φŗбƒîℓз !!! !!! !!! !</value>
+    <value>Οрзη à ťáь ώΐţĥ ţђè δεƒāűĺţ ρяθƒίłё !!! !!! !!! !</value>
     <comment>An option to choose from for the "First window preference" setting. Open the default profile.</comment>
   </data>
   <data name="Globals_FirstWindowPreferencePersistedWindowLayout.Content" xml:space="preserve">
-    <value>Őρёņ ẁĭŋđбẁś ƒřоm å φřэνįőüş ś℮ŝśĭōⁿ !!! !!! !!! !</value>
+    <value>Орéŋ ẅϊηďóωš ƒřōm ă φяèνιôùś şęŝśîőň !!! !!! !!! !</value>
     <comment>An option to choose from for the "First window preference" setting. Reopen the layouts from the last session.</comment>
   </data>
   <data name="Globals_LaunchMode.Header" xml:space="preserve">
-    <value>Ŀąųηčħ моďē !!!</value>
+    <value>₤дΰⁿçћ mοďè !!!</value>
     <comment>Header for a control to select what mode to launch the terminal in.</comment>
   </data>
   <data name="Globals_LaunchMode.HelpText" xml:space="preserve">
-    <value>Ήοŵ тĥз ťзґмιлαľ ẅīĺŀ άφрēăř őи łãűйċн. ₣ǿ¢μŝ ẁїℓℓ ĥϊđέ ŧћē ŧâвś ªиď ţìτļé вªя. !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ηóώ ţĥè ţěѓmϊиаľ ẁίĺĺ àρρ℮åг σⁿ łåŭⁿ¢ĥ. ₣οċύŝ ẁīłł ђїδė ţђê ťªьş āńð тιŧľ℮ вăŕ. !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>'Focus' must match &lt;Globals_LaunchModeFocus.Content&gt;.</comment>
   </data>
   <data name="Globals_LaunchParameters.Header" xml:space="preserve">
-    <value>Ŀáüη¢ħ φâяǻмĕτέгš !!! !!</value>
+    <value>£ăŭŉсн рąґăмěţеґŝ !!! !!</value>
     <comment>Header for a set of settings that determine how terminal launches. These settings include the launch mode, launch position and whether the terminal should center itself on launch.</comment>
   </data>
   <data name="Globals_LaunchParameters.HelpText" xml:space="preserve">
-    <value>Śēŧτïŋğş τндт ċōŉτгόĺ нøẅ τђě ţєяmϊńąļ ℓâύņćĥёš !!! !!! !!! !!! !!</value>
+    <value>Ѕèттîŋĝś ŧħªŧ ςôňťѓσŀ ĥõщ ţнè ţĕŗmîйåℓ ℓăµňĉнэś !!! !!! !!! !!! !!</value>
     <comment>A description for what the "launch parameters" expander contains. Presented near "Globals_LaunchParameters.Header".</comment>
   </data>
   <data name="Globals_LaunchModeSetting.Text" xml:space="preserve">
-    <value>Łаųпçћ мθðę !!!</value>
+    <value>Ŀäцñсн mőď℮ !!!</value>
     <comment>Header for a control to select what mode to launch the terminal in.</comment>
   </data>
   <data name="Globals_LaunchModeSetting.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ĥŏώ ŧħě ŧëŗmΐпаł ώίłļ дφρεäґ őñ ļǻũπсн. ₣õċúš ώΐļĺ ĥїđ℮ ŧĥє тąъѕ айδ ŧíτℓē ьαř. !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ηōŵ ţнέ тěřmіηªĺ ẃΐŀľ ąρρëäґ öñ ļǻûй¢ћ. ₣όςµŝ ẅїļł ħĭďē τћε ŧªъš āηď ŧìťℓέ ьář. !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>'Focus' must match &lt;Globals_LaunchModeFocus.Content&gt;.</comment>
   </data>
   <data name="Globals_LaunchModeDefault.Content" xml:space="preserve">
-    <value>Đēƒãΰļţ !!</value>
+    <value>Ďěƒάυŀţ !!</value>
     <comment>An option to choose from for the "launch mode" setting. Default option.</comment>
   </data>
   <data name="Globals_LaunchModeFullscreen.Content" xml:space="preserve">
-    <value>₣ūļł šĉґё℮и !!!</value>
+    <value>₣ųľľ ѕ¢řέей !!!</value>
     <comment>An option to choose from for the "launch mode" setting. Opens the app in a full screen state.</comment>
   </data>
   <data name="Globals_LaunchModeMaximized.Content" xml:space="preserve">
-    <value>Мäжιmìżзď !!!</value>
+    <value>Μâ×įміźέď !!!</value>
     <comment>An option to choose from for the "launch mode" setting. Opens the app maximized (covers the whole screen).</comment>
   </data>
   <data name="Globals_WindowingBehavior.Header" xml:space="preserve">
-    <value>Ńéώ īňšťâиćė вĕћανįőŗ !!! !!!</value>
+    <value>Νēщ ίńѕţãиςé ьęĥâνΐог !!! !!!</value>
     <comment>Header for a control to select how new app instances are handled.</comment>
   </data>
   <data name="Globals_WindowingBehavior.HelpText" xml:space="preserve">
-    <value>Ćőňťгбļš ĥõώ ⁿзш ťèŕmìηάŀ îņŝŧαńсзѕ дŧťάсн το ėхΐśţιйğ ẁìńδσщś. !!! !!! !!! !!! !!! !!! </value>
+    <value>Ĉöñтŕбℓš ћøш иēŵ τêгmîⁿàļ ĩπšţáπςεŝ άťţдčн тö є×ĭšτіņğ ώілđøẃş. !!! !!! !!! !!! !!! !!! </value>
     <comment>A description for what the "windowing behavior" setting does. Presented near "Globals_WindowingBehavior.Header".</comment>
   </data>
   <data name="Globals_WindowingBehaviorUseNew.Content" xml:space="preserve">
-    <value>Ċѓėªтē á ņëω щīňđσщ !!! !!!</value>
+    <value>Ćяèàťέ д ήéẃ ẃĭлďőω !!! !!!</value>
     <comment>An option to choose from for the "windowing behavior" setting. When selected, new instances create a new window.</comment>
   </data>
   <data name="Globals_WindowingBehaviorUseAnyExisting.Content" xml:space="preserve">
-    <value>Ǻťτą¢ћ ŧô ţħè mοśţ ŕęĉзⁿťľỳ ũŝєδ ẅĭⁿďбŵ !!! !!! !!! !!!</value>
+    <value>Ăţţăčĥ ŧó тħέ mõŝŧ řěçèпŧļý ŭśëď ẃįňδσω !!! !!! !!! !!!</value>
     <comment>An option to choose from for the "windowing behavior" setting. When selected, new instances open in the most recently used window.</comment>
   </data>
   <data name="Globals_WindowingBehaviorUseExisting.Content" xml:space="preserve">
-    <value>Ăţŧαςђ τó ťĥе mòśţ ŕęςēńŧļÿ űşėď ẅįņδθŵ òл ţћîş ďëśķťôφ !!! !!! !!! !!! !!! !</value>
+    <value>Äţŧαĉђ τǿ τħе mοѕт ѓěςęńτļγ ûѕєď ŵíñðοω øи тћϊѕ ďёšкτǿφ !!! !!! !!! !!! !!! !</value>
     <comment>An option to choose from for the "windowing behavior" setting. When selected, new instances open in the most recently used window on this virtual desktop.</comment>
   </data>
   <data name="Globals_RenderingDisclaimer.Text" xml:space="preserve">
-    <value>Ţћёšè ŝéťτîŉģŝ mąỳ ьε ũѕêƒцℓ ƒõя τяöúъľėŝћõότįŉġ äи ĩѕšµ℮, нοшèνзŕ тђėỳ ẃĩℓľ ìмρдćţ ўǿџг рęґƒοґmåñ¢ё. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Τћέŝė ѕëτтίņģš мâу ьê üѕēƒµľ ƒόґ τřóųьŀėѕĥбοτілġ ǻл іŝśü℮, нσώéνєŕ τĥêў ŵīŀł ΐmρåςť убŭя ρěгƒόґмåñĉę. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A disclaimer presented at the top of a page.</comment>
   </data>
   <data name="Globals_ShowTitlebar.Header" xml:space="preserve">
-    <value>Ηіδě ţћĕ ťіτŀє вªř (ŗ℮qϋϊгёş řέľåџⁿсħ) !!! !!! !!! !!</value>
+    <value>Ĥìđε тħê τīţĺё ъªř (ŗėqūΐŗêś яеľаϋŉčћ) !!! !!! !!! !!</value>
     <comment>Header for a control to toggle whether the title bar should be shown or not. Changing this setting requires the user to relaunch the app.</comment>
   </data>
   <data name="Globals_ShowTitlebar.HelpText" xml:space="preserve">
-    <value>Щħзń ďîѕāвļēđ, ţĥĕ τιтļę ьąŗ ωΐļľ ãррєàѓ āьõνę τĥě ťąьş. !!! !!! !!! !!! !!! !</value>
+    <value>Ẃћèп ðϊŝαъłėð, тнė ťĭτłê вąѓ ẁιĺł ąφφёǻŕ äвöνė ŧħė ťãьś. !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "show titlebar" setting does. Presented near "Globals_ShowTitlebar.Header".</comment>
   </data>
   <data name="Globals_AcrylicTabRow.Header" xml:space="preserve">
-    <value>Ûŝē âςгýℓĩс мáτεŗιäŀ ĭή ţђε τàъ ŗôω !!! !!! !!! !</value>
+    <value>Ūŝē àςѓýłīć мãτęѓįάł ϊή ťнę ťāъ гоω !!! !!! !!! !</value>
     <comment>Header for a control to toggle whether "acrylic material" is used. "Acrylic material" is a Microsoft-specific term: https://docs.microsoft.com/en-us/windows/apps/design/style/acrylic</comment>
   </data>
   <data name="Globals_ShowTitleInTitlebar.Header" xml:space="preserve">
-    <value>Цŝé ǻċτіνè ţзґmïňǻĺ ťіŧľé αś ªρφłιçâŧΐόп ŧίŧĺє !!! !!! !!! !!! !</value>
+    <value>Ůŝě å¢ťįνέ τèґmĭŉαĺ τįτľé äš дρφℓīĉатĭǿŉ ţιţľē !!! !!! !!! !!! !</value>
     <comment>Header for a control to toggle whether the terminal's title is shown as the application title, or not.</comment>
   </data>
   <data name="Globals_ShowTitleInTitlebar.HelpText" xml:space="preserve">
-    <value>Щнĕπ đіšǻъℓéď, ŧћє тĭтłê ьªѓ ẅїľł ьэ 'Ťéѓmìйаł'. !!! !!! !!! !!! !!</value>
+    <value>Ŵћéή đíѕǻьļεď, тħè ťįτłе ьǻŗ ẁїℓł вє 'Ťěѓмĩⁿăĺ'. !!! !!! !!! !!! !!</value>
     <comment>A description for what the "show title in titlebar" setting does. Presented near "Globals_ShowTitleInTitlebar.Header".{Locked="Windows"}</comment>
   </data>
   <data name="Globals_SnapToGridOnResize.Header" xml:space="preserve">
-    <value>Ŝńâρ щіňðоŵ ŗзşìžіŋğ ťб ĉнáŕåčτєѓ ğяįδ !!! !!! !!! !!</value>
+    <value>Ŝиάρ щίйðõщ яēşΐžíпĝ тõ čħáѓä¢ťέѓ ģѓĩδ !!! !!! !!! !!</value>
     <comment>Header for a control to toggle whether the terminal snaps the window to the character grid when resizing, or not.</comment>
   </data>
   <data name="Globals_SnapToGridOnResize.HelpText" xml:space="preserve">
-    <value>Ŵĥėή đΐŝάъĺēď, ŧнë шϊⁿđǿẅ ώїľĺ ŗзśΐżę ѕмòöтħļŷ. !!! !!! !!! !!! !!</value>
+    <value>Ẅн℮ñ ðìşāьļĕð, τĥė ŵΐņďòώ ẃíļĺ řėŝîżē šмõόтнłγ. !!! !!! !!! !!! !!</value>
     <comment>A description for what the "snap to grid on resize" setting does. Presented near "Globals_SnapToGridOnResize.Header".</comment>
   </data>
   <data name="Globals_SoftwareRendering.Header" xml:space="preserve">
-    <value>Ũśë şōƒŧẃáяę гéņđзгîŋğ !!! !!! </value>
+    <value>Ųѕε ŝόƒťщаřė яĕŋðεříлğ !!! !!! </value>
     <comment>Header for a control to toggle whether the terminal should use software to render content instead of the hardware.</comment>
   </data>
   <data name="Globals_SoftwareRendering.HelpText" xml:space="preserve">
-    <value>Щĥéň ęņăъŀēð, ţнз ťєґмĭηăļ ẃιŀŀ ūśэ ţнє şбƒťẅåŕё řєⁿδëяęŗ (ã.ќ.á. Ẅ∆ŘР) îⁿŝť℮äď ǿƒ τнε нàŕδώάґē ǿиз. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ẅнέⁿ éñâвĺĕď, ŧĥë тěřmϊñăľ шîľĺ ŭşē ŧнé šбƒţẅāяē ґэпδėѓεŕ (д.к.ă. ẀÅЃΡ) ĭñŝτéāđ оƒ тħё ĥάґđẃаяē οлε. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "software rendering" setting does. Presented near "Globals_SoftwareRendering.Header".</comment>
   </data>
   <data name="Globals_StartOnUserLogin.Header" xml:space="preserve">
-    <value>Ľàûлсĥ бη mªçћìńë ŝťαřтùр !!! !!! !</value>
+    <value>₤áϋпςħ ôл мαςĥĭñę ŝťąřťûρ !!! !!! !</value>
     <comment>Header for a control to toggle whether the app should launch when the user's machine starts up, or not.</comment>
   </data>
   <data name="Globals_StartOnUserLogin.HelpText" xml:space="preserve">
-    <value>Δџţõmаťì¢дĺľу ĺǻûņсн Ťęѓmĭиâĺ щħęŋ ÿоυ ľôĝ įŋ ţø Windows. !!! !!! !!! !!! !!! !!</value>
+    <value>Āũŧοмªτĩčäĺļỳ ŀªūⁿ¢ћ Ťëŗmįŋāℓ ẃнęņ ўоű ŀóġ ìπ τσ Шĩņðоẁѕ. !!! !!! !!! !!! !!! !!</value>
     <comment>A description for what the "start on user login" setting does. Presented near "Globals_StartOnUserLogin.Header". {Locked="Windows"}</comment>
   </data>
   <data name="Globals_CenterOnLaunchCentered" xml:space="preserve">
-    <value>Çэпŧεґéđ !!</value>
+    <value>Ćêŋťєŕеδ !!</value>
     <comment>Shorthand, explanatory text displayed when the user has enabled the feature indicated by "Globals_CenterOnLaunch.Text".</comment>
   </data>
   <data name="Globals_CenterOnLaunch.Text" xml:space="preserve">
-    <value>Ćéлŧ℮ř õŉ ŀáμŉčћ !!! !</value>
+    <value>Ćēňτєѓ ŏŋ ľäūńçђ !!! !</value>
     <comment>Header for a control to toggle whether the app should launch in the center of the screen, or not.</comment>
   </data>
   <data name="Globals_CenterOnLaunch.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ẃĥзń ēňāвĺзď, тнε ẅΐπđбẅ ωĩłł ъĕ φľāĉэď ιп ťħε ¢ėпţéř öƒ тђε ščгĕ℮ņ шħĕй łаΰйċћзð. !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Ẁђēи ėⁿąьĺëđ, ţħė ωīņďбώ ώїłľ ъė рℓªςέð ïⁿ ŧĥε сęⁿтєř ǿƒ ŧħè ŝćŕėęή ẁћêŉ ĺдűňĉĥεđ. !!! !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>A description for what the "center on launch" setting does. Presented near "Globals_CenterOnLaunch.Header".</comment>
   </data>
   <data name="Globals_AlwaysOnTop.Header" xml:space="preserve">
-    <value>Äĺώąŷŝ õń тóρ !!! </value>
+    <value>Аŀẅâγš ōп ŧбφ !!! </value>
     <comment>Header for a control to toggle if the app will always be presented on top of other windows, or is treated normally (when disabled).</comment>
   </data>
   <data name="Globals_AlwaysOnTop.HelpText" xml:space="preserve">
-    <value>Ŧёřmĭήαŀ ẁīℓℓ аℓшäγѕ ъę ţħэ τǿφmöşţ ωϊπðθώ όή ţћє ðëѕĸťōр. !!! !!! !!! !!! !!! !!</value>
+    <value>Ťèřmĭήäľ ŵϊłļ àļщāÿş ъĕ ŧħє ţóрmόѕŧ шíñđθώ όи ŧħě δεşĸţбφ. !!! !!! !!! !!! !!! !!</value>
     <comment>A description for what the "always on top" setting does. Presented near "Globals_AlwaysOnTop.Header".</comment>
   </data>
   <data name="Globals_TabWidthMode.Header" xml:space="preserve">
-    <value>Тªъ ẅìđţĥ мöđê !!! !</value>
+    <value>Ťâв ώΐđťн mбðě !!! !</value>
     <comment>Header for a control to choose how wide the tabs are.</comment>
   </data>
   <data name="Globals_TabWidthMode.HelpText" xml:space="preserve">
-    <value>Ćőmρáćŧ ẅìĺŀ śнřιиķ ĩπąςŧīνę ťǻъš το ŧђè ŝïžе ŏƒ τнё ϊĉση. !!! !!! !!! !!! !!! !!</value>
+    <value>Ćôмрáçτ ώĭĺļ ŝнгíñк ïŋãċţïνе тâъѕ ťö тĥε ѕіźë ŏƒ ŧн℮ ĩćóň. !!! !!! !!! !!! !!! !!</value>
     <comment>A description for what the "tab width mode" setting does. Presented near "Globals_TabWidthMode.Header". 'Compact' must match the value for &lt;Globals_TabWidthModeCompact.Content&gt;.</comment>
   </data>
   <data name="Globals_TabWidthModeCompact.Content" xml:space="preserve">
-    <value>Čбmрåсţ !!</value>
+    <value>Ċøмрªĉť !!</value>
     <comment>An option to choose from for the "tab width mode" setting. When selected, unselected tabs collapse to show only their icon. The selected tab adjusts to display the content within the tab.</comment>
   </data>
   <data name="Globals_TabWidthModeEqual.Content" xml:space="preserve">
-    <value>Ĕqύáł !</value>
+    <value>Εqüáł !</value>
     <comment>An option to choose from for the "tab width mode" setting. When selected, each tab has the same width.</comment>
   </data>
   <data name="Globals_TabWidthModeTitleLength.Content" xml:space="preserve">
-    <value>Ţΐŧłé ļέлĝŧђ !!! </value>
+    <value>Тīτľе ľεňĝτђ !!! </value>
     <comment>An option to choose from for the "tab width mode" setting. When selected, each tab adjusts its width to the content within the tab.</comment>
   </data>
   <data name="Globals_Theme.Header" xml:space="preserve">
-    <value>Ăφρℓĭςäτιбň Τĥєм℮ !!! !!</value>
+    <value>Αрρłΐćàтīòñ Ŧнèм℮ !!! !!</value>
     <comment>Header for a control to choose the theme colors used in the app.</comment>
   </data>
   <data name="Globals_ThemeDark.Content" xml:space="preserve">
-    <value>Ðăгк !</value>
+    <value>Đăгќ !</value>
     <comment>An option to choose from for the "theme" setting. When selected, the app is in dark theme and darker colors are used throughout the app.</comment>
   </data>
   <data name="Globals_ThemeSystem.Content" xml:space="preserve">
-    <value>Ŭśê Ẁįπδŏшś ťнèмě !!! !!</value>
+    <value>Űŝ℮ Щįņđоẃś тћěmе !!! !!</value>
     <comment>An option to choose from for the "theme" setting. When selected, the app uses the theme selected in the Windows operating system.</comment>
   </data>
   <data name="Globals_ThemeLight.Content" xml:space="preserve">
-    <value>£ĭġнţ !</value>
+    <value>Ĺιģћť !</value>
     <comment>An option to choose from for the "theme" setting. When selected, the app is in light theme and lighter colors are used throughout the app.</comment>
   </data>
   <data name="Globals_ThemeDarkLegacy.Content" xml:space="preserve">
-    <value>Đàяќ (Ļëġдćŷ) !!! </value>
+    <value>Ďāґќ (₤єĝåçŷ) !!! </value>
     <comment>An option to choose from for the "theme" setting. When selected, the app is in dark theme and darker colors are used throughout the app. This is an older version of the "dark" theme</comment>
   </data>
   <data name="Globals_ThemeSystemLegacy.Content" xml:space="preserve">
-    <value>Ũѕė Ẃĭπδθώś тђēмё (Ĺеğãčŷ) !!! !!! !</value>
+    <value>Ùśê Щΐŉδøщŝ ťħéмě (Łèĝąçу) !!! !!! !</value>
     <comment>An option to choose from for the "theme" setting. When selected, the app uses the theme selected in the Windows operating system. This is an older version of the "Use Windows theme" theme</comment>
   </data>
   <data name="Globals_ThemeLightLegacy.Content" xml:space="preserve">
-    <value>Ŀíġђŧ (Ŀĕĝãсу) !!! !</value>
+    <value>Ŀїģнţ (Łεĝäċÿ) !!! !</value>
     <comment>An option to choose from for the "theme" setting. When selected, the app is in light theme and lighter colors are used throughout the app. This is an older version of the "light" theme</comment>
   </data>
   <data name="Globals_WordDelimiters.Header" xml:space="preserve">
-    <value>Ŵóґđ ðĕļímίťėŕš !!! !</value>
+    <value>Щοґδ đэļιмϊŧеѓş !!! !</value>
     <comment>Header for a control to determine what delimiters to use to identify separate words during word selection.</comment>
   </data>
   <data name="Globals_WordDelimiters.HelpText" xml:space="preserve">
-    <value>Тђéśě ŝўмвǿŀѕ ẅΐłŀ ъэ ûś℮ð ẃĥêπ уôů δøυьℓε-čļíсκ ťĕ×т ìη ŧħė ŧзřmìйǻĺ θř áćŧïνāтэ "Μäŕĸ мôđє". !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ţћзŝ℮ ѕумвöŀѕ шιŀℓ вê ùŝеď ẃнёñ ỳõµ ďбùвŀэ-ċľϊčк ţε×ť ïⁿ ţћě τєґmїиаℓ ŏѓ αсτϊνãŧě "Мάřк mŏđë". !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "word delimiters" setting does. Presented near "Globals_WordDelimiters.Header". "Mark" is used in the sense of "choosing something to interact with."</comment>
   </data>
   <data name="Nav_Appearance.Content" xml:space="preserve">
-    <value>Ąφрêąřǻŉς℮ !!!</value>
+    <value>Λρρёªгąńсё !!!</value>
     <comment>Header for the "appearance" menu item. This navigates to a page that lets you see and modify settings related to the app's appearance.</comment>
   </data>
   <data name="Nav_ColorSchemes.Content" xml:space="preserve">
-    <value>Çŏŀоř şćĥеmеś !!! </value>
+    <value>Ċōľøя š¢нēměѕ !!! </value>
     <comment>Header for the "color schemes" menu item. This navigates to a page that lets you see and modify schemes of colors that can be used by the terminal.</comment>
   </data>
   <data name="Nav_Interaction.Content" xml:space="preserve">
-    <value>Іπţέядćţīóń !!!</value>
+    <value>Íŋт℮řâçτîöй !!!</value>
     <comment>Header for the "interaction" menu item. This navigates to a page that lets you see and modify settings related to the user's mouse and touch interactions with the app.</comment>
   </data>
   <data name="Nav_Launch.Content" xml:space="preserve">
-    <value>Ŝŧǻŗτūφ !!</value>
+    <value>Ѕţâŕτűр !!</value>
     <comment>Header for the "startup" menu item. This navigates to a page that lets you see and modify settings related to the app's launch experience (i.e. screen position, mode, etc.)</comment>
   </data>
   <data name="Nav_OpenJSON.Content" xml:space="preserve">
-    <value>Θрėπ ĴŜŌŅ ƒįĺę !!! !</value>
+    <value>Фφëņ ЈŞŐŅ ƒϊĺэ !!! !</value>
     <comment>Header for a menu item. This opens the JSON file that is used to log the app's settings.</comment>
   </data>
   <data name="Nav_ProfileDefaults.Content" xml:space="preserve">
-    <value>Ďėƒåúŀтś !!</value>
+    <value>Đэƒαűŀţş !!</value>
     <comment>Header for the "defaults" menu item. This navigates to a page that lets you see and modify settings that affect profiles. This is the lowest layer of profile settings that all other profile settings are based on. If a profile doesn't define a setting, this page is responsible for figuring out what that setting is supposed to be.</comment>
   </data>
   <data name="Nav_Rendering.Content" xml:space="preserve">
-    <value>Γёηđěŕїπĝ !!!</value>
+    <value>Ŕэⁿðэŕίńğ !!!</value>
     <comment>Header for the "rendering" menu item. This navigates to a page that lets you see and modify settings related to the app's rendering of text in the terminal.</comment>
   </data>
   <data name="Nav_Actions.Content" xml:space="preserve">
-    <value>Ãćŧϊŏńš !!</value>
+    <value>Ăςтιòñš !!</value>
     <comment>Header for the "actions" menu item. This navigates to a page that lets you see and modify commands, key bindings, and actions that can be done in the app.</comment>
   </data>
   <data name="Profile_OpacitySlider.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ъāςќĝŗŏϋиδ οφáçįτỳ !!! !!</value>
+    <value>βά¢ĸĝŕõúήđ ǿрãĉĩŧÿ !!! !!</value>
     <comment>Name for a control to determine the level of opacity for the background of the control. The user can choose to make the background of the app more or less opaque.</comment>
   </data>
   <data name="Profile_Opacity.Header" xml:space="preserve">
-    <value>ßǻςĸġřōŭñð õφăčìτÿ !!! !!</value>
+    <value>βāĉκğřôμηď óρăĉїŧỳ !!! !!</value>
     <comment>Header for a control to determine the level of opacity for the background of the control. The user can choose to make the background of the app more or less opaque.</comment>
   </data>
   <data name="Profile_Opacity.HelpText" xml:space="preserve">
-    <value>Ѕеŧś тħë όρăĉιťý όƒ τнё ẁιиđοш. !!! !!! !!!</value>
+    <value>Ŝεŧŝ ţђé ǿφąċϊτŷ ôƒ ťђé ẃіŋďοẁ. !!! !!! !!!</value>
     <comment>A description for what the "opacity" setting does. Presented near "Profile_Opacity.Header".</comment>
   </data>
   <data name="Profile_Advanced.Header" xml:space="preserve">
-    <value>Ãðνăήćěď !!</value>
+    <value>Дδναиċēδ !!</value>
     <comment>Header for a sub-page of profile settings focused on more advanced scenarios.</comment>
   </data>
   <data name="Profile_AltGrAliasing.Header" xml:space="preserve">
-    <value>AltGr дľіâѕīпġ !!! !</value>
+    <value>ΛŀţĢř ąĺîàśιⁿģ !!! !</value>
     <comment>Header for a control to toggle whether the app treats ctrl+alt as the AltGr (also known as the Alt Graph) modifier key found on keyboards. {Locked="AltGr"}</comment>
   </data>
   <data name="Profile_AltGrAliasing.HelpText" xml:space="preserve">
-    <value>Ву ďэƒάμŀŧ, Windows τŗēдŧѕ Çтґł+Ãℓţ áŝ аⁿ âłіåś ƒōŕ ÂĺţĠґ. Ŧħϊś ѕêťŧĭňġ ωїłĺ όνєŕŕĭđē Windows' đêƒдцℓť ьзħªνΐõŗ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Βу ďёƒдџĺţ, Ŵϊńďŏшš τřεåτš Ċťґℓ+Аłτ åѕ αń àłĩάš ƒŏг ДŀŧĢř. Τħїś śёťтїлğ ŵíℓĺ õνёяřΐďё Ŵìŉďôщѕ' ďэƒâüŀт ьĕђāνïŏř. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>A description for what the "AltGr aliasing" setting does. Presented near "Profile_AltGrAliasing.Header". {Locked="Windows"}</comment>
   </data>
   <data name="Profile_AntialiasingMode.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ŧêжτ άñţîãľïäšïйġ !!! !!</value>
+    <value>Ŧεжτ āпŧїåℓїášĩňģ !!! !!</value>
     <comment>Name for a control to select the graphical anti-aliasing format of text.</comment>
   </data>
   <data name="Profile_AntialiasingMode.Header" xml:space="preserve">
-    <value>Ťзжţ αиţīăļíαšіπĝ !!! !!</value>
+    <value>Ŧėжţ âлтίāℓïãšìņĝ !!! !!</value>
     <comment>Header for a control to select the graphical anti-aliasing format of text.</comment>
   </data>
   <data name="Profile_AntialiasingMode.HelpText" xml:space="preserve">
-    <value>Ċôптяσłŝ нòώ ŧεхŧ ĩš аŉťìáľĭдŝēđ іп ťнé ŕзņδêŕέŗ. !!! !!! !!! !!! !!!</value>
+    <value>€σŋťгǿĺś ноώ τë×ţ ĭŝ āηтįāĺįäŝзđ ïⁿ тнê ŕëⁿðęг℮ř. !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "antialiasing mode" setting does. Presented near "Profile_AntialiasingMode.Header".</comment>
   </data>
   <data name="Profile_AntialiasingModeAliased.Content" xml:space="preserve">
-    <value>Αľіǻѕёð !!</value>
+    <value>Ǻłìдšèδ !!</value>
     <comment>An option to choose from for the "text antialiasing" setting. When selected, the app's text renderer does not use antialiasing techniques.</comment>
   </data>
   <data name="Profile_AntialiasingModeClearType.Content" xml:space="preserve">
-    <value>ClearType !!!</value>
+    <value>ĊłėāřŦўрε !!!</value>
     <comment>An option to choose from for the "text antialiasing" setting. When selected, the app's text renderer uses a "ClearType" antialiasing technique. {Locked="ClearType"}</comment>
   </data>
   <data name="Profile_AntialiasingModeGrayscale.Content" xml:space="preserve">
-    <value>Ġгдуś¢áļ℮ !!!</value>
+    <value>Ġѓǻỳşćãľ℮ !!!</value>
     <comment>An option to choose from for the "text antialiasing" setting. When selected, the app's text renderer uses a grayscale antialiasing technique.</comment>
   </data>
   <data name="Profile_Appearance.Header" xml:space="preserve">
-    <value>Арφęáяãņςė !!!</value>
+    <value>Äррéâřăйςё !!!</value>
     <comment>Header for a sub-page of profile settings focused on customizing the appearance of the profile.</comment>
   </data>
   <data name="Profile_BackgroundImageBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Вăсκġгõûπđ įмãġë рªťħ !!! !!!</value>
+    <value>Вãćκĝґõцńð ιмăġέ ратĥ !!! !!!</value>
     <comment>Name for a control to determine the image presented on the background of the app.</comment>
   </data>
   <data name="Profile_BackgroundImage.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>βªςкģŕóµйδ ïmàģē φåтħ !!! !!!</value>
+    <value>Βãĉķğѓθцňď ΐмάģ℮ φªţĥ !!! !!!</value>
     <comment>Name for a control to determine the image presented on the background of the app.</comment>
   </data>
   <data name="Profile_BackgroundImage.Header" xml:space="preserve">
-    <value>ßâсќģѓøûņđ îmäģė ρåŧђ !!! !!!</value>
+    <value>βäċκġяǿúпđ ĩмåĝё φατн !!! !!!</value>
     <comment>Header for a control to determine the image presented on the background of the app.</comment>
   </data>
   <data name="Profile_BackgroundImage.HelpText" xml:space="preserve">
-    <value>₣īŀё ĺôçāťїòπ оƒ τĥé įmáĝě ύşěδ ιŉ ťћē ъąċќģґŏυňđ óƒ ťћê шĩņδöẅ. !!! !!! !!! !!! !!! !!! !</value>
+    <value>₣įĺė łóςąтιǿŋ òƒ ŧħê íмάğз űšéδ їŉ ťĥ℮ вǻ¢κĝяőųиď őƒ ţĥė ώĭŋδбŵ. !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "background image path" setting does. Presented near "Profile_BackgroundImage".</comment>
   </data>
   <data name="Profile_BackgroundImageAlignment.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>βåсκġŗõûήď ïмąĝё ãĺϊğńмėήт !!! !!! !</value>
+    <value>ßάсĸģŗǿџηδ ιmãģê αĺĭġήmēлť !!! !!! !</value>
     <comment>Name for a control to choose the visual alignment of the image presented on the background of the app.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignment.Header" xml:space="preserve">
-    <value>Ъăсĸġяôũπď įmąġė āļĭĝπмēņŧ !!! !!! !</value>
+    <value>Бαčĸğяōΰηđ їмåĝэ åłĭğŉмεлŧ !!! !!! !</value>
     <comment>Header for a control to choose the visual alignment of the image presented on the background of the app.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignment.HelpText" xml:space="preserve">
-    <value>Ŝêťš нσŵ тђ℮ ъªĉќġŕóμⁿď ίмąğė αľīĝйś ťθ ťђė вõϋňðąŗϊеŝ óƒ τĥē ẅìпδǿш. !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ś℮ţŝ ћöẅ τĥę ва¢κğŗθŭйδ ìmдğē αŀíģņś то τħę вóµŉďăгĩěѕ öƒ τћз щĭńðǿẃ. !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "background image alignment" setting does. Presented near "Profile_BackgroundImageAlignment".</comment>
   </data>
   <data name="Profile_BackgroundImageAlignmentBottom.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ьοτťόм !</value>
+    <value>Βŏτŧøм !</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignmentBottomLeft.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ьоŧţôм ļèƒţ !!!</value>
+    <value>Βòττōм łéƒŧ !!!</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignmentBottomRight.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Вóтťǿм ŕϊĝнţ !!! </value>
+    <value>Вбŧŧŏм ŗίģнť !!! </value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignmentCenter.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Сêⁿŧĕŗ !</value>
+    <value>Ĉêñť℮ř !</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignmentLeft.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>₤ēƒţ !</value>
+    <value>Ŀèƒţ !</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignmentRight.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Γįģнţ !</value>
+    <value>Ŗĭģħŧ !</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignmentTop.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ţõр </value>
+    <value>Ťθφ </value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignmentTopLeft.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ŧŏφ ľєƒť !!</value>
+    <value>Ţθр ļέƒτ !!</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
   <data name="Profile_BackgroundImageAlignmentTopRight.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Тŏρ ŕįģĥţ !!!</value>
+    <value>Тøρ ŕĩġћт !!!</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
   <data name="Profile_BackgroundImageBrowse.Content" xml:space="preserve">
-    <value>Ьřοώşє... !!!</value>
+    <value>Ьřоẅşé... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
   <data name="Profile_AddNewFontAxis.Text" xml:space="preserve">
-    <value>Δďđ лéẅ !!</value>
+    <value>Λďð ňéẁ !!</value>
     <comment>Button label that adds a new font axis for the current font.</comment>
   </data>
   <data name="Profile_AddNewFontFeature.Text" xml:space="preserve">
-    <value>Άðδ ŉеẃ !!</value>
+    <value>Άðδ ⁿэщ !!</value>
     <comment>Button label that adds a new font feature for the current font.</comment>
   </data>
   <data name="Profile_BackgroundImageOpacitySlider.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ьǻçќğřόũпđ ïmàĝė ōφåĉіτÿ !!! !!! !</value>
+    <value>Βαċĸġґθũηď ϊmдġэ орάсιτу !!! !!! !</value>
     <comment>Name for a control to choose the opacity of the image presented on the background of the app.</comment>
   </data>
   <data name="Profile_BackgroundImageOpacity.Header" xml:space="preserve">
-    <value>Ъªĉĸġѓσџńδ ĩмâğэ ǿρãċĩŧý !!! !!! !</value>
+    <value>Βàĉĸġгòΰлð ϊmąġє бφáĉΐţÿ !!! !!! !</value>
     <comment>Header for a control to choose the opacity of the image presented on the background of the app.</comment>
   </data>
   <data name="Profile_BackgroundImageOpacity.HelpText" xml:space="preserve">
-    <value>Śęţś ŧħ℮ ŏραçίţý ŏƒ τĥε ьªĉќğгòŭпδ îmãġě. !!! !!! !!! !!!</value>
+    <value>Ŝέтŝ тĥě ōφâĉіţŷ θƒ ŧħë ъâćќğŕоŭńð ĩмαĝę. !!! !!! !!! !!!</value>
     <comment>A description for what the "background image opacity" setting does. Presented near "Profile_BackgroundImageOpacity".</comment>
   </data>
   <data name="Profile_BackgroundImageStretchMode.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ьдçкģяôúπđ įмãģė ŝτяеţ¢ћ мόðέ !!! !!! !!!</value>
+    <value>Вάĉĸġřόϋⁿð ĩмăğе şťŗ℮ŧĉђ мòδ℮ !!! !!! !!!</value>
     <comment>Name for a control to choose the stretch mode of the image presented on the background of the app. Stretch mode is how the image is resized to fill its allocated space.</comment>
   </data>
   <data name="Profile_BackgroundImageStretchMode.Header" xml:space="preserve">
-    <value>Ьāċĸġгθűⁿđ ΐмáĝē šţяєťčн мŏďє !!! !!! !!!</value>
+    <value>ßäскġŗǿůπď īмâġэ şтŗĕтсħ мőďè !!! !!! !!!</value>
     <comment>Header for a control to choose the stretch mode of the image presented on the background of the app. Stretch mode is how the image is resized to fill its allocated space.</comment>
   </data>
   <data name="Profile_BackgroundImageStretchMode.HelpText" xml:space="preserve">
-    <value>Ѕέŧś нŏщ ŧћε ьáςкġгοцπδ ïmаĝе íš ř℮ŝįźєδ ťø ƒíĺŀ ťћέ щīŋďóщ. !!! !!! !!! !!! !!! !!!</value>
+    <value>Šëτş ħσω ŧħё ьãćķĝгøµπð īмαğę ϊš řĕŝіżèď ţθ ƒĭŀł ťћέ ωїηđôẁ. !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "background image stretch mode" setting does. Presented near "Profile_BackgroundImageStretchMode".</comment>
   </data>
   <data name="Profile_BackgroundImageStretchModeFill.Content" xml:space="preserve">
-    <value>₣ΐĺĺ !</value>
+    <value>₣ίľļ !</value>
     <comment>An option to choose from for the "background image stretch mode" setting. When selected, the image is resized to fill the destination dimensions. The aspect ratio is not preserved.</comment>
   </data>
   <data name="Profile_BackgroundImageStretchModeNone.Content" xml:space="preserve">
-    <value>Лőле !</value>
+    <value>Ŋŏⁿé !</value>
     <comment>An option to choose from for the "background image stretch mode" setting. When selected, the image preserves its original size.</comment>
   </data>
   <data name="Profile_BackgroundImageStretchModeUniform.Content" xml:space="preserve">
-    <value>Ũήĩƒοѓm !!</value>
+    <value>Üⁿĭƒòгm !!</value>
     <comment>An option to choose from for the "background image stretch mode" setting. When selected,the image is resized to fit in the destination dimensions while it preserves its native aspect ratio.</comment>
   </data>
   <data name="Profile_BackgroundImageStretchModeUniformToFill.Content" xml:space="preserve">
-    <value>Ùπīƒŏřм ŧǿ ƒīŀℓ !!! !</value>
+    <value>Úⁿîƒŏŕм τо ƒіļļ !!! !</value>
     <comment>An option to choose from for the "background image stretch mode" setting. When selected, the content is resized to fill the destination dimensions while it preserves its native aspect ratio. But if the aspect ratio of the destination differs, the image is clipped to fit in the space (to fill the space)</comment>
   </data>
   <data name="Profile_CloseOnExit.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ρґόƒіľз ťęŕmïиąτίόŋ ъêĥăνįöѓ !!! !!! !!</value>
+    <value>Рѓǿƒïłė ţέřmįпąťїоп ьэндνіõя !!! !!! !!</value>
     <comment>Name for a control to select the behavior of a terminal session (a profile) when it closes.</comment>
   </data>
   <data name="Profile_CloseOnExit.Header" xml:space="preserve">
-    <value>Ρřŏƒîľэ ťęґмιŉãτíοπ взнąνіóř !!! !!! !!</value>
+    <value>Рŗσƒīļє τеŗmíŋªťιοñ вěђâνίøя !!! !!! !!</value>
     <comment>Header for a control to select the behavior of a terminal session (a profile) when it closes.</comment>
   </data>
   <data name="Profile_CloseOnExitAlways.Content" xml:space="preserve">
-    <value>Čľоѕе ωħëй ρгôςеŝš ë×їţś, ƒåìℓѕ, õя çѓâѕĥëѕ !!! !!! !!! !!! </value>
+    <value>Сĺöѕę ẃђèи φяô¢єśş êжîţš, ƒäιļš, оř ¢řąŝнéś !!! !!! !!! !!! </value>
     <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled (exit) or uncontrolled (fail or crash) scenario.</comment>
   </data>
   <data name="Profile_CloseOnExitGraceful.Content" xml:space="preserve">
-    <value>Ċľόšě øńļý ώнěń ρґō¢зśš ëжітś śμ¢ĉėśšƒµłľγ !!! !!! !!! !!! </value>
+    <value>Сłбşê бńļγ ẅнēή рřόс℮śŝ ęжιτś ŝџçсĕšѕƒŭŀłў !!! !!! !!! !!! </value>
     <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully.</comment>
   </data>
   <data name="Profile_CloseOnExitNever.Content" xml:space="preserve">
-    <value>Ñėνέř ĉłŏśέ άűţõмáťĭċąℓℓγ !!! !!! !</value>
+    <value>Ŋ℮νĕŗ ćļǿѕê äμτőмâťĩċªļŀў !!! !!! !</value>
     <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal never closes, even if the process exits in a controlled or uncontrolled scenario. The user would have to manually close the terminal.</comment>
   </data>
   <data name="Profile_CloseOnExitAutomatic.Content" xml:space="preserve">
-    <value>Āųτσmåтίς !!!</value>
+    <value>Ãµťøмäтïč !!!</value>
     <comment>An option to choose from for the "profile termination behavior" (or "close on exit") setting. When selected, the terminal closes if the process exits in a controlled scenario successfully and the process was launched by Windows Terminal.</comment>
   </data>
   <data name="Profile_ColorScheme.Header" xml:space="preserve">
-    <value>Ćθℓοř ŝςнémз !!! </value>
+    <value>Çŏłőг ŝćнĕмε !!! </value>
     <comment>Header for a control to select the scheme (or set) of colors used in the session. This is selected from a list of options managed by the user.</comment>
   </data>
   <data name="Profile_Commandline.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ċôмmáήδ ľįйё !!! </value>
+    <value>€οмmǻпδ łįŉε !!! </value>
     <comment>Name for a control to determine commandline executable (i.e. a .exe file) to run when a terminal session of this profile is launched.</comment>
   </data>
   <data name="Profile_Commandline.Header" xml:space="preserve">
-    <value>Čóмmдńđ ŀìпэ !!! </value>
+    <value>Соммаňð ℓιπë !!! </value>
     <comment>Header for a control to determine commandline executable (i.e. a .exe file) to run when a terminal session of this profile is launched.</comment>
   </data>
   <data name="Profile_CommandlineBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Сömmàŉð ŀΐηέ !!! </value>
+    <value>Çŏммǻиδ ŀϊňè !!! </value>
     <comment>Name for a control to determine commandline executable (i.e. a .exe file) to run when a terminal session of this profile is launched.</comment>
   </data>
   <data name="Profile_Commandline.HelpText" xml:space="preserve">
-    <value>È×ë¢ūŧąьľé ϋşēδ ιи ťħ℮ ρřőƒĩļè. !!! !!! !!!</value>
+    <value>Эхĕçΰтдьłё ūśëď įñ ţħè рŕòƒĭŀз. !!! !!! !!!</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
   <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
-    <value>Бřбώšê... !!!</value>
+    <value>ßгθшşє... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
   <data name="Profile_CursorHeight.Header" xml:space="preserve">
-    <value>Ćµŕѕóř ħëїğђт !!! </value>
+    <value>Сµгŝőґ ђēîĝħт !!! </value>
     <comment>Header for a control to determine the height of the text cursor.</comment>
   </data>
   <data name="Profile_CursorHeight.HelpText" xml:space="preserve">
-    <value>Śётŝ ŧђе φêŕćęńтάğε ħεîĝћť õƒ тђė ¢ΰѓšσґ ŝŧªѓтîńġ ƒŗом ţĥê ъοττόм. Őπłγ шθřĸş шĩτђ τħē νīήŧąġë ĉûгѕöŕ śђáрè. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Šеτѕ тĥέ φегсеŋтåĝě ћēíġĥт öƒ ťĥέ ¢úґšόг ŝŧάřťīŉģ ƒŕõм τћ℮ воţŧōм. Φņľγ шбŕķş ωітĥ τђĕ νĭŋťάġз ¢ūґşσř ŝнāφē. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>A description for what the "cursor height" setting does. Presented near "Profile_CursorHeight".</comment>
   </data>
   <data name="Profile_CursorShape.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Сùřšŏř ŝħāрę !!! </value>
+    <value>Ćũяšòѓ ŝђàρĕ !!! </value>
     <comment>Name for a control to select the shape of the text cursor.</comment>
   </data>
   <data name="Profile_CursorShape.Header" xml:space="preserve">
-    <value>Сûѓšόя ŝħâφє !!! </value>
+    <value>Ĉϋřšǿг śнâρε !!! </value>
     <comment>Header for a control to select the shape of the text cursor.</comment>
   </data>
   <data name="Profile_AdjustIndistinguishableColorsNever.Content" xml:space="preserve">
-    <value>Ņĕνеŗ !</value>
+    <value>Ñèνêř !</value>
     <comment>An option to choose from for the "adjust indistinguishable colors" setting. When selected, we will never adjust the text colors.</comment>
   </data>
   <data name="Profile_AdjustIndistinguishableColorsIndexed.Content" xml:space="preserve">
-    <value>Òлľγ ƒǿř сôℓôřś îп ţнэ ćοļōя şčђёmè !!! !!! !!! !</value>
+    <value>Òňľỳ ƒθг çöłőґš ΐл ťħé сøłθґ ŝĉћ℮мё !!! !!! !!! !</value>
     <comment>An option to choose from for the "adjust indistinguishable colors" setting. When selected, we will adjust the text colors for visibility only when the colors are part of this profile's color scheme's color table.</comment>
   </data>
   <data name="Profile_AdjustIndistinguishableColorsAlways.Content" xml:space="preserve">
-    <value>Λĺщαÿŝ !</value>
+    <value>Åļωάỳš !</value>
     <comment>An option to choose from for the "adjust indistinguishable colors" setting. When selected, we will adjust the text colors for visibility.</comment>
   </data>
   <data name="Profile_CursorShapeBar.Content" xml:space="preserve">
-    <value>Βдŗ ( ┃ ) !!!</value>
+    <value>Ъâг ( ┃ ) !!!</value>
     <comment>{Locked="┃"} An option to choose from for the "cursor shape" setting. When selected, the cursor will look like a vertical bar. The character in the parentheses is used to show what it looks like.</comment>
   </data>
   <data name="Profile_CursorShapeEmptyBox.Content" xml:space="preserve">
-    <value>Ĕмφτў ъö× ( ▯ ) !!! !</value>
+    <value>Емρţý ьǿ× ( ▯ ) !!! !</value>
     <comment>{Locked="▯"} An option to choose from for the "cursor shape" setting. When selected, the cursor will look like an empty box. The character in the parentheses is used to show what it looks like.</comment>
   </data>
   <data name="Profile_CursorShapeFilledBox.Content" xml:space="preserve">
-    <value>₣ìłŀёď ъòж ( █ ) !!! !</value>
+    <value>₣ιŀłęđ вσж ( █ ) !!! !</value>
     <comment>{Locked="█"} An option to choose from for the "cursor shape" setting. When selected, the cursor will look like a filled box. The character in the parentheses is used to show what it looks like.</comment>
   </data>
   <data name="Profile_CursorShapeUnderscore.Content" xml:space="preserve">
-    <value>Ůŉδєŗśςǿřз ( ▁ ) !!! !</value>
+    <value>Ùήđĕřŝċогё ( ▁ ) !!! !</value>
     <comment>{Locked="▁"} An option to choose from for the "cursor shape" setting. When selected, the cursor will look like an underscore. The character in the parentheses is used to show what it looks like.</comment>
   </data>
   <data name="Profile_CursorShapeVintage.Content" xml:space="preserve">
-    <value>Vįйţαĝë ( ▃ ) !!! </value>
+    <value>Vίпτâĝĕ ( ▃ ) !!! </value>
     <comment>{Locked="▃"} An option to choose from for the "cursor shape" setting. When selected, the cursor will look like a thick underscore. This is the vintage and classic look of a cursor for terminals. The character in the parentheses is used to show what it looks like.</comment>
   </data>
   <data name="Profile_CursorShapeDoubleUnderscore.Content" xml:space="preserve">
-    <value>Ďσūьŀе ΰпď℮ґŝĉôґε ( ‗ ) !!! !!! </value>
+    <value>Ďòûьĺē ύηđεґşćбяĕ ( ‗ ) !!! !!! </value>
     <comment>{Locked="‗"} An option to choose from for the "cursor shape" setting. When selected, the cursor will look like a stacked set of two underscores. The character in the parentheses is used to show what it looks like.</comment>
   </data>
   <data name="Profile_FontFace.Header" xml:space="preserve">
-    <value>₣öņť ƒä¢℮ !!!</value>
+    <value>₣øñт ƒâςę !!!</value>
     <comment>Header for a control to select the font for text in the app.</comment>
   </data>
   <data name="Profile_FontFaceBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>₣ǿπт ƒâ¢ë !!!</value>
+    <value>₣øñŧ ƒдсέ !!!</value>
     <comment>Name for a control to select the font for text in the app.</comment>
   </data>
   <data name="Profile_FontSize.Header" xml:space="preserve">
-    <value>₣ōпτ ѕιźэ !!!</value>
+    <value>₣ŏňτ şίźε !!!</value>
     <comment>Header for a control to determine the size of the text in the app.</comment>
   </data>
   <data name="Profile_FontSizeBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>₣őπŧ şίżê !!!</value>
+    <value>₣оňť şίżє !!!</value>
     <comment>Name for a control to determine the size of the text in the app.</comment>
   </data>
   <data name="Profile_FontSize.HelpText" xml:space="preserve">
-    <value>Ŝΐżє õƒ ţĥε ƒòňť іń φоĭŉţš. !!! !!! !!</value>
+    <value>Šіžё ǿƒ тнé ƒõņτ їņ φσîйτş. !!! !!! !!</value>
     <comment>A description for what the "font size" setting does. Presented near "Profile_FontSize".</comment>
   </data>
   <data name="Profile_LineHeight.Header" xml:space="preserve">
-    <value>£ΐйэ ћêίģћť !!!</value>
+    <value>Ŀīйĕ ĥĕΐĝђŧ !!!</value>
     <comment>Header for a control that sets the text line height.</comment>
   </data>
   <data name="Profile_LineHeightBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ŀĭⁿε ћ℮ïģћť !!!</value>
+    <value>₤ìŋè ħέίģћť !!!</value>
     <comment>Header for a control that sets the text line height.</comment>
   </data>
   <data name="Profile_LineHeight.HelpText" xml:space="preserve">
-    <value>Ōνéґѓιďэ ťћэ ℓīпê ђēіğћŧ óƒ ţħĕ ţëгmįηáł. Μèаşŭŕ℮đ ǻś ä мùℓŧіρľě θƒ ťĥэ ƒõńţ śΐźě. Τћ℮ ðèƒäŭℓт νаłůë ðєрейδŝ оⁿ убúŗ ƒόπτ дŋð īś üšύªĺℓу αŗõциď 1.2. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Ονëřŗíďĕ тђэ ℓìŉё ћëîğнτ оƒ ŧнè τёґмįņªļ. Мēáśυґ℮đ аś ª mϋłţìρℓè õƒ тне ƒõήτ ѕΐżë. Тђê ďέƒāųŀţ νâŀüē δέρěņđš ǿň ỳőυя ƒôŉт ąŉď ΐş υşūäľŀÿ àŗôüŋđ 1.2. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>A description for what the "line height" setting does. Presented near "Profile_LineHeight".</comment>
   </data>
   <data name="Profile_LineHeightBox.PlaceholderText" xml:space="preserve">
@@ -907,854 +907,886 @@
     <comment>"1.2" is a decimal number.</comment>
   </data>
   <data name="Profile_EnableBuiltinGlyphs.Header" xml:space="preserve">
-    <value>βüĩℓŧīŋ Ġļýрĥś !!! !</value>
+    <value>Ьùïľŧïň Ģłуφĥś !!! !</value>
     <comment>The main label of a toggle. When enabled, certain characters (glyphs) are replaced with better looking ones.</comment>
   </data>
   <data name="Profile_EnableBuiltinGlyphs.HelpText" xml:space="preserve">
-    <value>Шнеñ ℮ⁿαвŀêδ, ţђē тėгмïлаľ ðядшš ċūśτóм ĝłγφħŝ ƒõř ъĺŏςκ éĺēmĕήт àňď вбх ďřάшīňĝ снãřăĉτèѓѕ ìñśтеåð οƒ υšΐиĝ тħэ ƒǿńť. Τћіѕ ƒєдтμгэ őиļŷ ẅőґќѕ ẅĥéⁿ ĢΡÙ Ăćĉěĺзяäťïôй ίś ąνаїľªвŀē. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Ẅħĕň еņªъℓёð, тћз τēгмïπдℓ ðѓáшş çύšτом ģļўφħѕ ƒǿя ъĺôсĸ éℓêm℮ήŧ àñð ъο× ðгдωΐπĝ čћдŗąςŧέѓś ìπŝţėãđ ŏƒ ũŝіⁿğ ťћę ƒбηŧ. Ţћιş ƒзаτџŕè οŉĺŷ ωóгκŝ ẁĥéŋ ĢΡŬ Àςĉеŀèѓдτισñ ĩѕ ǻνãîļåвłę. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>A longer description of the "Profile_EnableBuiltinGlyphs" toggle. "glyphs", "block element" and "box drawing characters" are technical terms from the Unicode specification.</comment>
   </data>
   <data name="Profile_EnableColorGlyphs.Header" xml:space="preserve">
-    <value>₣ŭℓℓ-ćόŀőг Ēмőјĭ !!! !</value>
+    <value>₣џłŀ-сθℓøґ Έmόјї !!! !</value>
     <comment>The main label of a toggle. When enabled, certain characters (emoji in this case) are displayed with multiple colors.</comment>
   </data>
   <data name="Profile_EnableColorGlyphs.HelpText" xml:space="preserve">
-    <value>Шђέń зйάьłēď, Ĕмõĵī åŕз ðìśφℓàўέđ ĩŉ ƒųĺℓ ċóℓōŕ. !!! !!! !!! !!! !!</value>
+    <value>Ẅнзп έňåвłёδ, Эмöĵī ãŕě ďíşρľǻỳęð ίñ ƒμŀℓ ćоļöŕ. !!! !!! !!! !!! !!</value>
     <comment>A longer description of the "Profile_EnableColorGlyphs" toggle.</comment>
   </data>
   <data name="Profile_FontWeightComboBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>₣őиτ ẁěìĝнť !!!</value>
+    <value>₣οиτ ẅэíğħť !!!</value>
     <comment>Name for a control to select the weight (i.e. bold, thin, etc.) of the text in the app.</comment>
   </data>
   <data name="Profile_FontWeightSlider.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>₣ǿňτ шěïġћŧ !!!</value>
+    <value>₣õиτ ŵėíğĥŧ !!!</value>
     <comment>Name for a control to select the weight (i.e. bold, thin, etc.) of the text in the app.</comment>
   </data>
   <data name="Profile_FontWeight.Header" xml:space="preserve">
-    <value>₣őиţ ẃęїĝнτ !!!</value>
+    <value>₣оňτ ŵειġнт !!!</value>
     <comment>Header for a control to select the weight (i.e. bold, thin, etc.) of the text in the app.</comment>
   </data>
   <data name="Profile_FontWeight.HelpText" xml:space="preserve">
-    <value>Ŝěţš ŧнэ ώęĭĝнţ (ľїĝĥтηěŝŝ öг ђзåνΐⁿεšş оƒ тћє śтѓбĸëş) ƒōґ ţћė ģινėŋ ƒôйŧ. !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ŝéŧѕ ţђέ ẁèϊģнť (łϊğħţⁿéşś όř ђзâνĩηзśş óƒ ŧĥė śťгόќęŝ) ƒθґ тħέ ġįνэи ƒőňţ. !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "font weight" setting does. Presented near "Profile_FontWeight".</comment>
   </data>
   <data name="Profile_FontAxes.Header" xml:space="preserve">
-    <value>Vářīâъļз ƒōñť âжеš !!! !!</value>
+    <value>Vαгįдвłз ƒôηŧ á×ęś !!! !!</value>
     <comment>Header for a control to allow editing the font axes.</comment>
   </data>
   <data name="Profile_FontAxesAvailable.Text" xml:space="preserve">
-    <value>Äðð øř ѓємôνё ƒŏπţ ǻхеş ƒőґ тħē ģíνëη ƒòñţ. !!! !!! !!! !!! </value>
+    <value>Āðδ θѓ ŗēмôνε ƒŏŋτ āжеŝ ƒóř ťћè ġīνęŋ ƒóήτ. !!! !!! !!! !!! </value>
     <comment>A description for what the "font axes" setting does. Presented near "Profile_FontAxes".</comment>
   </data>
   <data name="Profile_FontAxesUnavailable.Text" xml:space="preserve">
-    <value>Ţћê ѕêĺėçţėð ƒōŋť ħąş ⁿб νąŗϊàвľέ ƒσňτ á×ēş. !!! !!! !!! !!! !</value>
+    <value>Тђέ šěļεċťєď ƒŏηŧ ћάś πø νäѓїдвłз ƒōπт αжęš. !!! !!! !!! !!! !</value>
     <comment>A description provided when the font axes setting is disabled. Presented near "Profile_FontAxes".</comment>
   </data>
   <data name="Profile_FontFeatures.Header" xml:space="preserve">
-    <value>₣ǿńŧ ƒęåτüŗěś !!! </value>
+    <value>₣оŉτ ƒзåŧŭŕέś !!! </value>
     <comment>Header for a control to allow editing the font features.</comment>
   </data>
   <data name="Profile_FontFeaturesAvailable.Text" xml:space="preserve">
-    <value>Дδδ őг ŕёмőνе ƒοŉŧ ƒεāтùґ℮ѕ ƒбг τĥë ġĭνέⁿ ƒσňţ. !!! !!! !!! !!! !!</value>
+    <value>Ǻďð όŗ řěmòνě ƒóńт ƒєãťüгęś ƒθг тнĕ ĝĩνёŋ ƒόŋţ. !!! !!! !!! !!! !!</value>
     <comment>A description for what the "font features" setting does. Presented near "Profile_FontFeatures".</comment>
   </data>
   <data name="Profile_FontFeaturesUnavailable.Text" xml:space="preserve">
-    <value>Тĥε ѕзĺëċтέδ ƒбňť нāś лô ƒòπτ ƒèдτűřëš. !!! !!! !!! !!!</value>
+    <value>Τћē ŝэŀëсŧзð ƒőйť нâŝ иο ƒòиŧ ƒėäţцŕэś. !!! !!! !!! !!!</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
   <data name="Profile_General.Header" xml:space="preserve">
-    <value>Ģęńёяаℓ !!</value>
+    <value>Ġеŉėяâĺ !!</value>
     <comment>Header for a sub-page of profile settings focused on more general scenarios.</comment>
   </data>
   <data name="Profile_Hidden.Header" xml:space="preserve">
-    <value>Ηίď℮ φŕøƒϊłê ƒяŏм đгόрďθωή !!! !!! !</value>
+    <value>Ήîď℮ φябƒίļĕ ƒѓòm ďřóφδόшπ !!! !!! !</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
   <data name="Profile_Hidden.HelpText" xml:space="preserve">
-    <value>Їƒ ėиªьļěδ, τĥě ρŕôƒίℓę ωìľŀ ņōť αрφέåŕ įй ŧħе ĺĩśŧ ôƒ φřθƒįłėŝ. Ŧнїş ċдņ ьё υşěď ťó ђĭđ℮ đέƒåυℓť ρřŏƒĩĺεŝ аńđ đуπªmίćàłłу ĝэήзřǻτ℮ð φѓōƒĩļęŝ, шђìļě ľ℮άνίйĝ ţнëm ίл γǿŭŕ šέţŧīиğš ƒïĺэ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Їƒ ĕηάъℓěđ, ťĥэ φѓóƒїłę щíĺŀ иǿτ āφрĕдґ ΐŋ ŧћ℮ ŀīѕţ ǿƒ ρřŏƒīłėѕ. Ţђіş ςǻⁿ ъê ūšέð ťŏ ђĩðė δëƒǻūļт φґøƒíļέş аņð ďγñăмïĉâļℓÿ ģěиēяāŧεð ρřòƒίļзŝ, ẁĥιľє łэăνīⁿĝ ťĥèм ϊŉ ỳôцг śэťŧιйğŝ ƒιľë. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
   </data>
   <data name="Profile_Elevate.Header" xml:space="preserve">
-    <value>Ѓύň ŧћίѕ φяóƒіℓε åś Λðмįñĩšŧŗатǿř !!! !!! !!! </value>
+    <value>Гµл тђįş φѓöƒιļэ åş Λđmįňίšтŕàтоя !!! !!! !!! </value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
   </data>
   <data name="Profile_Elevate.HelpText" xml:space="preserve">
-    <value>Įƒ єŋáъľεð, ŧђē φґоƒïŀє ẁĭĺŀ ορèп іⁿ äŉ Αδміл т℮гмìπαł ẁĩņđôщ дüţõмāťïćáŀŀŷ. İƒ ťнę сųŕя℮иŧ ŵïŋδöώ ϊѕ ǻľѓěąðŷ řΰηņîήĝ áś āδmϊń, įτ'ľĺ οрëή īи τђїѕ ώíňδøш. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ìƒ éņãвļзδ, ŧĥĕ рŗоƒīľё ẅιľł óрėŋ ΐή åň Ąďmįŋ теѓmίидŀ шïпδσώ аůţòмăтìсаļļγ. Ĭƒ ŧĥе čцѓґ℮ⁿť ẁįлđόŵ їŝ áŀřėãďу ŕύŋņïπġ āš αðмīŉ, ϊţ'ŀℓ σрèń ĩй тħїŝ ẅīйδõẁ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
-    <value>Ηĭšţǿŕý śіżė !!! </value>
+    <value>Нíşŧôŗỳ ѕιźë !!! </value>
     <comment>Header for a control to determine how many lines of text can be saved in a session. In terminals, the "history" is the output generated within your session.</comment>
   </data>
   <data name="Profile_HistorySizeBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ĥΐśţоŕŷ śīźę !!! </value>
+    <value>Ĥіśţόѓÿ šιžё !!! </value>
     <comment>Name for a control to determine how many lines of text can be saved in a session. In terminals, the "history" is the output generated within your session.</comment>
   </data>
   <data name="Profile_HistorySize.HelpText" xml:space="preserve">
-    <value>Ťн℮ пųmъэґ óƒ ļїйєŝ ãьονε ţће ǿŉέş δīšφļâÿĕď įη τħ℮ щĩⁿđõŵ уθù ċάй šćгõŀł ъãςĸ ťǿ. !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Тђě ņůмвέґ όƒ ļïлèѕ àьόνэ τнέ ôиεŝ ďίşрℓâýèď ΐη ŧћз ẃΐлđóẃ ŷòц сåп şçřбŀľ вªćķ ťσ. !!! !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>A description for what the "history size" setting does. Presented near "Profile_HistorySize".</comment>
   </data>
   <data name="Profile_Icon.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Їčбή !</value>
+    <value>Îčόŋ !</value>
     <comment>Name for a control to determine what icon can be used to represent this profile. This is not necessarily a file path, but can be one.</comment>
   </data>
   <data name="Profile_Icon.Header" xml:space="preserve">
-    <value>Ісбŋ !</value>
+    <value>İ¢оń !</value>
     <comment>Header for a control to determine what icon can be used to represent this profile. This is not necessarily a file path, but can be one.</comment>
   </data>
   <data name="Profile_IconBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ϊсōπ !</value>
+    <value>Į¢òп !</value>
     <comment>Name for a control to determine what icon can be used to represent this profile. This is not necessarily a file path, but can be one.</comment>
   </data>
   <data name="Profile_Icon.HelpText" xml:space="preserve">
-    <value>Ęmοјį óř ïmáğз ƒíℓё ℓθςâţīόη óƒ тħε іćòŋ ŭѕėð ĩň тĥè ρгõƒїłє. !!! !!! !!! !!! !!! !!!</value>
+    <value>Ęmőĵì õř îmаĝė ƒìĺĕ ļöĉǻтïòπ ǿƒ ŧђē ісǿⁿ ùšεð іń τĥε φřôƒιľê. !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "icon" setting does. Presented near "Profile_Icon".</comment>
   </data>
   <data name="Profile_IconBrowse.Content" xml:space="preserve">
-    <value>ßřθẃśė... !!!</value>
+    <value>Ьřòẁśз... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
   <data name="Profile_PaddingSlider.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Рåðďìйĝ !!</value>
+    <value>Рáðđĩñġ !!</value>
     <comment>Name for a control to determine the amount of space between text in a terminal and the edge of the window.</comment>
   </data>
   <data name="Profile_Padding.Header" xml:space="preserve">
-    <value>Рåδďìйğ !!</value>
+    <value>Ρáððìŉğ !!</value>
     <comment>Header for a control to determine the amount of space between text in a terminal and the edge of the window. The space can be any combination of the top, bottom, left, and right side of the window.</comment>
   </data>
   <data name="Profile_Padding.HelpText" xml:space="preserve">
-    <value>Ѕέτś ţħè раďðίлġ äгōúňð тђé тёжţ ώíтћΐň ŧĥε ώϊŉδøŵ. !!! !!! !!! !!! !!!</value>
+    <value>Śěтš тђ℮ ρªđδїлğ ăѓоūńđ ŧћέ τεжт ẃĭтħϊп τħέ ẃίņδθẁ. !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "padding" setting does. Presented near "Profile_Padding".</comment>
   </data>
   <data name="Profile_RetroTerminalEffect.Header" xml:space="preserve">
-    <value>Γеťяθ ŧēѓmïпàŀ еƒƒėćţѕ !!! !!! </value>
+    <value>Яęтѓō тéѓmιйăĺ ëƒƒέсŧŝ !!! !!! </value>
     <comment>Header for a control to toggle classic CRT display effects, which gives the terminal a retro look.</comment>
   </data>
   <data name="Profile_RetroTerminalEffect.HelpText" xml:space="preserve">
-    <value>Ѕђοŵ гёťгŏ-ѕťỳłе ťėѓmіηªŀ έƒƒёςŧś ѕũċћ ąş ġĺöщîйġ ţёжŧ äŉď śçªή ŀίйėś. !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Śĥбẅ гзτřō-şтγłе τëѓmīⁿдĺ еƒƒέсτś şúćђ αş ğℓōώĩиġ ţέхť άηδ šςаи ľìиėš. !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "retro terminal effects" setting does. Presented near "Profile_RetroTerminalEffect". "Retro" is a common English prefix that suggests a nostalgic, dated appearance.</comment>
   </data>
   <data name="Profile_AdjustIndistinguishableColors.Header" xml:space="preserve">
-    <value>Āúтǿмαŧі¢ªļłÿ âδјŭşŧ łίĝħţлèşŝ òƒ ìⁿďíšŧĩⁿģûĩśħäьŀє тëжť !!! !!! !!! !!! !!! !</value>
+    <value>Аŭťοмäтĩčāĺłỳ ăδјΰѕť ļϊģђτπ℮şѕ ǿƒ їиδιšťΐņğűīşћāвłэ тêжť !!! !!! !!! !!! !!! !</value>
     <comment>Header for a control to toggle if we should adjust the foreground color's lightness to make it more visible when necessary, based on the background color.</comment>
   </data>
   <data name="Profile_AdjustIndistinguishableColors.HelpText" xml:space="preserve">
-    <value>Áΰŧōmατιċåĺłý ъŕīĝħŧĕйѕ öя đаřκεⁿş ţêжт τо мακέ ίť мôŗĕ νįśίъłě. Éνĕи ẃħєⁿ èпдвłêð, ťћįş αδјüşťmέņт шίłļ σŉľŷ όсċύř щĥ℮й ă çömьíⁿдτίõŉ όƒ ƒôřέġŗǿџπđ àñđ ъªċќĝґõϋπď čбľőřš ωöůℓð řεšùļτ ïń роôѓ ćøñţґдśŧ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>∆ųţοmäţιċãℓľў ьŗϊġĥťëñś ǿŗ δåřķēиѕ ťěжŧ ťò mäќε ĭŧ mόґз νίşìъŀĕ. Зνёŋ ẃћéŋ ęηāьℓёδ, τћιѕ äđјυšŧměйŧ ẃìℓŀ õñℓў ôćčцг ŵђěи ǻ çøмъĩⁿãτĩθñ øƒ ƒбřεġґòϋňδ áηď вāсκģřŏŭпδ čółοřş ẁóΰłđ я℮şŭľτ ìñ ρőόŗ сõŉтгáѕт. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "adjust indistinguishable colors" setting does. Presented near "Profile_AdjustIndistinguishableColors".</comment>
   </data>
   <data name="Profile_ScrollbarVisibility.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Šćгοŀļьăŕ νïşìьїľιту !!! !!!</value>
+    <value>Šсґσļľвąя νĩѕìъįłіťу !!! !!!</value>
     <comment>Name for a control to select the visibility of the scrollbar in a session.</comment>
   </data>
   <data name="Profile_ScrollbarVisibility.Header" xml:space="preserve">
-    <value>Śςŗοŀŀьàŗ νіşĩвīľιтŷ !!! !!!</value>
+    <value>Ščяòľŀвåŕ νίšιъįŀιτÿ !!! !!!</value>
     <comment>Header for a control to select the visibility of the scrollbar in a session.</comment>
   </data>
   <data name="Profile_ScrollbarVisibilityHidden.Content" xml:space="preserve">
-    <value>Ήíðđέņ !</value>
+    <value>Ĥΐδđēⁿ !</value>
     <comment>An option to choose from for the "scrollbar visibility" setting. When selected, the scrollbar is hidden.</comment>
   </data>
   <data name="Profile_ScrollbarVisibilityVisible.Content" xml:space="preserve">
-    <value>Vĭşįъľέ !!</value>
+    <value>Vїşівłε !!</value>
     <comment>An option to choose from for the "scrollbar visibility" setting. When selected, the scrollbar is visible but may dynamically shrink.</comment>
   </data>
   <data name="Profile_ScrollbarVisibilityAlways.Content" xml:space="preserve">
-    <value>Ąℓŵàўѕ !</value>
+    <value>Âℓώãýѕ !</value>
     <comment>An option to choose from for the "scrollbar visibility" setting. When selected, the scrollbar is always visible.</comment>
   </data>
   <data name="Profile_SnapOnInput.Header" xml:space="preserve">
-    <value>Ѕçřõĺľ ťô ίñφųţ ωћĕπ тýφίŋĝ !!! !!! !!</value>
+    <value>Śсгόľĺ ťσ їŋрυт ẃħęπ ţỳφįⁿģ !!! !!! !!</value>
     <comment>Header for a control to toggle if keyboard input should automatically scroll to where the input was placed.</comment>
   </data>
   <data name="Profile_StartingDirectory.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Śтãґτīņğ ðіґэċťõřў !!! !!</value>
+    <value>Ŝταяτìлĝ ðĩѓ℮ćτоŗỳ !!! !!</value>
     <comment>Name for a control to determine the directory the session opens it at launch. This is on a text box that accepts folder paths.</comment>
   </data>
   <data name="Profile_StartingDirectory.Header" xml:space="preserve">
-    <value>Şŧªѓťΐňĝ δíяë¢ťòгÿ !!! !!</value>
+    <value>Ѕťåřťіπġ đíгëĉţöґγ !!! !!</value>
     <comment>Header for a control to determine the directory the session opens it at launch. This is on a text box that accepts folder paths.</comment>
   </data>
   <data name="Profile_StartingDirectoryBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Šŧαґŧϊñġ ðϊяē¢ţõřγ !!! !!</value>
+    <value>Šтдřтíⁿģ đϊŕёςŧôŗў !!! !!</value>
     <comment>Name for a control to determine the directory the session opens it at launch. This is on a text box that accepts folder paths.</comment>
   </data>
   <data name="Profile_StartingDirectory.HelpText" xml:space="preserve">
-    <value>Τħ℮ đігέĉтõŗý ţне φяøƒîℓè ѕţаŗťŝ ΐŋ ŵħĕņ ίт ΐѕ ĺοâðεđ. !!! !!! !!! !!! !!! !</value>
+    <value>Ţћé đĭŗéçťòŕу τħе рѓøƒĩŀе śťªřťş ïή ẅћĕл îţ ίѕ ŀбдδėď. !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
   </data>
   <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
-    <value>Ьѓθώѕé... !!!</value>
+    <value>Ьŕōωŝē... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
   <data name="Profile_StartingDirectoryUseParentCheckbox.Content" xml:space="preserve">
-    <value>Ůѕę рăґέňτ ρґõċэśš δĭг℮çτöŗу !!! !!! !!</value>
+    <value>Üŝè φαŗèńŧ рřоĉěѕѕ đĭřё¢τоґý !!! !!! !!</value>
     <comment>A supplementary setting to the "starting directory" setting. "Parent" refers to the parent process of the current process.</comment>
   </data>
   <data name="Profile_StartingDirectoryUseParentCheckbox.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>İƒ éⁿäвℓеδ, ťħїş φřõƒìŀэ ŵϊŀľ šрāщŉ їŋ ŧħє ðïяěçťоѓў ƒгбm шђίςћ Τëřмϊňãŀ ẃãš ℓäџńсĥеđ. !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Îƒ έпãьłëď, тђìš ρѓòƒìĺè ωιĺℓ ŝρǻẁň іň ţћę ðіяеçţбгγ ƒřőм щћįςђ Теямĭņàł ẃªş ŀáцⁿĉħёđ. !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the supplementary "use parent process directory" setting does. Presented near "Profile_StartingDirectoryUseParentCheckbox".</comment>
   </data>
   <data name="Profile_HideIconCheckbox.Content" xml:space="preserve">
-    <value>Ηіďê ĭ¢бń !!!</value>
+    <value>Ηϊðё îçǿй !!!</value>
     <comment>A supplementary setting to the "icon" setting.</comment>
   </data>
   <data name="Profile_HideIconCheckbox.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Їƒ éňáъļёð, тĥįѕ φѓōƒϊłė ẃīľļ ĥаνз πò ĭсǿй. !!! !!! !!! !!! </value>
+    <value>Íƒ ёηдъļэδ, ŧĥϊŝ φгōƒιℓз шіℓŀ ђдνê ňö ΐĉôй. !!! !!! !!! !!! </value>
     <comment>A description for what the supplementary "Hide icon" setting does. Presented near "Profile_HideIconCheckbox".</comment>
   </data>
   <data name="Profile_SuppressApplicationTitle.Header" xml:space="preserve">
-    <value>Ŝúрρґэśŝ ŧітĺэ ĉħаņġėş !!! !!! </value>
+    <value>Ѕΰφφřэśš τíťļė čħªŉĝèѕ !!! !!! </value>
     <comment>Header for a control to toggle changes in the app title.</comment>
   </data>
   <data name="Profile_SuppressApplicationTitle.HelpText" xml:space="preserve">
-    <value>Ϊġиоѓĕ ǻφφĺĭćǻτΐōņ řéqυëşтş ŧó ςћǻηğё ŧħĕ τíтĺĕ (OSC 2). !!! !!! !!! !!! !!! !</value>
+    <value>Íġπόŗэ áρρĺіćâţìǿŋ ŗέqúёśţś ťò çђâηğě ťђê тįтŀé (ΘЅĆ 2). !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "suppress application title" setting does. Presented near "Profile_SuppressApplicationTitle". "OSC 2" is a technical term that is understood in the industry. {Locked="OSC 2"}</comment>
   </data>
   <data name="Profile_TabTitle.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ťдъ ŧīŧľĕ !!!</value>
+    <value>Τάъ ŧїŧļê !!!</value>
     <comment>Name for a control to determine the title of the tab. This is represented using a text box.</comment>
   </data>
   <data name="Profile_TabTitle.Header" xml:space="preserve">
-    <value>Ŧαв τιτľē !!!</value>
+    <value>Ťǻв τįťłэ !!!</value>
     <comment>Header for a control to determine the title of the tab. This is represented using a text box.</comment>
   </data>
   <data name="Profile_TabTitle.HelpText" xml:space="preserve">
-    <value>Ѓęρľåςěѕ τћэ ρřõƒιℓё πâмĕ âš τнē тĩτĺё тó рǻѕѕ тō ŧĥз ѕнэĺļ őη šтâŗτūφ. !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ŕèφłǻčèş ţће рřöƒîℓέ иάмз äş τне тíŧŀë ŧŏ φāѕş ŧό ţĥë şђëℓł öņ śťâгŧûρ. !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "tab title" setting does. Presented near "Profile_TabTitle".</comment>
   </data>
   <data name="Profile_UnfocusedAppearanceTextBlock.Text" xml:space="preserve">
-    <value>Ūŉƒσčůśеð ąφφεªřαисě !!! !!!</value>
+    <value>Ûηƒŏċμşεď äррėāŕαńćё !!! !!!</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
   <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Ċѓēǻŧэ Åррêāґāńĉê !!! !!</value>
+    <value>Ĉřêάŧэ Δрφзάŕãñςε !!! !!</value>
     <comment>Button label that adds an unfocused appearance for this profile.</comment>
   </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
-    <value>Đèłєτз !</value>
+    <value>Ðéľėŧê !</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
   </data>
   <data name="Profile_UseAcrylic.Header" xml:space="preserve">
-    <value>Эπãъℓз āċŕÿļîς мáţĕґĩǻļ !!! !!! </value>
+    <value>Єňάьłē дсѓŷĺĭс mąτěřìªŀ !!! !!! </value>
     <comment>Header for a control to toggle the use of acrylic material for the background. "Acrylic material" is a Microsoft-specific term: https://docs.microsoft.com/en-us/windows/apps/design/style/acrylic</comment>
   </data>
   <data name="Profile_UseAcrylic.HelpText" xml:space="preserve">
-    <value>Ąррłιêš å τřàŉşŀμĉёñŧ ťê×ťŭřе τб τћé ьдčκġřóũňđ ôƒ тħĕ ώíпđοẁ. !!! !!! !!! !!! !!! !!! </value>
+    <value>Àφρļįëś ã ţґάήŝℓűсэиŧ тēжτυŗэ ťό тĥ℮ ъάćĸĝґõυήď õƒ ţћ℮ щϊηðǿщ. !!! !!! !!! !!! !!! !!! </value>
     <comment>A description for what the "Profile_UseAcrylic" setting does.</comment>
   </data>
   <data name="Profile_UseDesktopImage.Content" xml:space="preserve">
-    <value>Џŝé ďęşκţōр ẃªĺŀраφëŕ !!! !!!</value>
+    <value>Ŭŝē đεśķτòр ẃąℓłραрĕя !!! !!!</value>
     <comment>A supplementary setting to the "background image" setting. When enabled, the OS desktop wallpaper is used as the background image. Presented near "Profile_BackgroundImage".</comment>
   </data>
   <data name="Profile_UseDesktopImage.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ůѕе τђе ďëšĸτσр ωåŀŀρªφ℮ґ ĩmąğĕ αѕ ŧнэ вǻςќĝґóϋлď ĭмǻğє ƒσř ťħé тëřmïлąľ. !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Ůšê тнè ďєśķťōρ ŵªĺļраφēř ímǻğё αś тħэ ъąĉκġřōůлđ іmãġè ƒόґ ŧн℮ ţэґмϊлªļ. !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>A description for what the supplementary "use desktop image" setting does. Presented near "Profile_UseDesktopImage".</comment>
   </data>
   <data name="Settings_ResetSettingsButton.Content" xml:space="preserve">
-    <value>Ďįşсǻѓď ćнäñğēś !!! !</value>
+    <value>Ďìš¢αŗð ĉђăŉġęѕ !!! !</value>
     <comment>Text label for a destructive button that discards the changes made to the settings.</comment>
   </data>
   <data name="Settings_ResetSettingsButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ďïşčãѓđ áŀļ µŋśāνέδ şěŧτіñģš. !!! !!! !!!</value>
+    <value>Ðĭŝĉäŕð дĺľ цŋşåνёď ѕεťŧīńġś. !!! !!! !!!</value>
     <comment>A description for what the "discard changes" button does. Presented near "Settings_ResetSettingsButton".</comment>
   </data>
   <data name="Settings_SaveSettingsButton.Content" xml:space="preserve">
-    <value>Ѕāνë !</value>
+    <value>Śāνэ !</value>
     <comment>Text label for the confirmation button that saves the changes made to the settings.</comment>
   </data>
   <data name="Settings_UnsavedSettingsWarning.Text" xml:space="preserve">
-    <value>⚠ Ϋöџ ђаνё цńšªνĕδ çђαηģėš. !!! !!! !!</value>
+    <value>⚠ Υŏű нâνě цπśąνêδ ¢ђãпġēš. !!! !!! !!</value>
     <comment>{Locked="⚠"} A disclaimer that appears when the unsaved changes to the settings are present.</comment>
   </data>
   <data name="Nav_AddNewProfile.Content" xml:space="preserve">
-    <value>Ăďδ α πеώ рґőƒΐℓè !!! !!</value>
+    <value>Ãđδ α ηèŵ ряоƒіľэ !!! !!</value>
     <comment>Header for the "add new" menu item. This navigates to the page where users can add a new profile.</comment>
   </data>
   <data name="Nav_Profiles.Content" xml:space="preserve">
-    <value>Рŕòƒϊĺёŝ !!</value>
+    <value>Ρґőƒϊłеѕ !!</value>
     <comment>Header for the "profiles" menu items. This acts as a divider to introduce profile-related menu items.</comment>
   </data>
   <data name="Globals_LaunchModeFocus.Content" xml:space="preserve">
-    <value>₣ŏċūš !</value>
+    <value>₣őćџŝ !</value>
     <comment>An option to choose from for the "launch mode" setting. Focus mode is a mode designed to help you focus.</comment>
   </data>
   <data name="Globals_LaunchModeMaximizedFocus.Content" xml:space="preserve">
-    <value>Мª×ïмîźëδ ƒòċùş !!! !</value>
+    <value>Μãхîмížęď ƒòćύŝ !!! !</value>
     <comment>An option to choose from for the "launch mode" setting. Opens the app maximized and in focus mode.</comment>
   </data>
   <data name="Globals_LaunchModeMaximizedFullscreen.Content" xml:space="preserve">
-    <value>Μα×їмīžēđ ƒūĺļ ś¢гęēñ !!! !!!</value>
+    <value>Мª×įmίźėδ ƒύļĺ šсґèэη !!! !!!</value>
     <comment>An option to choose from for the "launch mode" setting. Opens the app maximized and in full screen.</comment>
   </data>
   <data name="Globals_LaunchModeFullscreenFocus.Content" xml:space="preserve">
-    <value>₣űŀŀ ŝĉгеєй ƒòċΰѕ !!! !!</value>
+    <value>₣üĺℓ śčřèéη ƒŏćŭś !!! !!</value>
     <comment>An option to choose from for the "launch mode" setting. Opens the app in full screen and in focus mode.</comment>
   </data>
   <data name="Globals_LaunchModeMaximizedFullscreenFocus.Content" xml:space="preserve">
-    <value>Мă×ίмìžęď ƒцŀℓ śçřεёη ƒθċûš !!! !!! !!</value>
+    <value>Μąжįмīźēď ƒµĺļ śсяé℮ⁿ ƒθčϋš !!! !!! !!</value>
     <comment>An option to choose from for the "launch mode" setting. Opens the app maximized in full screen and in focus mode.</comment>
   </data>
   <data name="Profile_BellStyle.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>βêłĺ йότϊƒįċāŧіσñ ѕţŷļę !!! !!! </value>
+    <value>Бэĺł иőťíƒΐćªŧίøл ѕţуĺз !!! !!! </value>
     <comment>Name for a control to select the how the app notifies the user. "Bell" is the common term in terminals for the BEL character (like the metal device used to chime).</comment>
   </data>
   <data name="Profile_BellStyle.Header" xml:space="preserve">
-    <value>Бєŀŀ лŏťìƒϊ¢äťîŏп šťўŀê !!! !!! </value>
+    <value>Веĺł йθŧϊƒīçǻťΐθп ŝťỳℓé !!! !!! </value>
     <comment>Header for a control to select the how the app notifies the user. "Bell" is the common term in terminals for the BEL character (like the metal device used to chime).</comment>
   </data>
   <data name="Profile_BellStyle.HelpText" xml:space="preserve">
-    <value>Çŏήτяоĺş щђâт нāρφęñŝ щћéŉ ŧĥë ąφρℓіčǻťіøл эмιţş α BEL ςђåгǻçťęř. !!! !!! !!! !!! !!! !!! !</value>
+    <value>Ĉøήτѓōℓѕ ẅнǻτ ђдρφéпš шђĕñ тнē ąρрĺιčάτĩоň емìťś а ЬΕ£ ćђãяд¢ţĕř. !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "bell style" setting does. Presented near "Profile_BellStyle".{Locked="BEL"}</comment>
   </data>
   <data name="Profile_ReloadEnvVars.Header" xml:space="preserve">
-    <value>Ļªůиčђ ŧĥîš аρφŀîçǻтїőл щĩţħ а ňёώ зиνĭяöņмёņť ьŀŏćκ !!! !!! !!! !!! !!! </value>
+    <value>£αüņ¢ħ ŧћΐš аρφℓîсäŧïōп ŵìţн α йéω ёňνΐѓõлmĕπţ ъłосќ !!! !!! !!! !!! !!! </value>
     <comment>"environment variables" are user-definable values that can affect the way running processes will behave on a computer</comment>
   </data>
   <data name="Profile_ReloadEnvVars.HelpText" xml:space="preserve">
-    <value>Ŵђĕⁿ еñáьℓëδ, τħё Τëгмïŋăļ щïŀļ ģēņéѓàţε à иęщ ёŋνìѓõήмεит вŀоçĸ ŵђēи čřèατіņġ ņεẁ τάвś øŕ ρǻπєş ẁΐťћ ŧћїѕ ρŗόƒіľ℮. Ŵħёη đïšäвļĕđ, тħě ťав/φǻйě ŵĩℓℓ ìиşţėāđ įñħэгìť τнë νáŕìãвℓ℮ś τћё Ŧēямїлдℓ ŵаš šťäřťèð ẃΐŧħ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ẁћέл εņаьŀèď, τħё Ŧëгmĩňªľ ẅīŀℓ ğεлěяαте å ŉэщ еńνîřόńмęñт ьŀøĉĸ ŵħ℮л čґēãťîņğ ŉεώ τâвѕ όя рªлёѕ щĭτћ тĥĭѕ ρŗòƒΐℓė. Ẅђêй ðìšąвļėđ, τћë ťąь/рáňε шîŀĺ íñśτėáđ īήђзŕίτ τђė νăяϊаьℓĕŝ ţђε Ťęřmíŋаŀ ẁαŝ śťäřťέδ ωįтħ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "Reload environment variables" setting does. Presented near "Profile_ReloadEnvVars".</comment>
   </data>
   <data name="Profile_VtPassthrough.Header" xml:space="preserve">
-    <value>∑лάъłз ě×φєŕіmэηţàĺ νιŕŧũáł т℮ґміŋǻļ φāŝšţнŕōμġĥ !!! !!! !!! !!! !!</value>
+    <value>Зńăьℓē эхφзґímėпτªŀ νіѓтűǻļ τ℮ґмϊñāļ φаśşтнґöúģн !!! !!! !!! !!! !!</value>
     <comment>An option to enable experimental virtual terminal passthrough connectivity option with the underlying ConPTY</comment>
   </data>
+  <data name="Profile_RightClickContextMenu.Header" xml:space="preserve">
+    <value>Ðįşφłąÿ ǻ мèηΰ όή řïĝĥť-ćľїçķ !!! !!! !!!</value>
+    <comment>This controls how a right-click behaves in the terminal</comment>
+  </data>
+  <data name="Profile_RightClickContextMenu.HelpText" xml:space="preserve">
+    <value>Ẁђéŋ êπäвĺεð, ţĥё Τéŕмįⁿął ẃìļŀ ďïśρĺąỳ ã мέиц öη ŕìğĥţ-сℓĩ¢ķ. Ŵћëŉ đϊśªьŀèð, řιġћţ-čℓî¢ķιñĝ ẁĩłℓ ĉσрÿ тħē şèłэĉţĕđ ŧэжτ (ŏя рâŝтé ΐƒ ťћзяę'ś йб śзľĕćţîбñ). !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <comment>A description for what the "Display a menu on right-click" setting does. Presented near "Profile_RightClickContextMenu".</comment>
+  </data>
+  <data name="Profile_ShowMarks.Header" xml:space="preserve">
+    <value>Ďιşрĺąŷ мǻŕĸş θй ţĥě ŝćřбŀŀъáŕ !!! !!! !!!</value>
+    <comment>"Marks" are small visual indicators that can help the user identify the position of useful info in the scrollbar</comment>
+  </data>
+  <data name="Profile_ShowMarks.HelpText" xml:space="preserve">
+    <value>Ẅĥέň ёпдъļêď, τĥ℮ Τëгmįиªł ẃĩľļ ðΐśρℓăỳ мāѓκś ιñ ţħє şĉѓòℓľьªŗ ŵħëⁿ ŝēãѓçђιŋĝ ƒθř ťèжт, σѓ ŵћзп šђêļŀ ίπтέğґãťîόи іś εŋäьłёđ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <comment>A description for what the "Display marks on the scrollbar" setting does. Presented near "Profile_ShowMarks".</comment>
+  </data>
+  <data name="Profile_AutoMarkPrompts.Header" xml:space="preserve">
+    <value>∆űŧòмåťĩċǻłļγ маѓķ ρřǿmρŧş óй φґěѕşіиğ Еŋŧєř !!! !!! !!! !!! !</value>
+    <comment>"Enter" is the enter/return key on the keyboard. This will add a mark indicating the position of a shell prompt when the user presses enter.</comment>
+  </data>
+  <data name="Profile_AutoMarkPrompts.HelpText" xml:space="preserve">
+    <value>Ẃћеⁿ эņáвļēď, тħè Тěřмíиãŀ ǻµтοмăťìςǻℓľу åδď ã мâŕĸ іиđιςåŧïⁿġ тħé рσŝĩţίол öƒ ţђé ęņð øƒ τĥę ςбmмǻйδ ẃћéи ýθů φŕэѕѕ ēиŧęѓ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <comment>A description for what the "Automatically mark prompts on pressing Enter" setting does. Presented near "Profile_AutoMarkPrompts".</comment>
+  </data>
+  <data name="Profile_RepositionCursorWithMouse.Header" xml:space="preserve">
+    <value>Ê×рэґїmзŉτâļ: Гэрŏśΐťĩőⁿ τћέ ćũŕšσŕ ẁіτн mσůśё ċℓīċĸѕ !!! !!! !!! !!! !!! </value>
+    <comment>This allows the user to move the text cursor just by clicking with the mouse.</comment>
+  </data>
+  <data name="Profile_RepositionCursorWithMouse.HelpText" xml:space="preserve">
+    <value>Ẅћзή ℮йăъļэð, ĉľīćкїηġ ιňśīðè ŧĥё ρŕσmρŧ ωïŀļ мσνэ ţћё čúřšŏѓ тő ţħάŧ рōŝΐτíôⁿ. Ŧђΐŝ ŕéqűїřέѕ šћėľľ іñţεģřãţīǿň тø ъē зŋāвłêð ιπ убųѓ ѕћєľĺ τó ẃθѓκ ăѕ зжφĕčτēď. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <comment>A description for what the "Reload environment variables" setting does. Presented near "Profile_RepositionCursorWithMouse".</comment>
+  </data>
   <data name="Profile_BellStyleAudible.Content" xml:space="preserve">
-    <value>Λűδĩъℓé !!</value>
+    <value>∆ůðĭъĺę !!</value>
     <comment>An option to choose from for the "bell style" setting. When selected, an audible cue is used to notify the user.</comment>
   </data>
   <data name="Profile_BellStyleNone.Content" xml:space="preserve">
-    <value>Иöŋë !</value>
+    <value>Ñбŉĕ !</value>
     <comment>An option to choose from for the "bell style" setting. When selected, notifications are silenced.</comment>
   </data>
   <data name="Globals_DisableAnimations.Header" xml:space="preserve">
-    <value>Ðіşªъĺ℮ ρåŉĕ ąлīmâţίσⁿś !!! !!! </value>
+    <value>Đїŝâвŀè рăŋě ǻйįmąтіǿňŝ !!! !!! </value>
     <comment>Header for a control to toggle animations on panes. "Enabled" value disables the animations.</comment>
   </data>
   <data name="Profile_FontWeightBlack.Content" xml:space="preserve">
-    <value>Ьļãçќ !</value>
+    <value>Вĺåčќ !</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightBold.Content" xml:space="preserve">
-    <value>Вбℓđ !</value>
+    <value>Ъθĺď !</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightCustom.Content" xml:space="preserve">
-    <value>Ĉŭŝţõm !</value>
+    <value>Ćцѕτσm !</value>
     <comment>This is an entry that allows the user to select their own font weight value outside of the simplified list of options.</comment>
   </data>
   <data name="Profile_FontWeightExtra-black.Content" xml:space="preserve">
-    <value>Ĕ×τřă-Вĺâċќ !!!</value>
+    <value>Ĕжťŗā-Βļаċк !!!</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightExtra-bold.Content" xml:space="preserve">
-    <value>Ёжŧґà-Бοŀð !!!</value>
+    <value>Ёжţгд-Боļδ !!!</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightExtra-light.Content" xml:space="preserve">
-    <value>Ěхťгά-Ľїğћŧ !!!</value>
+    <value>Ę×тяā-£ïĝћţ !!!</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightLight.Content" xml:space="preserve">
-    <value>₤ĩĝĥт !</value>
+    <value>Ŀιğĥŧ !</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightMedium.Content" xml:space="preserve">
-    <value>Мэδιυм !</value>
+    <value>Μєđιϋм !</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightNormal.Content" xml:space="preserve">
-    <value>Йбгmâŀ !</value>
+    <value>Ňŏŗmªĺ !</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightSemi-bold.Content" xml:space="preserve">
-    <value>Şëмĩ-Ьσℓδ !!!</value>
+    <value>Şèмï-Вōłđ !!!</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightSemi-light.Content" xml:space="preserve">
-    <value>Ѕèmΐ-Ļιĝнτ !!!</value>
+    <value>Ѕėmį-₤іģħŧ !!!</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontWeightThin.Content" xml:space="preserve">
-    <value>Τнίň !</value>
+    <value>Ŧħīň !</value>
     <comment>This is the formal name for a font weight.</comment>
   </data>
   <data name="Profile_FontFeature_rlig" xml:space="preserve">
-    <value>Γёqúířзđ łίğāŧџřēś !!! !!</value>
+    <value>Ŗéqùїяëď ľîģąτüřеŝ !!! !!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_locl" xml:space="preserve">
-    <value>Ĺóčâľížёδ ƒбѓmŝ !!! !</value>
+    <value>£ǿčãłϊźэď ƒŏгмş !!! !</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_ccmp" xml:space="preserve">
-    <value>Ćомрòşįťїόπ/ðêċоmρōšīŧįθπ !!! !!! !</value>
+    <value>Ćóмρőśĭťϊοņ/ðέċömφóšίτìøη !!! !!! !</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_calt" xml:space="preserve">
-    <value>Ĉōňŧêжтµåľ âłтêŗňăţêš !!! !!!</value>
+    <value>Сθⁿте×тüáŀ ǻℓţėŗпαтēŝ !!! !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_liga" xml:space="preserve">
-    <value>Ѕťаπδāгđ łїģąтũяεѕ !!! !!</value>
+    <value>Ѕτάлďάґð ℓíġąтŭѓεѕ !!! !!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_clig" xml:space="preserve">
-    <value>Çóⁿтęхтũàŀ ļîĝαŧūřέś !!! !!!</value>
+    <value>Ċоňťêжţũāł łіġăŧµѓèś !!! !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_rvrn" xml:space="preserve">
-    <value>Γėqŭιřėď νåѓϊăτίбή дℓţėґйàтзş !!! !!! !!!</value>
+    <value>Ŕëqџìґêð νãяìâтïöп ªļтĕгñąţëš !!! !!! !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_kern" xml:space="preserve">
-    <value>Κεŕήïñġ !!</value>
+    <value>Ќεřпĩńģ !!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_mark" xml:space="preserve">
-    <value>Μàřк ρøşíţīόпìηġ !!! !</value>
+    <value>Мăґĸ φбśїτìõйίήģ !!! !</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_mkmk" xml:space="preserve">
-    <value>Μäяκ тô mäřκ рøśιŧìøŉїπğ !!! !!! !</value>
+    <value>Мªяκ ŧθ máгķ φбşίţīōпîņĝ !!! !!! !</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_dist" xml:space="preserve">
-    <value>Ďіşŧǻⁿċё !!</value>
+    <value>Ďïşťªпčє !!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_aalt" xml:space="preserve">
-    <value>Āċςэѕş ǻℓł àŀтёřйąтęş !!! !!!</value>
+    <value>Âĉċēśş αłł ǻĺтэяńáťėş !!! !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_case" xml:space="preserve">
-    <value>Ċäŝě śêйşįтїνз ƒσřмš !!! !!!</value>
+    <value>€αŝē śεⁿŝιţіνé ƒǿŗmŝ !!! !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_dnom" xml:space="preserve">
-    <value>Ďëлоmįņãŧоґ !!!</value>
+    <value>Đēñômĭņąţόя !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_fina" xml:space="preserve">
-    <value>Τзѓmійäĺ ƒόгмś !!! !</value>
+    <value>Ŧēгмιπáļ ƒόŕmś !!! !</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_frac" xml:space="preserve">
-    <value>₣ŕдςτìóиś !!!</value>
+    <value>₣ŕãçŧїõήŝ !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_init" xml:space="preserve">
-    <value>Ίńîťϊäℓ ƒǿѓmѕ !!! </value>
+    <value>Īήíťĭàľ ƒõяmŝ !!! </value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_medi" xml:space="preserve">
-    <value>Мèďіªł ƒбгmѕ !!! </value>
+    <value>Μеďìαℓ ƒбřмš !!! </value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_numr" xml:space="preserve">
-    <value>Νµмэѓǻτőґ !!!</value>
+    <value>Ňϋмēгªţőř !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_ordn" xml:space="preserve">
-    <value>Οѓðìйăľś !!</value>
+    <value>Οřďĩŋäℓѕ !!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_rclt" xml:space="preserve">
-    <value>Ŗĕqμîяĕď ¢σйŧēжţũăℓ ąļţėřиàţεś !!! !!! !!!</value>
+    <value>Ŗèqŭīŗеð ĉοйτęхťüàĺ áľţėřŉãŧεŝ !!! !!! !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_sinf" xml:space="preserve">
-    <value>Ŝςïёήŧïƒįç īлƒĕřїοŗŝ !!! !!!</value>
+    <value>Śсϊèⁿťίƒιč ΐñƒєřīōŗŝ !!! !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_subs" xml:space="preserve">
-    <value>Šűвş¢яīφτ !!!</value>
+    <value>Śûвś¢řîρţ !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_sups" xml:space="preserve">
-    <value>Šüрéгŝςŕīρţ !!!</value>
+    <value>Ŝùρεřśčřîφŧ !!!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_zero" xml:space="preserve">
-    <value>Šŀãѕħέđ żёяō !!! </value>
+    <value>Ѕĺáѕħëď żêґø !!! </value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Profile_FontFeature_abvm" xml:space="preserve">
-    <value>Ąъǿνέ-вäŝĕ máѓќ φŏŝīŧīǿήîиğ !!! !!! !!</value>
+    <value>Λъŏνє-ъåѕέ мǻяќ φōśīτΐóņīлĝ !!! !!! !!</value>
     <comment>This is the formal name for a font feature.</comment>
   </data>
   <data name="Globals_LaunchSize.Header" xml:space="preserve">
-    <value>Ļâůлċђ šĭźě !!!</value>
+    <value>Łáцηсħ šіžē !!!</value>
     <comment>Header for a group of settings that control the size of the app. Presented near "Globals_InitialCols" and "Globals_InitialRows".</comment>
   </data>
   <data name="Globals_LaunchSize.HelpText" xml:space="preserve">
-    <value>Τђē иΰмъëŕ òƒ ŕŏшš âйð ćοℓũмήş ďίśрľâỳĕď ĭń ţħє щìⁿðòẁ üрòⁿ ƒігśτ ŀŏаδ. Мĕãѕűґєδ ϊй ςħâгâсŧеŗš. !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Τĥé ήυмвēŕ θƒ гόωş äйđ ςôľũмņś đΐşφĺąŷęđ îй ŧĥê ẃįňďŏώ ųрбŋ ƒїяšţ ļŏăď. Μêάşµřēď īй ςħαŕāçτέřś. !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the "rows" and "columns" settings do. Presented near "Globals_LaunchSize.Header".</comment>
   </data>
   <data name="Globals_LaunchPosition.Text" xml:space="preserve">
-    <value>Łâųńсн ρōѕιτìол !!! !</value>
+    <value>Ľâűπçћ φσѕíţįбŉ !!! !</value>
     <comment>Header for a group of settings that control the launch position of the app. Presented near "Globals_InitialPosX" and "Globals_InitialPosY".</comment>
   </data>
   <data name="Globals_LaunchPosition.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Τнē ĭňĩţϊāŀ φбśìŧïôŋ öƒ ţħе τёŕmīпàľ ẅįиδόщ ùрǿň śτдѓтūρ. Ẃħěŉ łαùπснιņĝ άş mã×ĭmížеð, ƒŭļĺ ѕčŗ℮ёņ, οř щįťћ "€έŋţęŗ σñ ŀãυήĉħ" ėñǻьłēđ, тћíŝ іš ůśęδ τǿ τàѓģετ τћē mōиιŧōř οƒ íņтêŕєšτ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Ťнέ īηĭţϊąĺ φǿšĩтīòл őƒ ŧђę τĕѓмīηäł ωĭиđŏщ ϋρőŉ śτåřťϋр. Ŵнέη ľãцпçђìŋģ άŝ mã×ĩмιż℮ď, ƒµļľ ŝ¢ґэ℮ň, øř ẃĩτħ "Çĕпτеґ ои łåúŋ¢ђ" ĕņǻвℓėδ, ŧĥíŝ íś џşĕď ţö ţάřĝēŧ тħē моŋітòя σƒ įпťēґēśŧ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>A description for what the "X position" and "Y position" settings do. Presented near "Globals_LaunchPosition.Header".</comment>
   </data>
   <data name="Profile_BellStyleAll.Content" xml:space="preserve">
-    <value>Άļļ </value>
+    <value>Äŀℓ </value>
     <comment>An option to choose from for the "bell style" setting. When selected, a combination of the other bell styles is used to notify the user.</comment>
   </data>
   <data name="Profile_BellStyleVisual.Content" xml:space="preserve">
-    <value>Vіśŭаŀ (ƒļαśĥ тªşĸьäŕ) !!! !!! </value>
+    <value>Vĭśũάŀ (ƒĺāşђ ţąşκвдѓ) !!! !!! </value>
   </data>
   <data name="Profile_BellStyleTaskbar.Content" xml:space="preserve">
-    <value>₣ľāśн ťάśќьàг !!! </value>
+    <value>₣ŀªśћ τâśќъäѓ !!! </value>
     <comment>An option to choose from for the "bell style" setting. When selected, a visual notification is used to notify the user. In this case, the taskbar is flashed.</comment>
   </data>
   <data name="Profile_BellStyleWindow.Content" xml:space="preserve">
-    <value>₣ℓªşн шĩñðóẃ !!! </value>
+    <value>₣łāŝћ ẅїňďŏщ !!! </value>
     <comment>An option to choose from for the "bell style" setting. When selected, a visual notification is used to notify the user. In this case, the window is flashed.</comment>
   </data>
   <data name="ColorScheme_AddNewButton.Text" xml:space="preserve">
-    <value>Ãďđ йēщ !!</value>
+    <value>Äδď ⁿĕш !!</value>
     <comment>Button label that creates a new color scheme.</comment>
   </data>
   <data name="ColorScheme_DeleteButton.Text" xml:space="preserve">
-    <value>Ďєŀęτè ćоĺõř ѕсћémè !!! !!!</value>
+    <value>Ðєĺèŧĕ ¢оľōѓ ѕснεмė !!! !!!</value>
     <comment>Button label that deletes the selected color scheme.</comment>
   </data>
   <data name="ColorScheme_EditButton.Text" xml:space="preserve">
-    <value>Єðіŧ !</value>
+    <value>Σδϊт !</value>
     <comment>Button label that edits the currently selected color scheme.</comment>
   </data>
   <data name="ColorScheme_DeleteButton2.Text" xml:space="preserve">
-    <value>Đ℮ĺęтέ !</value>
+    <value>Đеļėŧę !</value>
     <comment>Button label that deletes the selected color scheme.</comment>
   </data>
   <data name="ColorScheme_Name.Header" xml:space="preserve">
-    <value>Иãмэ !</value>
+    <value>Ŋām℮ !</value>
     <comment>The name of the color scheme. Used as a label on the name control.</comment>
   </data>
   <data name="ColorScheme_Name.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ţнě ήαмė ōƒ τћέ çŏļöř ѕ¢нεмě. !!! !!! !!!</value>
+    <value>Ŧħё ŋąмэ őƒ τћě ¢ǿℓôѓ śçђéмē. !!! !!! !!!</value>
     <comment>Supplementary text (tooltip) for the control used to select a color scheme that is under view.</comment>
   </data>
   <data name="Profile_DeleteButton.Text" xml:space="preserve">
-    <value>Ðęℓęţё ρґŏƒïłë !!! !</value>
+    <value>Đёľĕŧз рŗõƒιŀê !!! !</value>
     <comment>Button label that deletes the current profile that is being viewed.</comment>
   </data>
   <data name="Profile_Name.HelpText" xml:space="preserve">
-    <value>Ťħē ńǻмē óƒ ťће φґõƒïļė ťђåт аφρεāŕŝ ïñ τĥз ðяōрðοшл. !!! !!! !!! !!! !!! </value>
+    <value>Ťћє ηǻмэ бƒ тнέ рřоƒïľé ţĥāτ άрρеαяѕ ĭπ ťћê đŕøφđóẃи. !!! !!! !!! !!! !!! </value>
     <comment>A description for what the "name" setting does. Presented near "Profile_Name".</comment>
   </data>
   <data name="Profile_Name.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ñâм℮ !</value>
+    <value>∏ãmê !</value>
     <comment>Name for a control to determine the name of the profile. This is a text box.</comment>
   </data>
   <data name="Profile_Name.Header" xml:space="preserve">
-    <value>Ñâмē !</value>
+    <value>Ņàmě !</value>
     <comment>Header for a control to determine the name of the profile. This is a text box.</comment>
   </data>
   <data name="Profile_TransparencyHeader.Text" xml:space="preserve">
-    <value>Ţгāⁿšφäѓĕŋсý !!! </value>
+    <value>Ţřąηѕρªґěňçÿ !!! </value>
     <comment>Header for a group of settings related to transparency, including the acrylic material background of the app.</comment>
   </data>
   <data name="Profile_BackgroundHeader.Text" xml:space="preserve">
-    <value>Ъàčќĝгôůŉď ĩмăĝз !!! !</value>
+    <value>Βдĉкġřöûⁿď ìmąĝέ !!! !</value>
     <comment>Header for a group of settings that control the image presented on the background of the app. Presented near "Profile_BackgroundImage" and other keys starting with "Profile_BackgroundImage".</comment>
   </data>
   <data name="Profile_CursorHeader.Text" xml:space="preserve">
-    <value>Čūѓѕöŗ !</value>
+    <value>Čυřŝóґ !</value>
     <comment>Header for a group of settings that control the appearance of the cursor. Presented near "Profile_CursorHeight" and other keys starting with "Profile_Cursor".</comment>
   </data>
   <data name="Profile_AdditionalSettingsHeader.Text" xml:space="preserve">
-    <value>Дððîтΐойаľ śєťŧΐηģѕ !!! !!!</value>
+    <value>∆ďδΐţіõпаľ śєτťΐņĝŝ !!! !!!</value>
     <comment>Header for the buttons that navigate to additional settings for the profile.</comment>
   </data>
   <data name="Profile_TextHeader.Text" xml:space="preserve">
-    <value>Ťèхŧ !</value>
+    <value>Ţέхţ !</value>
     <comment>Header for a group of settings that control the appearance of text in the app.</comment>
   </data>
   <data name="Profile_WindowHeader.Text" xml:space="preserve">
-    <value>Ẁįŋđόώ !</value>
+    <value>Щіňďош !</value>
     <comment>Header for a group of settings that control the appearance of the window frame of the app.</comment>
   </data>
   <data name="Nav_OpenJSON.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Οφєп γǿυř settings.json ƒіļ℮. Āľт+Çļіçк тó οрėл ỳőΰѓ defaults.json ƒíļę. !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Ώр℮п ỳõμѓ settings.json ƒιĺ℮. Áŀţ+Ċĺι¢ќ тθ ôφ℮л уοųѓ δěƒåџĺţş.јśŏл ƒïłе. !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>{Locked="settings.json"}, {Locked="defaults.json"}</comment>
   </data>
   <data name="Rename.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Яёņαmě !</value>
+    <value>Γ℮иάмê !</value>
     <comment>Text label for a button that can be used to begin the renaming process.</comment>
   </data>
   <data name="ColorScheme_DeleteButtonDisclaimerInBox.Text" xml:space="preserve">
-    <value>Тĥΐš ĉōłбѓ şćĥěmę ċăйŋøţ вē ðέļεтэð øř ѓеŉαmеð ъέсªùśē ίţ ΐš íńςℓűđ℮δ ьŷ δёƒãûĺŧ. !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Τћîŝ čŏļòя şċĥěмε ćâňñǿτ ьё đĕļ℮ťèδ ōŕ ґĕňãmėð ьēĉаūśё ĭţ îś їńċľůðзď ъγ đэƒāûŀŧ. !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>Disclaimer presented next to the delete button when it is disabled.</comment>
   </data>
   <data name="ColorScheme_DeleteConfirmationButton.Content" xml:space="preserve">
-    <value>Ỳēѕ, ďзℓэτë ¢ôℓöѓ şςĥéмė !!! !!! !</value>
+    <value>Ýëѕ, ðěĺέŧε çółöг śċћэмέ !!! !!! !</value>
     <comment>Button label for positive confirmation of deleting a color scheme (presented with "ColorScheme_DeleteConfirmationMessage")</comment>
   </data>
   <data name="ColorScheme_DeleteConfirmationMessage.Text" xml:space="preserve">
-    <value>Αŗè уöũ šúгє ỳθú ẃάŋť ŧõ đэĺĕτе ţĥϊŝ сθļōґ ѕčħεmε? !!! !!! !!! !!! !!!</value>
+    <value>Аŕë уоû şύŗê γǿџ ẃаηť ŧθ ðέłēтε тнíѕ çσľòř ѕćĥεмέ? !!! !!! !!! !!! !!!</value>
     <comment>A confirmation message displayed when the user intends to delete a color scheme.</comment>
   </data>
   <data name="RenameAccept.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Дсςėρť ґěŉăме !!! </value>
+    <value>Àćĉêрŧ ŕεηáмĕ !!! </value>
     <comment>Text label for a button that can be used to confirm a rename operation during the renaming process.</comment>
   </data>
   <data name="RenameCancel.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>€àπċ℮ľ řëⁿáмè !!! </value>
+    <value>Čªⁿςęℓ гëήдмέ !!! </value>
     <comment>Text label for a button that can be used to cancel a rename operation during the renaming process.</comment>
   </data>
   <data name="ColorSchemesDisclaimer.Text" xml:space="preserve">
-    <value>Šċнęméѕ δĕƒϊлêδ ħęřέ ςαл вĕ äφφℓіĕδ ťǿ ýθŭг рřōƒїℓėŝ ũлď℮ŕ тђе "Ãррёáŗàŉçєş" ŝēςţîőη όƒ ţħз φгòƒíłэ ѕěţτίиĝѕ ρăĝεş. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Šсћěмěš đèƒιñèđ ћėřė ċдŋ ъę αрφŀĩ℮ð ŧö ỳóцř ρґοƒįℓэŝ цйðĕř ŧћ℮ "Άρφêäгăήςεѕ" šєĉťΐόη θƒ τћę φґôƒіℓē şĕŧŧιⁿĝѕ рǻĝêѕ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A disclaimer presented at the top of a page. "Appearances" should match Profile_Appearance.Header.</comment>
   </data>
   <data name="Profile_BaseLayerDisclaimer.Text" xml:space="preserve">
-    <value>Śėţţīиĝŝ đêƒįñèđ ђêŗè ẅïĺℓ âρφĺÿ тθ àℓŀ ргθƒìŀéѕ ΰⁿľėśѕ тнеγ åŗε õνěгяíδðėņ вỳ ª φŗσƒíŀз'ŝ ѕєŧтįņĝѕ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Śéţţĩñģš ďėƒįňеδ ђеŗ℮ ẃίľĺ áφρℓý ŧō ªļł ряöƒíŀєš ūлĺèŝŝ ťħęу àгë σνэřřїδδέй ьγ а рŗőƒįŀé'ś ŝëтţіиġš. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A disclaimer presented at the top of a page. See "Nav_ProfileDefaults.Content" for a description on what the defaults layer does in the app.</comment>
   </data>
   <data name="Profile_DeleteConfirmationButton.Content" xml:space="preserve">
-    <value>Ýęѕ, δзŀёŧè ρяöƒïŀĕ !!! !!!</value>
+    <value>Ỳěŝ, ďзľетè ρřöƒīľé !!! !!!</value>
     <comment>Button label for positive confirmation of deleting a profile (presented with "Profile_DeleteConfirmationMessage")</comment>
   </data>
   <data name="Profile_DeleteConfirmationMessage.Text" xml:space="preserve">
-    <value>Ąŕė ỳоű ŝμŗē ўöμ ẅаήτ ťõ ðėĺéτě ťĥįś ρґøƒïľę? !!! !!! !!! !!! !</value>
+    <value>Дгè уøџ ѕŭřз ỳθū шдŋт ťö đěĺэţè ţћιś φгòƒίŀ℮? !!! !!! !!! !!! !</value>
     <comment>A confirmation message displayed when the user intends to delete a profile.</comment>
   </data>
   <data name="Settings_SaveSettingsButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ŝåνе àłŀ ΰŋşāνеð ѕĕţťΐήģѕ. !!! !!! !</value>
+    <value>Ѕąνε āľŀ ΰŉşаν℮ð šέťτϊŋģŝ. !!! !!! !</value>
     <comment>A description for what the "save" button does. Presented near "Settings_SaveSettingsButton".</comment>
   </data>
   <data name="Globals_TabSwitcherMode.Header" xml:space="preserve">
-    <value>Ťăь šẃίŧćĥеѓ ĭйţĕѓƒąĉę šţўĺє !!! !!! !!</value>
+    <value>Τãь ŝẃιťςђęř įⁿтëяƒā¢ĕ şтγℓε !!! !!! !!</value>
     <comment>Header for a control to choose how the tab switcher operates.</comment>
   </data>
   <data name="Globals_TabSwitcherMode.HelpText" xml:space="preserve">
-    <value>Šèľĕсťš шћîćħ ïŋţêґƒαċē ẅīℓŀ вĕ µşєð ẅħèŉ γôџ ŝшιтĉђ тâъѕ ŭŝîņģ ŧнé κėỳьбαřδ. !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>Śėℓĕčţś ẃħĩçћ īиŧēгƒаςэ ωīℓℓ вè цŝëδ шħёл ŷόџ şщīťĉђ ŧáвš ùśīлġ τнз ќèŷьóâяð. !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>A description for what the "tab switcher mode" setting does. Presented near "Globals_TabSwitcherMode.Header".</comment>
   </data>
   <data name="Globals_TabSwitcherModeMru.Content" xml:space="preserve">
-    <value>Šěφâŕåте ŵĭñďŏш, ΐп mοѕť ѓέ¢℮πτℓỳ úѕęδ òѓðěŗ !!! !!! !!! !!! !</value>
+    <value>Şéράŗâт℮ ŵĩñðōω, ïл mθŝť ŗĕčєπťℓу ūŝěď оŗδêґ !!! !!! !!! !!! !</value>
     <comment>An option to choose from for the "tab switcher mode" setting. The tab switcher overlay is shown in most recently used order.</comment>
   </data>
   <data name="Globals_TabSwitcherModeInOrder.Content" xml:space="preserve">
-    <value>Ѕерãѓąťě ώίлďőω, īⁿ τâь şţгïρ õѓďéŗ !!! !!! !!! !</value>
+    <value>Šєρãѓªτе ẅійđòẁ, îń ťāъ śŧґір σяðєŗ !!! !!! !!! !</value>
     <comment>An option to choose from for the "tab switcher mode" setting. The tab switcher overlay is shown in the order of the tabs at the top of the app.</comment>
   </data>
   <data name="Globals_TabSwitcherModeDisabled.Content" xml:space="preserve">
-    <value>Ťгäďíτїσŋàℓ ņãνîģäτĭòń, пø ѕéрαяåţэ ώĩπðоẃ !!! !!! !!! !!! </value>
+    <value>Ţřàðίţίöлàľ ήдνΐĝãťįθⁿ, ⁿô šэράŕăť℮ ẃĩηďøω !!! !!! !!! !!! </value>
     <comment>An option to choose from for the "tab switcher mode" setting. The tab switcher overlay is hidden and does not appear in a separate window.</comment>
   </data>
   <data name="Globals_CopyFormat.Header" xml:space="preserve">
-    <value>Тėхŧ ƒоŗmάтѕ ţό ςǿрý ŧθ ŧћė ¢ℓįφъóǻяδ !!! !!! !!! !!</value>
+    <value>Ţęхţ ƒόřмâтš ťσ ċορў ţő ťнё ĉĺїρвσагδ !!! !!! !!! !!</value>
     <comment>Header for a control to select the format of copied text.</comment>
   </data>
   <data name="Globals_CopyFormatNone.Content" xml:space="preserve">
-    <value>Ρľªĭⁿ тέ×ŧ õлľý !!! !</value>
+    <value>Ρĺαΐñ ŧëжť όиĺÿ !!! !</value>
     <comment>An option to choose from for the "copy formatting" setting. Store only plain text data.</comment>
   </data>
   <data name="Globals_CopyFormatHtml.Content" xml:space="preserve">
-    <value>ĤŤМĹ !</value>
+    <value>ΉТМ£ !</value>
     <comment>An option to choose from for the "copy formatting" setting. Store only HTML data.</comment>
   </data>
   <data name="Globals_CopyFormatRtf.Content" xml:space="preserve">
-    <value>ŖŦ₣ </value>
+    <value>ЯŢ₣ </value>
     <comment>An option to choose from for the "copy formatting" setting. Store only RTF data.</comment>
   </data>
   <data name="Globals_CopyFormatAll.Content" xml:space="preserve">
-    <value>Ьôťĥ ΉŤМ₤ äñð ЃŤ₣ !!! !!</value>
+    <value>βôτђ ΉŢΜŁ àήδ ГТ₣ !!! !!</value>
     <comment>An option to choose from for the "copy formatting" setting. Store both HTML and RTF data.</comment>
   </data>
   <data name="ColorScheme_RenameErrorTip.Subtitle" xml:space="preserve">
-    <value>Рłеåѕ℮ ĉнōöşè ª đïƒƒэřêйт йªмэ. !!! !!! !!!</value>
+    <value>Ρłęāѕë ċнǿőŝê å ðíƒƒ℮яēйţ ņãмέ. !!! !!! !!!</value>
     <comment>An error message that appears when the user attempts to rename a color scheme to something invalid. This appears as the subtitle and provides guidance to fix the issue.</comment>
   </data>
   <data name="ColorScheme_RenameErrorTip.Title" xml:space="preserve">
-    <value>Ťћιş çŏℓõя ş¢ћěмє пάмę ĭŝ дłřēàďÿ іŉ υѕě. !!! !!! !!! !!!</value>
+    <value>Τħīѕ çôŀóř ѕčћємє ŋдmë ĩѕ άĺŕėãďý ĭп ύšє. !!! !!! !!! !!!</value>
     <comment>An error message that appears when the user attempts to rename a color scheme to something invalid. This appears as the title, and explains the issue.</comment>
   </data>
   <data name="Globals_FocusFollowMouse.Header" xml:space="preserve">
-    <value>Αųтǿмáţìсãłľу ƒόćϋś φăήе øŋ мõµšє ħονęŗ !!! !!! !!! !!!</value>
+    <value>Áϋτомàţīćąłłý ƒόćŭś рåπę öń мõùšě ђöνëŗ !!! !!! !!! !!!</value>
     <comment>Header for a control to toggle the "focus follow mouse" setting. When enabled, hovering over a pane puts it in focus.</comment>
   </data>
   <data name="Globals_DisableAnimationsReversed.Header" xml:space="preserve">
-    <value>Рдñě αŉĩmåτΐσπѕ !!! !</value>
+    <value>Ρǻйě ǻйϊмäţіőηş !!! !</value>
     <comment>Header for a control to toggle animations on panes. "Enabled" value enables the animations.</comment>
   </data>
   <data name="Globals_AlwaysShowNotificationIcon.Header" xml:space="preserve">
-    <value>Δℓŵǻўś ðΐŝрĺąý áп ĭčθŋ ιń τħē ⁿõťíƒιςªтīôŉ ãгëå !!! !!! !!! !!! !!</value>
+    <value>Äľŵαŷś ďιśφĺαу дⁿ ìčǿи їň ţнē ŋöťϊƒĭćåţιøй αřεд !!! !!! !!! !!! !!</value>
     <comment>Header for a control to toggle whether the notification icon should always be shown.</comment>
   </data>
   <data name="Globals_MinimizeToNotificationArea.Header" xml:space="preserve">
-    <value>Ħїđé Ťëґmíñдĺ ϊņ ţĥε ŉŏťϊƒϊċаţϊόñ åŗєǻ шнёи ïт ìş mΐⁿιмĩźėð !!! !!! !!! !!! !!! !!!</value>
+    <value>Ήïδė Ŧěŗмìπàł ïň τħз ⁿøтíƒĩçąтіοй âŕéă ẁћēή ΐť ίś mìлїmïźєđ !!! !!! !!! !!! !!! !!!</value>
     <comment>Header for a control to toggle whether the terminal should hide itself in the notification area instead of the taskbar when minimized.</comment>
   </data>
   <data name="SettingContainer_OverrideMessageBaseLayer" xml:space="preserve">
-    <value>Řěŝ℮τ ťô ìйħęřïτ℮ð νãļũэ. !!! !!! !</value>
+    <value>Яėşĕт ťо ίлћėŕίťеď νãľΰę. !!! !!! !</value>
     <comment>This button will remove a user's customization from a given setting, restoring it to the value that the profile inherited. This is a text label on a button.</comment>
   </data>
   <data name="ColorScheme_TerminalColorsHeader.Text" xml:space="preserve">
-    <value>Ťзямιñāℓ ςоŀøгś !!! !</value>
+    <value>Тêѓmíņäľ ¢бŀòгŝ !!! !</value>
     <comment>A header for a grouping of colors in the color scheme. These colors are used for basic parts of the terminal.</comment>
   </data>
   <data name="ColorScheme_SystemColorsHeader.Text" xml:space="preserve">
-    <value>Ѕŷšтêм ςółσѓš !!! </value>
+    <value>Ŝўѕţèm čøĺøгѕ !!! </value>
     <comment>A header for a grouping of colors in the color scheme. These colors are used for functional parts of the terminal.</comment>
   </data>
   <data name="ColorScheme_ColorsHeader.Header" xml:space="preserve">
-    <value>Ĉōŀοŕš !</value>
+    <value>Ċôŀŏŕŝ !</value>
     <comment>A header for the grouping of colors in the color scheme.</comment>
   </data>
   <data name="SettingContainer_OverrideMessageFragmentExtension" xml:space="preserve">
-    <value>Ŕêšέт ţб νǻĺûę ƒґøm: {} !!! !!! </value>
+    <value>Γ℮šĕţ τǿ νăļϋè ƒяŏm: {} !!! !!! </value>
     <comment>{} is replaced by the name of another profile or generator. This is a text label on a button that is dynamically generated and provides more context in the {}.</comment>
   </data>
   <data name="Profile_FontFaceShowAllFonts.Content" xml:space="preserve">
-    <value>Śћőш ªłℓ ƒõňťš !!! !</value>
+    <value>Şħбω ąłļ ƒőňŧś !!! !</value>
     <comment>A supplementary setting to the "font face" setting. Toggling this control updates the font face control to show all of the fonts installed.</comment>
   </data>
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>İƒ ęπάьļёď, śноẃ αℓℓ ΐⁿšтāℓļёð ƒθπţѕ ĩⁿ τĥе ŀιšτ áьσνè. Øτнëгŵïšз, øпłỳ ѕħôẃ тнέ łîśτ ôƒ môńσşрąçę ƒòņτś. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
+    <value>Įƒ ěлåвℓεď, šħöω ăℓŀ їήšτаļľêð ƒõņŧŝ ίл τне ľíşť ªвσνє. Öťĥέŕωíŝě, ôπľγ ŝĥσẃ ţĥэ ľíѕτ θƒ mōйǿѕφâčз ƒоņτŝ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
   </data>
   <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ċяēåт℮ Λрρěåѓàņćé !!! !!</value>
+    <value>Çřëаţë Ăφрзαѓăŉ¢έ !!! !!</value>
     <comment>Name for a control which creates an the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
   </data>
   <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Čгèāтé äⁿ ύήƒοçцśéð ăφρзąřäήćε ƒõŕ τђїŝ рŗσƒîľè. Ţћĩѕ ωϊŀľ вē ŧнэ áφреàѓāп¢є оƒ τђë ряôƒϊľз ŵнел įт ιš ϊлåςţίνэ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
+    <value>Ċґêâŧέ āл ûηƒοćüšεð аφрěąґªŋčέ ƒòř тнìş φřòƒîľέ. Ţнīѕ ωïĺľ вé ťнē αррêãřªήç℮ οƒ ŧћê ρґőƒίļė ŵħėņ īŧ ίš ïńαčτîν℮. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
     <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ðěłет℮ Ǻρρєåяайçє !!! !!</value>
+    <value>Ďєľéтę Āρρєαяâп¢ė !!! !!</value>
     <comment>Name for a control which deletes an the unfocused appearance settings for this profile.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ďēĺėţ℮ ţнε úиƒоčϋѕёđ áрредŗªⁿčё ƒøŕ τĥίŝ рѓǿƒíľë. !!! !!! !!! !!! !!!</value>
+    <value>Ðěłêţэ ŧђέ џпƒоćΰѕēď ǻρрέāяāηĉé ƒŏѓ τђįś φřōƒĭŀĕ. !!! !!! !!! !!! !!!</value>
     <comment>A description for what the delete unfocused appearance button does.</comment>
   </data>
   <data name="Actions_DeleteConfirmationButton.Content" xml:space="preserve">
-    <value>¥єš, δеłéтε ĸэÿ ъΐⁿδĩňĝ !!! !!! </value>
+    <value>Ýęѕ, ďэļěŧέ ќêý ьïⁿďїňĝ !!! !!! </value>
     <comment>Button label that confirms deletion of a key binding entry.</comment>
   </data>
   <data name="Actions_DeleteConfirmationMessage.Text" xml:space="preserve">
-    <value>Åŕĕ ýōű śūгé уοµ шǻηţ ťò đ℮ŀеτε τћϊş кεγ вїйðіņğ? !!! !!! !!! !!! !!!</value>
+    <value>Άѓє ŷøü şΰŗė ŷóц ẁаńт ťб ðеℓ℮тè ŧђįś κëÿ вΐπðϊńġ? !!! !!! !!! !!! !!!</value>
     <comment>Confirmation message displayed when the user attempts to delete a key binding entry.</comment>
   </data>
   <data name="Actions_InvalidKeyChordMessage" xml:space="preserve">
-    <value>Ĭηνâłϊδ ќ℮ý ĉĥőřð. Ρłęąşє єπтëя ä νàľίδ κзў ¢нōřδ. !!! !!! !!! !!! !!!</value>
+    <value>Іпνáŀįδ κέу ¢ђòřď. Ρľеαşέ ëπŧзŕ ā νāŀϊđ ķэў čђθґð. !!! !!! !!! !!! !!!</value>
     <comment>Error message displayed when an invalid key chord is input by the user.</comment>
   </data>
   <data name="Actions_RenameConflictConfirmationAcceptButton" xml:space="preserve">
-    <value>Ỳεš </value>
+    <value>Υэŝ </value>
     <comment>Button label that confirms the deletion of a conflicting key binding to allow the current key binding to be registered.</comment>
   </data>
   <data name="Actions_RenameConflictConfirmationMessage" xml:space="preserve">
-    <value>Τĥě φŗбνīđëð кеý ĉĥöяď їş ăŀґεǻðу вέιņĝ цѕзđ ьý ŧнз ƒοļļθẅїπġ āĉτĭóή: !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ţнз рŕǿνĭđêδ κęγ ĉноřď ΐś аŀгèαďý ьеїńġ úśέð ьу ţĥē ƒбľĺõẅΐňĝ ăćŧìôň: !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>Error message displayed when a key chord that is already in use is input by the user. The name of the conflicting key chord is displayed after this message.</comment>
   </data>
   <data name="Actions_RenameConflictConfirmationQuestion" xml:space="preserve">
-    <value>Ẅőűℓđ ÿóů ŀįќė ŧø θνèящѓìťĕ іţ? !!! !!! !!!</value>
+    <value>Шőűľđ ỳŏυ ĺïķэ тō όνēѓщřΐтê ιţ? !!! !!! !!!</value>
     <comment>Confirmation message displayed when a key chord that is already in use is input by the user. This is intended to ask the user if they wish to delete the conflicting key binding, and assign the current key chord (or binding) instead. This is presented in the context of Actions_RenameConflictConfirmationMessage. The subject of this sentence is the object of that one.</comment>
   </data>
   <data name="Actions_UnnamedCommandName" xml:space="preserve">
-    <value>&lt;µŋŋámėď ċŏммăηδ&gt; !!! !!</value>
+    <value>&lt;цŉňαmеδ ĉŏmмάŋð&gt; !!! !!</value>
     <comment>{Locked="&lt;"} {Locked="&gt;"} The text shown when referring to a command that is unnamed.</comment>
   </data>
   <data name="Actions_AcceptButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Δс¢ёрţ !</value>
+    <value>Ăç¢еρт !</value>
     <comment>Text label for a button that can be used to accept changes to a key binding entry.</comment>
   </data>
   <data name="Actions_CancelButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ċãиčëľ !</value>
+    <value>Çäňçèĺ !</value>
     <comment>Text label for a button that can be used to cancel changes to a key binding entry</comment>
   </data>
   <data name="Actions_DeleteButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ďзŀęŧë !</value>
+    <value>Đēŀéт℮ !</value>
     <comment>Text label for a button that can be used to delete a key binding entry.</comment>
   </data>
   <data name="Actions_EditButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Еđιť !</value>
+    <value>Σδĩţ !</value>
     <comment>Text label for a button that can be used to begin making changes to a key binding entry.</comment>
   </data>
   <data name="Actions_AddNewTextBlock.Text" xml:space="preserve">
-    <value>Äďď йęẃ !!</value>
+    <value>Дδđ ñėώ !!</value>
     <comment>Button label that creates a new action on the actions page.</comment>
   </data>
   <data name="Actions_ActionComboBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Âċţϊŏη !</value>
+    <value>Α¢тίōй !</value>
     <comment>Label for a control that sets the action of a key binding.</comment>
   </data>
   <data name="KeyChordListener.[using:Windows.UI.Xaml.Automation]AutomationProperties.HelpText" xml:space="preserve">
-    <value>Ϊňрųŧ ỳσυř ðèšìяéð ĸεуъõāѓδ şћοґťĉΰŧ. !!! !!! !!! !!</value>
+    <value>Ійрûť ýőџѓ ďеśîґеδ кĕÿьôǻґđ ŝнόґŧĉüτ. !!! !!! !!! !!</value>
     <comment>Help text directing users how to use the "KeyChordListener" control. Pressing a keyboard shortcut will be recorded by this control.</comment>
   </data>
   <data name="KeyChordListener.[using:Windows.UI.Xaml.Automation]AutomationProperties.LocalizedControlType" xml:space="preserve">
-    <value>šћóґŧςΰт ĺΐŝţĕηèř !!! !!</value>
+    <value>ŝћøŕтςųţ ℓįŝтèŉêŗ !!! !!</value>
     <comment>The control type for a control that awaits keyboard input and records it.</comment>
   </data>
   <data name="KeyChordListener.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ѕĥöятčūť !!</value>
+    <value>Şħōяŧ¢цτ !!</value>
     <comment>The label for a "key chord listener" control that sets the keys a key binding is bound to.</comment>
   </data>
   <data name="Appearance_TextFormattingHeader.Text" xml:space="preserve">
-    <value>Ţé×т ₣θяmāŧтïπğ !!! !</value>
+    <value>Ťĕхτ ₣ôямåτţίŉğ !!! !</value>
     <comment>Header for a control to how text is formatted</comment>
   </data>
   <data name="Appearance_IntenseTextStyle.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Ĭптèņŝê ŧěжτ ѕţýļê !!! !!</value>
+    <value>Ϊηŧэйšè ŧзжт şťÿĺë !!! !!</value>
     <comment>Name for a control to select how "intense" text is formatted (bold, bright, both or none)</comment>
   </data>
   <data name="Appearance_IntenseTextStyle.Header" xml:space="preserve">
-    <value>İⁿŧ℮ńş℮ τе×ŧ šŧỳŀє !!! !!</value>
+    <value>Ĭиτзиśě τёжт şτўĺє !!! !!</value>
     <comment>Header for a control to select how "intense" text is formatted (bold, bright, both or none)</comment>
   </data>
   <data name="Appearance_IntenseTextStyleNone.Content" xml:space="preserve">
-    <value>Иøńэ !</value>
+    <value>∏őйě !</value>
     <comment>An option to choose from for the "intense text format" setting. When selected, "intense" text will not be rendered differently</comment>
   </data>
   <data name="Appearance_IntenseTextStyleBold.Content" xml:space="preserve">
-    <value>Воĺð ƒσńţ !!!</value>
+    <value>Ьθℓď ƒσŉŧ !!!</value>
     <comment>An option to choose from for the "intense text format" setting. When selected, "intense" text will be rendered as bold text</comment>
   </data>
   <data name="Appearance_IntenseTextStyleBright.Content" xml:space="preserve">
-    <value>ßѓіğħť ςσℓőгś !!! </value>
+    <value>βгïĝĥт çőĺǿгş !!! </value>
     <comment>An option to choose from for the "intense text format" setting. When selected, "intense" text will be rendered in a brighter color</comment>
   </data>
   <data name="Appearance_IntenseTextStyleAll.Content" xml:space="preserve">
-    <value>Вôľď ƒõŋτ ώіţћ ьŗίģĥť сθℓσѓś !!! !!! !!</value>
+    <value>Βοŀð ƒόπť ωіŧĥ вгϊģћţ čõĺόřş !!! !!! !!</value>
     <comment>An option to choose from for the "intense text format" setting. When selected, "intense" text will be rendered as both bold text and in a brighter color</comment>
   </data>
   <data name="Globals_AutoHideWindow.Header" xml:space="preserve">
-    <value>Āúτõмдтìċąľľŷ нīδє ẃіπđóẅ !!! !!! !</value>
+    <value>Ǻùţόmǻŧіĉąĺĺỳ ħíďз ώìñδǿẅ !!! !!! !</value>
     <comment>Header for a control to toggle the "Automatically hide window" setting. If enabled, the terminal will be hidden as soon as you switch to another window.</comment>
   </data>
   <data name="Globals_AutoHideWindow.HelpText" xml:space="preserve">
-    <value>Ìƒ êήāъℓêδ, τħè ŧέґmĩŋдļ ẃϊļľ ьз ђíðδéή ãś ѕőση åŝ ўŏΰ ѕŵįтćĥ тŏ āńǿţħęґ ẃίŋδóŵ. !!! !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Įƒ εⁿàъļêď, тђĕ ťέґmιпäļ щìℓŀ ъэ нîďδзñ ąś ѕõθŋ âş γôù śшίτċн ťø àпøťнзř шíήðόщ. !!! !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "Automatically hide window" setting does.</comment>
   </data>
   <data name="ColorScheme_DeleteDisclaimerInBox" xml:space="preserve">
-    <value>Τђιş ςôľǿѓ ѕċħêмĕ ¢àηñöť ьє ďéľéтеδ ьзĉăùŝ℮ īŧ ΐş ιñςļύð℮ď ъγ ďєƒǻµĺť. !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ťĥíŝ ćσľõѓ şсħéмэ ĉãйпόŧ в℮ δεĺёт℮ð ьèċàцśě îţ ìš іŋçļųďĕđ вý đ℮ƒдџļť. !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>Disclaimer presented near the controls to delete the selected color scheme when that functionality is disabled.</comment>
   </data>
   <data name="ColorScheme_RenameDisclaimerInBox" xml:space="preserve">
-    <value>Ťнìş çόļσř şċĥëмê ςαńńǿţ вĕ ŗęŋämêđ ъèçăùšэ ΐŧ ĩѕ ιŋċļūđёð ъу ðęƒàùļт. !!! !!! !!! !!! !!! !!! !!!</value>
+    <value>Ŧĥιѕ сбĺθѓ ś¢ĥěмэ ĉαлήôť вė ŕ℮ňąmëđ ь℮ςăΰśĕ ĩт ìš ϊņċĺμďĕđ ъỳ đέƒãüłτ. !!! !!! !!! !!! !!! !!! !!!</value>
     <comment>Disclaimer presented near the controls to rename the color scheme when that functionality is disabled.</comment>
   </data>
   <data name="ColorScheme_DefaultTag.Text" xml:space="preserve">
-    <value>ðēƒáűļτ !!</value>
+    <value>ðéƒαųŀť !!</value>
     <comment>Text label displayed adjacent to a "color scheme" entry signifying that it is currently set as the default color scheme to be used.</comment>
   </data>
   <data name="ColorScheme_SetAsDefaultButton.Content" xml:space="preserve">
-    <value>Şэτ ąŝ ðзƒãúľť !!! !</value>
+    <value>Şëť åѕ ďзƒªџŀτ !!! !</value>
     <comment>Text label for a button that, when invoked, sets the selected color scheme as the default scheme to use.</comment>
   </data>
   <data name="Globals_ConfirmCloseAllTabs.Header" xml:space="preserve">
-    <value>Ẃаŕп щђėņ сŀθşΐňĝ мõřě ţнαŉ ōŋé тǻв !!! !!! !!! !</value>
+    <value>Ẃářй ẅђëπ ĉľôśĩήĝ mǿѓĕ тĥąπ òπё τάь !!! !!! !!! !</value>
     <comment>Header for a control to toggle whether to show a confirm dialog box when closing the application with multiple tabs open.</comment>
   </data>
   <data name="Settings_PortableModeNote.Text" xml:space="preserve">
-    <value>Ẅîйđσώš Тэґmîńаℓ ìś ґűñиїпġ ĩŉ φóґŧāъŀέ мōδ℮. !!! !!! !!! !!! !</value>
+    <value>Ẅїηðσшѕ Ţеřmíńăľ īѕ ґϋййïŉģ ĭņ рόѓťáъℓė mōďе. !!! !!! !!! !!! !</value>
     <comment>A disclaimer that indicates that Terminal is running in a mode that saves settings to a different folder.</comment>
   </data>
   <data name="Settings_PortableModeInfoLink.NavigateUri" xml:space="preserve">
@@ -1762,15 +1794,15 @@
     <comment>{Locked}</comment>
   </data>
   <data name="Settings_PortableModeInfoLinkTextRun.Text" xml:space="preserve">
-    <value>Ļėâřп mõřэ. !!!</value>
+    <value>Ļĕдŗⁿ мõгĕ. !!!</value>
     <comment>A hyperlink displayed near Settings_PortableModeNote.Text that the user can follow for more information.</comment>
   </data>
   <data name="Profile_FontFace_ProportionalFontWarning.Title" xml:space="preserve">
-    <value>Ẅаřňīήģ: !!</value>
+    <value>Ẃãялíŉĝ: !!</value>
     <comment>Title for the warning info bar used when a non monospace font face is chosen to indicate that there may be visual artifacts</comment>
   </data>
   <data name="Profile_FontFace_ProportionalFontWarning.Message" xml:space="preserve">
-    <value>Çĥθőŝїпģ ã ηõπ-мóиőŝφä¢ёð ƒóπť ẃíĺļ łíκ℮ľỳ ѓëşŭĺŧ ίň νіşцаľ ªяţĩƒдĉтś. Цśë ąт ỳôμґ οωи ðϊš¢řěтíοŋ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
+    <value>€ħσõśïŉğ ą ñой-мõποşφãĉєδ ƒŏŋţ ẅіľľ łîķέℓў ŕєŝùłţ íй νΐşūαℓ āѓťīƒдςţŝ. Џŝè àţ ÿοùŗ øẁη δíśčґ℮ťîбņ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>Warning info bar used when a non monospace font face is chosen to indicate that there may be visual artifacts</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/qps-ploc/Resources.resw
@@ -118,610 +118,610 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="SetColorSchemeParentCommandName" xml:space="preserve">
-    <value>Šěļеςŧ ¢οĺσŗ śĉђёmĕ... !!! !!! </value>
+    <value>Ŝêĺĕćţ ćŏĺбŕ ѕćнêmē... !!! !!! </value>
   </data>
   <data name="NewTabParentCommandName" xml:space="preserve">
-    <value>Иęω Ťдъ... !!!</value>
+    <value>Ŋéŵ Тάъ... !!!</value>
   </data>
   <data name="SplitPaneParentCommandName" xml:space="preserve">
-    <value>Śрŀíт Ρáйё... !!! </value>
+    <value>Śрĺíŧ Рāлë... !!! </value>
   </data>
   <data name="ApplicationDisplayNamePortable" xml:space="preserve">
-    <value>Ťęґмϊήåľ (Ρöяťªъℓë) !!! !!!</value>
+    <value>Ţèѓmĩŋąĺ (Ρθŗτаьℓ℮) !!! !!!</value>
     <comment>This display name is used when the Terminal application is running in a "portable" mode, where settings are not stored in a shared location.</comment>
   </data>
   <data name="ApplicationDisplayNameUnpackaged" xml:space="preserve">
-    <value>Ŧёѓмîлдℓ (Űлрãĉĸãģέď) !!! !!!</value>
+    <value>Ţèямīйдŀ (Üйφάçќãģėđ) !!! !!!</value>
     <comment>This display name is used when the application's name cannot be determined</comment>
   </data>
   <data name="ApplicationVersionUnknown" xml:space="preserve">
-    <value>Цñķŉøẃл !!</value>
+    <value>Ūņķиοщπ !!</value>
     <comment>This is displayed when the version of the application cannot be determined</comment>
   </data>
   <data name="AdjustFontSizeCommandKey" xml:space="preserve">
-    <value>Áđĵűşţ ƒоŋť şίżε !!! !</value>
+    <value>Дđјůŝť ƒōлт ѕĩźé !!! !</value>
   </data>
   <data name="CloseOtherTabsCommandKey" xml:space="preserve">
-    <value>Çŀǿŝε τàъŝ бŧћεř тĥǻπ іήðęж {0} !!! !!! !!!</value>
+    <value>Ćļóşé ťäвś σťнĕѓ ŧħãń íŋđэ× {0} !!! !!! !!!</value>
     <comment>{0} will be replaced with a number</comment>
   </data>
   <data name="CloseOtherTabsDefaultCommandKey" xml:space="preserve">
-    <value>Ĉĺôšě āℓł öţђэя ťăъś !!! !!!</value>
+    <value>€ĺòśє ąļľ σţђéѓ ŧαьŝ !!! !!!</value>
   </data>
   <data name="ClosePaneCommandKey" xml:space="preserve">
-    <value>Çĺőśэ рåŋз !!!</value>
+    <value>Сļóѕє ρâŋз !!!</value>
   </data>
   <data name="CloseTabAtIndexCommandKey" xml:space="preserve">
-    <value>Сŀóѕз ŧăь āţ ĭņđę× {0} !!! !!! </value>
+    <value>Сľбšе τáь àţ ΐńđę× {0} !!! !!! </value>
     <comment>{0} will be replaced with a number</comment>
   </data>
   <data name="CloseTabCommandKey" xml:space="preserve">
-    <value>Ćļοѕэ ŧǻв !!!</value>
+    <value>Čļőšє ťдв !!!</value>
   </data>
   <data name="CloseTabsAfterCommandKey" xml:space="preserve">
-    <value>Čŀōšз тäьѕ ªƒτĕґ įлďėж {0} !!! !!! !</value>
+    <value>Čℓоśз ţαьŝ äƒтèŗ ĭⁿðέ× {0} !!! !!! !</value>
     <comment>{0} will be replaced with a number</comment>
   </data>
   <data name="CopySuffix" xml:space="preserve">
-    <value>Сŏφγ !</value>
+    <value>Ćόφу !</value>
     <comment>The suffix we add to the name of a duplicated profile.</comment>
   </data>
   <data name="MoveTabCommandKey" xml:space="preserve">
-    <value>Μσνз τáь {0} !!! </value>
+    <value>Μονé ţãь {0} !!! </value>
     <comment>{0} will be replaced with a "forward" / "backward"</comment>
   </data>
   <data name="MoveTabToWindowCommandKey" xml:space="preserve">
-    <value>Мŏνę ŧáь ŧσ ẁîňđσŵ "{0}" !!! !!! !</value>
+    <value>Мōνё тâв ŧó щîηďōẃ "{0}" !!! !!! !</value>
     <comment>{0} will be replaced with a user-specified name of a window</comment>
   </data>
   <data name="MoveTabToNewWindowCommandKey" xml:space="preserve">
-    <value>Мбνё ťāь τθ ǻ пêẅ ώιиđôŵ !!! !!! !</value>
+    <value>Μŏνĕ ťåъ тο ā ńęẃ шįŋďôẁ !!! !!! !</value>
   </data>
   <data name="MoveTabDirectionForward" xml:space="preserve">
-    <value>ƒóѓẅâřđ !!</value>
+    <value>ƒояώäřđ !!</value>
   </data>
   <data name="MoveTabDirectionBackward" xml:space="preserve">
-    <value>ъάçкẁăгď !!</value>
+    <value>ьāςкωагð !!</value>
   </data>
   <data name="CloseTabsAfterDefaultCommandKey" xml:space="preserve">
-    <value>€ļōšє áļℓ ťάвš ąƒтея τћέ ςüŕřėňτ тåв !!! !!! !!! !</value>
+    <value>Сłòšε àŀļ τãъš äƒťêѓ ŧĥĕ ĉŭґг℮ńτ тǻъ !!! !!! !!! !</value>
   </data>
   <data name="CloseWindowCommandKey" xml:space="preserve">
-    <value>Çłøşě шίņďθẃ !!! </value>
+    <value>Çłõŝе ẁїиðõŵ !!! </value>
   </data>
   <data name="OpenSystemMenuCommandKey" xml:space="preserve">
-    <value>Öφêи ŝýѕтęm mзⁿů !!! !</value>
+    <value>Ώρēņ şγŝŧèм мèŉϋ !!! !</value>
   </data>
   <data name="CommandPromptDisplayName" xml:space="preserve">
-    <value>Čômмàπď Ρŕόmρţ !!! !</value>
+    <value>Çбмmǻⁿδ Ρřǿmφţ !!! !</value>
     <comment>This is the name of "Command Prompt", as localized in Windows. The localization here should match the one in the Windows product for "Command Prompt"</comment>
   </data>
   <data name="CopyTextAsSingleLineCommandKey" xml:space="preserve">
-    <value>Čŏφỳ ťёжτ дš â śιйĝĺé ℓїйè !!! !!! !</value>
+    <value>Čōрγ тэхť áş д śіηĝļе ℓïⁿз !!! !!! !</value>
   </data>
   <data name="CopyTextCommandKey" xml:space="preserve">
-    <value>Сöρý ťě×т !!!</value>
+    <value>€őрў ţэ×ť !!!</value>
   </data>
   <data name="DecreaseFontSizeCommandKey" xml:space="preserve">
-    <value>Ðėčґздŝĕ ƒолŧ šίźэ !!! !!</value>
+    <value>Ðęčґёāšê ƒõⁿţ ŝîźę !!! !!</value>
   </data>
   <data name="DecreaseFontSizeWithAmountCommandKey" xml:space="preserve">
-    <value>Ďėćяėдѕě ƒóŉţ ѕιźë, åмоűηť: {0} !!! !!! !!!</value>
+    <value>Đęćŕєāšė ƒőňţ śíž℮, ămθúпţ: {0} !!! !!! !!!</value>
     <comment>{0} will be replaced with a positive number</comment>
   </data>
   <data name="DirectionDown" xml:space="preserve">
-    <value>δôẁņ !</value>
+    <value>ďοẃл !</value>
   </data>
   <data name="DirectionLeft" xml:space="preserve">
-    <value>łêƒŧ !</value>
+    <value>ľęƒţ !</value>
   </data>
   <data name="DirectionRight" xml:space="preserve">
-    <value>ŗîĝнŧ !</value>
+    <value>řϊğĥŧ !</value>
   </data>
   <data name="DirectionUp" xml:space="preserve">
-    <value>цφ </value>
+    <value>űρ </value>
   </data>
   <data name="DirectionPrevious" xml:space="preserve">
-    <value>ряëνîóύś !!</value>
+    <value>рѓěνĩøùş !!</value>
   </data>
   <data name="DuplicatePaneCommandKey" xml:space="preserve">
-    <value>Ðΰρłї¢ªте ρâņë !!! !</value>
+    <value>Đµφŀĩςαťє ρãиε !!! !</value>
   </data>
   <data name="DuplicateTabCommandKey" xml:space="preserve">
-    <value>Đυφŀϊςаτê ťáв !!! </value>
+    <value>Ďϋрļïćăτę ŧāь !!! </value>
   </data>
   <data name="ExecuteCommandlineCommandKey" xml:space="preserve">
-    <value>Ŕΰп ċθmmаиđĺìπє "{0}" įл ťħìŝ ωΐñδбẅ !!! !!! !!! !</value>
+    <value>Ґμπ ċôмmαⁿďļιŉê "{0}" ìŉ τħϊѕ ẃĩпđőẃ !!! !!! !!! !</value>
     <comment>{0} will be replaced with a user-defined commandline</comment>
   </data>
   <data name="FindCommandKey" xml:space="preserve">
-    <value>₣íŋď !</value>
+    <value>₣ïήð !</value>
   </data>
   <data name="FindNextCommandKey" xml:space="preserve">
-    <value>₣ĩήđ ŉėжť ѕèàґçħ мáťςн !!! !!! </value>
+    <value>₣ĩŋđ ŋєхτ šęáгςђ mαţсĥ !!! !!! </value>
   </data>
   <data name="FindPrevCommandKey" xml:space="preserve">
-    <value>₣ĩňð рřéνĭομš śèąяčн мдţĉĥ !!! !!! !</value>
+    <value>₣įпđ ρѓèνïθŭş ѕěăґçħ mάтćĥ !!! !!! !</value>
   </data>
   <data name="IncreaseFontSizeCommandKey" xml:space="preserve">
-    <value>İñçя℮ǻŝє ƒōņţ śïźέ !!! !!</value>
+    <value>Ĭñçяēåśё ƒбήτ šΐžĕ !!! !!</value>
   </data>
   <data name="IncreaseFontSizeWithAmountCommandKey" xml:space="preserve">
-    <value>İňčŗёαśэ ƒőŉт ѕįžē, ämóüņŧ: {0} !!! !!! !!!</value>
+    <value>Íⁿ¢řęªŝě ƒǿηť šιźé, āmōΰήт: {0} !!! !!! !!!</value>
     <comment>{0} will be replaced with a positive number</comment>
   </data>
   <data name="MoveFocusCommandKey" xml:space="preserve">
-    <value>Μбνє ƒőĉμş !!!</value>
+    <value>Мŏν℮ ƒоćΰŝ !!!</value>
   </data>
   <data name="MoveFocusWithArgCommandKey" xml:space="preserve">
-    <value>Μονê ƒŏçüš {0} !!! !</value>
+    <value>Мǿνэ ƒőĉúš {0} !!! !</value>
     <comment>{0} will be replaced with one of the four directions "DirectionLeft", "DirectionRight", "DirectionUp", "DirectionDown"</comment>
   </data>
   <data name="MoveFocusToLastUsedPane" xml:space="preserve">
-    <value>Мõνĕ ƒøçüş ŧо тĥ℮ ℓàşτ џšεď ράйε !!! !!! !!! </value>
+    <value>Мőνэ ƒóčůš ťб тħε łάşт цŝęð ρąήέ !!! !!! !!! </value>
   </data>
   <data name="MoveFocusNextInOrder" xml:space="preserve">
-    <value>Μονє ƒô¢üŝ ŧо тĥэ ņэ×т φăиё íи όґðĕŗ !!! !!! !!! !</value>
+    <value>Мθνė ƒőςúś ŧŏ ŧн℮ йèхť рăńέ íη ояđеř !!! !!! !!! !</value>
   </data>
   <data name="MoveFocusPreviousInOrder" xml:space="preserve">
-    <value>Μονë ƒóċцѕ το тђέ ρřένΐöΰŝ ρăήε įή øŕðзґ !!! !!! !!! !!!</value>
+    <value>Μòνĕ ƒō¢ùš ťό ţĥė рѓэνΐσџѕ рǻйē ίп θѓďĕг !!! !!! !!! !!!</value>
   </data>
   <data name="MoveFocusFirstPane" xml:space="preserve">
-    <value>Μθνё ƒбςùś ŧø ŧћé ƒιґśţ φªηè !!! !!! !!</value>
+    <value>Мôνε ƒôćųŝ ţŏ τђε ƒïѓŝť рαňє !!! !!! !!</value>
   </data>
   <data name="MoveFocusParentPane" xml:space="preserve">
-    <value>Мōνε ƒòċųş τõ тћě ράґéлŧ рãиє !!! !!! !!!</value>
+    <value>Мõν℮ ƒøčūŝ ťø ťђě раѓéпτ φáñэ !!! !!! !!!</value>
   </data>
   <data name="MoveFocusChildPane" xml:space="preserve">
-    <value>Μöνе ƒбčΰş тθ ťĥė ćĥίℓδ рăⁿέ !!! !!! !!</value>
+    <value>Μôνé ƒóčųŝ ŧǿ ţнз ćћϊļð ρãлė !!! !!! !!</value>
   </data>
   <data name="SwapPaneCommandKey" xml:space="preserve">
-    <value>Śŵäρ φаиê !!!</value>
+    <value>Şωąр рāлē !!!</value>
   </data>
   <data name="SwapPaneWithArgCommandKey" xml:space="preserve">
-    <value>Ѕшдφ φâŉё {0} !!! </value>
+    <value>Ѕẃаφ φäņέ {0} !!! </value>
     <comment>{0} will be replaced with one of the four directions "DirectionLeft", "DirectionRight", "DirectionUp", "DirectionDown"</comment>
   </data>
   <data name="SwapPaneToLastUsedPane" xml:space="preserve">
-    <value>Şẅăρ рăⁿєŝ ẃíтĥ ŧĥë ļάşŧ ůşέđ ρǻⁿэ !!! !!! !!! !</value>
+    <value>Ѕшάφ рâπ℮š ẃїтħ τђё ŀåŝτ цѕęδ рáŋę !!! !!! !!! !</value>
   </data>
   <data name="SwapPaneNextInOrder" xml:space="preserve">
-    <value>Śώàр рàпэš ẃϊτђ τĥė ňè×ť φǻŉě ιп öŕď℮ř !!! !!! !!! !!</value>
+    <value>Śẅáр φãлэѕ ẁîţħ ťђê ñέхт рãήě ϊή őґđêґ !!! !!! !!! !!</value>
   </data>
   <data name="SwapPanePreviousInOrder" xml:space="preserve">
-    <value>Śώãр φǻпëš ωíťн тђе рřëνĭσµѕ ρåńê īŋ öѓðзґ !!! !!! !!! !!! </value>
+    <value>Śẃåφ φăⁿёś ŵіťћ тĥĕ φŕёνĩòϋŝ раή℮ їń ôґðēѓ !!! !!! !!! !!! </value>
   </data>
   <data name="SwapPaneFirstPane" xml:space="preserve">
-    <value>Ŝщдφ рåŉéś ωĭŧн τћė ƒîгşŧ φąпε !!! !!! !!!</value>
+    <value>Ŝщàφ рǻņεš шíţћ ťнĕ ƒίѓѕт ρāńз !!! !!! !!!</value>
   </data>
   <data name="NewTabCommandKey" xml:space="preserve">
-    <value>Ńëẃ ţаь !!</value>
+    <value>Йέẃ ţάь !!</value>
   </data>
   <data name="NewWindowCommandKey" xml:space="preserve">
-    <value>Ńěώ ẁíŋðŏщ !!!</value>
+    <value>Ņеŵ щìπðõш !!!</value>
   </data>
   <data name="IdentifyWindowCommandKey" xml:space="preserve">
-    <value>Įđэπтΐƒγ ẃĭńďøш !!! !</value>
+    <value>Íðэήŧїƒγ шίиðøẃ !!! !</value>
   </data>
   <data name="IdentifyWindowsCommandKey" xml:space="preserve">
-    <value>Ĩδзńŧίƒý ŵîņďθωš !!! !</value>
+    <value>Ìðĕņτιƒý шϊйδøẅѕ !!! !</value>
   </data>
   <data name="NextTabCommandKey" xml:space="preserve">
-    <value>Иěхτ ťаъ !!</value>
+    <value>Ŋêжŧ ţаь !!</value>
   </data>
   <data name="OpenBothSettingsFilesCommandKey" xml:space="preserve">
-    <value>Øφęń воţћ ŝêτţìňĝŝ ăŋď đěƒǻűĺт şëтţιйġŝ ƒιļзş (JSON) !!! !!! !!! !!! !!! </value>
+    <value>Оφεп ъбŧђ şēţтįлġŝ ąņδ ðэƒàμłţ ѕēтτîňĝš ƒΐℓëś (JSON) !!! !!! !!! !!! !!! </value>
     <comment>{Locked="JSON"}. "JSON" is the extension of the file that will be opened.</comment>
   </data>
   <data name="OpenDefaultSettingsCommandKey" xml:space="preserve">
-    <value>Őφęŉ đέƒáüľţ šєтťīήġš ƒîļє (JSON) !!! !!! !!! </value>
+    <value>Ŏреп ðеƒăûĺť şėттîņĝŝ ƒíļë (JSON) !!! !!! !!! </value>
     <comment>{Locked="JSON"}. "JSON" is the extension of the file that will be opened.</comment>
   </data>
   <data name="OpenNewTabDropdownCommandKey" xml:space="preserve">
-    <value>Θφěņ ηεŵ ŧáь ďřŏφδóŵл !!! !!!</value>
+    <value>Θрёή ňеш ţäь ďřóρðóŵή !!! !!!</value>
   </data>
   <data name="OpenSettingsCommandKey" xml:space="preserve">
-    <value>Οφ℮ŉ ś℮ťţìлĝŝ ƒīĺē (JSON) !!! !!! !</value>
+    <value>Őρęň ŝέŧτїйģѕ ƒіĺē (JSON) !!! !!! !</value>
     <comment>{Locked="JSON"}. "JSON" is the extension of the file that will be opened.</comment>
   </data>
   <data name="OpenTabColorPickerCommandKey" xml:space="preserve">
-    <value>Šέţ тħέ ţав ćŏłбř... !!! !!!</value>
+    <value>Şėŧ ŧнę ťáь ċσŀőґ... !!! !!!</value>
   </data>
   <data name="PasteTextCommandKey" xml:space="preserve">
-    <value>Ρåšŧě !</value>
+    <value>Ρášτé !</value>
   </data>
   <data name="PrevTabCommandKey" xml:space="preserve">
-    <value>Ρřєνίōūѕ тäъ !!! </value>
+    <value>Ρř℮νϊòϋš ţãъ !!! </value>
   </data>
   <data name="RenameTabCommandKey" xml:space="preserve">
-    <value>Řзŋámė ţáъ ţó "{0}" !!! !!!</value>
+    <value>Ѓзήämė τдв ťσ "{0}" !!! !!!</value>
     <comment>{0} will be replaced with a user-defined string</comment>
   </data>
   <data name="ResetFontSizeCommandKey" xml:space="preserve">
-    <value>Гєѕĕŧ ƒоņτ şΐžé !!! !</value>
+    <value>Гėŝ℮ţ ƒŏήт şїžě !!! !</value>
   </data>
   <data name="ResetTabColorCommandKey" xml:space="preserve">
-    <value>Řэŝěŧ ţдв ĉõĺοř !!! !</value>
+    <value>Ŕеѕéт τăь сõļоґ !!! !</value>
   </data>
   <data name="ResetTabNameCommandKey" xml:space="preserve">
-    <value>Ґэśęτ τäъ тìŧļ℮ !!! !</value>
+    <value>Řėś℮ŧ тαв τįтℓę !!! !</value>
   </data>
   <data name="OpenTabRenamerCommandKey" xml:space="preserve">
-    <value>Ŗ℮лǻmĕ ţάъ ťìŧŀё... !!! !!!</value>
+    <value>Гęйªm℮ тåъ ŧīτļĕ... !!! !!!</value>
   </data>
   <data name="ResizePaneCommandKey" xml:space="preserve">
-    <value>Ŗєşίžё ρåňε !!!</value>
+    <value>Ґëśîžє рãле !!!</value>
   </data>
   <data name="ResizePaneWithArgCommandKey" xml:space="preserve">
-    <value>Řеŝįźĕ рαлε {0} !!! !</value>
+    <value>Яэşìżе ρåņê {0} !!! !</value>
     <comment>{0} will be replaced with one of the four directions "DirectionLeft", "DirectionRight", "DirectionUp", or "DirectionDown"</comment>
   </data>
   <data name="ScrollDownCommandKey" xml:space="preserve">
-    <value>Š¢ŗоłł đôẅņ !!!</value>
+    <value>Şςяôĺļ đσши !!!</value>
   </data>
   <data name="ScrollDownSeveralRowsCommandKey" xml:space="preserve">
-    <value>Śςŕǿļļ ďŏẃη {0} ľιйέ(ş) !!! !!! </value>
+    <value>Śсгθĺł đσẃņ {0} ŀĭпз(ś) !!! !!! </value>
     <comment>{0} will be replaced with the number of lines to scroll"</comment>
   </data>
   <data name="ScrollDownPageCommandKey" xml:space="preserve">
-    <value>Ѕ¢яσľļ ðøŵŋ óņё рдĝė !!! !!!</value>
+    <value>Şсяθℓļ ďοẃη όňê ρдĝę !!! !!!</value>
   </data>
   <data name="ScrollUpCommandKey" xml:space="preserve">
-    <value>Ş¢ѓøŀľ ũр !!!</value>
+    <value>Şċгõłł üρ !!!</value>
   </data>
   <data name="ScrollUpSeveralRowsCommandKey" xml:space="preserve">
-    <value>Šċřσļļ µρ {0} ļìņè(ş) !!! !!!</value>
+    <value>Şсѓòľŀ ūρ {0} ℓįňė(š) !!! !!!</value>
     <comment>{0} will be replaced with the number of lines to scroll"</comment>
   </data>
   <data name="ScrollUpPageCommandKey" xml:space="preserve">
-    <value>Şćгőĺℓ úρ оņ℮ φдĝè !!! !!</value>
+    <value>Šсŗøℓľ џφ ōņё ρâğэ !!! !!</value>
   </data>
   <data name="ScrollToTopCommandKey" xml:space="preserve">
-    <value>Š¢ŗőļł τǿ ťћє τòφ ŏƒ ħîšтόгỳ !!! !!! !!</value>
+    <value>Ś¢řόłℓ ťο ŧне τŏφ ōƒ ћϊśţбѓý !!! !!! !!</value>
   </data>
   <data name="ScrollToBottomCommandKey" xml:space="preserve">
-    <value>Şĉŗōĺℓ ţø ťђè ьôтţθм ǿƒ ніŝťóяŷ !!! !!! !!!</value>
+    <value>Śĉřòℓļ ťó ţħё вǿτтöm ǿƒ нϊŝţóгÿ !!! !!! !!!</value>
   </data>
   <data name="ScrollToPreviousMarkCommandKey" xml:space="preserve">
-    <value>Šċŗóļļ ţö τĥэ φѓэνīŏΰś mãřķ !!! !!! !!</value>
+    <value>Ŝςѓōŀļ то ţħέ ρŕеνïόцś мãřκ !!! !!! !!</value>
   </data>
   <data name="ScrollToNextMarkCommandKey" xml:space="preserve">
-    <value>Ŝ¢ŗôļℓ ťô ţђє иě×ţ мǻѓќ !!! !!! </value>
+    <value>Śčґòľŀ τо тђê ñежт мāŕќ !!! !!! </value>
   </data>
   <data name="ScrollToFirstMarkCommandKey" xml:space="preserve">
-    <value>Ŝ¢řŏľŀ ťō τћè ƒΐřşт màŗк !!! !!! !</value>
+    <value>Ŝсґŏłℓ тõ ťĥë ƒïгѕτ мàгķ !!! !!! !</value>
   </data>
   <data name="ScrollToLastMarkCommandKey" xml:space="preserve">
-    <value>Ŝćřǿľł тσ ťħ℮ ļαşτ mäѓк !!! !!! </value>
+    <value>Ŝċřõļℓ тŏ ťћё ľäŝт мáѓќ !!! !!! </value>
   </data>
   <data name="AddMarkCommandKey" xml:space="preserve">
-    <value>Ǻδđ ā ş¢řоĺĺ màґκ !!! !!</value>
+    <value>∆đď ª ş¢ŗőļļ mâґķ !!! !!</value>
   </data>
   <data name="AddMarkWithColorCommandKey" xml:space="preserve">
-    <value>Δđδ á ś¢ґσłļ мάґĸ, color:{0} !!! !!! !!</value>
+    <value>Дďδ ä şċřõĺľ mаřκ, color:{0} !!! !!! !!</value>
     <comment>{Locked="color"}. "color" is a literal parameter name that shouldn't be translated. {0} will be replaced with a color in hexadecimal format, like `#123456`</comment>
   </data>
   <data name="ClearMarkCommandKey" xml:space="preserve">
-    <value>Ċļėāя măгк !!!</value>
+    <value>Çℓεàŗ мàгќ !!!</value>
   </data>
   <data name="ClearAllMarksCommandKey" xml:space="preserve">
-    <value>Сľєāř αŀĺ máґķš !!! !</value>
+    <value>Ċļéāґ àℓĺ màгķś !!! !</value>
   </data>
   <data name="SendInputCommandKey" xml:space="preserve">
-    <value>Ѕ℮пď Íñφūт: "{0}" !!! !!</value>
+    <value>Šêлđ Ìñрµť: "{0}" !!! !!</value>
     <comment>{0} will be replaced with a string of input as defined by the user</comment>
   </data>
   <data name="SetColorSchemeCommandKey" xml:space="preserve">
-    <value>Ѕĕτ çǿłόѓ ş¢ђ℮mє ťσ {0} !!! !!! </value>
+    <value>Şēţ ċõℓǿґ ѕčћёмē ţо {0} !!! !!! </value>
     <comment>{0} will be replaced with the name of a color scheme as defined by the user.</comment>
   </data>
   <data name="SetTabColorCommandKey" xml:space="preserve">
-    <value>Ѕєţ ţãь ςôłŏѓ ţò {0} !!! !!!</value>
+    <value>Š℮ŧ ŧαъ čõļοя ŧō {0} !!! !!!</value>
     <comment>{0} will be replaced with a color, displayed in hexadecimal (#RRGGBB) notation.</comment>
   </data>
   <data name="SplitHorizontalCommandKey" xml:space="preserve">
-    <value>Śρŀĩт рāŉе ђθřįžόйţǻĺĺỳ !!! !!! </value>
+    <value>Ѕφℓϊţ φάиз ĥǿřîżõŉтαℓĺу !!! !!! </value>
   </data>
   <data name="MovePaneCommandKey" xml:space="preserve">
-    <value>Μôνë рàпě !!!</value>
+    <value>Мôνé рαň℮ !!!</value>
   </data>
   <data name="MovePaneToNewWindowCommandKey" xml:space="preserve">
-    <value>Мōνέ ρãπę ŧô йёẃ ŵіⁿδόẃ !!! !!! </value>
+    <value>Мőνе φαñє ťõ лêẃ ẃįńδōŵ !!! !!! </value>
   </data>
   <data name="SplitPaneCommandKey" xml:space="preserve">
-    <value>Ŝφłϊŧ φáņę !!!</value>
+    <value>Šрℓīт φăηе !!!</value>
   </data>
   <data name="SplitVerticalCommandKey" xml:space="preserve">
-    <value>Şφļίţ φàńё νэяťιċăℓľý !!! !!!</value>
+    <value>Şрŀíŧ рдņє νęřτíçǻłłỳ !!! !!!</value>
   </data>
   <data name="SwitchToTabCommandKey" xml:space="preserve">
-    <value>Ŝώіťςħ ţō тąъ !!! </value>
+    <value>Šŵĩтċħ τŏ ťǻв !!! </value>
   </data>
   <data name="SwitchToLastTabCommandKey" xml:space="preserve">
-    <value>Şшίтςħ тŏ τнэ ļāśτ ŧаь !!! !!! </value>
+    <value>Ѕẃітčћ ţõ ťħέ ľάšť ţаь !!! !!! </value>
   </data>
   <data name="TabSearchCommandKey" xml:space="preserve">
-    <value>Śëāґçħ ƒσг ťåв... !!! !!</value>
+    <value>Ѕėàřĉħ ƒôґ ŧâь... !!! !!</value>
   </data>
   <data name="ToggleAlwaysOnTopCommandKey" xml:space="preserve">
-    <value>Тöģĝļě аľẁáγş оή ťôφ môδë !!! !!! !</value>
+    <value>Ŧōĝġļě αŀώªÿŝ òⁿ тοр мöðέ !!! !!! !</value>
   </data>
   <data name="ToggleCommandPaletteCommandKey" xml:space="preserve">
-    <value>Тσğĝℓē çǿmмǻйđ рąļěтťέ !!! !!! </value>
+    <value>Ţōĝğļė čσmmάήđ рåŀęŧŧз !!! !!! </value>
   </data>
   <data name="SuggestionsCommandHistoryCommandKey" xml:space="preserve">
-    <value>Γє¢еñт čбмmǻлđš... !!! !!</value>
+    <value>Γë¢єйť ćøмmåηđŝ... !!! !!</value>
   </data>
   <data name="SuggestionsCommandKey" xml:space="preserve">
-    <value>Фрęŉ şûġġĕѕтīõňѕ... !!! !!!</value>
+    <value>Ǿрέŉ şµġġеšŧìŏπѕ... !!! !!!</value>
   </data>
   <data name="ToggleCommandPaletteCommandLineModeCommandKey" xml:space="preserve">
-    <value>Тǿğģļе çοмmдńð рªℓέŧτє ΐŉ čŏmмдήď łįņз móďė !!! !!! !!! !!! </value>
+    <value>Ťŏġĝļĕ çбmмáήď φàłėŧτĕ ίη ċσmмäпδ ℓìņє mόð℮ !!! !!! !!! !!! </value>
   </data>
   <data name="ToggleFocusModeCommandKey" xml:space="preserve">
-    <value>Ťøĝġĺе ƒōċŭѕ mǿďэ !!! !!</value>
+    <value>Ţоģġľе ƒöςŭś mσďē !!! !!</value>
     <comment>"Focus mode" is a mode with minimal UI elements, for a distraction-free experience</comment>
   </data>
   <data name="EnableFocusModeCommandKey" xml:space="preserve">
-    <value>Έñάвļє ƒøčύŝ mόďе !!! !!</value>
+    <value>Еⁿâьℓё ƒσсùѕ мôðé !!! !!</value>
   </data>
   <data name="DisableFocusModeCommandKey" xml:space="preserve">
-    <value>Đіşåвĺέ ƒθçùś mŏďé !!! !!</value>
+    <value>Đīѕдвł℮ ƒосύš mõðé !!! !!</value>
   </data>
   <data name="ToggleFullscreenCommandKey" xml:space="preserve">
-    <value>Ŧŏġĝℓę ƒũŀŀśĉřєеŋ !!! !!</value>
+    <value>Тоğġℓē ƒϋłłśčŕęéи !!! !!</value>
   </data>
   <data name="EnableFullScreenCommandKey" xml:space="preserve">
-    <value>Éŋåъłė ƒцℓℓšсŗєēŋ !!! !!</value>
+    <value>Ėлдъļė ƒŭŀℓŝçŕěёη !!! !!</value>
   </data>
   <data name="DisableFullScreenCommandKey" xml:space="preserve">
-    <value>Ďιѕāвĺё ƒύļℓѕ¢ŕëéη !!! !!</value>
+    <value>Ðιšåвłз ƒűŀĺšςŕéэη !!! !!</value>
   </data>
   <data name="EnableMaximizedCommandKey" xml:space="preserve">
-    <value>Μдхΐmĩźė ẁïиđõω !!! !</value>
+    <value>Мā×įmїžё щìйđōŵ !!! !</value>
   </data>
   <data name="DisableMaximizedCommandKey" xml:space="preserve">
-    <value>Ґĕśţõŕé мд×ΐmįżęδ ẃίňďбẃ !!! !!! !</value>
+    <value>Геśţóŗ℮ mã×îмĭżëď ώîйďöẃ !!! !!! !</value>
   </data>
   <data name="ToggleSplitOrientationCommandKey" xml:space="preserve">
-    <value>Τбģğŀê ρаņз şφĺĩţ òřìėπтäţĭǿň !!! !!! !!!</value>
+    <value>Ŧόğĝℓέ рάлê šрľîť òяίĕŋτªŧĭőⁿ !!! !!! !!!</value>
   </data>
   <data name="TogglePaneZoomCommandKey" xml:space="preserve">
-    <value>Тбğğℓ℮ φдńê źθοм !!! !</value>
+    <value>Ťöģĝł℮ рªńέ żθθm !!! !</value>
   </data>
   <data name="TogglePaneReadOnlyCommandKey" xml:space="preserve">
-    <value>Ŧòğĝľę ρàňє ґёаđ-ǿпℓγ моðė !!! !!! !</value>
+    <value>Ŧōĝğľé ρåŋê яэãď-όńļу моđě !!! !!! !</value>
   </data>
   <data name="EnablePaneReadOnlyCommandKey" xml:space="preserve">
-    <value>Έⁿªъℓê раŋé яęдδ-θиℓŷ mǿðέ !!! !!! !</value>
+    <value>Ęňǻъℓ℮ ρåηé яěǻδ-όňłу мбδэ !!! !!! !</value>
   </data>
   <data name="DisablePaneReadOnlyCommandKey" xml:space="preserve">
-    <value>Đîšąвļē ρåŉє ŕέâð-όηļŷ мθđĕ !!! !!! !!</value>
+    <value>Ďіšªвłē φãηé яĕāď-σņĺў мοδë !!! !!! !!</value>
   </data>
   <data name="ToggleShaderEffectsCommandKey" xml:space="preserve">
-    <value>Ŧοģğℓě ţęяmїήаł νìŝųãł εƒƒėčţŝ !!! !!! !!!</value>
+    <value>Ţóģğļ℮ ŧëгміпął νіšúąļ єƒƒеčţš !!! !!! !!!</value>
   </data>
   <data name="BreakIntoDebuggerCommandKey" xml:space="preserve">
-    <value>Ьŗėäк îŉŧó ţђė ðēьŭģġёŗ !!! !!! </value>
+    <value>Вгεаĸ ĩňŧθ ŧђė đěвцģģέŕ !!! !!! </value>
   </data>
   <data name="OpenSettingsUICommandKey" xml:space="preserve">
-    <value>Фρêи ŝεтτіńġѕ... !!! !</value>
+    <value>Öφéη ѕēττϊⁿğš... !!! !</value>
   </data>
   <data name="RenameWindowCommandKey" xml:space="preserve">
-    <value>Ґëпâмє ωĩиďôẃ ŧõ "{0}" !!! !!! </value>
+    <value>Γзňãмē шіňďоώ ŧō "{0}" !!! !!! </value>
     <comment>{0} will be replaced with a user-defined string</comment>
   </data>
   <data name="ResetWindowNameCommandKey" xml:space="preserve">
-    <value>Ŗėŝēţ ẁìŋďŏŵ πàmē !!! !!</value>
+    <value>Ŗεšзť ωĩйδōẁ ñâмé !!! !!</value>
   </data>
   <data name="OpenWindowRenamerCommandKey" xml:space="preserve">
-    <value>Ŗέήąmέ ẅїлďôш... !!! !</value>
+    <value>Ґёŉάmë шϊйďθŵ... !!! !</value>
   </data>
   <data name="DisplayWorkingDirectoryCommandKey" xml:space="preserve">
-    <value>Ďíşφļăý Ŧěямίŉąℓ'š ςûѓґêит ẃόŗĸίпğ ðіřēċτθřỳ !!! !!! !!! !!! !</value>
+    <value>Ďіŝρłάỳ Τ℮ѓmìйаĺ'š čûŗяēŉτ ώоřκìņĝ ďιяęĉтσґỳ !!! !!! !!! !!! !</value>
   </data>
   <data name="GlobalSummonCommandKey" xml:space="preserve">
-    <value>Šĥσẃ/Ηΐδє τнé Ţэгmïπâł шìпďóŵ !!! !!! !!!</value>
+    <value>Şђбщ/Ĥīđз τĥз Ŧëяmіńаℓ ẅіηďоŵ !!! !!! !!!</value>
   </data>
   <data name="QuakeModeCommandKey" xml:space="preserve">
-    <value>Ŝћόщ/Ĥîδε Qūǻкě ωíŉδōщ !!! !!! </value>
+    <value>Şђõẅ/Нϊđε Qџдĸє ẃįπđŏẃ !!! !!! </value>
     <comment>Quake is a well-known computer game and isn't related to earthquakes, etc. See https://en.wikipedia.org/wiki/Quake_(video_game)</comment>
   </data>
   <data name="FocusPaneCommandKey" xml:space="preserve">
-    <value>₣õĉúš ρдⁿě {0} !!! !</value>
+    <value>₣ôĉύѕ рàņε {0} !!! !</value>
     <comment>{0} will be replaced with a user-specified number</comment>
   </data>
   <data name="ExportBufferToPathCommandKey" xml:space="preserve">
-    <value>Ēжрŏѓŧ τė×ţ ťő {0} !!! !!</value>
+    <value>Ε×рοŗţ ŧë×т ťσ {0} !!! !!</value>
     <comment>{0} will be replaced with a user-specified file path</comment>
   </data>
   <data name="ExportBufferCommandKey" xml:space="preserve">
-    <value>Ę×ροŗτ τê×т !!!</value>
+    <value>Ε×ρθŗт ŧęхτ !!!</value>
   </data>
   <data name="ClearAllCommandKey" xml:space="preserve">
-    <value>Ċŀёäг ьûƒƒεг !!! </value>
+    <value>Çłĕăг ьũƒƒèŗ !!! </value>
     <comment>A command to clear the entirety of the Terminal output buffer</comment>
   </data>
   <data name="ClearViewportCommandKey" xml:space="preserve">
-    <value>Сłєąŗ νїęẁρоŗţ !!! !</value>
+    <value>Ĉļзãг νίзώрбŗť !!! !</value>
     <comment>A command to clear the active viewport of the Terminal</comment>
   </data>
   <data name="ClearScrollbackCommandKey" xml:space="preserve">
-    <value>Čĺèāг ѕçŕøľļвάçк !!! !</value>
+    <value>Ćℓёäŕ šçѓоℓŀьäçķ !!! !</value>
     <comment>A command to clear the part of the buffer above the viewport</comment>
   </data>
   <data name="DefaultWindowsConsoleName" xml:space="preserve">
-    <value>Ĺëŧ Ẅίņđŏщš δёςιďĕ !!! !!</value>
+    <value>Ľëτ Ẁιñďõŵš đěćîðé !!! !!</value>
     <comment>This is the default option if a user doesn't choose to override Microsoft's choice of a Terminal.</comment>
   </data>
   <data name="InboxWindowsConsoleAuthor" xml:space="preserve">
-    <value>Мĭčґоşσƒŧ Ĉояφőѓāтîöη !!! !!!</value>
+    <value>Μī¢řόѕõƒŧ Ćŏŕрσгåтΐøπ !!! !!!</value>
     <comment>Paired with `InboxWindowsConsoleName`, this is the application author... which is us: Microsoft.</comment>
   </data>
   <data name="InboxWindowsConsoleName" xml:space="preserve">
-    <value>Ŵїηďòщŝ Čθñŝøℓè Ήοśŧ !!! !!!</value>
+    <value>Ẃîпďōώś €ōŋşбļэ Ήбѕτ !!! !!!</value>
     <comment>Name describing the usage of the classic windows console as the terminal UI. (`conhost.exe`)</comment>
   </data>
   <data name="QuitCommandKey" xml:space="preserve">
-    <value>Qџίŧ ŧħë Тēŗmĩπаł !!! !!</value>
+    <value>Qυϊτ ŧħз Τέяmίŋăŀ !!! !!</value>
   </data>
   <data name="SetOpacityParentCommandName" xml:space="preserve">
-    <value>Şзţ ъаćкĝŗóµηð ōρã¢ΐŧŷ... !!! !!! !</value>
+    <value>Ѕěт ьªċķĝґøūņð óφǻĉїτў... !!! !!! !</value>
   </data>
   <data name="IncreaseOpacityCommandKey" xml:space="preserve">
-    <value>Îń¢ґěäşё ьãçκĝѓθµŉđ σрαсĭŧŷ ъý {0}% !!! !!! !!! !</value>
+    <value>Ĭñçŕ℮àŝę ваċкġřŏųлď ǿφāςíτу ьỳ {0}% !!! !!! !!! !</value>
     <comment>A command to change how transparent the background of the window is</comment>
   </data>
   <data name="DecreaseOpacityCommandKey" xml:space="preserve">
-    <value>Ďєсřėаşě ъаċĸġřбϋŉδ őρăĉĭŧγ вỳ {0}% !!! !!! !!! !</value>
+    <value>Ďέсŕēāšε ъªċĸğгóüиđ õρąсïту ьγ {0}% !!! !!! !!! !</value>
     <comment>A command to change how transparent the background of the window is</comment>
   </data>
   <data name="AdjustOpacityCommandKey" xml:space="preserve">
-    <value>Şęţ ьâčĸģřőūŋđ őφàçĩťý τǿ {0}% !!! !!! !!!</value>
+    <value>Śêţ вąćķģřŏυńδ õφãςįţÿ ţθ {0}% !!! !!! !!!</value>
     <comment>A command to change how transparent the background of the window is</comment>
   </data>
   <data name="RestoreLastClosedCommandKey" xml:space="preserve">
-    <value>Гεşтøѓè ťнě ĺàśţ čļöѕĕð φâηэ θř ŧäв !!! !!! !!! !</value>
+    <value>Г℮ѕτøŕé тђě ŀάѕŧ ςĺσşëð рдиè ôг ŧàь !!! !!! !!! !</value>
   </data>
   <data name="SelectAllCommandKey" xml:space="preserve">
-    <value>Śēļéčŧ ăℓļ ťежŧ !!! !</value>
+    <value>Śēĺèċť ªĺľ ťėхť !!! !</value>
   </data>
   <data name="MarkModeCommandKey" xml:space="preserve">
-    <value>Ţǿģğľé mαŕκ мσδё !!! !</value>
+    <value>Ŧõğģļє mагĸ mθðé !!! !</value>
     <comment>A command that will toggle "mark mode". This is a mode in the application where the user can mark the text by selecting portions of the text.</comment>
   </data>
   <data name="ToggleBlockSelectionCommandKey" xml:space="preserve">
-    <value>Ţσĝğĺе вľõςķ ŝέĺĕςťίôη !!! !!! </value>
+    <value>Ťøġğŀę ъĺôĉκ ѕëŀèçτіöŋ !!! !!! </value>
   </data>
   <data name="SwitchSelectionEndpointCommandKey" xml:space="preserve">
-    <value>Śẁíŧĉħ šęĺеćŧіόπ ĕпðρõĭňτ !!! !!! !</value>
+    <value>Şшїτçн şėļèςţίǿл ĕηðρóΐńт !!! !!! !</value>
   </data>
   <data name="ColorSelection_allMatches" xml:space="preserve">
-    <value>дľĺ мäŧ¢ħëş !!!</value>
+    <value>ãℓļ мåŧćћєŝ !!!</value>
     <comment>This is used in the description of an action which changes the color of selected text, to indicate that not only the selected text will be colored, but also all matching text.</comment>
   </data>
   <data name="ColorSelection_fg_action" xml:space="preserve">
-    <value>Ĉσľőѓ šєłεćŧįοη, ƒόřеĝŕбµпð: {0}{1} !!! !!! !!! !</value>
+    <value>Çσľøř ѕĕĺęćťιбņ, ƒøŗěĝяöùńđ: {0}{1} !!! !!! !!! !</value>
     <comment>This is the description of an action which changes the color of selected text. {0}: the color. {1}: empty string OR a clause indicating that all matching text will be colored (ColorSelection_allMatches).</comment>
   </data>
   <data name="ColorSelection_bg_action" xml:space="preserve">
-    <value>Ćбľоѓ šэľêςŧìбŉ, ъªсκģѓóŭŉđ: {0}{1} !!! !!! !!! !</value>
+    <value>Çöłôř śэļě¢ŧΐǿл, ьǻсќĝгбυňđ: {0}{1} !!! !!! !!! !</value>
     <comment>This is the description of an action which changes the background color of selected text. {0}: the color. {1}: empty string OR a clause indicating that all matching text will be colored (ColorSelection_allMatches).</comment>
   </data>
   <data name="ColorSelection_fg_bg_action" xml:space="preserve">
-    <value>Сσŀōŕ śěļĕĉťίοñ, ƒόřêğґбϋňð: {0}, ъáçκĝгбϋйδ: {1}{2} !!! !!! !!! !!! !!! </value>
+    <value>Ćòľóř šєł℮ςťїöⁿ, ƒòřέģŗǿџπð: {0}, ъάċќğґōϋиď: {1}{2} !!! !!! !!! !!! !!! </value>
     <comment>This is the description of an action which changes the color of selected text and the background. {0}: the foreground color. {1}: the background color. {2}: empty string OR a clause indicating that all matching text will be colored (ColorSelection_allMatches).</comment>
   </data>
   <data name="ColorSelection_default_action" xml:space="preserve">
-    <value>Çθľοř šęļёċŧíŏŉ, (ďéƒаùĺτ ƒθřěģřбµηď/ьāсќĝřόμπď){0} !!! !!! !!! !!! !!!</value>
+    <value>Ĉøłбѓ ś℮ŀêċťΐõŋ, (đ℮ƒаűļŧ ƒоґёġřθϋηď/вăсķĝŗòμŋď){0} !!! !!! !!! !!! !!!</value>
     <comment>This is the description of an action which changes the color of selected text and the background to the default colors. {0}: empty string OR a clause indicating that all matching text will be colored (ColorSelection_allMatches).</comment>
   </data>
   <data name="ColorSelection_defaultColor" xml:space="preserve">
-    <value>[đèƒάύłť] !!!</value>
+    <value>[ðеƒǻúĺŧ] !!!</value>
     <comment>This is used in the description of an action which changes the color of selected text, as a placeholder for a color, to indicate that the default (foreground or background) color will be used.</comment>
   </data>
   <data name="ColorSelection_Black" xml:space="preserve">
-    <value>вĺă¢к !</value>
+    <value>ьłâсќ !</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_Red" xml:space="preserve">
-    <value>řêð </value>
+    <value>řéδ </value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_Green" xml:space="preserve">
-    <value>ĝŕéĕи !</value>
+    <value>ğŕêεŋ !</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_Yellow" xml:space="preserve">
-    <value>γēļļоẁ !</value>
+    <value>ýεľŀбẅ !</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_Blue" xml:space="preserve">
-    <value>ьℓµє !</value>
+    <value>ьŀü℮ !</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_Purple" xml:space="preserve">
-    <value>ρџґрℓэ !</value>
+    <value>рũгφŀέ !</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_Cyan" xml:space="preserve">
-    <value>сγąл !</value>
+    <value>çÿåń !</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_White" xml:space="preserve">
-    <value>щћїтė !</value>
+    <value>ŵђϊţе !</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_BrightBlack" xml:space="preserve">
-    <value>вяιģħť ьŀäсκ !!! </value>
+    <value>ьřïġћт ъℓāčķ !!! </value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_BrightRed" xml:space="preserve">
-    <value>ъřΐĝĥŧ ŗĕð !!!</value>
+    <value>ьѓīğнτ řέδ !!!</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_BrightGreen" xml:space="preserve">
-    <value>вříĝĥť ġяêęņ !!! </value>
+    <value>ъґΐğћť ğѓέεⁿ !!! </value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_BrightYellow" xml:space="preserve">
-    <value>ьřіģĥт ýєŀℓōώ !!! </value>
+    <value>ьяīĝђт ýεłŀǿẅ !!! </value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_BrightBlue" xml:space="preserve">
-    <value>вѓíģћŧ вĺűě !!!</value>
+    <value>вяĭġħт ьℓцέ !!!</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_BrightPurple" xml:space="preserve">
-    <value>ъříğнτ φυŗρℓê !!! </value>
+    <value>ъяîĝнť ρúřρľε !!! </value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_BrightCyan" xml:space="preserve">
-    <value>ъѓíĝĥť ćŷǻй !!!</value>
+    <value>вгїğħť ćÿªń !!!</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_BrightWhite" xml:space="preserve">
-    <value>ьѓíġђť ẅђíťë !!! </value>
+    <value>вŕīğħť ẅнĭŧэ !!! </value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ExpandSelectionToWordCommandKey" xml:space="preserve">
-    <value>Єхρǻňď şєℓ℮¢ŧїőń τō шǿгð !!! !!! !</value>
+    <value>Зхрάиď śёľęςŧіôņ τό щòгδ !!! !!! !</value>
   </data>
   <data name="ShowContextMenuCommandKey" xml:space="preserve">
-    <value>Ѕћσщ ćόņτё×ť мэйú !!! !!</value>
+    <value>Şнöẃ ćóηтë×ŧ мèⁿμ !!! !!</value>
   </data>
   <data name="CloseOtherPanesCommandKey" xml:space="preserve">
-    <value>Ċľõѕ℮ ąłļ οţĥëя ρāηĕş !!! !!!</value>
+    <value>Сļôѕз ăľŀ øţнèŕ φáŉêś !!! !!!</value>
   </data>
   <data name="ToggleBroadcastInputCommandKey" xml:space="preserve">
-    <value>Ţóġģĺě ъґóáđčαšŧ īⁿрûţ тŏ ªŀĺ ρàηēś !!! !!! !!! !</value>
+    <value>Тōģĝℓ℮ ьяοäð¢ªѕт ïŉρύτ ţò äļℓ φаиεś !!! !!! !!! !</value>
     <comment>When enabled, input will go to all panes in this tab simultaneously</comment>
   </data>
   <data name="RestartConnectionKey" xml:space="preserve">
-    <value>Řεšţаřŧ čøňйêċτίθп !!! !!</value>
+    <value>Ŗ℮ŝţāґт čõŉлęčŧįоή !!! !!</value>
   </data>
   <data name="SelectOutputNextCommandKey" xml:space="preserve">
-    <value>Ŝёℓĕċť ⁿęхţ ¢ǿмmáήδ θµτρùŧ !!! !!! !</value>
+    <value>Šēłεĉτ πĕжţ ċômmàлð ŏµŧρūţ !!! !!! !</value>
   </data>
   <data name="SelectOutputPreviousCommandKey" xml:space="preserve">
-    <value>Šέŀęςт рязνíǿцŝ сόmмǻⁿδ ŏύŧρџτ !!! !!! !!!</value>
+    <value>Śеľê¢ť φŕзνíôùś ςθммãиð σùтφμť !!! !!! !!!</value>
   </data>
   <data name="SelectCommandNextCommandKey" xml:space="preserve">
-    <value>Şёŀêčţ ⁿêжт сøммǻлđ !!! !!!</value>
+    <value>Ѕĕŀёĉτ πежт ¢όmmªήď !!! !!!</value>
   </data>
   <data name="SelectCommandPreviousCommandKey" xml:space="preserve">
-    <value>Ѕěļêçť рŕзνίōϋś ¢бmmǻпð !!! !!! </value>
+    <value>Ѕέļεćť ргėνîóųѕ çōmmдпð !!! !!! </value>
   </data>
   <data name="SearchForTextCommandKey" xml:space="preserve">
-    <value>Şеąŗ¢ћ {0} !!!</value>
+    <value>Šєāяćĥ {0} !!!</value>
     <comment>{0} will be replaced with a user-specified URL to a web page</comment>
   </data>
   <data name="SearchWebCommandKey" xml:space="preserve">
-    <value>Şėàѓçħ ţђ℮ ẁέь ƒθŕ ѕĕŀёςтёď ŧë×т !!! !!! !!! </value>
+    <value>Ѕεάгςн τђё ẅēъ ƒŏŕ śзĺėċţêđ ţехť !!! !!! !!! </value>
     <comment>This will open a web browser to search for some user-selected text</comment>
   </data>
   <data name="OpenAboutCommandKey" xml:space="preserve">
-    <value>Οφєņ двőûτ δîåĺσĝ !!! !!</value>
+    <value>Οφёņ ǻвőųŧ đĭдłбģ !!! !!</value>
     <comment>This will open the "about" dialog, to display version info and other documentation</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/qps-ploca/Resources.resw
@@ -118,610 +118,610 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="SetColorSchemeParentCommandName" xml:space="preserve">
-    <value>Šеĺėĉτ čǿŀθŗ ščĥèмē... !!! !!! </value>
+    <value>Ŝêĺĕćţ ćŏĺбŕ ѕćнêmē... !!! !!! </value>
   </data>
   <data name="NewTabParentCommandName" xml:space="preserve">
-    <value>Ňещ Τãъ... !!!</value>
+    <value>Ŋéŵ Тάъ... !!!</value>
   </data>
   <data name="SplitPaneParentCommandName" xml:space="preserve">
-    <value>Śрłĭŧ Ρаńз... !!! </value>
+    <value>Śрĺíŧ Рāлë... !!! </value>
   </data>
   <data name="ApplicationDisplayNamePortable" xml:space="preserve">
-    <value>Ţèŕмїηαł (Ρøятáвľê) !!! !!!</value>
+    <value>Ţèѓmĩŋąĺ (Ρθŗτаьℓ℮) !!! !!!</value>
     <comment>This display name is used when the Terminal application is running in a "portable" mode, where settings are not stored in a shared location.</comment>
   </data>
   <data name="ApplicationDisplayNameUnpackaged" xml:space="preserve">
-    <value>Ŧēřмϊлάŀ (Űŋρǻçĸäġēď) !!! !!!</value>
+    <value>Ţèямīйдŀ (Üйφάçќãģėđ) !!! !!!</value>
     <comment>This display name is used when the application's name cannot be determined</comment>
   </data>
   <data name="ApplicationVersionUnknown" xml:space="preserve">
-    <value>Ųņķиσẁη !!</value>
+    <value>Ūņķиοщπ !!</value>
     <comment>This is displayed when the version of the application cannot be determined</comment>
   </data>
   <data name="AdjustFontSizeCommandKey" xml:space="preserve">
-    <value>Дðĵύśт ƒøпţ ŝίżê !!! !</value>
+    <value>Дđјůŝť ƒōлт ѕĩźé !!! !</value>
   </data>
   <data name="CloseOtherTabsCommandKey" xml:space="preserve">
-    <value>€ļŏŝэ тáьś òτћ℮ř τĥåń įήδэх {0} !!! !!! !!!</value>
+    <value>Ćļóşé ťäвś σťнĕѓ ŧħãń íŋđэ× {0} !!! !!! !!!</value>
     <comment>{0} will be replaced with a number</comment>
   </data>
   <data name="CloseOtherTabsDefaultCommandKey" xml:space="preserve">
-    <value>Сłбšĕ αļĺ ôτĥёя τάъš !!! !!!</value>
+    <value>€ĺòśє ąļľ σţђéѓ ŧαьŝ !!! !!!</value>
   </data>
   <data name="ClosePaneCommandKey" xml:space="preserve">
-    <value>Ĉľóŝé ρàпе !!!</value>
+    <value>Сļóѕє ρâŋз !!!</value>
   </data>
   <data name="CloseTabAtIndexCommandKey" xml:space="preserve">
-    <value>Ĉŀσśê ťªъ ąŧ ΐñδеж {0} !!! !!! </value>
+    <value>Сľбšе τáь àţ ΐńđę× {0} !!! !!! </value>
     <comment>{0} will be replaced with a number</comment>
   </data>
   <data name="CloseTabCommandKey" xml:space="preserve">
-    <value>€ŀòѕέ ťåъ !!!</value>
+    <value>Čļőšє ťдв !!!</value>
   </data>
   <data name="CloseTabsAfterCommandKey" xml:space="preserve">
-    <value>€łóŝ℮ ţάвš ǻƒŧεѓ íήδёх {0} !!! !!! !</value>
+    <value>Čℓоśз ţαьŝ äƒтèŗ ĭⁿðέ× {0} !!! !!! !</value>
     <comment>{0} will be replaced with a number</comment>
   </data>
   <data name="CopySuffix" xml:space="preserve">
-    <value>Çôру !</value>
+    <value>Ćόφу !</value>
     <comment>The suffix we add to the name of a duplicated profile.</comment>
   </data>
   <data name="MoveTabCommandKey" xml:space="preserve">
-    <value>Мόνę ŧäь {0} !!! </value>
+    <value>Μονé ţãь {0} !!! </value>
     <comment>{0} will be replaced with a "forward" / "backward"</comment>
   </data>
   <data name="MoveTabToWindowCommandKey" xml:space="preserve">
-    <value>Мōνз τãв тô ẃїⁿðöω "{0}" !!! !!! !</value>
+    <value>Мōνё тâв ŧó щîηďōẃ "{0}" !!! !!! !</value>
     <comment>{0} will be replaced with a user-specified name of a window</comment>
   </data>
   <data name="MoveTabToNewWindowCommandKey" xml:space="preserve">
-    <value>Μöνę ŧαъ τō ā л℮щ ẁίńďбш !!! !!! !</value>
+    <value>Μŏνĕ ťåъ тο ā ńęẃ шįŋďôẁ !!! !!! !</value>
   </data>
   <data name="MoveTabDirectionForward" xml:space="preserve">
-    <value>ƒõґẁάгď !!</value>
+    <value>ƒояώäřđ !!</value>
   </data>
   <data name="MoveTabDirectionBackward" xml:space="preserve">
-    <value>ъăčķẅăѓď !!</value>
+    <value>ьāςкωагð !!</value>
   </data>
   <data name="CloseTabsAfterDefaultCommandKey" xml:space="preserve">
-    <value>Čℓóśє ăℓł ŧäьŝ åƒŧêѓ ťћĕ ςůѓѓεйт ťдв !!! !!! !!! !</value>
+    <value>Сłòšε àŀļ τãъš äƒťêѓ ŧĥĕ ĉŭґг℮ńτ тǻъ !!! !!! !!! !</value>
   </data>
   <data name="CloseWindowCommandKey" xml:space="preserve">
-    <value>Čŀöśé ẁįⁿðθŵ !!! </value>
+    <value>Çłõŝе ẁїиðõŵ !!! </value>
   </data>
   <data name="OpenSystemMenuCommandKey" xml:space="preserve">
-    <value>Όφėⁿ şуşţέм мэⁿů !!! !</value>
+    <value>Ώρēņ şγŝŧèм мèŉϋ !!! !</value>
   </data>
   <data name="CommandPromptDisplayName" xml:space="preserve">
-    <value>Çŏmmǻηđ Рŗόмφť !!! !</value>
+    <value>Çбмmǻⁿδ Ρřǿmφţ !!! !</value>
     <comment>This is the name of "Command Prompt", as localized in Windows. The localization here should match the one in the Windows product for "Command Prompt"</comment>
   </data>
   <data name="CopyTextAsSingleLineCommandKey" xml:space="preserve">
-    <value>Ćθρŷ ţё×ť ãś ä śíπĝľє ĺιие !!! !!! !</value>
+    <value>Čōрγ тэхť áş д śіηĝļе ℓïⁿз !!! !!! !</value>
   </data>
   <data name="CopyTextCommandKey" xml:space="preserve">
-    <value>€õφу ŧĕхт !!!</value>
+    <value>€őрў ţэ×ť !!!</value>
   </data>
   <data name="DecreaseFontSizeCommandKey" xml:space="preserve">
-    <value>Đеćřёåśэ ƒőⁿţ śіźê !!! !!</value>
+    <value>Ðęčґёāšê ƒõⁿţ ŝîźę !!! !!</value>
   </data>
   <data name="DecreaseFontSizeWithAmountCommandKey" xml:space="preserve">
-    <value>Ðέçřĕåѕë ƒοлτ şĭżė, άмøůиτ: {0} !!! !!! !!!</value>
+    <value>Đęćŕєāšė ƒőňţ śíž℮, ămθúпţ: {0} !!! !!! !!!</value>
     <comment>{0} will be replaced with a positive number</comment>
   </data>
   <data name="DirectionDown" xml:space="preserve">
-    <value>ďбŵπ !</value>
+    <value>ďοẃл !</value>
   </data>
   <data name="DirectionLeft" xml:space="preserve">
-    <value>ŀέƒт !</value>
+    <value>ľęƒţ !</value>
   </data>
   <data name="DirectionRight" xml:space="preserve">
-    <value>ѓîģђτ !</value>
+    <value>řϊğĥŧ !</value>
   </data>
   <data name="DirectionUp" xml:space="preserve">
-    <value>џφ </value>
+    <value>űρ </value>
   </data>
   <data name="DirectionPrevious" xml:space="preserve">
-    <value>φяένíöúŝ !!</value>
+    <value>рѓěνĩøùş !!</value>
   </data>
   <data name="DuplicatePaneCommandKey" xml:space="preserve">
-    <value>Ďŭрℓіćąŧ℮ φāйê !!! !</value>
+    <value>Đµφŀĩςαťє ρãиε !!! !</value>
   </data>
   <data name="DuplicateTabCommandKey" xml:space="preserve">
-    <value>Ðμрĺϊ¢ªţ℮ ταь !!! </value>
+    <value>Ďϋрļïćăτę ŧāь !!! </value>
   </data>
   <data name="ExecuteCommandlineCommandKey" xml:space="preserve">
-    <value>Ŗυи сŏммãŉđĺїńε "{0}" ϊñ τĥіś ẃìŉđόẅ !!! !!! !!! !</value>
+    <value>Ґμπ ċôмmαⁿďļιŉê "{0}" ìŉ τħϊѕ ẃĩпđőẃ !!! !!! !!! !</value>
     <comment>{0} will be replaced with a user-defined commandline</comment>
   </data>
   <data name="FindCommandKey" xml:space="preserve">
-    <value>₣îйð !</value>
+    <value>₣ïήð !</value>
   </data>
   <data name="FindNextCommandKey" xml:space="preserve">
-    <value>₣ϊŋď ńέхτ ŝēдгĉн мдŧ¢ħ !!! !!! </value>
+    <value>₣ĩŋđ ŋєхτ šęáгςђ mαţсĥ !!! !!! </value>
   </data>
   <data name="FindPrevCommandKey" xml:space="preserve">
-    <value>₣ĩňδ ргëνĭòųş ŝêąŕçĥ mªţĉђ !!! !!! !</value>
+    <value>₣įпđ ρѓèνïθŭş ѕěăґçħ mάтćĥ !!! !!! !</value>
   </data>
   <data name="IncreaseFontSizeCommandKey" xml:space="preserve">
-    <value>Ίńçřεãѕє ƒöňţ šіžê !!! !!</value>
+    <value>Ĭñçяēåśё ƒбήτ šΐžĕ !!! !!</value>
   </data>
   <data name="IncreaseFontSizeWithAmountCommandKey" xml:space="preserve">
-    <value>Ĭπсŕеάѕε ƒоήτ šíźë, ąmóüηт: {0} !!! !!! !!!</value>
+    <value>Íⁿ¢řęªŝě ƒǿηť šιźé, āmōΰήт: {0} !!! !!! !!!</value>
     <comment>{0} will be replaced with a positive number</comment>
   </data>
   <data name="MoveFocusCommandKey" xml:space="preserve">
-    <value>Мőνē ƒôċµѕ !!!</value>
+    <value>Мŏν℮ ƒоćΰŝ !!!</value>
   </data>
   <data name="MoveFocusWithArgCommandKey" xml:space="preserve">
-    <value>Μöνз ƒōćũš {0} !!! !</value>
+    <value>Мǿνэ ƒőĉúš {0} !!! !</value>
     <comment>{0} will be replaced with one of the four directions "DirectionLeft", "DirectionRight", "DirectionUp", "DirectionDown"</comment>
   </data>
   <data name="MoveFocusToLastUsedPane" xml:space="preserve">
-    <value>Мőν℮ ƒòсũŝ ŧŏ ŧћё ŀăšť ûŝεđ φąиê !!! !!! !!! </value>
+    <value>Мőνэ ƒóčůš ťб тħε łάşт цŝęð ρąήέ !!! !!! !!! </value>
   </data>
   <data name="MoveFocusNextInOrder" xml:space="preserve">
-    <value>Μóνě ƒõ¢ûş ţο τћє ή℮жт ρâńě ïп όŕðзř !!! !!! !!! !</value>
+    <value>Мθνė ƒőςúś ŧŏ ŧн℮ йèхť рăńέ íη ояđеř !!! !!! !!! !</value>
   </data>
   <data name="MoveFocusPreviousInOrder" xml:space="preserve">
-    <value>Μŏνє ƒσсùѕ τõ ŧнĕ ρřêνīθυѕ φàňέ їŉ θгđéŕ !!! !!! !!! !!!</value>
+    <value>Μòνĕ ƒō¢ùš ťό ţĥė рѓэνΐσџѕ рǻйē ίп θѓďĕг !!! !!! !!! !!!</value>
   </data>
   <data name="MoveFocusFirstPane" xml:space="preserve">
-    <value>Мõνè ƒбçυѕ ţö ťћè ƒϊřşŧ рªńě !!! !!! !!</value>
+    <value>Мôνε ƒôćųŝ ţŏ τђε ƒïѓŝť рαňє !!! !!! !!</value>
   </data>
   <data name="MoveFocusParentPane" xml:space="preserve">
-    <value>Μŏνé ƒбçџš ţō τĥэ рâѓëⁿт ράňè !!! !!! !!!</value>
+    <value>Мõν℮ ƒøčūŝ ťø ťђě раѓéпτ φáñэ !!! !!! !!!</value>
   </data>
   <data name="MoveFocusChildPane" xml:space="preserve">
-    <value>Мόνέ ƒõćùŝ τõ ŧђ℮ ĉћįļď φäпé !!! !!! !!</value>
+    <value>Μôνé ƒóčųŝ ŧǿ ţнз ćћϊļð ρãлė !!! !!! !!</value>
   </data>
   <data name="SwapPaneCommandKey" xml:space="preserve">
-    <value>Ѕώäр ράņè !!!</value>
+    <value>Şωąр рāлē !!!</value>
   </data>
   <data name="SwapPaneWithArgCommandKey" xml:space="preserve">
-    <value>Şẁªρ φаņє {0} !!! </value>
+    <value>Ѕẃаφ φäņέ {0} !!! </value>
     <comment>{0} will be replaced with one of the four directions "DirectionLeft", "DirectionRight", "DirectionUp", "DirectionDown"</comment>
   </data>
   <data name="SwapPaneToLastUsedPane" xml:space="preserve">
-    <value>Ѕẃãρ φάήėѕ ẃĭŧħ ŧнε ļąŝť ύŝєď ράńє !!! !!! !!! !</value>
+    <value>Ѕшάφ рâπ℮š ẃїтħ τђё ŀåŝτ цѕęδ рáŋę !!! !!! !!! !</value>
   </data>
   <data name="SwapPaneNextInOrder" xml:space="preserve">
-    <value>Šώäр рäηėś ẅϊţђ тĥё пēжţ φåπę ίή òяδèг !!! !!! !!! !!</value>
+    <value>Śẅáр φãлэѕ ẁîţħ ťђê ñέхт рãήě ϊή őґđêґ !!! !!! !!! !!</value>
   </data>
   <data name="SwapPanePreviousInOrder" xml:space="preserve">
-    <value>Şŵǻρ ρåńέš ẅîŧħ тħė рŗéνĩòűѕ ρаñĕ ĭπ òяðèŗ !!! !!! !!! !!! </value>
+    <value>Śẃåφ φăⁿёś ŵіťћ тĥĕ φŕёνĩòϋŝ раή℮ їń ôґðēѓ !!! !!! !!! !!! </value>
   </data>
   <data name="SwapPaneFirstPane" xml:space="preserve">
-    <value>Šŵåр φάňєś ẅїţћ ťĥë ƒїŕşŧ ρàйέ !!! !!! !!!</value>
+    <value>Ŝщàφ рǻņεš шíţћ ťнĕ ƒίѓѕт ρāńз !!! !!! !!!</value>
   </data>
   <data name="NewTabCommandKey" xml:space="preserve">
-    <value>Νēŵ ŧаъ !!</value>
+    <value>Йέẃ ţάь !!</value>
   </data>
   <data name="NewWindowCommandKey" xml:space="preserve">
-    <value>Ŋēẁ ώïпďоω !!!</value>
+    <value>Ņеŵ щìπðõш !!!</value>
   </data>
   <data name="IdentifyWindowCommandKey" xml:space="preserve">
-    <value>İðĕńŧіƒу шîňđбш !!! !</value>
+    <value>Íðэήŧїƒγ шίиðøẃ !!! !</value>
   </data>
   <data name="IdentifyWindowsCommandKey" xml:space="preserve">
-    <value>İďèпţіƒў ώïⁿďоẅś !!! !</value>
+    <value>Ìðĕņτιƒý шϊйδøẅѕ !!! !</value>
   </data>
   <data name="NextTabCommandKey" xml:space="preserve">
-    <value>Л℮жţ таь !!</value>
+    <value>Ŋêжŧ ţаь !!</value>
   </data>
   <data name="OpenBothSettingsFilesCommandKey" xml:space="preserve">
-    <value>Øρεņ вöτħ śëŧτΐñğš ãñđ δзƒåùĺť šεťтĭйġŝ ƒįłęѕ (JSON) !!! !!! !!! !!! !!! </value>
+    <value>Оφεп ъбŧђ şēţтįлġŝ ąņδ ðэƒàμłţ ѕēтτîňĝš ƒΐℓëś (JSON) !!! !!! !!! !!! !!! </value>
     <comment>{Locked="JSON"}. "JSON" is the extension of the file that will be opened.</comment>
   </data>
   <data name="OpenDefaultSettingsCommandKey" xml:space="preserve">
-    <value>Õрэй δэƒªµľт şêţтĭлĝş ƒϊľè (JSON) !!! !!! !!! </value>
+    <value>Ŏреп ðеƒăûĺť şėттîņĝŝ ƒíļë (JSON) !!! !!! !!! </value>
     <comment>{Locked="JSON"}. "JSON" is the extension of the file that will be opened.</comment>
   </data>
   <data name="OpenNewTabDropdownCommandKey" xml:space="preserve">
-    <value>Ώφєп леẅ τâъ ðяòрδōŵи !!! !!!</value>
+    <value>Θрёή ňеш ţäь ďřóρðóŵή !!! !!!</value>
   </data>
   <data name="OpenSettingsCommandKey" xml:space="preserve">
-    <value>Ōрêη ŝĕтτїŋğŝ ƒΐℓз (JSON) !!! !!! !</value>
+    <value>Őρęň ŝέŧτїйģѕ ƒіĺē (JSON) !!! !!! !</value>
     <comment>{Locked="JSON"}. "JSON" is the extension of the file that will be opened.</comment>
   </data>
   <data name="OpenTabColorPickerCommandKey" xml:space="preserve">
-    <value>Ś℮ť τћĕ ţǻь сбłǿѓ... !!! !!!</value>
+    <value>Şėŧ ŧнę ťáь ċσŀőґ... !!! !!!</value>
   </data>
   <data name="PasteTextCommandKey" xml:space="preserve">
-    <value>Ρąşŧė !</value>
+    <value>Ρášτé !</value>
   </data>
   <data name="PrevTabCommandKey" xml:space="preserve">
-    <value>Ρřęνĭōűѕ ţãв !!! </value>
+    <value>Ρř℮νϊòϋš ţãъ !!! </value>
   </data>
   <data name="RenameTabCommandKey" xml:space="preserve">
-    <value>Ŕëńáмê ţåв ţǿ "{0}" !!! !!!</value>
+    <value>Ѓзήämė τдв ťσ "{0}" !!! !!!</value>
     <comment>{0} will be replaced with a user-defined string</comment>
   </data>
   <data name="ResetFontSizeCommandKey" xml:space="preserve">
-    <value>Язşėť ƒøņτ ѕîżę !!! !</value>
+    <value>Гėŝ℮ţ ƒŏήт şїžě !!! !</value>
   </data>
   <data name="ResetTabColorCommandKey" xml:space="preserve">
-    <value>Ŕεšёť ťăв ĉοłόŕ !!! !</value>
+    <value>Ŕеѕéт τăь сõļоґ !!! !</value>
   </data>
   <data name="ResetTabNameCommandKey" xml:space="preserve">
-    <value>Ѓеśěţ ťåь ŧįŧĺê !!! !</value>
+    <value>Řėś℮ŧ тαв τįтℓę !!! !</value>
   </data>
   <data name="OpenTabRenamerCommandKey" xml:space="preserve">
-    <value>Ѓęπāmє τáв ťïŧļè... !!! !!!</value>
+    <value>Гęйªm℮ тåъ ŧīτļĕ... !!! !!!</value>
   </data>
   <data name="ResizePaneCommandKey" xml:space="preserve">
-    <value>Я℮śĩžε φàņέ !!!</value>
+    <value>Ґëśîžє рãле !!!</value>
   </data>
   <data name="ResizePaneWithArgCommandKey" xml:space="preserve">
-    <value>Řєšîžέ φäńé {0} !!! !</value>
+    <value>Яэşìżе ρåņê {0} !!! !</value>
     <comment>{0} will be replaced with one of the four directions "DirectionLeft", "DirectionRight", "DirectionUp", or "DirectionDown"</comment>
   </data>
   <data name="ScrollDownCommandKey" xml:space="preserve">
-    <value>Şçѓθľℓ ðǿщπ !!!</value>
+    <value>Şςяôĺļ đσши !!!</value>
   </data>
   <data name="ScrollDownSeveralRowsCommandKey" xml:space="preserve">
-    <value>Ѕ¢гöℓł ďôẁή {0} ℓίň℮(ŝ) !!! !!! </value>
+    <value>Śсгθĺł đσẃņ {0} ŀĭпз(ś) !!! !!! </value>
     <comment>{0} will be replaced with the number of lines to scroll"</comment>
   </data>
   <data name="ScrollDownPageCommandKey" xml:space="preserve">
-    <value>Şςяøŀļ δǿŵη öⁿé раġė !!! !!!</value>
+    <value>Şсяθℓļ ďοẃη όňê ρдĝę !!! !!!</value>
   </data>
   <data name="ScrollUpCommandKey" xml:space="preserve">
-    <value>Şćгöℓŀ ûφ !!!</value>
+    <value>Şċгõłł üρ !!!</value>
   </data>
   <data name="ScrollUpSeveralRowsCommandKey" xml:space="preserve">
-    <value>Śςґôĺℓ ūр {0} łΐñέ(ş) !!! !!!</value>
+    <value>Şсѓòľŀ ūρ {0} ℓįňė(š) !!! !!!</value>
     <comment>{0} will be replaced with the number of lines to scroll"</comment>
   </data>
   <data name="ScrollUpPageCommandKey" xml:space="preserve">
-    <value>Śçřõłł ΰρ øⁿё рăĝę !!! !!</value>
+    <value>Šсŗøℓľ џφ ōņё ρâğэ !!! !!</value>
   </data>
   <data name="ScrollToTopCommandKey" xml:space="preserve">
-    <value>Śςяöļļ ŧö ţћэ τθρ ōƒ ђΐšŧóгý !!! !!! !!</value>
+    <value>Ś¢řόłℓ ťο ŧне τŏφ ōƒ ћϊśţбѓý !!! !!! !!</value>
   </data>
   <data name="ScrollToBottomCommandKey" xml:space="preserve">
-    <value>Ŝςѓοłł ţö ŧћз ъоŧτöm οƒ ћįѕтόŕу !!! !!! !!!</value>
+    <value>Śĉřòℓļ ťó ţħё вǿτтöm ǿƒ нϊŝţóгÿ !!! !!! !!!</value>
   </data>
   <data name="ScrollToPreviousMarkCommandKey" xml:space="preserve">
-    <value>Ŝсřόŀļ ţǿ ťħё ρѓενīōμś мąѓķ !!! !!! !!</value>
+    <value>Ŝςѓōŀļ то ţħέ ρŕеνïόцś мãřκ !!! !!! !!</value>
   </data>
   <data name="ScrollToNextMarkCommandKey" xml:space="preserve">
-    <value>Ѕĉřõĺŀ ŧб тнз ήëхт măѓќ !!! !!! </value>
+    <value>Śčґòľŀ τо тђê ñежт мāŕќ !!! !!! </value>
   </data>
   <data name="ScrollToFirstMarkCommandKey" xml:space="preserve">
-    <value>Ŝĉѓоℓļ τô ťĥё ƒïґѕť mąŕķ !!! !!! !</value>
+    <value>Ŝсґŏłℓ тõ ťĥë ƒïгѕτ мàгķ !!! !!! !</value>
   </data>
   <data name="ScrollToLastMarkCommandKey" xml:space="preserve">
-    <value>Ŝčřθℓł ţθ ţнє ľáѕť мàґќ !!! !!! </value>
+    <value>Ŝċřõļℓ тŏ ťћё ľäŝт мáѓќ !!! !!! </value>
   </data>
   <data name="AddMarkCommandKey" xml:space="preserve">
-    <value>Аďď á š¢ŗσłŀ măѓκ !!! !!</value>
+    <value>∆đď ª ş¢ŗőļļ mâґķ !!! !!</value>
   </data>
   <data name="AddMarkWithColorCommandKey" xml:space="preserve">
-    <value>Ąđđ à ѕсřôłĺ мãřķ, color:{0} !!! !!! !!</value>
+    <value>Дďδ ä şċřõĺľ mаřκ, color:{0} !!! !!! !!</value>
     <comment>{Locked="color"}. "color" is a literal parameter name that shouldn't be translated. {0} will be replaced with a color in hexadecimal format, like `#123456`</comment>
   </data>
   <data name="ClearMarkCommandKey" xml:space="preserve">
-    <value>Čľ℮àѓ мáґќ !!!</value>
+    <value>Çℓεàŗ мàгќ !!!</value>
   </data>
   <data name="ClearAllMarksCommandKey" xml:space="preserve">
-    <value>Ċľєάŕ äľℓ мâřкś !!! !</value>
+    <value>Ċļéāґ àℓĺ màгķś !!! !</value>
   </data>
   <data name="SendInputCommandKey" xml:space="preserve">
-    <value>Ѕеήδ İňрûť: "{0}" !!! !!</value>
+    <value>Šêлđ Ìñрµť: "{0}" !!! !!</value>
     <comment>{0} will be replaced with a string of input as defined by the user</comment>
   </data>
   <data name="SetColorSchemeCommandKey" xml:space="preserve">
-    <value>Ѕєţ ¢öłòř šćђεmε тò {0} !!! !!! </value>
+    <value>Şēţ ċõℓǿґ ѕčћёмē ţо {0} !!! !!! </value>
     <comment>{0} will be replaced with the name of a color scheme as defined by the user.</comment>
   </data>
   <data name="SetTabColorCommandKey" xml:space="preserve">
-    <value>Ŝєť ťαв ćőľǿŗ τό {0} !!! !!!</value>
+    <value>Š℮ŧ ŧαъ čõļοя ŧō {0} !!! !!!</value>
     <comment>{0} will be replaced with a color, displayed in hexadecimal (#RRGGBB) notation.</comment>
   </data>
   <data name="SplitHorizontalCommandKey" xml:space="preserve">
-    <value>Śρℓϊţ рдņè ĥοгΐżσŉŧāĺŀỳ !!! !!! </value>
+    <value>Ѕφℓϊţ φάиз ĥǿřîżõŉтαℓĺу !!! !!! </value>
   </data>
   <data name="MovePaneCommandKey" xml:space="preserve">
-    <value>Μбνэ ρăήέ !!!</value>
+    <value>Мôνé рαň℮ !!!</value>
   </data>
   <data name="MovePaneToNewWindowCommandKey" xml:space="preserve">
-    <value>Мōνė φάŉз тб ŉ℮ώ ωιŉďǿщ !!! !!! </value>
+    <value>Мőνе φαñє ťõ лêẃ ẃįńδōŵ !!! !!! </value>
   </data>
   <data name="SplitPaneCommandKey" xml:space="preserve">
-    <value>Ѕрĺĩţ φаņě !!!</value>
+    <value>Šрℓīт φăηе !!!</value>
   </data>
   <data name="SplitVerticalCommandKey" xml:space="preserve">
-    <value>Ѕрłïŧ φāňè νёґтΐċăļłγ !!! !!!</value>
+    <value>Şрŀíŧ рдņє νęřτíçǻłłỳ !!! !!!</value>
   </data>
   <data name="SwitchToTabCommandKey" xml:space="preserve">
-    <value>Ŝώįŧċђ τǿ ŧàь !!! </value>
+    <value>Šŵĩтċħ τŏ ťǻв !!! </value>
   </data>
   <data name="SwitchToLastTabCommandKey" xml:space="preserve">
-    <value>Ŝшíťçĥ ťο ťĥё ℓάšţ таъ !!! !!! </value>
+    <value>Ѕẃітčћ ţõ ťħέ ľάšť ţаь !!! !!! </value>
   </data>
   <data name="TabSearchCommandKey" xml:space="preserve">
-    <value>Şєаяĉн ƒóř ţâъ... !!! !!</value>
+    <value>Ѕėàřĉħ ƒôґ ŧâь... !!! !!</value>
   </data>
   <data name="ToggleAlwaysOnTopCommandKey" xml:space="preserve">
-    <value>Ťбġġļĕ ăľẁăÿѕ øп ŧøр мŏðє !!! !!! !</value>
+    <value>Ŧōĝġļě αŀώªÿŝ òⁿ тοр мöðέ !!! !!! !</value>
   </data>
   <data name="ToggleCommandPaletteCommandKey" xml:space="preserve">
-    <value>Ţóğġℓэ čômмâпđ рάļēτтė !!! !!! </value>
+    <value>Ţōĝğļė čσmmάήđ рåŀęŧŧз !!! !!! </value>
   </data>
   <data name="SuggestionsCommandHistoryCommandKey" xml:space="preserve">
-    <value>Яèсěⁿţ ¢бмmǻńðš... !!! !!</value>
+    <value>Γë¢єйť ćøмmåηđŝ... !!! !!</value>
   </data>
   <data name="SuggestionsCommandKey" xml:space="preserve">
-    <value>Õрėŋ ŝūģğέѕţĩǿήѕ... !!! !!!</value>
+    <value>Ǿрέŉ şµġġеšŧìŏπѕ... !!! !!!</value>
   </data>
   <data name="ToggleCommandPaletteCommandLineModeCommandKey" xml:space="preserve">
-    <value>Ţőģġłė ¢öмmαŋđ ράĺεţŧе ΐŋ ćōmмáήð ľΐлε mόδ℮ !!! !!! !!! !!! </value>
+    <value>Ťŏġĝļĕ çбmмáήď φàłėŧτĕ ίη ċσmмäпδ ℓìņє mόð℮ !!! !!! !!! !!! </value>
   </data>
   <data name="ToggleFocusModeCommandKey" xml:space="preserve">
-    <value>Тőġĝŀέ ƒőĉúš мόďê !!! !!</value>
+    <value>Ţоģġľе ƒöςŭś mσďē !!! !!</value>
     <comment>"Focus mode" is a mode with minimal UI elements, for a distraction-free experience</comment>
   </data>
   <data name="EnableFocusModeCommandKey" xml:space="preserve">
-    <value>Ĕŉάвļę ƒôçųŝ mōđĕ !!! !!</value>
+    <value>Еⁿâьℓё ƒσсùѕ мôðé !!! !!</value>
   </data>
   <data name="DisableFocusModeCommandKey" xml:space="preserve">
-    <value>Ďίšáъŀз ƒøćϋš møďе !!! !!</value>
+    <value>Đīѕдвł℮ ƒосύš mõðé !!! !!</value>
   </data>
   <data name="ToggleFullscreenCommandKey" xml:space="preserve">
-    <value>Ťòģģłě ƒυľłŝĉѓėëй !!! !!</value>
+    <value>Тоğġℓē ƒϋłłśčŕęéи !!! !!</value>
   </data>
   <data name="EnableFullScreenCommandKey" xml:space="preserve">
-    <value>Зйǻвℓέ ƒűľļşсяέêŉ !!! !!</value>
+    <value>Ėлдъļė ƒŭŀℓŝçŕěёη !!! !!</value>
   </data>
   <data name="DisableFullScreenCommandKey" xml:space="preserve">
-    <value>Đΐšäьłě ƒùĺłšçяèэл !!! !!</value>
+    <value>Ðιšåвłз ƒűŀĺšςŕéэη !!! !!</value>
   </data>
   <data name="EnableMaximizedCommandKey" xml:space="preserve">
-    <value>Мªжιмιžē ωįηðоώ !!! !</value>
+    <value>Мā×įmїžё щìйđōŵ !!! !</value>
   </data>
   <data name="DisableMaximizedCommandKey" xml:space="preserve">
-    <value>Гέşŧοѓ℮ мáхιmϊžёď ẅïήđощ !!! !!! !</value>
+    <value>Геśţóŗ℮ mã×îмĭżëď ώîйďöẃ !!! !!! !</value>
   </data>
   <data name="ToggleSplitOrientationCommandKey" xml:space="preserve">
-    <value>Ţôģĝĺé ρáñз ŝрłīτ θяĭēйтäтϊθñ !!! !!! !!!</value>
+    <value>Ŧόğĝℓέ рάлê šрľîť òяίĕŋτªŧĭőⁿ !!! !!! !!!</value>
   </data>
   <data name="TogglePaneZoomCommandKey" xml:space="preserve">
-    <value>Ŧθġğŀé ρäπė żøōм !!! !</value>
+    <value>Ťöģĝł℮ рªńέ żθθm !!! !</value>
   </data>
   <data name="TogglePaneReadOnlyCommandKey" xml:space="preserve">
-    <value>Ţбġģℓз φãńэ гэäđ-σŉļÿ môđę !!! !!! !</value>
+    <value>Ŧōĝğľé ρåŋê яэãď-όńļу моđě !!! !!! !</value>
   </data>
   <data name="EnablePaneReadOnlyCommandKey" xml:space="preserve">
-    <value>Εņãвļė φãпé ŕěªδ-олℓу мõďе !!! !!! !</value>
+    <value>Ęňǻъℓ℮ ρåηé яěǻδ-όňłу мбδэ !!! !!! !</value>
   </data>
   <data name="DisablePaneReadOnlyCommandKey" xml:space="preserve">
-    <value>Ďίѕдъŀë ρªлē ґėдđ-σńŀŷ mσđз !!! !!! !!</value>
+    <value>Ďіšªвłē φãηé яĕāď-σņĺў мοδë !!! !!! !!</value>
   </data>
   <data name="ToggleShaderEffectsCommandKey" xml:space="preserve">
-    <value>Тοģĝĺē ťēřmїлąľ νιşúаĺ ℮ƒƒěсτŝ !!! !!! !!!</value>
+    <value>Ţóģğļ℮ ŧëгміпął νіšúąļ єƒƒеčţš !!! !!! !!!</value>
   </data>
   <data name="BreakIntoDebuggerCommandKey" xml:space="preserve">
-    <value>βřзªķ ϊňтø тнê ðеъџġġёř !!! !!! </value>
+    <value>Вгεаĸ ĩňŧθ ŧђė đěвцģģέŕ !!! !!! </value>
   </data>
   <data name="OpenSettingsUICommandKey" xml:space="preserve">
-    <value>Õφзŋ śєτţιⁿğŝ... !!! !</value>
+    <value>Öφéη ѕēττϊⁿğš... !!! !</value>
   </data>
   <data name="RenameWindowCommandKey" xml:space="preserve">
-    <value>Яèñдmé ẃĭŋđòẁ тб "{0}" !!! !!! </value>
+    <value>Γзňãмē шіňďоώ ŧō "{0}" !!! !!! </value>
     <comment>{0} will be replaced with a user-defined string</comment>
   </data>
   <data name="ResetWindowNameCommandKey" xml:space="preserve">
-    <value>Ѓėšëт ẅíňðôш иаmé !!! !!</value>
+    <value>Ŗεšзť ωĩйδōẁ ñâмé !!! !!</value>
   </data>
   <data name="OpenWindowRenamerCommandKey" xml:space="preserve">
-    <value>Ѓëйǻmё ωϊиđōẁ... !!! !</value>
+    <value>Ґёŉάmë шϊйďθŵ... !!! !</value>
   </data>
   <data name="DisplayWorkingDirectoryCommandKey" xml:space="preserve">
-    <value>Ðΐşφļдÿ Ţēŕmīпàł'š сűřŗέпť шθŕκïηġ δίяĕсτőřÿ !!! !!! !!! !!! !</value>
+    <value>Ďіŝρłάỳ Τ℮ѓmìйаĺ'š čûŗяēŉτ ώоřκìņĝ ďιяęĉтσґỳ !!! !!! !!! !!! !</value>
   </data>
   <data name="GlobalSummonCommandKey" xml:space="preserve">
-    <value>Śћôẃ/Ήіđė ťĥê Тěŗmíñάĺ ώîπδőщ !!! !!! !!!</value>
+    <value>Şђбщ/Ĥīđз τĥз Ŧëяmіńаℓ ẅіηďоŵ !!! !!! !!!</value>
   </data>
   <data name="QuakeModeCommandKey" xml:space="preserve">
-    <value>Ŝћθẅ/Ħїď℮ Qũäκė шίńðσώ !!! !!! </value>
+    <value>Şђõẅ/Нϊđε Qџдĸє ẃįπđŏẃ !!! !!! </value>
     <comment>Quake is a well-known computer game and isn't related to earthquakes, etc. See https://en.wikipedia.org/wiki/Quake_(video_game)</comment>
   </data>
   <data name="FocusPaneCommandKey" xml:space="preserve">
-    <value>₣ōčŭş φâŉэ {0} !!! !</value>
+    <value>₣ôĉύѕ рàņε {0} !!! !</value>
     <comment>{0} will be replaced with a user-specified number</comment>
   </data>
   <data name="ExportBufferToPathCommandKey" xml:space="preserve">
-    <value>Ėхφοгτ ťĕ×т ŧǿ {0} !!! !!</value>
+    <value>Ε×рοŗţ ŧë×т ťσ {0} !!! !!</value>
     <comment>{0} will be replaced with a user-specified file path</comment>
   </data>
   <data name="ExportBufferCommandKey" xml:space="preserve">
-    <value>Êхφôřτ τě×ŧ !!!</value>
+    <value>Ε×ρθŗт ŧęхτ !!!</value>
   </data>
   <data name="ClearAllCommandKey" xml:space="preserve">
-    <value>Çľèąŕ ъύƒƒєѓ !!! </value>
+    <value>Çłĕăг ьũƒƒèŗ !!! </value>
     <comment>A command to clear the entirety of the Terminal output buffer</comment>
   </data>
   <data name="ClearViewportCommandKey" xml:space="preserve">
-    <value>€ĺëâґ νϊēώρøŗŧ !!! !</value>
+    <value>Ĉļзãг νίзώрбŗť !!! !</value>
     <comment>A command to clear the active viewport of the Terminal</comment>
   </data>
   <data name="ClearScrollbackCommandKey" xml:space="preserve">
-    <value>Çłεâѓ şċřǿℓŀьăçκ !!! !</value>
+    <value>Ćℓёäŕ šçѓоℓŀьäçķ !!! !</value>
     <comment>A command to clear the part of the buffer above the viewport</comment>
   </data>
   <data name="DefaultWindowsConsoleName" xml:space="preserve">
-    <value>Ļěτ Шίпðőẃš ðêςïδэ !!! !!</value>
+    <value>Ľëτ Ẁιñďõŵš đěćîðé !!! !!</value>
     <comment>This is the default option if a user doesn't choose to override Microsoft's choice of a Terminal.</comment>
   </data>
   <data name="InboxWindowsConsoleAuthor" xml:space="preserve">
-    <value>Мïċѓøŝοƒţ Ćöŕφσґáŧïбň !!! !!!</value>
+    <value>Μī¢řόѕõƒŧ Ćŏŕрσгåтΐøπ !!! !!!</value>
     <comment>Paired with `InboxWindowsConsoleName`, this is the application author... which is us: Microsoft.</comment>
   </data>
   <data name="InboxWindowsConsoleName" xml:space="preserve">
-    <value>Ẅîńðθωѕ Ĉōπѕòĺз Ηöśτ !!! !!!</value>
+    <value>Ẃîпďōώś €ōŋşбļэ Ήбѕτ !!! !!!</value>
     <comment>Name describing the usage of the classic windows console as the terminal UI. (`conhost.exe`)</comment>
   </data>
   <data name="QuitCommandKey" xml:space="preserve">
-    <value>Qúìт тĥė Ţéřmîñǻł !!! !!</value>
+    <value>Qυϊτ ŧħз Τέяmίŋăŀ !!! !!</value>
   </data>
   <data name="SetOpacityParentCommandName" xml:space="preserve">
-    <value>Ŝèţ ьǻćкĝѓõůňđ õφäсīţỳ... !!! !!! !</value>
+    <value>Ѕěт ьªċķĝґøūņð óφǻĉїτў... !!! !!! !</value>
   </data>
   <data name="IncreaseOpacityCommandKey" xml:space="preserve">
-    <value>Ìŋсŕêâśє ъăçĸġřόџŋð σрдςįτŷ вỳ {0}% !!! !!! !!! !</value>
+    <value>Ĭñçŕ℮àŝę ваċкġřŏųлď ǿφāςíτу ьỳ {0}% !!! !!! !!! !</value>
     <comment>A command to change how transparent the background of the window is</comment>
   </data>
   <data name="DecreaseOpacityCommandKey" xml:space="preserve">
-    <value>Đèςř℮αšε ьâςκğŕǿüñð òφǻĉíŧў ъŷ {0}% !!! !!! !!! !</value>
+    <value>Ďέсŕēāšε ъªċĸğгóüиđ õρąсïту ьγ {0}% !!! !!! !!! !</value>
     <comment>A command to change how transparent the background of the window is</comment>
   </data>
   <data name="AdjustOpacityCommandKey" xml:space="preserve">
-    <value>Šéť вǻсκğгòûпđ όφäčїτÿ τó {0}% !!! !!! !!!</value>
+    <value>Śêţ вąćķģřŏυńδ õφãςįţÿ ţθ {0}% !!! !!! !!!</value>
     <comment>A command to change how transparent the background of the window is</comment>
   </data>
   <data name="RestoreLastClosedCommandKey" xml:space="preserve">
-    <value>Ґέѕťõŕė тħё ĺåśŧ ¢ĺöѕэđ φáňё őř ŧàь !!! !!! !!! !</value>
+    <value>Г℮ѕτøŕé тђě ŀάѕŧ ςĺσşëð рдиè ôг ŧàь !!! !!! !!! !</value>
   </data>
   <data name="SelectAllCommandKey" xml:space="preserve">
-    <value>Ѕ℮ŀєčť αľľ ŧę×т !!! !</value>
+    <value>Śēĺèċť ªĺľ ťėхť !!! !</value>
   </data>
   <data name="MarkModeCommandKey" xml:space="preserve">
-    <value>Τŏğĝŀє mąґķ mθðέ !!! !</value>
+    <value>Ŧõğģļє mагĸ mθðé !!! !</value>
     <comment>A command that will toggle "mark mode". This is a mode in the application where the user can mark the text by selecting portions of the text.</comment>
   </data>
   <data name="ToggleBlockSelectionCommandKey" xml:space="preserve">
-    <value>Тбģģŀē ьłǿĉк şëļёςţįόⁿ !!! !!! </value>
+    <value>Ťøġğŀę ъĺôĉκ ѕëŀèçτіöŋ !!! !!! </value>
   </data>
   <data name="SwitchSelectionEndpointCommandKey" xml:space="preserve">
-    <value>Şώĭŧсћ ѕёℓёĉтιόи ęηđроïŋτ !!! !!! !</value>
+    <value>Şшїτçн şėļèςţίǿл ĕηðρóΐńт !!! !!! !</value>
   </data>
   <data name="ColorSelection_allMatches" xml:space="preserve">
-    <value>άľĺ мàтčĥеś !!!</value>
+    <value>ãℓļ мåŧćћєŝ !!!</value>
     <comment>This is used in the description of an action which changes the color of selected text, to indicate that not only the selected text will be colored, but also all matching text.</comment>
   </data>
   <data name="ColorSelection_fg_action" xml:space="preserve">
-    <value>Сóŀŏя śэľ℮сţíόň, ƒõřėğґθџńđ: {0}{1} !!! !!! !!! !</value>
+    <value>Çσľøř ѕĕĺęćťιбņ, ƒøŗěĝяöùńđ: {0}{1} !!! !!! !!! !</value>
     <comment>This is the description of an action which changes the color of selected text. {0}: the color. {1}: empty string OR a clause indicating that all matching text will be colored (ColorSelection_allMatches).</comment>
   </data>
   <data name="ColorSelection_bg_action" xml:space="preserve">
-    <value>Сбłóґ šēŀёčтίŏи, вąςĸğŗŏυňď: {0}{1} !!! !!! !!! !</value>
+    <value>Çöłôř śэļě¢ŧΐǿл, ьǻсќĝгбυňđ: {0}{1} !!! !!! !!! !</value>
     <comment>This is the description of an action which changes the background color of selected text. {0}: the color. {1}: empty string OR a clause indicating that all matching text will be colored (ColorSelection_allMatches).</comment>
   </data>
   <data name="ColorSelection_fg_bg_action" xml:space="preserve">
-    <value>Çθŀöг šēłěсτĭōŉ, ƒθяέğŕоцņď: {0}, вάскġяõµⁿď: {1}{2} !!! !!! !!! !!! !!! </value>
+    <value>Ćòľóř šєł℮ςťїöⁿ, ƒòřέģŗǿџπð: {0}, ъάċќğґōϋиď: {1}{2} !!! !!! !!! !!! !!! </value>
     <comment>This is the description of an action which changes the color of selected text and the background. {0}: the foreground color. {1}: the background color. {2}: empty string OR a clause indicating that all matching text will be colored (ColorSelection_allMatches).</comment>
   </data>
   <data name="ColorSelection_default_action" xml:space="preserve">
-    <value>Çόļбг ѕěļêčťιôи, (ďěƒаūłτ ƒõřèĝŗσûйđ/ъáçкĝѓőϋńđ){0} !!! !!! !!! !!! !!!</value>
+    <value>Ĉøłбѓ ś℮ŀêċťΐõŋ, (đ℮ƒаűļŧ ƒоґёġřθϋηď/вăсķĝŗòμŋď){0} !!! !!! !!! !!! !!!</value>
     <comment>This is the description of an action which changes the color of selected text and the background to the default colors. {0}: empty string OR a clause indicating that all matching text will be colored (ColorSelection_allMatches).</comment>
   </data>
   <data name="ColorSelection_defaultColor" xml:space="preserve">
-    <value>[đёƒªųŀτ] !!!</value>
+    <value>[ðеƒǻúĺŧ] !!!</value>
     <comment>This is used in the description of an action which changes the color of selected text, as a placeholder for a color, to indicate that the default (foreground or background) color will be used.</comment>
   </data>
   <data name="ColorSelection_Black" xml:space="preserve">
-    <value>вĺάćк !</value>
+    <value>ьłâсќ !</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_Red" xml:space="preserve">
-    <value>ѓеδ </value>
+    <value>řéδ </value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_Green" xml:space="preserve">
-    <value>ğŕзєń !</value>
+    <value>ğŕêεŋ !</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_Yellow" xml:space="preserve">
-    <value>уэĺĺοщ !</value>
+    <value>ýεľŀбẅ !</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_Blue" xml:space="preserve">
-    <value>вļū℮ !</value>
+    <value>ьŀü℮ !</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_Purple" xml:space="preserve">
-    <value>φûгφĺė !</value>
+    <value>рũгφŀέ !</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_Cyan" xml:space="preserve">
-    <value>çŷåή !</value>
+    <value>çÿåń !</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_White" xml:space="preserve">
-    <value>шнîťē !</value>
+    <value>ŵђϊţе !</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_BrightBlack" xml:space="preserve">
-    <value>вґĭģћτ ьℓдčк !!! </value>
+    <value>ьřïġћт ъℓāčķ !!! </value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_BrightRed" xml:space="preserve">
-    <value>ъřĭĝнŧ гëđ !!!</value>
+    <value>ьѓīğнτ řέδ !!!</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_BrightGreen" xml:space="preserve">
-    <value>вřĩġнť ġяĕëπ !!! </value>
+    <value>ъґΐğћť ğѓέεⁿ !!! </value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_BrightYellow" xml:space="preserve">
-    <value>ъгіġђŧ γёļŀöẃ !!! </value>
+    <value>ьяīĝђт ýεłŀǿẅ !!! </value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_BrightBlue" xml:space="preserve">
-    <value>ьřιğђť ъℓϋэ !!!</value>
+    <value>вяĭġħт ьℓцέ !!!</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_BrightPurple" xml:space="preserve">
-    <value>ьŗìğђť ρцŕρłē !!! </value>
+    <value>ъяîĝнť ρúřρľε !!! </value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_BrightCyan" xml:space="preserve">
-    <value>ъříģħţ ¢ýал !!!</value>
+    <value>вгїğħť ćÿªń !!!</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_BrightWhite" xml:space="preserve">
-    <value>ъŗϊğђт ẃĥīťε !!! </value>
+    <value>вŕīğħť ẅнĭŧэ !!! </value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ExpandSelectionToWordCommandKey" xml:space="preserve">
-    <value>Є×рāηđ ŝĕľęčтïőň ţб ωθřđ !!! !!! !</value>
+    <value>Зхрάиď śёľęςŧіôņ τό щòгδ !!! !!! !</value>
   </data>
   <data name="ShowContextMenuCommandKey" xml:space="preserve">
-    <value>Śнöẅ ċοπťèжţ мεиϋ !!! !!</value>
+    <value>Şнöẃ ćóηтë×ŧ мèⁿμ !!! !!</value>
   </data>
   <data name="CloseOtherPanesCommandKey" xml:space="preserve">
-    <value>Ċľόŝє ǻŀł õţнёŕ раñέŝ !!! !!!</value>
+    <value>Сļôѕз ăľŀ øţнèŕ φáŉêś !!! !!!</value>
   </data>
   <data name="ToggleBroadcastInputCommandKey" xml:space="preserve">
-    <value>Тόġğŀэ вгбäďċāѕŧ ΐņρŭŧ ţò ăłĺ рªŉēş !!! !!! !!! !</value>
+    <value>Тōģĝℓ℮ ьяοäð¢ªѕт ïŉρύτ ţò äļℓ φаиεś !!! !!! !!! !</value>
     <comment>When enabled, input will go to all panes in this tab simultaneously</comment>
   </data>
   <data name="RestartConnectionKey" xml:space="preserve">
-    <value>Ŗèѕţǻřţ ¢оņⁿэčţĩόņ !!! !!</value>
+    <value>Ŗ℮ŝţāґт čõŉлęčŧįоή !!! !!</value>
   </data>
   <data name="SelectOutputNextCommandKey" xml:space="preserve">
-    <value>Šëĺêćŧ иĕжţ ςōммãηď õūтρџť !!! !!! !</value>
+    <value>Šēłεĉτ πĕжţ ċômmàлð ŏµŧρūţ !!! !!! !</value>
   </data>
   <data name="SelectOutputPreviousCommandKey" xml:space="preserve">
-    <value>Šеłёćţ φяėνìôųś ćǿmмαňð óΰтрџŧ !!! !!! !!!</value>
+    <value>Śеľê¢ť φŕзνíôùś ςθммãиð σùтφμť !!! !!! !!!</value>
   </data>
   <data name="SelectCommandNextCommandKey" xml:space="preserve">
-    <value>Ŝзℓ℮ćт ñëхŧ сόmмάńð !!! !!!</value>
+    <value>Ѕĕŀёĉτ πежт ¢όmmªήď !!! !!!</value>
   </data>
   <data name="SelectCommandPreviousCommandKey" xml:space="preserve">
-    <value>Ѕ℮łę¢ŧ рřěνíǿµš ςøммăήđ !!! !!! </value>
+    <value>Ѕέļεćť ргėνîóųѕ çōmmдпð !!! !!! </value>
   </data>
   <data name="SearchForTextCommandKey" xml:space="preserve">
-    <value>Ѕëăřсħ {0} !!!</value>
+    <value>Šєāяćĥ {0} !!!</value>
     <comment>{0} will be replaced with a user-specified URL to a web page</comment>
   </data>
   <data name="SearchWebCommandKey" xml:space="preserve">
-    <value>Ѕзăŕćн ŧħз ωэв ƒòѓ šеℓĕċτєď ŧе×ţ !!! !!! !!! </value>
+    <value>Ѕεάгςн τђё ẅēъ ƒŏŕ śзĺėċţêđ ţехť !!! !!! !!! </value>
     <comment>This will open a web browser to search for some user-selected text</comment>
   </data>
   <data name="OpenAboutCommandKey" xml:space="preserve">
-    <value>Όφεй āвóûť δîαľōġ !!! !!</value>
+    <value>Οφёņ ǻвőųŧ đĭдłбģ !!! !!</value>
     <comment>This will open the "about" dialog, to display version info and other documentation</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/qps-plocm/Resources.resw
@@ -118,610 +118,610 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="SetColorSchemeParentCommandName" xml:space="preserve">
-    <value>Ŝĕŀéçŧ ςσľбя śсћéмė... !!! !!! </value>
+    <value>Ŝêĺĕćţ ćŏĺбŕ ѕćнêmē... !!! !!! </value>
   </data>
   <data name="NewTabParentCommandName" xml:space="preserve">
-    <value>Ńěш Τªъ... !!!</value>
+    <value>Ŋéŵ Тάъ... !!!</value>
   </data>
   <data name="SplitPaneParentCommandName" xml:space="preserve">
-    <value>Şφℓιŧ Рáле... !!! </value>
+    <value>Śрĺíŧ Рāлë... !!! </value>
   </data>
   <data name="ApplicationDisplayNamePortable" xml:space="preserve">
-    <value>Ťзямїйαľ (Рőяτāвłę) !!! !!!</value>
+    <value>Ţèѓmĩŋąĺ (Ρθŗτаьℓ℮) !!! !!!</value>
     <comment>This display name is used when the Terminal application is running in a "portable" mode, where settings are not stored in a shared location.</comment>
   </data>
   <data name="ApplicationDisplayNameUnpackaged" xml:space="preserve">
-    <value>Ŧêгmįлãļ (Ũирâсκǻĝєδ) !!! !!!</value>
+    <value>Ţèямīйдŀ (Üйφάçќãģėđ) !!! !!!</value>
     <comment>This display name is used when the application's name cannot be determined</comment>
   </data>
   <data name="ApplicationVersionUnknown" xml:space="preserve">
-    <value>Ųŉĸйоώп !!</value>
+    <value>Ūņķиοщπ !!</value>
     <comment>This is displayed when the version of the application cannot be determined</comment>
   </data>
   <data name="AdjustFontSizeCommandKey" xml:space="preserve">
-    <value>Âđĵűŝţ ƒõлт šīžê !!! !</value>
+    <value>Дđјůŝť ƒōлт ѕĩźé !!! !</value>
   </data>
   <data name="CloseOtherTabsCommandKey" xml:space="preserve">
-    <value>Çŀõѕ℮ ťąьŝ ǿťђёŗ тĥāπ įñďę× {0} !!! !!! !!!</value>
+    <value>Ćļóşé ťäвś σťнĕѓ ŧħãń íŋđэ× {0} !!! !!! !!!</value>
     <comment>{0} will be replaced with a number</comment>
   </data>
   <data name="CloseOtherTabsDefaultCommandKey" xml:space="preserve">
-    <value>Čĺθѕэ ăľℓ ǿтћеŗ ţåъś !!! !!!</value>
+    <value>€ĺòśє ąļľ σţђéѓ ŧαьŝ !!! !!!</value>
   </data>
   <data name="ClosePaneCommandKey" xml:space="preserve">
-    <value>Čŀōŝē ρäиĕ !!!</value>
+    <value>Сļóѕє ρâŋз !!!</value>
   </data>
   <data name="CloseTabAtIndexCommandKey" xml:space="preserve">
-    <value>Çľōšз τǻь ăŧ ΐńđэж {0} !!! !!! </value>
+    <value>Сľбšе τáь àţ ΐńđę× {0} !!! !!! </value>
     <comment>{0} will be replaced with a number</comment>
   </data>
   <data name="CloseTabCommandKey" xml:space="preserve">
-    <value>€ľбśέ τáв !!!</value>
+    <value>Čļőšє ťдв !!!</value>
   </data>
   <data name="CloseTabsAfterCommandKey" xml:space="preserve">
-    <value>Ċľöѕè τåъş ąƒŧэя ΐñδэх {0} !!! !!! !</value>
+    <value>Čℓоśз ţαьŝ äƒтèŗ ĭⁿðέ× {0} !!! !!! !</value>
     <comment>{0} will be replaced with a number</comment>
   </data>
   <data name="CopySuffix" xml:space="preserve">
-    <value>Ċθрŷ !</value>
+    <value>Ćόφу !</value>
     <comment>The suffix we add to the name of a duplicated profile.</comment>
   </data>
   <data name="MoveTabCommandKey" xml:space="preserve">
-    <value>Μσνė тåв {0} !!! </value>
+    <value>Μονé ţãь {0} !!! </value>
     <comment>{0} will be replaced with a "forward" / "backward"</comment>
   </data>
   <data name="MoveTabToWindowCommandKey" xml:space="preserve">
-    <value>Μονę тäь тσ ẅíŋďòẅ "{0}" !!! !!! !</value>
+    <value>Мōνё тâв ŧó щîηďōẃ "{0}" !!! !!! !</value>
     <comment>{0} will be replaced with a user-specified name of a window</comment>
   </data>
   <data name="MoveTabToNewWindowCommandKey" xml:space="preserve">
-    <value>Μθνę ţáь ţσ á ήéώ ŵĭⁿđöω !!! !!! !</value>
+    <value>Μŏνĕ ťåъ тο ā ńęẃ шįŋďôẁ !!! !!! !</value>
   </data>
   <data name="MoveTabDirectionForward" xml:space="preserve">
-    <value>ƒóґщåѓď !!</value>
+    <value>ƒояώäřđ !!</value>
   </data>
   <data name="MoveTabDirectionBackward" xml:space="preserve">
-    <value>ъãċĸŵăřð !!</value>
+    <value>ьāςкωагð !!</value>
   </data>
   <data name="CloseTabsAfterDefaultCommandKey" xml:space="preserve">
-    <value>Ĉłǿŝė áℓľ ťãьŝ ãƒťёѓ ŧħз сυřŕ℮ņť ťăв !!! !!! !!! !</value>
+    <value>Сłòšε àŀļ τãъš äƒťêѓ ŧĥĕ ĉŭґг℮ńτ тǻъ !!! !!! !!! !</value>
   </data>
   <data name="CloseWindowCommandKey" xml:space="preserve">
-    <value>Çℓόŝє ẃīлδòώ !!! </value>
+    <value>Çłõŝе ẁїиðõŵ !!! </value>
   </data>
   <data name="OpenSystemMenuCommandKey" xml:space="preserve">
-    <value>Ορëñ ŝýšţєм mėήû !!! !</value>
+    <value>Ώρēņ şγŝŧèм мèŉϋ !!! !</value>
   </data>
   <data name="CommandPromptDisplayName" xml:space="preserve">
-    <value>Čøмmάŋđ Рřõмρţ !!! !</value>
+    <value>Çбмmǻⁿδ Ρřǿmφţ !!! !</value>
     <comment>This is the name of "Command Prompt", as localized in Windows. The localization here should match the one in the Windows product for "Command Prompt"</comment>
   </data>
   <data name="CopyTextAsSingleLineCommandKey" xml:space="preserve">
-    <value>Ćŏρŷ τêхť âś á ѕίⁿĝłę łįⁿè !!! !!! !</value>
+    <value>Čōрγ тэхť áş д śіηĝļе ℓïⁿз !!! !!! !</value>
   </data>
   <data name="CopyTextCommandKey" xml:space="preserve">
-    <value>Ćŏрў ţêжт !!!</value>
+    <value>€őрў ţэ×ť !!!</value>
   </data>
   <data name="DecreaseFontSizeCommandKey" xml:space="preserve">
-    <value>Ďèćґзαѕę ƒоⁿт šīźέ !!! !!</value>
+    <value>Ðęčґёāšê ƒõⁿţ ŝîźę !!! !!</value>
   </data>
   <data name="DecreaseFontSizeWithAmountCommandKey" xml:space="preserve">
-    <value>Đêċřèăşê ƒóñţ ѕίżэ, аmόùŉт: {0} !!! !!! !!!</value>
+    <value>Đęćŕєāšė ƒőňţ śíž℮, ămθúпţ: {0} !!! !!! !!!</value>
     <comment>{0} will be replaced with a positive number</comment>
   </data>
   <data name="DirectionDown" xml:space="preserve">
-    <value>đŏщп !</value>
+    <value>ďοẃл !</value>
   </data>
   <data name="DirectionLeft" xml:space="preserve">
-    <value>ℓзƒť !</value>
+    <value>ľęƒţ !</value>
   </data>
   <data name="DirectionRight" xml:space="preserve">
-    <value>ŕϊĝĥт !</value>
+    <value>řϊğĥŧ !</value>
   </data>
   <data name="DirectionUp" xml:space="preserve">
-    <value>µρ </value>
+    <value>űρ </value>
   </data>
   <data name="DirectionPrevious" xml:space="preserve">
-    <value>ρгэνîöцš !!</value>
+    <value>рѓěνĩøùş !!</value>
   </data>
   <data name="DuplicatePaneCommandKey" xml:space="preserve">
-    <value>Ďύрļïςąτé раήê !!! !</value>
+    <value>Đµφŀĩςαťє ρãиε !!! !</value>
   </data>
   <data name="DuplicateTabCommandKey" xml:space="preserve">
-    <value>Đυρŀі¢àťё ŧάь !!! </value>
+    <value>Ďϋрļïćăτę ŧāь !!! </value>
   </data>
   <data name="ExecuteCommandlineCommandKey" xml:space="preserve">
-    <value>Яųη čοммαńδŀΐňè "{0}" ĭπ ţĥĭš щīńðøẅ !!! !!! !!! !</value>
+    <value>Ґμπ ċôмmαⁿďļιŉê "{0}" ìŉ τħϊѕ ẃĩпđőẃ !!! !!! !!! !</value>
     <comment>{0} will be replaced with a user-defined commandline</comment>
   </data>
   <data name="FindCommandKey" xml:space="preserve">
-    <value>₣ïňđ !</value>
+    <value>₣ïήð !</value>
   </data>
   <data name="FindNextCommandKey" xml:space="preserve">
-    <value>₣ĩлđ ŉė×т şéáґċћ mǻтсн !!! !!! </value>
+    <value>₣ĩŋđ ŋєхτ šęáгςђ mαţсĥ !!! !!! </value>
   </data>
   <data name="FindPrevCommandKey" xml:space="preserve">
-    <value>₣îńð рŕэνīōΰŝ şéдŕçћ máţćĥ !!! !!! !</value>
+    <value>₣įпđ ρѓèνïθŭş ѕěăґçħ mάтćĥ !!! !!! !</value>
   </data>
   <data name="IncreaseFontSizeCommandKey" xml:space="preserve">
-    <value>İπčг℮άśε ƒοņţ şïźĕ !!! !!</value>
+    <value>Ĭñçяēåśё ƒбήτ šΐžĕ !!! !!</value>
   </data>
   <data name="IncreaseFontSizeWithAmountCommandKey" xml:space="preserve">
-    <value>İŉĉґεαšё ƒοņт šіżέ, ämбΰйţ: {0} !!! !!! !!!</value>
+    <value>Íⁿ¢řęªŝě ƒǿηť šιźé, āmōΰήт: {0} !!! !!! !!!</value>
     <comment>{0} will be replaced with a positive number</comment>
   </data>
   <data name="MoveFocusCommandKey" xml:space="preserve">
-    <value>Μôνє ƒόсџş !!!</value>
+    <value>Мŏν℮ ƒоćΰŝ !!!</value>
   </data>
   <data name="MoveFocusWithArgCommandKey" xml:space="preserve">
-    <value>Мбνė ƒσċůѕ {0} !!! !</value>
+    <value>Мǿνэ ƒőĉúš {0} !!! !</value>
     <comment>{0} will be replaced with one of the four directions "DirectionLeft", "DirectionRight", "DirectionUp", "DirectionDown"</comment>
   </data>
   <data name="MoveFocusToLastUsedPane" xml:space="preserve">
-    <value>Мòνē ƒóčüš ţσ ťħε ļāѕť üšĕð рăй℮ !!! !!! !!! </value>
+    <value>Мőνэ ƒóčůš ťб тħε łάşт цŝęð ρąήέ !!! !!! !!! </value>
   </data>
   <data name="MoveFocusNextInOrder" xml:space="preserve">
-    <value>Мŏνē ƒоċûś ţθ тĥĕ лēжτ φàηĕ ïŋ οяďея !!! !!! !!! !</value>
+    <value>Мθνė ƒőςúś ŧŏ ŧн℮ йèхť рăńέ íη ояđеř !!! !!! !!! !</value>
   </data>
   <data name="MoveFocusPreviousInOrder" xml:space="preserve">
-    <value>Μóνë ƒôçцѕ ťθ τĥέ φѓзνΐσµş φãñĕ ίⁿ ŏґďęř !!! !!! !!! !!!</value>
+    <value>Μòνĕ ƒō¢ùš ťό ţĥė рѓэνΐσџѕ рǻйē ίп θѓďĕг !!! !!! !!! !!!</value>
   </data>
   <data name="MoveFocusFirstPane" xml:space="preserve">
-    <value>Мονë ƒǿçµş тŏ ŧħę ƒîřѕť ρªήé !!! !!! !!</value>
+    <value>Мôνε ƒôćųŝ ţŏ τђε ƒïѓŝť рαňє !!! !!! !!</value>
   </data>
   <data name="MoveFocusParentPane" xml:space="preserve">
-    <value>Мōνз ƒθćùѕ ŧо ŧђé ρãřєńŧ ράŋε !!! !!! !!!</value>
+    <value>Мõν℮ ƒøčūŝ ťø ťђě раѓéпτ φáñэ !!! !!! !!!</value>
   </data>
   <data name="MoveFocusChildPane" xml:space="preserve">
-    <value>Мθνë ƒô¢џŝ ŧô тħз čĥìℓđ рăñё !!! !!! !!</value>
+    <value>Μôνé ƒóčųŝ ŧǿ ţнз ćћϊļð ρãлė !!! !!! !!</value>
   </data>
   <data name="SwapPaneCommandKey" xml:space="preserve">
-    <value>Śẅäφ ρäŋε !!!</value>
+    <value>Şωąр рāлē !!!</value>
   </data>
   <data name="SwapPaneWithArgCommandKey" xml:space="preserve">
-    <value>Śщăφ ραлé {0} !!! </value>
+    <value>Ѕẃаφ φäņέ {0} !!! </value>
     <comment>{0} will be replaced with one of the four directions "DirectionLeft", "DirectionRight", "DirectionUp", "DirectionDown"</comment>
   </data>
   <data name="SwapPaneToLastUsedPane" xml:space="preserve">
-    <value>Ѕшαφ ρаńзŝ ωįŧн ţђé ℓášť ųśěđ ρаиĕ !!! !!! !!! !</value>
+    <value>Ѕшάφ рâπ℮š ẃїтħ τђё ŀåŝτ цѕęδ рáŋę !!! !!! !!! !</value>
   </data>
   <data name="SwapPaneNextInOrder" xml:space="preserve">
-    <value>Šẃªφ рάиěѕ ẃïťħ ŧћė ŉė×т ρāлę ΐñ őяδēг !!! !!! !!! !!</value>
+    <value>Śẅáр φãлэѕ ẁîţħ ťђê ñέхт рãήě ϊή őґđêґ !!! !!! !!! !!</value>
   </data>
   <data name="SwapPanePreviousInOrder" xml:space="preserve">
-    <value>Şẅãφ ρàⁿεѕ ŵĭŧĥ тћз φяéνΐоùѕ φǻńĕ ΐⁿ οѓďзґ !!! !!! !!! !!! </value>
+    <value>Śẃåφ φăⁿёś ŵіťћ тĥĕ φŕёνĩòϋŝ раή℮ їń ôґðēѓ !!! !!! !!! !!! </value>
   </data>
   <data name="SwapPaneFirstPane" xml:space="preserve">
-    <value>Ŝŵäφ φăņėš ωìţн ťĥę ƒіѓšт рāňє !!! !!! !!!</value>
+    <value>Ŝщàφ рǻņεš шíţћ ťнĕ ƒίѓѕт ρāńз !!! !!! !!!</value>
   </data>
   <data name="NewTabCommandKey" xml:space="preserve">
-    <value>Νэẁ ŧāъ !!</value>
+    <value>Йέẃ ţάь !!</value>
   </data>
   <data name="NewWindowCommandKey" xml:space="preserve">
-    <value>∏ëω шіņďоω !!!</value>
+    <value>Ņеŵ щìπðõш !!!</value>
   </data>
   <data name="IdentifyWindowCommandKey" xml:space="preserve">
-    <value>Ĩďëńťιƒý ẅіńđθŵ !!! !</value>
+    <value>Íðэήŧїƒγ шίиðøẃ !!! !</value>
   </data>
   <data name="IdentifyWindowsCommandKey" xml:space="preserve">
-    <value>Іđέńťіƒý ẃīⁿðǿώš !!! !</value>
+    <value>Ìðĕņτιƒý шϊйδøẅѕ !!! !</value>
   </data>
   <data name="NextTabCommandKey" xml:space="preserve">
-    <value>Ņёжţ ťąь !!</value>
+    <value>Ŋêжŧ ţаь !!</value>
   </data>
   <data name="OpenBothSettingsFilesCommandKey" xml:space="preserve">
-    <value>Θрěй ьǿτћ šéţťĩŋğś аñđ ďěƒäûℓт ŝёţтιηğş ƒίĺēş (JSON) !!! !!! !!! !!! !!! </value>
+    <value>Оφεп ъбŧђ şēţтįлġŝ ąņδ ðэƒàμłţ ѕēтτîňĝš ƒΐℓëś (JSON) !!! !!! !!! !!! !!! </value>
     <comment>{Locked="JSON"}. "JSON" is the extension of the file that will be opened.</comment>
   </data>
   <data name="OpenDefaultSettingsCommandKey" xml:space="preserve">
-    <value>Ωφêη ðэƒаџℓτ ѕéтťїŉġŝ ƒįŀè (JSON) !!! !!! !!! </value>
+    <value>Ŏреп ðеƒăûĺť şėттîņĝŝ ƒíļë (JSON) !!! !!! !!! </value>
     <comment>{Locked="JSON"}. "JSON" is the extension of the file that will be opened.</comment>
   </data>
   <data name="OpenNewTabDropdownCommandKey" xml:space="preserve">
-    <value>Οφęη ŉзẅ τдъ đгòρďôωⁿ !!! !!!</value>
+    <value>Θрёή ňеш ţäь ďřóρðóŵή !!! !!!</value>
   </data>
   <data name="OpenSettingsCommandKey" xml:space="preserve">
-    <value>Ωφ℮π śέτţίйĝѕ ƒїĺë (JSON) !!! !!! !</value>
+    <value>Őρęň ŝέŧτїйģѕ ƒіĺē (JSON) !!! !!! !</value>
     <comment>{Locked="JSON"}. "JSON" is the extension of the file that will be opened.</comment>
   </data>
   <data name="OpenTabColorPickerCommandKey" xml:space="preserve">
-    <value>Şěτ ŧђè ţâъ ¢οĺøѓ... !!! !!!</value>
+    <value>Şėŧ ŧнę ťáь ċσŀőґ... !!! !!!</value>
   </data>
   <data name="PasteTextCommandKey" xml:space="preserve">
-    <value>Рåśţε !</value>
+    <value>Ρášτé !</value>
   </data>
   <data name="PrevTabCommandKey" xml:space="preserve">
-    <value>Ρŗĕνїоϋŝ тăв !!! </value>
+    <value>Ρř℮νϊòϋš ţãъ !!! </value>
   </data>
   <data name="RenameTabCommandKey" xml:space="preserve">
-    <value>Ѓεńαмє ŧǻь тö "{0}" !!! !!!</value>
+    <value>Ѓзήämė τдв ťσ "{0}" !!! !!!</value>
     <comment>{0} will be replaced with a user-defined string</comment>
   </data>
   <data name="ResetFontSizeCommandKey" xml:space="preserve">
-    <value>Γеśэτ ƒóητ ѕїź℮ !!! !</value>
+    <value>Гėŝ℮ţ ƒŏήт şїžě !!! !</value>
   </data>
   <data name="ResetTabColorCommandKey" xml:space="preserve">
-    <value>Ŕëѕ℮τ ţάв čőľбя !!! !</value>
+    <value>Ŕеѕéт τăь сõļоґ !!! !</value>
   </data>
   <data name="ResetTabNameCommandKey" xml:space="preserve">
-    <value>Γεѕэŧ τάв ŧιтℓé !!! !</value>
+    <value>Řėś℮ŧ тαв τįтℓę !!! !</value>
   </data>
   <data name="OpenTabRenamerCommandKey" xml:space="preserve">
-    <value>Ŕëпам℮ ťαъ τîτĺė... !!! !!!</value>
+    <value>Гęйªm℮ тåъ ŧīτļĕ... !!! !!!</value>
   </data>
   <data name="ResizePaneCommandKey" xml:space="preserve">
-    <value>Ŕêšíżè φáήє !!!</value>
+    <value>Ґëśîžє рãле !!!</value>
   </data>
   <data name="ResizePaneWithArgCommandKey" xml:space="preserve">
-    <value>Ѓëŝĭžę ρǻñέ {0} !!! !</value>
+    <value>Яэşìżе ρåņê {0} !!! !</value>
     <comment>{0} will be replaced with one of the four directions "DirectionLeft", "DirectionRight", "DirectionUp", or "DirectionDown"</comment>
   </data>
   <data name="ScrollDownCommandKey" xml:space="preserve">
-    <value>Šċгόℓŀ đοẁñ !!!</value>
+    <value>Şςяôĺļ đσши !!!</value>
   </data>
   <data name="ScrollDownSeveralRowsCommandKey" xml:space="preserve">
-    <value>Şćřõłℓ đőωŋ {0} łΐŉέ(ŝ) !!! !!! </value>
+    <value>Śсгθĺł đσẃņ {0} ŀĭпз(ś) !!! !!! </value>
     <comment>{0} will be replaced with the number of lines to scroll"</comment>
   </data>
   <data name="ScrollDownPageCommandKey" xml:space="preserve">
-    <value>Ŝċгбľļ ďσщή οπē φàğё !!! !!!</value>
+    <value>Şсяθℓļ ďοẃη όňê ρдĝę !!! !!!</value>
   </data>
   <data name="ScrollUpCommandKey" xml:space="preserve">
-    <value>Şĉŗøℓĺ ύр !!!</value>
+    <value>Şċгõłł üρ !!!</value>
   </data>
   <data name="ScrollUpSeveralRowsCommandKey" xml:space="preserve">
-    <value>Šςяòłĺ ϋφ {0} ľίŋё(ş) !!! !!!</value>
+    <value>Şсѓòľŀ ūρ {0} ℓįňė(š) !!! !!!</value>
     <comment>{0} will be replaced with the number of lines to scroll"</comment>
   </data>
   <data name="ScrollUpPageCommandKey" xml:space="preserve">
-    <value>Ŝсŕσłł ùρ øпê ρàġĕ !!! !!</value>
+    <value>Šсŗøℓľ џφ ōņё ρâğэ !!! !!</value>
   </data>
   <data name="ScrollToTopCommandKey" xml:space="preserve">
-    <value>Ŝсяοĺĺ ŧô тћє ŧǿφ оƒ ĥϊśţόŕў !!! !!! !!</value>
+    <value>Ś¢řόłℓ ťο ŧне τŏφ ōƒ ћϊśţбѓý !!! !!! !!</value>
   </data>
   <data name="ScrollToBottomCommandKey" xml:space="preserve">
-    <value>Śçґōŀŀ ťσ τнę ъοţťσм ǿƒ ĥíśťöяγ !!! !!! !!!</value>
+    <value>Śĉřòℓļ ťó ţħё вǿτтöm ǿƒ нϊŝţóгÿ !!! !!! !!!</value>
   </data>
   <data name="ScrollToPreviousMarkCommandKey" xml:space="preserve">
-    <value>Šςґбľŀ ťõ ŧħĕ ρŕένΐôџŝ máяќ !!! !!! !!</value>
+    <value>Ŝςѓōŀļ то ţħέ ρŕеνïόцś мãřκ !!! !!! !!</value>
   </data>
   <data name="ScrollToNextMarkCommandKey" xml:space="preserve">
-    <value>Śċŗôℓŀ тθ ŧĥэ ŉėжτ mαґκ !!! !!! </value>
+    <value>Śčґòľŀ τо тђê ñежт мāŕќ !!! !!! </value>
   </data>
   <data name="ScrollToFirstMarkCommandKey" xml:space="preserve">
-    <value>Ѕςřθℓĺ ŧó тħз ƒīяśτ mãяĸ !!! !!! !</value>
+    <value>Ŝсґŏłℓ тõ ťĥë ƒïгѕτ мàгķ !!! !!! !</value>
   </data>
   <data name="ScrollToLastMarkCommandKey" xml:space="preserve">
-    <value>Ѕĉяθŀĺ τõ ţнэ ŀăѕτ мάґĸ !!! !!! </value>
+    <value>Ŝċřõļℓ тŏ ťћё ľäŝт мáѓќ !!! !!! </value>
   </data>
   <data name="AddMarkCommandKey" xml:space="preserve">
-    <value>Áďď à şċгőľľ mãґĸ !!! !!</value>
+    <value>∆đď ª ş¢ŗőļļ mâґķ !!! !!</value>
   </data>
   <data name="AddMarkWithColorCommandKey" xml:space="preserve">
-    <value>Ăδð å ŝćгöļĺ mäřк, color:{0} !!! !!! !!</value>
+    <value>Дďδ ä şċřõĺľ mаřκ, color:{0} !!! !!! !!</value>
     <comment>{Locked="color"}. "color" is a literal parameter name that shouldn't be translated. {0} will be replaced with a color in hexadecimal format, like `#123456`</comment>
   </data>
   <data name="ClearMarkCommandKey" xml:space="preserve">
-    <value>Čłéаґ мäгķ !!!</value>
+    <value>Çℓεàŗ мàгќ !!!</value>
   </data>
   <data name="ClearAllMarksCommandKey" xml:space="preserve">
-    <value>Ĉℓėάѓ ãℓł mâŗķš !!! !</value>
+    <value>Ċļéāґ àℓĺ màгķś !!! !</value>
   </data>
   <data name="SendInputCommandKey" xml:space="preserve">
-    <value>Şěπď Įŉφŭτ: "{0}" !!! !!</value>
+    <value>Šêлđ Ìñрµť: "{0}" !!! !!</value>
     <comment>{0} will be replaced with a string of input as defined by the user</comment>
   </data>
   <data name="SetColorSchemeCommandKey" xml:space="preserve">
-    <value>Śêţ ςόļōґ ѕ¢ћемέ ţő {0} !!! !!! </value>
+    <value>Şēţ ċõℓǿґ ѕčћёмē ţо {0} !!! !!! </value>
     <comment>{0} will be replaced with the name of a color scheme as defined by the user.</comment>
   </data>
   <data name="SetTabColorCommandKey" xml:space="preserve">
-    <value>Ŝèŧ ťãв çőłôѓ ŧõ {0} !!! !!!</value>
+    <value>Š℮ŧ ŧαъ čõļοя ŧō {0} !!! !!!</value>
     <comment>{0} will be replaced with a color, displayed in hexadecimal (#RRGGBB) notation.</comment>
   </data>
   <data name="SplitHorizontalCommandKey" xml:space="preserve">
-    <value>Şρŀιτ рâηε нοřĭżóήťǻℓľу !!! !!! </value>
+    <value>Ѕφℓϊţ φάиз ĥǿřîżõŉтαℓĺу !!! !!! </value>
   </data>
   <data name="MovePaneCommandKey" xml:space="preserve">
-    <value>Μоνé ρªñе !!!</value>
+    <value>Мôνé рαň℮ !!!</value>
   </data>
   <data name="MovePaneToNewWindowCommandKey" xml:space="preserve">
-    <value>Μονз ρãήé тó ŋєẅ щĭŉðощ !!! !!! </value>
+    <value>Мőνе φαñє ťõ лêẃ ẃįńδōŵ !!! !!! </value>
   </data>
   <data name="SplitPaneCommandKey" xml:space="preserve">
-    <value>Śφľīτ φäлє !!!</value>
+    <value>Šрℓīт φăηе !!!</value>
   </data>
   <data name="SplitVerticalCommandKey" xml:space="preserve">
-    <value>Ѕρļίť рåñє νèřτīćąĺŀу !!! !!!</value>
+    <value>Şрŀíŧ рдņє νęřτíçǻłłỳ !!! !!!</value>
   </data>
   <data name="SwitchToTabCommandKey" xml:space="preserve">
-    <value>Ѕώΐţċн τσ тáв !!! </value>
+    <value>Šŵĩтċħ τŏ ťǻв !!! </value>
   </data>
   <data name="SwitchToLastTabCommandKey" xml:space="preserve">
-    <value>Ѕŵíτćħ тö ŧĥë ľªѕτ ťāь !!! !!! </value>
+    <value>Ѕẃітčћ ţõ ťħέ ľάšť ţаь !!! !!! </value>
   </data>
   <data name="TabSearchCommandKey" xml:space="preserve">
-    <value>Śєąѓĉн ƒоѓ τáь... !!! !!</value>
+    <value>Ѕėàřĉħ ƒôґ ŧâь... !!! !!</value>
   </data>
   <data name="ToggleAlwaysOnTopCommandKey" xml:space="preserve">
-    <value>Ťοģġŀè áℓŵдỳѕ òŉ ŧθр mǿðē !!! !!! !</value>
+    <value>Ŧōĝġļě αŀώªÿŝ òⁿ тοр мöðέ !!! !!! !</value>
   </data>
   <data name="ToggleCommandPaletteCommandKey" xml:space="preserve">
-    <value>Тоğğļε ċõммàйð рąłĕţτê !!! !!! </value>
+    <value>Ţōĝğļė čσmmάήđ рåŀęŧŧз !!! !!! </value>
   </data>
   <data name="SuggestionsCommandHistoryCommandKey" xml:space="preserve">
-    <value>Γέ¢èŉŧ ċòммªŉδŝ... !!! !!</value>
+    <value>Γë¢єйť ćøмmåηđŝ... !!! !!</value>
   </data>
   <data name="SuggestionsCommandKey" xml:space="preserve">
-    <value>Øрęⁿ şŭġġěśτιòиš... !!! !!!</value>
+    <value>Ǿрέŉ şµġġеšŧìŏπѕ... !!! !!!</value>
   </data>
   <data name="ToggleCommandPaletteCommandLineModeCommandKey" xml:space="preserve">
-    <value>Ťσğĝĺе ĉоmмąñđ рάłēţτě іⁿ ¢οmмайδ ľîηε møðε !!! !!! !!! !!! </value>
+    <value>Ťŏġĝļĕ çбmмáήď φàłėŧτĕ ίη ċσmмäпδ ℓìņє mόð℮ !!! !!! !!! !!! </value>
   </data>
   <data name="ToggleFocusModeCommandKey" xml:space="preserve">
-    <value>Τбġģĺê ƒоĉùś мøďέ !!! !!</value>
+    <value>Ţоģġľе ƒöςŭś mσďē !!! !!</value>
     <comment>"Focus mode" is a mode with minimal UI elements, for a distraction-free experience</comment>
   </data>
   <data name="EnableFocusModeCommandKey" xml:space="preserve">
-    <value>Ēηªъŀє ƒŏсũš мőðė !!! !!</value>
+    <value>Еⁿâьℓё ƒσсùѕ мôðé !!! !!</value>
   </data>
   <data name="DisableFocusModeCommandKey" xml:space="preserve">
-    <value>Ðīşáьĺë ƒо¢űš мŏδĕ !!! !!</value>
+    <value>Đīѕдвł℮ ƒосύš mõðé !!! !!</value>
   </data>
   <data name="ToggleFullscreenCommandKey" xml:space="preserve">
-    <value>Ŧбġğĺë ƒųłℓşсѓêëи !!! !!</value>
+    <value>Тоğġℓē ƒϋłłśčŕęéи !!! !!</value>
   </data>
   <data name="EnableFullScreenCommandKey" xml:space="preserve">
-    <value>Σйάьĺë ƒůĺℓŝςŕэзи !!! !!</value>
+    <value>Ėлдъļė ƒŭŀℓŝçŕěёη !!! !!</value>
   </data>
   <data name="DisableFullScreenCommandKey" xml:space="preserve">
-    <value>Đΐŝдъℓē ƒµĺľѕčяèеŋ !!! !!</value>
+    <value>Ðιšåвłз ƒűŀĺšςŕéэη !!! !!</value>
   </data>
   <data name="EnableMaximizedCommandKey" xml:space="preserve">
-    <value>Μâжιmîźê ŵîⁿδōщ !!! !</value>
+    <value>Мā×įmїžё щìйđōŵ !!! !</value>
   </data>
   <data name="DisableMaximizedCommandKey" xml:space="preserve">
-    <value>Ґèşтοгë mάжιмížëδ ẁіηδοẁ !!! !!! !</value>
+    <value>Геśţóŗ℮ mã×îмĭżëď ώîйďöẃ !!! !!! !</value>
   </data>
   <data name="ToggleSplitOrientationCommandKey" xml:space="preserve">
-    <value>Ţøġģĺ℮ рǻиê şρŀίţ ŏяїеπŧªţίòή !!! !!! !!!</value>
+    <value>Ŧόğĝℓέ рάлê šрľîť òяίĕŋτªŧĭőⁿ !!! !!! !!!</value>
   </data>
   <data name="TogglePaneZoomCommandKey" xml:space="preserve">
-    <value>Тöğğľę рàŋê źǿόm !!! !</value>
+    <value>Ťöģĝł℮ рªńέ żθθm !!! !</value>
   </data>
   <data name="TogglePaneReadOnlyCommandKey" xml:space="preserve">
-    <value>Ťóġġĺε ρąņë řεãð-õйļý мοδέ !!! !!! !</value>
+    <value>Ŧōĝğľé ρåŋê яэãď-όńļу моđě !!! !!! !</value>
   </data>
   <data name="EnablePaneReadOnlyCommandKey" xml:space="preserve">
-    <value>Ëńǻвŀė рдⁿε ŗēáď-öήŀγ möđē !!! !!! !</value>
+    <value>Ęňǻъℓ℮ ρåηé яěǻδ-όňłу мбδэ !!! !!! !</value>
   </data>
   <data name="DisablePaneReadOnlyCommandKey" xml:space="preserve">
-    <value>Ðіśάъł℮ φàлě ґ℮àδ-ǿиℓу мбδě !!! !!! !!</value>
+    <value>Ďіšªвłē φãηé яĕāď-σņĺў мοδë !!! !!! !!</value>
   </data>
   <data name="ToggleShaderEffectsCommandKey" xml:space="preserve">
-    <value>Ţòģģłė ťěґмїńаĺ νĭšúªŀ èƒƒέçτѕ !!! !!! !!!</value>
+    <value>Ţóģğļ℮ ŧëгміпął νіšúąļ єƒƒеčţš !!! !!! !!!</value>
   </data>
   <data name="BreakIntoDebuggerCommandKey" xml:space="preserve">
-    <value>Вŕĕаĸ ĩпţό ţђé δ℮ьцģģěř !!! !!! </value>
+    <value>Вгεаĸ ĩňŧθ ŧђė đěвцģģέŕ !!! !!! </value>
   </data>
   <data name="OpenSettingsUICommandKey" xml:space="preserve">
-    <value>Оφěй şэťŧïńĝѕ... !!! !</value>
+    <value>Öφéη ѕēττϊⁿğš... !!! !</value>
   </data>
   <data name="RenameWindowCommandKey" xml:space="preserve">
-    <value>Ŗέŉämè ẁĩńδóώ тò "{0}" !!! !!! </value>
+    <value>Γзňãмē шіňďоώ ŧō "{0}" !!! !!! </value>
     <comment>{0} will be replaced with a user-defined string</comment>
   </data>
   <data name="ResetWindowNameCommandKey" xml:space="preserve">
-    <value>Ŗеŝэτ щιņδõщ лãmè !!! !!</value>
+    <value>Ŗεšзť ωĩйδōẁ ñâмé !!! !!</value>
   </data>
   <data name="OpenWindowRenamerCommandKey" xml:space="preserve">
-    <value>Ґ℮йаm℮ ώΐⁿďόώ... !!! !</value>
+    <value>Ґёŉάmë шϊйďθŵ... !!! !</value>
   </data>
   <data name="DisplayWorkingDirectoryCommandKey" xml:space="preserve">
-    <value>Ðīšφļâγ Τέŕmΐńªŀ'ѕ ċύŗґĕⁿτ ŵòяκîñġ ðĭřĕĉťóŗŷ !!! !!! !!! !!! !</value>
+    <value>Ďіŝρłάỳ Τ℮ѓmìйаĺ'š čûŗяēŉτ ώоřκìņĝ ďιяęĉтσґỳ !!! !!! !!! !!! !</value>
   </data>
   <data name="GlobalSummonCommandKey" xml:space="preserve">
-    <value>Šћőш/Ηίðē ťħε Ťěřмΐñął ŵϊņďǿẅ !!! !!! !!!</value>
+    <value>Şђбщ/Ĥīđз τĥз Ŧëяmіńаℓ ẅіηďоŵ !!! !!! !!!</value>
   </data>
   <data name="QuakeModeCommandKey" xml:space="preserve">
-    <value>Śћóώ/Ήĩđę Qŭâќё ẃΐήδõω !!! !!! </value>
+    <value>Şђõẅ/Нϊđε Qџдĸє ẃįπđŏẃ !!! !!! </value>
     <comment>Quake is a well-known computer game and isn't related to earthquakes, etc. See https://en.wikipedia.org/wiki/Quake_(video_game)</comment>
   </data>
   <data name="FocusPaneCommandKey" xml:space="preserve">
-    <value>₣öćųś рãήέ {0} !!! !</value>
+    <value>₣ôĉύѕ рàņε {0} !!! !</value>
     <comment>{0} will be replaced with a user-specified number</comment>
   </data>
   <data name="ExportBufferToPathCommandKey" xml:space="preserve">
-    <value>Ĕ×рõяτ ŧёжţ тό {0} !!! !!</value>
+    <value>Ε×рοŗţ ŧë×т ťσ {0} !!! !!</value>
     <comment>{0} will be replaced with a user-specified file path</comment>
   </data>
   <data name="ExportBufferCommandKey" xml:space="preserve">
-    <value>È×рóŕţ ťêжť !!!</value>
+    <value>Ε×ρθŗт ŧęхτ !!!</value>
   </data>
   <data name="ClearAllCommandKey" xml:space="preserve">
-    <value>Ćŀěāѓ ьŭƒƒэŕ !!! </value>
+    <value>Çłĕăг ьũƒƒèŗ !!! </value>
     <comment>A command to clear the entirety of the Terminal output buffer</comment>
   </data>
   <data name="ClearViewportCommandKey" xml:space="preserve">
-    <value>Čļĕǻř νìēώρоŗŧ !!! !</value>
+    <value>Ĉļзãг νίзώрбŗť !!! !</value>
     <comment>A command to clear the active viewport of the Terminal</comment>
   </data>
   <data name="ClearScrollbackCommandKey" xml:space="preserve">
-    <value>Сĺėāŕ š¢řθℓℓвάсķ !!! !</value>
+    <value>Ćℓёäŕ šçѓоℓŀьäçķ !!! !</value>
     <comment>A command to clear the part of the buffer above the viewport</comment>
   </data>
   <data name="DefaultWindowsConsoleName" xml:space="preserve">
-    <value>£ĕţ Ẅΐņďθщŝ ðęçїďе !!! !!</value>
+    <value>Ľëτ Ẁιñďõŵš đěćîðé !!! !!</value>
     <comment>This is the default option if a user doesn't choose to override Microsoft's choice of a Terminal.</comment>
   </data>
   <data name="InboxWindowsConsoleAuthor" xml:space="preserve">
-    <value>Μĩ¢ґōśθƒť €όгφōѓâτїõñ !!! !!!</value>
+    <value>Μī¢řόѕõƒŧ Ćŏŕрσгåтΐøπ !!! !!!</value>
     <comment>Paired with `InboxWindowsConsoleName`, this is the application author... which is us: Microsoft.</comment>
   </data>
   <data name="InboxWindowsConsoleName" xml:space="preserve">
-    <value>Щїⁿδŏωѕ Çбήšŏŀē Ήǿѕţ !!! !!!</value>
+    <value>Ẃîпďōώś €ōŋşбļэ Ήбѕτ !!! !!!</value>
     <comment>Name describing the usage of the classic windows console as the terminal UI. (`conhost.exe`)</comment>
   </data>
   <data name="QuitCommandKey" xml:space="preserve">
-    <value>Qϋіť τнé Тέѓmіŋάļ !!! !!</value>
+    <value>Qυϊτ ŧħз Τέяmίŋăŀ !!! !!</value>
   </data>
   <data name="SetOpacityParentCommandName" xml:space="preserve">
-    <value>Ѕęţ ьàçĸĝяоųŋδ õφªςϊŧγ... !!! !!! !</value>
+    <value>Ѕěт ьªċķĝґøūņð óφǻĉїτў... !!! !!! !</value>
   </data>
   <data name="IncreaseOpacityCommandKey" xml:space="preserve">
-    <value>Íπċгĕàš℮ ьăćķġѓǿùиð όραċĭŧý ъý {0}% !!! !!! !!! !</value>
+    <value>Ĭñçŕ℮àŝę ваċкġřŏųлď ǿφāςíτу ьỳ {0}% !!! !!! !!! !</value>
     <comment>A command to change how transparent the background of the window is</comment>
   </data>
   <data name="DecreaseOpacityCommandKey" xml:space="preserve">
-    <value>Đĕċřèäśê вαćķģřōűŉď őφäĉîту ву {0}% !!! !!! !!! !</value>
+    <value>Ďέсŕēāšε ъªċĸğгóüиđ õρąсïту ьγ {0}% !!! !!! !!! !</value>
     <comment>A command to change how transparent the background of the window is</comment>
   </data>
   <data name="AdjustOpacityCommandKey" xml:space="preserve">
-    <value>Ѕέт вαċķĝѓòũⁿđ őρăćϊтỳ ťŏ {0}% !!! !!! !!!</value>
+    <value>Śêţ вąćķģřŏυńδ õφãςįţÿ ţθ {0}% !!! !!! !!!</value>
     <comment>A command to change how transparent the background of the window is</comment>
   </data>
   <data name="RestoreLastClosedCommandKey" xml:space="preserve">
-    <value>Ŕεśŧοґĕ ţћę ĺåşŧ ćłŏşзð рāηē оґ тαъ !!! !!! !!! !</value>
+    <value>Г℮ѕτøŕé тђě ŀάѕŧ ςĺσşëð рдиè ôг ŧàь !!! !!! !!! !</value>
   </data>
   <data name="SelectAllCommandKey" xml:space="preserve">
-    <value>Ŝэļеćŧ ãℓľ ţĕжŧ !!! !</value>
+    <value>Śēĺèċť ªĺľ ťėхť !!! !</value>
   </data>
   <data name="MarkModeCommandKey" xml:space="preserve">
-    <value>Ŧθĝğĺ℮ måřĸ мóđέ !!! !</value>
+    <value>Ŧõğģļє mагĸ mθðé !!! !</value>
     <comment>A command that will toggle "mark mode". This is a mode in the application where the user can mark the text by selecting portions of the text.</comment>
   </data>
   <data name="ToggleBlockSelectionCommandKey" xml:space="preserve">
-    <value>Ţǿġģłě вľŏск ŝéĺ℮¢ŧίōπ !!! !!! </value>
+    <value>Ťøġğŀę ъĺôĉκ ѕëŀèçτіöŋ !!! !!! </value>
   </data>
   <data name="SwitchSelectionEndpointCommandKey" xml:space="preserve">
-    <value>Śщìŧċĥ ѕěℓεĉτιбл éńðρöïñŧ !!! !!! !</value>
+    <value>Şшїτçн şėļèςţίǿл ĕηðρóΐńт !!! !!! !</value>
   </data>
   <data name="ColorSelection_allMatches" xml:space="preserve">
-    <value>åŀℓ мàŧçћēѕ !!!</value>
+    <value>ãℓļ мåŧćћєŝ !!!</value>
     <comment>This is used in the description of an action which changes the color of selected text, to indicate that not only the selected text will be colored, but also all matching text.</comment>
   </data>
   <data name="ColorSelection_fg_action" xml:space="preserve">
-    <value>Ćŏŀǿř ŝеℓёċτīôη, ƒθгěğŕóùйð: {0}{1} !!! !!! !!! !</value>
+    <value>Çσľøř ѕĕĺęćťιбņ, ƒøŗěĝяöùńđ: {0}{1} !!! !!! !!! !</value>
     <comment>This is the description of an action which changes the color of selected text. {0}: the color. {1}: empty string OR a clause indicating that all matching text will be colored (ColorSelection_allMatches).</comment>
   </data>
   <data name="ColorSelection_bg_action" xml:space="preserve">
-    <value>Čбłøѓ šёℓêςŧĭσⁿ, ьάςκġяσµπď: {0}{1} !!! !!! !!! !</value>
+    <value>Çöłôř śэļě¢ŧΐǿл, ьǻсќĝгбυňđ: {0}{1} !!! !!! !!! !</value>
     <comment>This is the description of an action which changes the background color of selected text. {0}: the color. {1}: empty string OR a clause indicating that all matching text will be colored (ColorSelection_allMatches).</comment>
   </data>
   <data name="ColorSelection_fg_bg_action" xml:space="preserve">
-    <value>Čôłσř ŝέĺėćťĩőп, ƒǿгзĝŗóΰⁿđ: {0}, вǻ¢кġѓőųηď: {1}{2} !!! !!! !!! !!! !!! </value>
+    <value>Ćòľóř šєł℮ςťїöⁿ, ƒòřέģŗǿџπð: {0}, ъάċќğґōϋиď: {1}{2} !!! !!! !!! !!! !!! </value>
     <comment>This is the description of an action which changes the color of selected text and the background. {0}: the foreground color. {1}: the background color. {2}: empty string OR a clause indicating that all matching text will be colored (ColorSelection_allMatches).</comment>
   </data>
   <data name="ColorSelection_default_action" xml:space="preserve">
-    <value>Čøĺóѓ šėļéćţìõń, (ðёƒǻύļţ ƒθřęġŕθųŉδ/ьά¢кĝґσūⁿδ){0} !!! !!! !!! !!! !!!</value>
+    <value>Ĉøłбѓ ś℮ŀêċťΐõŋ, (đ℮ƒаűļŧ ƒоґёġřθϋηď/вăсķĝŗòμŋď){0} !!! !!! !!! !!! !!!</value>
     <comment>This is the description of an action which changes the color of selected text and the background to the default colors. {0}: empty string OR a clause indicating that all matching text will be colored (ColorSelection_allMatches).</comment>
   </data>
   <data name="ColorSelection_defaultColor" xml:space="preserve">
-    <value>[δεƒāúľŧ] !!!</value>
+    <value>[ðеƒǻúĺŧ] !!!</value>
     <comment>This is used in the description of an action which changes the color of selected text, as a placeholder for a color, to indicate that the default (foreground or background) color will be used.</comment>
   </data>
   <data name="ColorSelection_Black" xml:space="preserve">
-    <value>ьℓαск !</value>
+    <value>ьłâсќ !</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_Red" xml:space="preserve">
-    <value>řēđ </value>
+    <value>řéδ </value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_Green" xml:space="preserve">
-    <value>ğгεэŋ !</value>
+    <value>ğŕêεŋ !</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_Yellow" xml:space="preserve">
-    <value>γёļŀōώ !</value>
+    <value>ýεľŀбẅ !</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_Blue" xml:space="preserve">
-    <value>вℓµè !</value>
+    <value>ьŀü℮ !</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_Purple" xml:space="preserve">
-    <value>φūѓρľė !</value>
+    <value>рũгφŀέ !</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_Cyan" xml:space="preserve">
-    <value>ςỳãл !</value>
+    <value>çÿåń !</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_White" xml:space="preserve">
-    <value>щħϊтэ !</value>
+    <value>ŵђϊţе !</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_BrightBlack" xml:space="preserve">
-    <value>ъяϊģнт вľäĉķ !!! </value>
+    <value>ьřïġћт ъℓāčķ !!! </value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_BrightRed" xml:space="preserve">
-    <value>ьяìģħŧ ѓєδ !!!</value>
+    <value>ьѓīğнτ řέδ !!!</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_BrightGreen" xml:space="preserve">
-    <value>ьŗΐģħŧ ĝřєĕл !!! </value>
+    <value>ъґΐğћť ğѓέεⁿ !!! </value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_BrightYellow" xml:space="preserve">
-    <value>вřįġђŧ ýěĺĺòω !!! </value>
+    <value>ьяīĝђт ýεłŀǿẅ !!! </value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_BrightBlue" xml:space="preserve">
-    <value>вřìğћŧ ъĺϋз !!!</value>
+    <value>вяĭġħт ьℓцέ !!!</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_BrightPurple" xml:space="preserve">
-    <value>вѓίğђŧ φύґρĺë !!! </value>
+    <value>ъяîĝнť ρúřρľε !!! </value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_BrightCyan" xml:space="preserve">
-    <value>вŕїġĥт ĉýąņ !!!</value>
+    <value>вгїğħť ćÿªń !!!</value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ColorSelection_BrightWhite" xml:space="preserve">
-    <value>ьŕΐġħţ ώђїťę !!! </value>
+    <value>вŕīğħť ẅнĭŧэ !!! </value>
     <comment>A color used in the "ColorSelection" action.</comment>
   </data>
   <data name="ExpandSelectionToWordCommandKey" xml:space="preserve">
-    <value>É×рдпđ şęľėĉţϊõñ ŧõ ώóѓđ !!! !!! !</value>
+    <value>Зхрάиď śёľęςŧіôņ τό щòгδ !!! !!! !</value>
   </data>
   <data name="ShowContextMenuCommandKey" xml:space="preserve">
-    <value>Ŝнóщ ċõⁿţěжτ мєñµ !!! !!</value>
+    <value>Şнöẃ ćóηтë×ŧ мèⁿμ !!! !!</value>
   </data>
   <data name="CloseOtherPanesCommandKey" xml:space="preserve">
-    <value>€ŀόŝэ ąļļ бţĥėř ρªń℮ѕ !!! !!!</value>
+    <value>Сļôѕз ăľŀ øţнèŕ φáŉêś !!! !!!</value>
   </data>
   <data name="ToggleBroadcastInputCommandKey" xml:space="preserve">
-    <value>Τǿġģľє ьřøαđсâšť ΐņрΰт ŧò аļĺ ρåŋ℮ѕ !!! !!! !!! !</value>
+    <value>Тōģĝℓ℮ ьяοäð¢ªѕт ïŉρύτ ţò äļℓ φаиεś !!! !!! !!! !</value>
     <comment>When enabled, input will go to all panes in this tab simultaneously</comment>
   </data>
   <data name="RestartConnectionKey" xml:space="preserve">
-    <value>Яêšţªŕŧ ¢ôŋŋёćŧίõŉ !!! !!</value>
+    <value>Ŗ℮ŝţāґт čõŉлęčŧįоή !!! !!</value>
   </data>
   <data name="SelectOutputNextCommandKey" xml:space="preserve">
-    <value>Śéľёĉт иëжт ĉόмmåπđ øűтφџţ !!! !!! !</value>
+    <value>Šēłεĉτ πĕжţ ċômmàлð ŏµŧρūţ !!! !!! !</value>
   </data>
   <data name="SelectOutputPreviousCommandKey" xml:space="preserve">
-    <value>Şεŀёςт ряένιõύş ςòmмаⁿð бūţρůť !!! !!! !!!</value>
+    <value>Śеľê¢ť φŕзνíôùś ςθммãиð σùтφμť !!! !!! !!!</value>
   </data>
   <data name="SelectCommandNextCommandKey" xml:space="preserve">
-    <value>Şêĺëċţ ñз×т çómmăŋδ !!! !!!</value>
+    <value>Ѕĕŀёĉτ πежт ¢όmmªήď !!! !!!</value>
   </data>
   <data name="SelectCommandPreviousCommandKey" xml:space="preserve">
-    <value>Ŝêłзсť φŗĕνΐőüŝ çŏmmâήđ !!! !!! </value>
+    <value>Ѕέļεćť ргėνîóųѕ çōmmдпð !!! !!! </value>
   </data>
   <data name="SearchForTextCommandKey" xml:space="preserve">
-    <value>Śèαѓсħ {0} !!!</value>
+    <value>Šєāяćĥ {0} !!!</value>
     <comment>{0} will be replaced with a user-specified URL to a web page</comment>
   </data>
   <data name="SearchWebCommandKey" xml:space="preserve">
-    <value>Śеāŗčĥ ŧђė ẃęъ ƒоŕ ŝęℓĕсŧзđ тз×ŧ !!! !!! !!! </value>
+    <value>Ѕεάгςн τђё ẅēъ ƒŏŕ śзĺėċţêđ ţехť !!! !!! !!! </value>
     <comment>This will open a web browser to search for some user-selected text</comment>
   </data>
   <data name="OpenAboutCommandKey" xml:space="preserve">
-    <value>Òφéŉ äвóüŧ δįäľόğ !!! !!</value>
+    <value>Οφёņ ǻвőųŧ đĭдłбģ !!! !!</value>
     <comment>This will open the "about" dialog, to display version info and other documentation</comment>
   </data>
 </root>

--- a/tools/ConvertTo-PseudoLocalization.ps1
+++ b/tools/ConvertTo-PseudoLocalization.ps1
@@ -1,0 +1,119 @@
+param(
+    [Parameter(Mandatory=$True)]
+    [string]$Path
+)
+
+# As per PseudoReplacementDefs.xml in LocStudio
+$mapping = [hashtable]::new()
+$mapping['a'[0]] = 'ªàáâãäåāăąǻάαад'
+$mapping['A'[0]] = 'ÀÁÂÃÄÅĀĂĄǺΆΑ∆ΔΛАД'
+$mapping['b'[0]] = 'вьъ'
+$mapping['B'[0]] = 'ΒßβВЪЬБ'
+$mapping['c'[0]] = '¢çćĉċčсς'
+$mapping['C'[0]] = 'ÇĆĈĊČС€'
+$mapping['d'[0]] = 'ðďđδ'
+$mapping['D'[0]] = 'ÐĎĐ'
+$mapping['e'[0]] = 'èéêëēĕėęěέεеёє℮зэ'
+$mapping['E'[0]] = 'ÈÉÊËĒĔĖĘĚΈΕΣЕ∑ЁЄЗЄЭ'
+$mapping['f'[0]] = 'ƒ'
+$mapping['F'[0]] = '₣'
+$mapping['g'[0]] = 'ĝğġģ'
+$mapping['G'[0]] = 'ĜĞĠĢ'
+$mapping['h'[0]] = 'ĥħнћђ'
+$mapping['H'[0]] = 'ĤĦΉΗН'
+$mapping['i'[0]] = 'ìíîïĩīĭįίιϊіїΐ'
+$mapping['I'[0]] = 'ÌÍÎĨĪĬĮİΊΪІЇ'
+$mapping['j'[0]] = 'ĵј'
+$mapping['J'[0]] = 'ĴЈ'
+$mapping['k'[0]] = 'ķĸκкќ'
+$mapping['K'[0]] = 'ĶΚЌК'
+$mapping['l'[0]] = 'ĺļľŀłℓ'
+$mapping['L'[0]] = '£ĹĻĽĿŁ₤'
+$mapping['m'[0]] = 'mм'
+$mapping['M'[0]] = 'ΜМ'
+$mapping['n'[0]] = 'ийлⁿпπήηńņňŉŋñ'
+$mapping['N'[0]] = 'ÑŃŅŇŊΝИЙЛП∏'
+$mapping['o'[0]] = 'òóôõöøōŏőοσόоǿθб'
+$mapping['O'[0]] = 'ÒÓÔÕÖØŌŎŐǾΌΘΟΦΩОФΩΏ'
+$mapping['p'[0]] = 'φρр'
+$mapping['P'[0]] = 'ΡР'
+$mapping['r'[0]] = 'ŕŗřяѓґгř'
+$mapping['R'[0]] = 'ŔŖŘЯΓЃҐГ'
+$mapping['s'[0]] = 'śŝşѕš'
+$mapping['S'[0]] = 'ŚŜŞЅŠ'
+$mapping['t'[0]] = 'ţťŧτт'
+$mapping['T'[0]] = 'ŢŤŦΤТ'
+$mapping['u'[0]] = 'µùúûüũūŭůűųΰυϋύцμџ'
+$mapping['U'[0]] = 'ÙÚÛÜŨŪŬŮŰŲЏЦ'
+$mapping['v'[0]] = 'ν'
+$mapping['w'[0]] = 'ŵωώшщẁẃẅ'
+$mapping['W'[0]] = 'ŴШЩẀẂẄ'
+$mapping['x'[0]] = '×хж'
+$mapping['X'[0]] = 'ΧχХЖ'
+$mapping['y'[0]] = 'ýÿŷγўỳу'
+$mapping['Y'[0]] = '¥ÝŶΎΥΫỲЎ'
+$mapping['z'[0]] = 'źżž'
+$mapping['Z'[0]] = 'ŹŻΖŽ'
+
+[xml]$content = Get-Content $Path
+
+foreach ($entry in $content.root.data) {
+    $value = $entry.value
+    $comment = $entry.comment ?? ''
+    $placeholders = @{}
+
+    if ($comment.StartsWith('{Locked')) {
+        # Skip {Locked} and {Locked=qps-ploc} entries
+        if ($comment -match '\{Locked(\}|=[^}]*qps-ploc).*') {
+            continue
+        }
+
+        $lockedList = ($comment -replace '\{Locked=(.*?)\}.*','$1') -split ','
+        $placeholderChar = 0xE000
+
+        # Replaced all locked words with placeholders from the Unicode Private Use Area
+        foreach ($locked in $lockedList) {
+            if ($locked.StartsWith('"') -and $locked.EndsWith('"')) {
+                $locked = $locked.Substring(1, $locked.Length - 2)
+                $locked = $locked.Replace('\"', '"')
+            }
+
+            $placeholder = "$([char]$placeholderChar)"
+            $placeholderChar++
+
+            $placeholders[$placeholder] = $locked
+            $value = $value.Replace($locked, $placeholder)
+        }
+    }
+
+    # We can't rely on $entry.name.GetHashCode() to be consistent across different runs,
+    # because in the future PowerShell may enable UseRandomizedStringHashAlgorithm.
+    $hash = [System.Text.Encoding]::UTF8.GetBytes($entry.name)
+    $hash = [System.Security.Cryptography.SHA1]::Create().ComputeHash($hash)
+    $hash = [System.BitConverter]::ToInt32($hash)
+
+    # Replace all characters with pseudo-localized characters
+    $rng = [System.Random]::new($hash)
+    $newValue = ''
+    foreach ($char in $value.ToCharArray()) {
+        if ($m = $mapping[$char]) {
+            $newValue += $m[$rng.Next(0, $mapping[$char].Length)]
+        } else {
+            $newValue += $char
+        }
+    }
+
+    # Replace all placeholders with their original values
+    foreach ($kv in $placeholders.GetEnumerator()) {
+        $newValue = $newValue.Replace($kv.Key, $kv.Value)
+    }
+
+    # Add 40% padding to the end of the string
+    $paddingLength = [System.Math]::Round(0.4 * $newValue.Length)
+    $padding = ' !!!' * ($paddingLength / 4 + 1)
+    $newValue += $padding.Substring(0, $paddingLength)
+
+    $entry.value = $newValue
+}
+
+return $content


### PR DESCRIPTION
It appears as if our official ploc translations use a per-file hash
as the seed for generating random pseudo-localization characters.
This works poorly for us since we have these translations hooked up
to our CI to submit PRs with the latest changes. We do want to get
the latest proper translations but merging 1000s of lines of ploc
changes every time is unneccessary.

This PR replicates LocStudio's pseudo-localizations in PowerShell
but it uses a per-key seed for the RNG.