### PR TITLE
Quick copy/Quick jump

### DIFF
--- a/src/buffer/out/UTextAdapter.cpp
+++ b/src/buffer/out/UTextAdapter.cpp
@@ -327,3 +327,18 @@ til::point_span Microsoft::Console::ICU::BufferRangeFromMatch(UText* ut, URegula
 
     return ret;
 }
+
+UText Microsoft::Console::ICU::UTextForWrappableRow(const TextBuffer& textBuffer, til::CoordType& row) noexcept
+{
+    const auto startRow = row;
+    auto length = 0;
+    while (textBuffer.GetRowByOffset(row).WasWrapForced())
+    {
+        row++;
+        length += textBuffer.GetRowByOffset(row).size();
+    }
+    length += textBuffer.GetRowByOffset(row).size();
+    const auto ut = UTextFromTextBuffer(textBuffer, startRow, row + 1);
+
+    return ut;
+}

--- a/src/buffer/out/UTextAdapter.h
+++ b/src/buffer/out/UTextAdapter.h
@@ -14,4 +14,5 @@ namespace Microsoft::Console::ICU
     UText UTextFromTextBuffer(const TextBuffer& textBuffer, til::CoordType rowBeg, til::CoordType rowEnd) noexcept;
     unique_uregex CreateRegex(const std::wstring_view& pattern, uint32_t flags, UErrorCode* status) noexcept;
     til::point_span BufferRangeFromMatch(UText* ut, URegularExpression* re);
+    UText UTextForWrappableRow(const TextBuffer& textBuffer, til::CoordType& row) noexcept;
 }

--- a/src/buffer/out/search.h
+++ b/src/buffer/out/search.h
@@ -26,7 +26,7 @@ public:
     Search() = default;
 
     bool ResetIfStale(Microsoft::Console::Render::IRenderData& renderData, const std::wstring_view& needle, bool reverse, bool caseInsensitive);
-
+    void QuickSelectRegex(Microsoft::Console::Render::IRenderData& renderData, const std::wstring_view& needle, bool caseInsensitive);
     void MoveToCurrentSelection();
     void MoveToPoint(til::point anchor) noexcept;
     void MovePastPoint(til::point anchor) noexcept;
@@ -49,4 +49,5 @@ private:
     std::vector<til::point_span> _results;
     ptrdiff_t _index = 0;
     ptrdiff_t _step = 0;
+    static std::vector<til::point_span> _regexSearch(const Microsoft::Console::Render::IRenderData& renderData, const std::wstring_view& needle, bool caseInsensitive);
 };

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -561,6 +561,20 @@ namespace winrt::TerminalApp::implementation
         args.Handled(true);
     }
 
+    void TerminalPage::_HandleQuickSelect(const IInspectable& sender,
+                                          const ActionEventArgs& args)
+    {
+        if (const auto& realArgs = args.ActionArgs().try_as<QuickSelectArgs>())
+        {
+            if (const auto activeTab{ _senderOrFocusedTab(sender) })
+            {
+                _SetFocusedTab(*activeTab);
+                _QuickSelect(*activeTab, realArgs.Input(), realArgs.ShouldCopy());
+            }
+            args.Handled(true);
+        }
+    }
+
     void TerminalPage::_HandleResetFontSize(const IInspectable& /*sender*/,
                                             const ActionEventArgs& args)
     {

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -3551,6 +3551,14 @@ namespace winrt::TerminalApp::implementation
         }
     }
 
+    void TerminalPage::_QuickSelect(const TerminalTab& tab, std::wstring_view input, bool copy)
+    {
+        if (const auto& control{ tab.GetActiveTerminalControl() })
+        {
+            control.QuickSelect(input, copy);
+        }
+    }
+
     // Method Description:
     // - Toggles borderless mode. Hides the tab row, and raises our
     //   FocusModeChanged event.

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -440,6 +440,7 @@ namespace winrt::TerminalApp::implementation
         void _OnSwitchToTabRequested(const IInspectable& sender, const winrt::TerminalApp::TabBase& tab);
 
         void _Find(const TerminalTab& tab);
+        void _QuickSelect(const TerminalTab& tab, std::wstring_view input, bool copy);
 
         winrt::Microsoft::Terminal::Control::TermControl _CreateNewControlAndContent(const winrt::Microsoft::Terminal::Settings::Model::TerminalSettingsCreateResult& settings,
                                                                                      const winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection& connection);

--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -25,6 +25,8 @@
 #include "../buffer/out/search.h"
 #include "../buffer/out/TextColor.h"
 
+class QuickSelectHandler;
+
 namespace ControlUnitTests
 {
     class ControlCoreTests;
@@ -208,6 +210,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void SetEndSelectionPoint(const til::point position);
 
         void Search(const winrt::hstring& text, const bool goForward, const bool caseSensitive);
+        void EnterQuickSelectMode(const winrt::hstring& text, bool copy);
         void ClearSearch();
 
         Windows::Foundation::Collections::IVector<int32_t> SearchResultRows();
@@ -300,6 +303,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         winrt::com_ptr<ControlSettings> _settings{ nullptr };
 
         std::shared_ptr<::Microsoft::Terminal::Core::Terminal> _terminal{ nullptr };
+        std::unique_ptr<QuickSelectHandler> _quickSelectHandler;
 
         // NOTE: _renderEngine must be ordered before _renderer.
         //

--- a/src/cascadia/TerminalControl/ControlCore.idl
+++ b/src/cascadia/TerminalControl/ControlCore.idl
@@ -129,6 +129,7 @@ namespace Microsoft.Terminal.Control
         void BlinkAttributeTick();
 
         void Search(String text, Boolean goForward, Boolean caseSensitive);
+        void EnterQuickSelectMode(String text, Boolean copy);
         void ClearSearch();
         IVector<Int32> SearchResultRows { get; };
 

--- a/src/cascadia/TerminalControl/QuickSelectHandler.cpp
+++ b/src/cascadia/TerminalControl/QuickSelectHandler.cpp
@@ -1,0 +1,111 @@
+#include "pch.h"
+#include "QuickSelectHandler.h"
+
+#include "ControlInteractivity.h"
+#include "../../buffer/out/search.h"
+
+QuickSelectHandler::QuickSelectHandler(
+    const std::shared_ptr<Microsoft::Terminal::Core::Terminal>& terminal,
+    const std::shared_ptr<Microsoft::Console::Render::QuickSelectAlphabet>& quickSelectAlphabet)
+{
+    _terminal = terminal;
+    _quickSelectAlphabet = quickSelectAlphabet;
+}
+
+void QuickSelectHandler::EnterQuickSelectMode(
+    std::wstring_view text,
+    bool copyMode,
+    Search& searcher,
+    Microsoft::Console::Render::Renderer* renderer)
+{
+    _quickSelectAlphabet->Enabled(true);
+    _copyMode = copyMode;
+    searcher.QuickSelectRegex(*_terminal, text, true);
+    searcher.HighlightResults();
+    renderer->TriggerSelection();
+}
+
+bool QuickSelectHandler::Enabled() const
+{
+    return _quickSelectAlphabet->Enabled();
+}
+
+void QuickSelectHandler::HandleChar(const uint32_t vkey, Microsoft::Console::Render::Renderer* renderer) const
+{
+    if (vkey == VK_ESCAPE)
+    {
+        _quickSelectAlphabet->Enabled(false);
+        _quickSelectAlphabet->ClearChars();
+        _terminal->ClearSelection();
+        renderer->TriggerSelection();
+        return;
+    }
+
+    if (vkey == VK_BACK)
+    {
+        _quickSelectAlphabet->RemoveChar();
+        renderer->TriggerSelection();
+        return;
+    }
+
+    wchar_t vkeyText[2] = { 0 };
+    BYTE keyboardState[256];
+    if (!GetKeyboardState(keyboardState))
+    {
+        return;
+    }
+
+    keyboardState[VK_SHIFT] = 0x80;
+    ToUnicode(vkey, MapVirtualKey(vkey, MAPVK_VK_TO_VSC), keyboardState, vkeyText, 2, 0);
+
+    _quickSelectAlphabet->AppendChar(vkeyText);
+
+    if (_quickSelectAlphabet->AllCharsSet(_terminal->NumberOfVisibleSearchSelections()))
+    {
+        const auto index = _quickSelectAlphabet->GetIndexForChars();
+        const auto quickSelectResult = _terminal->GetViewportSelectionAtIndex(index);
+        if (quickSelectResult.has_value())
+        {
+            const auto startPoint = std::get<0>(quickSelectResult.value());
+            const auto endPoint = std::get<1>(quickSelectResult.value());
+
+            if (!_copyMode)
+            {
+                _quickSelectAlphabet->Enabled(false);
+                _quickSelectAlphabet->ClearChars();
+                _terminal->ClearSelection();
+                _terminal->SelectNewRegion(til::point{ startPoint.x, startPoint.y }, til::point{ startPoint.x, startPoint.y});
+                if (_terminal->SelectionMode() != Microsoft::Terminal::Core::Terminal::SelectionInteractionMode::Mark)
+                {
+                    _terminal->ToggleMarkMode();
+                }
+
+                renderer->TriggerSelection();
+            }
+            else
+            {
+                const auto req = TextBuffer::CopyRequest::FromConfig(_terminal->GetTextBuffer(), startPoint, endPoint, true, false, false);
+                const auto text = _terminal->GetTextBuffer().GetPlainText(req);
+                _terminal->CopyToClipboard(text);
+
+                std::thread hideTimerThread([this, renderer]() {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+                    {
+                        auto lock = _terminal->LockForWriting();
+                        _quickSelectAlphabet->Enabled(false);
+                        _quickSelectAlphabet->ClearChars();
+                        _terminal->ClearSelection();
+                        //This isn't technically safe.  There is a slight chance that the renderer is deleted
+                        //I think the fix is to make the renderer a shared pointer but I am not ready to mess with change core terminal stuff
+                        renderer->TriggerSelection();
+                        renderer->TriggerRedrawAll();
+                        renderer->NotifyPaintFrame();
+                    }
+                });
+                hideTimerThread.detach();
+            }
+        }
+    }
+    renderer->TriggerRedrawAll();
+    renderer->NotifyPaintFrame();
+}

--- a/src/cascadia/TerminalControl/QuickSelectHandler.h
+++ b/src/cascadia/TerminalControl/QuickSelectHandler.h
@@ -1,0 +1,31 @@
+#pragma once
+#include "../../renderer/base/Renderer.hpp"
+#include "../../cascadia/TerminalCore/Terminal.hpp"
+#include "../../renderer/base/lib/QuickSelectAlphabet.h"
+#include "search.h"
+
+class Search;
+
+namespace Microsoft::Console::Render
+{
+    class Renderer;
+}
+
+class QuickSelectHandler
+{
+private:
+    std::shared_ptr<Microsoft::Terminal::Core::Terminal> _terminal;
+    bool _copyMode = false;
+    std::shared_ptr<Microsoft::Console::Render::QuickSelectAlphabet> _quickSelectAlphabet;
+
+public:
+    QuickSelectHandler(
+        const std::shared_ptr<Microsoft::Terminal::Core::Terminal>& terminal,
+        const std::shared_ptr<Microsoft::Console::Render::QuickSelectAlphabet>& quickSelectAlphabet);
+    void EnterQuickSelectMode(std::wstring_view text,
+                              bool copyMode,
+                              Search& searcher,
+                              Microsoft::Console::Render::Renderer* renderer);
+    bool Enabled() const;
+    void HandleChar(uint32_t vkey, Microsoft::Console::Render::Renderer* renderer) const;
+};

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -456,6 +456,11 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         return _searchBox->TextBox().FocusState() == FocusState::Keyboard;
     }
 
+    void TermControl::QuickSelect(const winrt::hstring& text, bool copy)
+    {
+        _core.EnterQuickSelectMode(text, copy);
+    }
+
     // Method Description:
     // - Search text in text buffer. This is triggered if the user clicks the
     //   search button, presses enter, or changes the search criteria.

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -43,6 +43,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void SelectAll();
         bool ToggleBlockSelection();
         void ToggleMarkMode();
+        void QuickSelect(const winrt::hstring& text, bool copy);
         bool SwitchSelectionEndpoint();
         bool ExpandSelectionToWord();
         void Close();

--- a/src/cascadia/TerminalControl/TermControl.idl
+++ b/src/cascadia/TerminalControl/TermControl.idl
@@ -106,6 +106,7 @@ namespace Microsoft.Terminal.Control
         Boolean SearchBoxEditInFocus();
 
         void SearchMatch(Boolean goForward);
+        void QuickSelect(String needle, Boolean copy);
 
         void AdjustFontSize(Single fontSizeDelta);
         void ResetFontSize();

--- a/src/cascadia/TerminalControl/TerminalControlLib.vcxproj
+++ b/src/cascadia/TerminalControl/TerminalControlLib.vcxproj
@@ -9,7 +9,6 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <SubSystem>Console</SubSystem>
     <OpenConsoleUniversalApp>true</OpenConsoleUniversalApp>
-
     <!-- C++/WinRT sets the depth to 1 if there is a XAML file in the project
          Unfortunately for us, we need it to be 3. When the namespace merging
          depth is 1, Microsoft.Terminal.Control becomes "Microsoft",
@@ -20,18 +19,14 @@
     -->
     <CppWinRTNamespaceMergeDepth>3</CppWinRTNamespaceMergeDepth>
     <XamlComponentResourceLocation>nested</XamlComponentResourceLocation>
-
   </PropertyGroup>
-
   <PropertyGroup Label="NuGet Dependencies">
     <TerminalCppWinrt>true</TerminalCppWinrt>
     <TerminalMUX>true</TerminalMUX>
   </PropertyGroup>
-
   <Import Project="..\..\..\common.openconsole.props" Condition="'$(OpenConsoleDir)'==''" />
   <Import Project="$(OpenConsoleDir)src\common.nugetversions.props" />
   <Import Project="$(OpenConsoleDir)src\cppwinrt.build.pre.props" />
-
   <!-- ========================= Headers ======================== -->
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -41,6 +36,7 @@
     <ClInclude Include="ControlInteractivity.h">
       <DependentUpon>ControlInteractivity.idl</DependentUpon>
     </ClInclude>
+    <ClInclude Include="QuickSelectHandler.h" />
     <ClInclude Include="ScrollBarVisualStateManager.h">
       <DependentUpon>ScrollBarVisualStateManager.idl</DependentUpon>
     </ClInclude>
@@ -83,6 +79,7 @@
     <ClCompile Include="ControlInteractivity.cpp">
       <DependentUpon>ControlInteractivity.idl</DependentUpon>
     </ClCompile>
+    <ClCompile Include="QuickSelectHandler.cpp" />
     <ClCompile Include="ScrollBarVisualStateManager.cpp">
       <DependentUpon>ScrollBarVisualStateManager.idl</DependentUpon>
     </ClCompile>
@@ -194,9 +191,7 @@
   </ItemDefinitionGroup>
   <!-- ========================= Globals ======================== -->
   <Import Project="$(OpenConsoleDir)src\cppwinrt.build.post.props" />
-
   <!-- This -must- go after cppwinrt.build.post.props because that includes many VS-provided props including appcontainer.common.props, which stomps on what cppwinrt.targets did. -->
   <Import Project="$(OpenConsoleDir)src\common.nugetversions.targets" />
-
   <Import Project="$(SolutionDir)build\rules\CollectWildcardResources.targets" />
 </Project>

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -225,8 +225,13 @@ public:
     const til::point GetSelectionEnd() const noexcept override;
     const std::wstring_view GetConsoleTitle() const noexcept override;
     const bool IsUiaDataInitialized() const noexcept override;
+    bool InQuickSelectMode() override;
+    Microsoft::Console::Render::QuickSelectState GetQuickSelectState() noexcept override;
+    void SetQuickSelectAlphabet(std::shared_ptr<Console::Render::QuickSelectAlphabet> val);
 #pragma endregion
 
+    int32_t NumberOfVisibleSearchSelections();
+    std::optional<std::tuple<til::point, til::point>> GetViewportSelectionAtIndex(int32_t index);
     void SetWriteInputCallback(std::function<void(std::wstring_view)> pfn) noexcept;
     void SetWarningBellCallback(std::function<void()> pfn) noexcept;
     void SetTitleChangedCallback(std::function<void(std::wstring_view)> pfn) noexcept;
@@ -370,6 +375,7 @@ private:
     size_t _hyperlinkPatternId = 0;
 
     std::wstring _workingDirectory;
+    std::shared_ptr<Console::Render::QuickSelectAlphabet> _quickSelectAlphabet;
 
     // This default fake font value is only used to check if the font is a raster font.
     // Otherwise, the font is changed to a real value with the renderer via TriggerFontChange.

--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -716,6 +716,45 @@ void Terminal::SelectAll()
     _ScrollToPoint(_selection->start);
 }
 
+int32_t Terminal::NumberOfVisibleSearchSelections()
+{
+    auto lowerIt = std::lower_bound(_searchSelections.begin(), _searchSelections.end(), _GetVisibleViewport().Top(), [](const til::inclusive_rect& rect, til::CoordType value) {
+        return rect.top < value;
+    });
+
+    auto upperIt = std::upper_bound(_searchSelections.begin(), _searchSelections.end(), _GetVisibleViewport().BottomExclusive(), [](til::CoordType value, const til::inclusive_rect& rect) {
+        return value < rect.top;
+    });
+
+    auto num = static_cast<int32_t>(std::distance(lowerIt, upperIt));
+    return num;
+}
+
+std::optional<std::tuple<til::point, til::point>> Terminal::GetViewportSelectionAtIndex(int32_t index)
+{
+    if (_searchSelections.empty())
+    {
+        return std::nullopt;
+    }
+
+    auto lowerIt = std::lower_bound(_searchSelections.begin(), _searchSelections.end(), _GetVisibleViewport().Top(), [](const til::inclusive_rect& rect, til::CoordType value) {
+        return rect.top < value;
+    });
+
+    auto upperIt = std::upper_bound(_searchSelections.begin(), _searchSelections.end(), _GetVisibleViewport().BottomExclusive(), [](til::CoordType value, const til::inclusive_rect& rect) {
+        return value < rect.top;
+    });
+
+    auto distance = std::distance(lowerIt, upperIt);
+    if (index < 0 || index >= distance)
+    {
+        return std::nullopt;
+    }
+
+    auto rect = (lowerIt + index)[0];
+    return std::make_tuple(til::point{ rect.left, rect.top }, til::point{ rect.right, rect.bottom });
+}
+
 void Terminal::_MoveByChar(SelectionDirection direction, til::point& pos)
 {
     switch (direction)

--- a/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
@@ -45,6 +45,7 @@ static constexpr std::string_view AddMarkKey{ "addMark" };
 static constexpr std::string_view ClearMarkKey{ "clearMark" };
 static constexpr std::string_view ClearAllMarksKey{ "clearAllMarks" };
 static constexpr std::string_view SendInputKey{ "sendInput" };
+static constexpr std::string_view QuickSelectKey{ "quickSelect" };
 static constexpr std::string_view SetColorSchemeKey{ "setColorScheme" };
 static constexpr std::string_view SetTabColorKey{ "setTabColor" };
 static constexpr std::string_view SplitPaneKey{ "splitPane" };
@@ -381,6 +382,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                 { ShortcutAction::ClearMark, RS_(L"ClearMarkCommandKey") },
                 { ShortcutAction::ClearAllMarks, RS_(L"ClearAllMarksCommandKey") },
                 { ShortcutAction::SendInput, MustGenerate },
+                { ShortcutAction::QuickSelect, RS_(L"QuickSelectCommandKey") },
                 { ShortcutAction::SetColorScheme, MustGenerate },
                 { ShortcutAction::SetTabColor, RS_(L"ResetTabColorCommandKey") },
                 { ShortcutAction::SplitPane, RS_(L"SplitPaneCommandKey") },

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
@@ -17,6 +17,7 @@
 #include "SwapPaneArgs.g.cpp"
 #include "AdjustFontSizeArgs.g.cpp"
 #include "SendInputArgs.g.cpp"
+#include "QuickSelectArgs.g.cpp"
 #include "SplitPaneArgs.g.cpp"
 #include "OpenSettingsArgs.g.cpp"
 #include "SetFocusModeArgs.g.cpp"
@@ -409,6 +410,16 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         auto escapedInput = til::visualize_control_codes(Input());
         auto name = fmt::format(std::wstring_view(RS_(L"SendInputCommandKey")), escapedInput);
+        return winrt::hstring{ name };
+    }
+
+    winrt::hstring QuickSelectArgs::GenerateName() const
+    {
+        // The string will be similar to the following:
+        // * "Send Input: ...input..."
+
+        auto escapedInput = til::visualize_control_codes(Input());
+        auto name = fmt::format(std::wstring_view(RS_(L"QuickSelectCommandKey")), escapedInput);
         return winrt::hstring{ name };
     }
 

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -16,6 +16,7 @@
 #include "SwapPaneArgs.g.h"
 #include "AdjustFontSizeArgs.g.h"
 #include "SendInputArgs.g.h"
+#include "QuickSelectArgs.g.h"
 #include "SplitPaneArgs.g.h"
 #include "OpenSettingsArgs.g.h"
 #include "SetFocusModeArgs.g.h"
@@ -134,6 +135,11 @@ private:                                                                    \
 ////////////////////////////////////////////////////////////////////////////////
 #define SEND_INPUT_ARGS(X) \
     X(winrt::hstring, Input, "input", args->Input().empty(), L"")
+
+////////////////////////////////////////////////////////////////////////////////
+#define QUICK_SELECT_ARGS(X)                                      \
+    X(winrt::hstring, Input, "input", args->Input().empty(), L"") \
+    X(bool, ShouldCopy, "shouldCopy", false, false)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define OPEN_SETTINGS_ARGS(X) \
@@ -691,6 +697,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
     ACTION_ARGS_STRUCT(SendInputArgs, SEND_INPUT_ARGS);
 
+    ACTION_ARGS_STRUCT(QuickSelectArgs, QUICK_SELECT_ARGS);
+
     ACTION_ARGS_STRUCT(OpenSettingsArgs, OPEN_SETTINGS_ARGS);
 
     ACTION_ARGS_STRUCT(SetFocusModeArgs, SET_FOCUS_MODE_ARGS);
@@ -857,4 +865,5 @@ namespace winrt::Microsoft::Terminal::Settings::Model::factory_implementation
     BASIC_FACTORY(SuggestionsArgs);
     BASIC_FACTORY(SelectCommandArgs);
     BASIC_FACTORY(SelectOutputArgs);
+    BASIC_FACTORY(QuickSelectArgs);
 }

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -218,6 +218,13 @@ namespace Microsoft.Terminal.Settings.Model
         String Input { get; };
     };
 
+    [default_interface] runtimeclass QuickSelectArgs : IActionArgs
+    {
+        QuickSelectArgs();
+        String Input { get; };
+        Boolean ShouldCopy { get; };
+    };
+
     [default_interface] runtimeclass SplitPaneArgs : IActionArgs
     {
         SplitPaneArgs(SplitType splitMode, SplitDirection split, Double size, NewTerminalArgs terminalArgs);

--- a/src/cascadia/TerminalSettingsModel/AllShortcutActions.h
+++ b/src/cascadia/TerminalSettingsModel/AllShortcutActions.h
@@ -35,6 +35,7 @@
     ON_ALL_ACTIONS(NextTab)                 \
     ON_ALL_ACTIONS(PrevTab)                 \
     ON_ALL_ACTIONS(SendInput)               \
+    ON_ALL_ACTIONS(QuickSelect)             \
     ON_ALL_ACTIONS(SplitPane)               \
     ON_ALL_ACTIONS(ToggleSplitOrientation)  \
     ON_ALL_ACTIONS(TogglePaneZoom)          \
@@ -142,6 +143,7 @@
     ON_ALL_ACTIONS_WITH_ARGS(ScrollToMark)         \
     ON_ALL_ACTIONS_WITH_ARGS(AddMark)              \
     ON_ALL_ACTIONS_WITH_ARGS(SendInput)            \
+    ON_ALL_ACTIONS_WITH_ARGS(QuickSelect)          \
     ON_ALL_ACTIONS_WITH_ARGS(SetColorScheme)       \
     ON_ALL_ACTIONS_WITH_ARGS(SetTabColor)          \
     ON_ALL_ACTIONS_WITH_ARGS(SplitPane)            \

--- a/src/cascadia/TerminalSettingsModel/Microsoft.Terminal.Settings.ModelLib.vcxproj
+++ b/src/cascadia/TerminalSettingsModel/Microsoft.Terminal.Settings.ModelLib.vcxproj
@@ -236,7 +236,9 @@
   </ItemGroup>
   <!-- ========================= Misc Files ======================== -->
   <ItemGroup>
-    <PRIResource Include="Resources\en-US\Resources.resw" />
+    <PRIResource Include="Resources\en-US\Resources.resw">
+      <SubType>Designer</SubType>
+    </PRIResource>
     <OCResourceDirectory Include="Resources" />
   </ItemGroup>
   <ItemGroup>
@@ -257,7 +259,6 @@
     <ProjectReference Include="$(OpenConsoleDir)src\internal\internal.vcxproj">
       <Project>{ef3e32a7-5ff6-42b4-b6e2-96cd7d033f00}</Project>
     </ProjectReference>
-
     <!-- For whatever reason, we can't include the TerminalControl and
     TerminalSettings projects' winmds via project references. So we'll have to
     manually include the winmds as References below
@@ -270,7 +271,6 @@
 
     We do still need to separately reference the winmds manually below, which is annoying.
     -->
-
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalControl\dll\TerminalControl.vcxproj">
       <!-- Private:true and ReferenceOutputAssembly:false, in combination with
       the manual reference to TerminalControl.winmd below make sure that this
@@ -279,7 +279,6 @@
       <Private>true</Private>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-
   </ItemGroup>
   <ItemGroup>
     <!-- Manually add references to each of our dependent winmds. Mark them as private=false and CopyLocalSatelliteAssemblies=false, so that we don't
@@ -322,7 +321,6 @@
   <!-- ========================= Globals ======================== -->
   <Import Project="$(OpenConsoleDir)src\cppwinrt.build.post.props" />
   <Import Project="$(OpenConsoleDir)src\common.nugetversions.targets" />
-
   <!-- PowerShell version check, outputs error if the wrong version is installed. -->
   <Import Project="$(SolutionDir)build\rules\CollectWildcardResources.targets" />
   <Target Name="BeforeResourceCompile" Inputs="defaults.json;userDefaults.json;enableColorSelection.json" Outputs="Generated Files\defaults.json;Generated Files\userDefaults.json;Generated Files\enableColorSelection.json">
@@ -332,5 +330,4 @@
     <Exec Command="pwsh.exe -NoProfile -ExecutionPolicy Unrestricted &quot;$(OpenConsoleDir)\tools\CompressJson.ps1&quot; -JsonFile userDefaults.json -OutPath &quot;Generated Files\userDefaults.json&quot;" />
     <Exec Command="pwsh.exe -NoProfile -ExecutionPolicy Unrestricted &quot;$(OpenConsoleDir)\tools\CompressJson.ps1&quot; -JsonFile enableColorSelection.json -OutPath &quot;Generated Files\enableColorSelection.json&quot;" />
   </Target>
-
 </Project>

--- a/src/cascadia/TerminalSettingsModel/Microsoft.Terminal.Settings.ModelLib.vcxproj.filters
+++ b/src/cascadia/TerminalSettingsModel/Microsoft.Terminal.Settings.ModelLib.vcxproj.filters
@@ -2,6 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Natvis Include="$(SolutionDir)tools\ConsoleTypes.natvis" />
+    <Natvis Include="$(MSBuildThisFileDirectory)..\..\natvis\wil.natvis" />
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="Resources\en-US\Resources.resw" />
@@ -99,6 +100,8 @@
     </ClInclude>
     <ClInclude Include="ActionArgsMagic.h" />
     <ClInclude Include="NewTabMenuEntry.h" />
+    <ClInclude Include="resource.h" />
+    <ClInclude Include="ModelSerializationHelpers.h" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="ActionArgs.idl" />
@@ -118,9 +121,8 @@
     <Midl Include="DefaultTerminal.idl" />
     <Midl Include="ApplicationState.idl" />
     <Midl Include="NewTabMenuEntry.idl" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
+    <Midl Include="Theme.idl" />
+    <Midl Include="ISettingsModelObject.idl" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="profileGeneration">
@@ -129,5 +131,8 @@
     <Filter Include="json">
       <UniqueIdentifier>{81a6314f-aa5b-4533-a499-13bc3a5c4af0}</UniqueIdentifier>
     </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="Microsoft.Terminal.Settings.Model.rc" />
   </ItemGroup>
 </Project>

--- a/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
@@ -411,6 +411,9 @@
     <value>Send Input: "{0}"</value>
     <comment>{0} will be replaced with a string of input as defined by the user</comment>
   </data>
+  <data name="QuickSelectCommandKey" xml:space="preserve">
+    <value>Quick Select</value>
+  </data>
   <data name="SetColorSchemeCommandKey" xml:space="preserve">
     <value>Set color scheme to {0}</value>
     <comment>{0} will be replaced with the name of a color scheme as defined by the user.</comment>

--- a/src/host/renderData.cpp
+++ b/src/host/renderData.cpp
@@ -434,3 +434,13 @@ const til::point RenderData::GetSelectionEnd() const noexcept
 
     return { x_pos, y_pos };
 }
+
+bool RenderData::InQuickSelectMode()
+{
+    return false;
+}
+
+Microsoft::Console::Render::QuickSelectState RenderData::GetQuickSelectState() noexcept
+{
+    return {};
+}

--- a/src/host/renderData.hpp
+++ b/src/host/renderData.hpp
@@ -59,4 +59,6 @@ public:
     const til::point GetSelectionAnchor() const noexcept override;
     const til::point GetSelectionEnd() const noexcept override;
     const bool IsUiaDataInitialized() const noexcept override { return true; }
+    bool InQuickSelectMode() override;
+    Microsoft::Console::Render::QuickSelectState GetQuickSelectState() noexcept override;
 };

--- a/src/renderer/base/QuickSelectAlphabet.cpp
+++ b/src/renderer/base/QuickSelectAlphabet.cpp
@@ -1,0 +1,150 @@
+#include "precomp.h"
+#include "lib/QuickSelectAlphabet.h"
+
+namespace Microsoft::Console::Render
+{
+    QuickSelectAlphabet::QuickSelectAlphabet()
+    {
+        _quickSelectAlphabet = { L'A', L'S', L'D', L'F', L'Q', L'W', L'E', L'R', L'Z', L'X', L'C', L'V', L'J', L'K', L'L', L'M', L'I', L'U', L'O', L'P', L'G', L'H', L'T', L'Y', L'B', L'N' };
+        for (int16_t i = 0; i < _quickSelectAlphabet.size(); ++i)
+        {
+            _quickSelectAlphabetMap[_quickSelectAlphabet[i]] = i;
+        }
+    }
+
+    bool QuickSelectAlphabet::Enabled() const
+    {
+        return _enabled;
+    }
+
+    void QuickSelectAlphabet::Enabled(bool val)
+    {
+        _enabled = val;
+    }
+
+    void QuickSelectAlphabet::AppendChar(wchar_t* ch)
+    {
+        _chars += ch;
+    }
+
+    void QuickSelectAlphabet::RemoveChar()
+    {
+        if (!_chars.empty())
+        {
+            _chars.pop_back();
+        }
+    }
+
+    void QuickSelectAlphabet::ClearChars()
+    {
+        _chars.clear();
+    }
+
+    std::vector<QuickSelectSelection> QuickSelectAlphabet::GetQuickSelectChars(int32_t number) const noexcept
+    try
+    {
+        auto result = std::vector<QuickSelectSelection>();
+        result.reserve(number);
+
+        int columns = 1;
+        while (std::pow(_quickSelectAlphabet.size(), columns) < number)
+        {
+            columns++;
+        }
+
+        std::vector<int> indices(columns, 0);
+
+        for (auto j = 0; j < number; j++)
+        {
+            bool allMatching = true;
+            std::vector<Microsoft::Console::Render::QuickSelectChar> chs;
+            for (int i = 0; i < indices.size(); i++)
+            {
+                auto idx = indices[i];
+                auto ch = Microsoft::Console::Render::QuickSelectChar{};
+                ch.val = _quickSelectAlphabet[idx];
+                if (i < _chars.size())
+                {
+                    if (_quickSelectAlphabet[idx] != _chars[i])
+                    {
+                        allMatching = false;
+                        //We are going to throw this away anyways
+                        break;
+                    }
+
+                    ch.isMatch = true;
+                }
+                else
+                {
+                    ch.isMatch = false;
+                }
+                chs.emplace_back(ch);
+            }
+
+            auto isCurrentMatch = false;
+            if ((_chars.size() == 0 || chs.size() >= _chars.size()) &&
+                allMatching)
+            {
+                isCurrentMatch = true;
+            }
+
+            auto toAdd = Microsoft::Console::Render::QuickSelectSelection{};
+            toAdd.isCurrentMatch = isCurrentMatch;
+
+            for (auto ch : chs)
+            {
+                toAdd.chars.emplace_back(ch);
+            }
+
+            result.emplace_back(toAdd);
+
+            for (int k = columns - 1; k >= 0; --k)
+            {
+                indices[k]++;
+                if (indices[k] < _quickSelectAlphabet.size())
+                {
+                    break; // No carry over, break the loop
+                }
+                indices[k] = 0; // Carry over to the previous column
+                if (j == 0)
+                {
+                    // If we exceed the alphabet * alphabet.  Give up and return empty result.
+                    return {};
+                }
+            }
+        }
+
+        return result;
+    }
+    catch (...)
+    {
+        LOG_CAUGHT_EXCEPTION();
+        return {};
+    }
+
+    bool QuickSelectAlphabet::AllCharsSet(int32_t number) const
+    {
+        int columns = 1;
+        while (std::pow(_quickSelectAlphabet.size(), columns) < number)
+        {
+            columns++;
+        }
+
+        auto result = _chars.size() == columns;
+        return result;
+    }
+
+    int32_t QuickSelectAlphabet::GetIndexForChars()
+    {
+        int16_t selectionIndex = 0;
+        int16_t power = static_cast<int16_t>(_chars.size() - 1);
+        for (int16_t i = 0; i < _chars.size(); i++)
+        {
+            auto ch = _chars[i];
+            auto index = _quickSelectAlphabetMap[ch];
+            selectionIndex += index * static_cast<int16_t>(std::pow(_quickSelectAlphabet.size(), power--));
+        }
+
+        return selectionIndex;
+    }
+}

--- a/src/renderer/base/lib/QuickSelectAlphabet.h
+++ b/src/renderer/base/lib/QuickSelectAlphabet.h
@@ -1,0 +1,41 @@
+#pragma once
+#include <map>
+
+namespace Microsoft::Console::Render
+{
+    struct QuickSelectChar
+    {
+        bool isMatch = false;
+        wchar_t val;
+    };
+
+    struct QuickSelectSelection
+    {
+        bool isCurrentMatch;
+        std::vector<QuickSelectChar> chars;
+        Microsoft::Console::Types::Viewport selection;
+    };
+
+    struct QuickSelectState
+    {
+        std::map<til::CoordType, std::vector<QuickSelectSelection>> selectionMap;
+    };
+    class QuickSelectAlphabet
+    {
+        bool _enabled = false;
+        std::vector<wchar_t> _quickSelectAlphabet;
+        std::unordered_map<wchar_t, int16_t> _quickSelectAlphabetMap;
+        std::wstring _chars;
+
+    public:
+        QuickSelectAlphabet();
+        bool Enabled() const;
+        void Enabled(bool val);
+        void AppendChar(wchar_t* ch);
+        void RemoveChar();
+        void ClearChars();
+        std::vector<Microsoft::Console::Render::QuickSelectSelection> GetQuickSelectChars(int32_t number) const noexcept;
+        bool AllCharsSet(int32_t number) const;
+        int32_t GetIndexForChars();
+    };
+}

--- a/src/renderer/base/lib/base.vcxproj
+++ b/src/renderer/base/lib/base.vcxproj
@@ -16,6 +16,7 @@
     <ClCompile Include="..\FontInfoBase.cpp" />
     <ClCompile Include="..\FontInfoDesired.cpp" />
     <ClCompile Include="..\FontResource.cpp" />
+    <ClCompile Include="..\QuickSelectAlphabet.cpp" />
     <ClCompile Include="..\RenderEngineBase.cpp" />
     <ClCompile Include="..\RenderSettings.cpp" />
     <ClCompile Include="..\renderer.cpp" />
@@ -40,6 +41,7 @@
     <ClInclude Include="..\precomp.h" />
     <ClInclude Include="..\renderer.hpp" />
     <ClInclude Include="..\thread.hpp" />
+    <ClInclude Include="QuickSelectAlphabet.h" />
   </ItemGroup>
   <!-- Careful reordering these. Some default props (contained in these files) are order sensitive. -->
   <Import Project="$(SolutionDir)src\common.build.post.props" />

--- a/src/renderer/base/lib/base.vcxproj.filters
+++ b/src/renderer/base/lib/base.vcxproj.filters
@@ -48,6 +48,9 @@
     <ClCompile Include="..\CSSLengthPercentage.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\QuickSelectAlphabet.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\precomp.h">
@@ -95,8 +98,12 @@
     <ClInclude Include="..\..\inc\CSSLengthPercentage.h">
       <Filter>Header Files\inc</Filter>
     </ClInclude>
+    <ClInclude Include="QuickSelectAlphabet.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Natvis Include="$(SolutionDir)tools\ConsoleTypes.natvis" />
+    <Natvis Include="$(MSBuildThisFileDirectory)..\..\natvis\wil.natvis" />
   </ItemGroup>
 </Project>

--- a/src/renderer/base/precomp.h
+++ b/src/renderer/base/precomp.h
@@ -22,3 +22,4 @@ Abstract:
 #include <wincon.h>
 
 #include "../../types/inc/viewport.hpp"
+#include <map>

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -100,7 +100,7 @@ namespace Microsoft::Console::Render
         bool _CheckViewportAndScroll();
         [[nodiscard]] HRESULT _PaintBackground(_In_ IRenderEngine* const pEngine);
         void _PaintBufferOutput(_In_ IRenderEngine* const pEngine);
-        void _PaintBufferOutputHelper(_In_ IRenderEngine* const pEngine, TextBufferCellIterator it, const til::point target, const bool lineWrapped);
+        void _PaintBufferOutputHelper(_In_ IRenderEngine* const pEngine, TextBufferCellIterator it, const til::point target, const bool lineWrapped, std::vector<QuickSelectSelection> highlights);
         void _PaintBufferOutputGridLineHelper(_In_ IRenderEngine* const pEngine, const TextAttribute textAttribute, const size_t cchLine, const til::point coordTarget);
         bool _isHoveredHyperlink(const TextAttribute& textAttribute) const noexcept;
         void _PaintSelection(_In_ IRenderEngine* const pEngine);

--- a/src/renderer/inc/IRenderData.hpp
+++ b/src/renderer/inc/IRenderData.hpp
@@ -16,6 +16,7 @@ Author(s):
 
 #include "../../host/conimeinfo.h"
 #include "../../buffer/out/TextAttribute.hpp"
+#include "../base/lib/QuickSelectAlphabet.h"
 
 class Cursor;
 
@@ -76,5 +77,7 @@ namespace Microsoft::Console::Render
         virtual const til::point GetSelectionAnchor() const noexcept = 0;
         virtual const til::point GetSelectionEnd() const noexcept = 0;
         virtual const bool IsUiaDataInitialized() const noexcept = 0;
+        virtual QuickSelectState GetQuickSelectState() noexcept = 0;
+        virtual bool InQuickSelectMode() = 0;
     };
 }


### PR DESCRIPTION
## Summary of the Pull Request
WezTerm has a Quick Select feature that allows you to specify a regex to find patterns within the buffer and quickly copy or navigate to the matches using alphabet hints.
https://wezfurlong.org/wezterm/quickselect.html

I added a implementation of this to my personal build and find that I use it for almost every copy/navigation operation.
- For my configs I defined 2 regexs, 1 for words and one for lines which seems to cover everything that I would want to do but it is nice to have the flexibility to define specific ones for stuff like hashes and addresses

In its current state I don't think that it makes sense to merge this.  But if you do decide to add something like this, I would love to work on it.

![QuickSelect](https://github.com/microsoft/terminal/assets/811029/5a636ae0-a7b1-43a3-9529-21f3ee9dfbc8)




Configs that I use.
```json
{
  "command": 
  {
    "action": "quickSelect",
    "input": "[\\w\\d\\S]+",
    "shouldCopy": true
  },
  "keys": "alt+shift+space",
  "name": "Quick Copy Word"
},
{
  "command": 
  {
    "action": "quickSelect",
    "input": "[\\w\\d\\S]+"
  },
  "keys": "alt+space",
  "name": "Quick Jump Word"
},
{
  "command": 
  {
    "action": "quickSelect",
      "input": ".*\\S",
      "shouldCopy": false
  },
    "keys": "alt+l",
    "name": "Quick Jump Line"
},
{
  "command": 
  {
    "action": "quickSelect",
    "input": ".*\\S",
    "shouldCopy": true
  },
  "keys": "alt+shift+l",
  "name": "Quick Copy Line"
},
```

## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
