### PR TITLE
Enable /Ob1 in Debug builds

### DIFF
--- a/src/common.build.pre.props
+++ b/src/common.build.pre.props
@@ -182,6 +182,7 @@
 
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;DBG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>


### PR DESCRIPTION
This makes the build a tiny bit faster (less time spent linking)
and makes everything run roughly 50% faster.