### PR TITLE
AtlasEngine: Make Direct2D/3D and Present1 configurable

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2332,12 +2332,20 @@
           },
           "type": "array"
         },
-        "experimental.rendering.forceFullRepaint": {
-          "description": "When set to true, we will redraw the entire screen each frame. When set to false, we will render only the updates to the screen between frames.",
+        "rendering.graphicsAPI": {
+          "description": "Direct3D 11 provides a more performant and feature-rich experience, whereas Direct2D is more stable. The default option "Automatic" will pick the API that best fits your graphics hardware. If you experience significant issues, consider using Direct2D.",
+          "type": "string",
+          "enum": [
+            "direct2d",
+            "direct3d11"
+          ]
+        },
+        "rendering.disablePartialInvalidation": {
+          "description": "By default, the text renderer uses a FLIP_SEQUENTIAL Swap Chain and declares dirty rectangles via the Present1 API. When this setting is enabled, a FLIP_DISCARD Swap Chain will be used instead, and no dirty rectangles will be declared. Whether one or the other is better depends on your hardware and various other factors.",
           "type": "boolean"
         },
-        "experimental.rendering.software": {
-          "description": "When set to true, we will use the software renderer (a.k.a. WARP) instead of the hardware one.",
+        "rendering.software": {
+          "description": "When enabled, the terminal will use a software rasterizer (WARP). This setting should be left disabled under almost all circumstances.",
           "type": "boolean"
         },
         "experimental.input.forceVT": {

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2333,7 +2333,7 @@
           "type": "array"
         },
         "rendering.graphicsAPI": {
-          "description": "Direct3D 11 provides a more performant and feature-rich experience, whereas Direct2D is more stable. The default option "Automatic" will pick the API that best fits your graphics hardware. If you experience significant issues, consider using Direct2D.",
+          "description": "Direct3D 11 provides a more performant and feature-rich experience, whereas Direct2D is more stable. The default option \"Automatic\" will pick the API that best fits your graphics hardware. If you experience significant issues, consider using Direct2D.",
           "type": "string",
           "enum": [
             "direct2d",

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -9,14 +9,13 @@
 #include <dsound.h>
 
 #include <DefaultSettings.h>
-#include <unicode.hpp>
 #include <utils.hpp>
-#include <WinUser.h>
 #include <LibraryResources.h>
 
 #include "EventArgs.h"
-#include "../../buffer/out/search.h"
 #include "../../renderer/atlas/AtlasEngine.h"
+#include "../../renderer/base/renderer.hpp"
+#include "../../renderer/uia/UiaRenderer.hpp"
 
 #include "ControlCore.g.cpp"
 #include "SelectionColor.g.cpp"
@@ -43,26 +42,26 @@ constexpr const auto SearchAfterChangeDelay = std::chrono::milliseconds(200);
 
 namespace winrt::Microsoft::Terminal::Control::implementation
 {
-    static winrt::Microsoft::Terminal::Core::OptionalColor OptionalFromColor(const til::color& c)
+    static winrt::Microsoft::Terminal::Core::OptionalColor OptionalFromColor(const til::color& c) noexcept
     {
         Core::OptionalColor result;
         result.Color = c;
         result.HasValue = true;
         return result;
     }
-    static winrt::Microsoft::Terminal::Core::OptionalColor OptionalFromColor(const std::optional<til::color>& c)
+
+    static ::Microsoft::Console::Render::Atlas::GraphicsAPI parseGraphicsAPI(GraphicsAPI api) noexcept
     {
-        Core::OptionalColor result;
-        if (c.has_value())
+        using GA = ::Microsoft::Console::Render::Atlas::GraphicsAPI;
+        switch (api)
         {
-            result.Color = *c;
-            result.HasValue = true;
+        case GraphicsAPI::Direct2D:
+            return GA::Direct2D;
+        case GraphicsAPI::Direct3D11:
+            return GA::Direct3D11;
+        default:
+            return GA::Automatic;
         }
-        else
-        {
-            result.HasValue = false;
-        }
-        return result;
     }
 
     TextColor SelectionColor::AsTextColor() const noexcept
@@ -388,6 +387,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             _renderEngine->SetRetroTerminalEffect(_settings->RetroTerminalEffect());
             _renderEngine->SetPixelShaderPath(_settings->PixelShaderPath());
             _renderEngine->SetPixelShaderImagePath(_settings->PixelShaderImagePath());
+            _renderEngine->SetGraphicsAPI(parseGraphicsAPI(_settings->GraphicsAPI()));
             _renderEngine->SetForceFullRepaintRendering(_settings->ForceFullRepaintRendering());
             _renderEngine->SetSoftwareRendering(_settings->SoftwareRendering());
 
@@ -396,8 +396,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             // GH#5098: Inform the engine of the opacity of the default text background.
             // GH#11315: Always do this, even if they don't have acrylic on.
             _renderEngine->EnableTransparentBackground(_isBackgroundTransparent());
-
-            THROW_IF_FAILED(_renderEngine->Enable());
 
             _initializedTerminal.store(true, std::memory_order_relaxed);
         } // scope for TerminalLock
@@ -883,6 +881,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             return;
         }
 
+        _renderEngine->SetGraphicsAPI(parseGraphicsAPI(_settings->GraphicsAPI()));
         _renderEngine->SetForceFullRepaintRendering(_settings->ForceFullRepaintRendering());
         _renderEngine->SetSoftwareRendering(_settings->SoftwareRendering());
         // Inform the renderer of our opacity
@@ -944,6 +943,21 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
             _renderer->TriggerRedrawAll(true, true);
         }
+    }
+
+    Control::IControlSettings ControlCore::Settings()
+    {
+        return *_settings;
+    }
+
+    Control::IControlAppearance ControlCore::FocusedAppearance() const
+    {
+        return *_settings->FocusedAppearance();
+    }
+
+    Control::IControlAppearance ControlCore::UnfocusedAppearance() const
+    {
+        return *_settings->UnfocusedAppearance();
     }
 
     void ControlCore::_updateAntiAliasingMode()
@@ -1960,13 +1974,13 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         UpdateSelectionMarkers.raise(*this, winrt::make<implementation::UpdateSelectionMarkersEventArgs>(!showMarkers));
     }
 
-    void ControlCore::AttachUiaEngine(::Microsoft::Console::Render::IRenderEngine* const pEngine)
+    void ControlCore::AttachUiaEngine(::Microsoft::Console::Render::UiaEngine* const pEngine)
     {
         // _renderer will always exist since it's introduced in the ctor
         const auto lock = _terminal->LockForWriting();
         _renderer->AddRenderEngine(pEngine);
     }
-    void ControlCore::DetachUiaEngine(::Microsoft::Console::Render::IRenderEngine* const pEngine)
+    void ControlCore::DetachUiaEngine(::Microsoft::Console::Render::UiaEngine* const pEngine)
     {
         const auto lock = _terminal->LockForWriting();
         _renderer->RemoveRenderEngine(pEngine);

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -388,7 +388,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             _renderEngine->SetPixelShaderPath(_settings->PixelShaderPath());
             _renderEngine->SetPixelShaderImagePath(_settings->PixelShaderImagePath());
             _renderEngine->SetGraphicsAPI(parseGraphicsAPI(_settings->GraphicsAPI()));
-            _renderEngine->SetForceFullRepaintRendering(_settings->ForceFullRepaintRendering());
+            _renderEngine->SetDisablePartialInvalidation(_settings->DisablePartialInvalidation());
             _renderEngine->SetSoftwareRendering(_settings->SoftwareRendering());
 
             _updateAntiAliasingMode();
@@ -882,7 +882,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         }
 
         _renderEngine->SetGraphicsAPI(parseGraphicsAPI(_settings->GraphicsAPI()));
-        _renderEngine->SetForceFullRepaintRendering(_settings->ForceFullRepaintRendering());
+        _renderEngine->SetDisablePartialInvalidation(_settings->DisablePartialInvalidation());
         _renderEngine->SetSoftwareRendering(_settings->SoftwareRendering());
         // Inform the renderer of our opacity
         _renderEngine->EnableTransparentBackground(_isBackgroundTransparent());

--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -18,12 +18,22 @@
 #include "ControlCore.g.h"
 #include "SelectionColor.g.h"
 #include "CommandHistoryContext.g.h"
+
 #include "ControlSettings.h"
 #include "../../audio/midi/MidiAudio.hpp"
-#include "../../renderer/base/Renderer.hpp"
+#include "../../buffer/out/search.h"
 #include "../../cascadia/TerminalCore/Terminal.hpp"
-#include "../buffer/out/search.h"
-#include "../buffer/out/TextColor.h"
+#include "../../renderer/inc/FontInfoDesired.hpp"
+
+namespace Microsoft::Console::Render::Atlas
+{
+    class AtlasEngine;
+}
+
+namespace Microsoft::Console::Render
+{
+    class UiaEngine;
+}
 
 namespace ControlUnitTests
 {
@@ -82,9 +92,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         void UpdateSettings(const Control::IControlSettings& settings, const IControlAppearance& newAppearance);
         void ApplyAppearance(const bool& focused);
-        Control::IControlSettings Settings() { return *_settings; };
-        Control::IControlAppearance FocusedAppearance() const { return *_settings->FocusedAppearance(); };
-        Control::IControlAppearance UnfocusedAppearance() const { return *_settings->UnfocusedAppearance(); };
+        Control::IControlSettings Settings();
+        Control::IControlAppearance FocusedAppearance() const;
+        Control::IControlAppearance UnfocusedAppearance() const;
         bool HasUnfocusedAppearance() const;
 
         winrt::Microsoft::Terminal::Core::Scheme ColorScheme() const noexcept;
@@ -219,8 +229,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                                  const bool isOnOriginalPosition,
                                  bool& selectionNeedsToBeCopied);
 
-        void AttachUiaEngine(::Microsoft::Console::Render::IRenderEngine* const pEngine);
-        void DetachUiaEngine(::Microsoft::Console::Render::IRenderEngine* const pEngine);
+        void AttachUiaEngine(::Microsoft::Console::Render::UiaEngine* const pEngine);
+        void DetachUiaEngine(::Microsoft::Console::Render::UiaEngine* const pEngine);
 
         bool IsInReadOnlyMode() const;
         void ToggleReadOnlyMode();
@@ -306,7 +316,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // As _renderer has a dependency on _renderEngine (through a raw pointer)
         // we must ensure the _renderer is deallocated first.
         // (C++ class members are destroyed in reverse order.)
-        std::unique_ptr<::Microsoft::Console::Render::IRenderEngine> _renderEngine{ nullptr };
+        std::unique_ptr<::Microsoft::Console::Render::Atlas::AtlasEngine> _renderEngine{ nullptr };
         std::unique_ptr<::Microsoft::Console::Render::Renderer> _renderer{ nullptr };
 
         ::Search _searcher;

--- a/src/cascadia/TerminalControl/EventArgs.idl
+++ b/src/cascadia/TerminalControl/EventArgs.idl
@@ -11,6 +11,12 @@ namespace Microsoft.Terminal.Control
         All = 0xffffffff
     };
 
+    enum GraphicsAPI
+    {
+        Automatic,
+        Direct2D,
+        Direct3D11,
+    };
 
     runtimeclass FontSizeChangedArgs
     {
@@ -90,7 +96,7 @@ namespace Microsoft.Terminal.Control
     {
         Boolean ShowOrHide { get; };
     }
-    
+
     runtimeclass UpdateSelectionMarkersEventArgs
     {
         Boolean ClearMarkers { get; };

--- a/src/cascadia/TerminalControl/HwndTerminal.cpp
+++ b/src/cascadia/TerminalControl/HwndTerminal.cpp
@@ -217,7 +217,6 @@ HRESULT HwndTerminal::Initialize()
 
     auto engine = std::make_unique<::Microsoft::Console::Render::AtlasEngine>();
     RETURN_IF_FAILED(engine->SetHwnd(_hwnd.get()));
-    RETURN_IF_FAILED(engine->Enable());
     _renderer->AddRenderEngine(engine.get());
 
     _UpdateFont(USER_DEFAULT_SCREEN_DPI);

--- a/src/cascadia/TerminalControl/IControlSettings.idl
+++ b/src/cascadia/TerminalControl/IControlSettings.idl
@@ -58,6 +58,7 @@ namespace Microsoft.Terminal.Control
         TextAntialiasingMode AntialiasingMode { get; };
 
         // Experimental Settings
+        Microsoft.Terminal.Control.GraphicsAPI GraphicsAPI { get; };
         Boolean ForceFullRepaintRendering { get; };
         Boolean SoftwareRendering { get; };
         Boolean ShowMarks { get; };

--- a/src/cascadia/TerminalControl/IControlSettings.idl
+++ b/src/cascadia/TerminalControl/IControlSettings.idl
@@ -59,7 +59,7 @@ namespace Microsoft.Terminal.Control
 
         // Experimental Settings
         Microsoft.Terminal.Control.GraphicsAPI GraphicsAPI { get; };
-        Boolean ForceFullRepaintRendering { get; };
+        Boolean DisablePartialInvalidation { get; };
         Boolean SoftwareRendering { get; };
         Boolean ShowMarks { get; };
         Boolean UseBackgroundImageForWindow { get; };

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2409,7 +2409,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         LOG_IF_FAILED(engine->UpdateDpi(dpi));
         LOG_IF_FAILED(engine->UpdateFont(desiredFont, actualFont));
 
-        const auto scale = engine->GetScaling();
+        const auto scale = dpi / static_cast<float>(USER_DEFAULT_SCREEN_DPI);
         const auto actualFontSize = actualFont.GetSize();
 
         // UWP XAML scrollbars aren't guaranteed to be the same size as the

--- a/src/cascadia/TerminalSettingsEditor/Rendering.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Rendering.xaml
@@ -15,12 +15,22 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="CommonResources.xaml" />
             </ResourceDictionary.MergedDictionaries>
+
+            <DataTemplate x:Key="EnumComboBoxTemplate"
+                          x:DataType="local:EnumEntry">
+                <TextBlock Text="{x:Bind EnumName}" />
+            </DataTemplate>
         </ResourceDictionary>
     </Page.Resources>
 
     <StackPanel Style="{StaticResource SettingsStackStyle}">
-        <TextBlock x:Uid="Globals_RenderingDisclaimer"
-                   Style="{StaticResource DisclaimerStyle}" />
+        <local:SettingContainer x:Uid="Globals_GraphicsAPI">
+            <ComboBox AutomationProperties.AccessibilityView="Content"
+                      ItemTemplate="{StaticResource EnumComboBoxTemplate}"
+                      ItemsSource="{x:Bind ViewModel.GraphicsAPIList}"
+                      SelectedItem="{x:Bind ViewModel.CurrentGraphicsAPI, Mode=TwoWay}"
+                      Style="{StaticResource ComboBoxSettingStyle}" />
+        </local:SettingContainer>
 
         <!--  Force Full Repaint  -->
         <local:SettingContainer x:Uid="Globals_ForceFullRepaint">

--- a/src/cascadia/TerminalSettingsEditor/Rendering.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Rendering.xaml
@@ -32,13 +32,11 @@
                       Style="{StaticResource ComboBoxSettingStyle}" />
         </local:SettingContainer>
 
-        <!--  Force Full Repaint  -->
-        <local:SettingContainer x:Uid="Globals_ForceFullRepaint">
-            <ToggleSwitch IsOn="{x:Bind ViewModel.ForceFullRepaintRendering, Mode=TwoWay}"
+        <local:SettingContainer x:Uid="Globals_DisablePartialInvalidation">
+            <ToggleSwitch IsOn="{x:Bind ViewModel.DisablePartialInvalidation, Mode=TwoWay}"
                           Style="{StaticResource ToggleSwitchInExpanderStyle}" />
         </local:SettingContainer>
 
-        <!--  Software Rendering  -->
         <local:SettingContainer x:Uid="Globals_SoftwareRendering">
             <ToggleSwitch IsOn="{x:Bind ViewModel.SoftwareRendering, Mode=TwoWay}"
                           Style="{StaticResource ToggleSwitchInExpanderStyle}" />

--- a/src/cascadia/TerminalSettingsEditor/RenderingViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/RenderingViewModel.cpp
@@ -3,6 +3,9 @@
 
 #include "pch.h"
 #include "RenderingViewModel.h"
+
+#include "EnumEntry.h"
+
 #include "RenderingViewModel.g.cpp"
 
 using namespace winrt::Windows::Foundation;
@@ -10,8 +13,9 @@ using namespace winrt::Microsoft::Terminal::Settings::Model;
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
-    RenderingViewModel::RenderingViewModel(Model::CascadiaSettings settings) noexcept :
+    RenderingViewModel::RenderingViewModel(CascadiaSettings settings) noexcept :
         _settings{ std::move(settings) }
     {
+        INITIALIZE_BINDABLE_ENUM_SETTING(GraphicsAPI, GraphicsAPI, winrt::Microsoft::Terminal::Control::GraphicsAPI, L"Globals_GraphicsAPI_", L"Text");
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/RenderingViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/RenderingViewModel.h
@@ -14,7 +14,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         explicit RenderingViewModel(Model::CascadiaSettings settings) noexcept;
 
         GETSET_BINDABLE_ENUM_SETTING(GraphicsAPI, winrt::Microsoft::Terminal::Control::GraphicsAPI, _settings.GlobalSettings().GraphicsAPI);
-        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_settings.GlobalSettings(), ForceFullRepaintRendering);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_settings.GlobalSettings(), DisablePartialInvalidation);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_settings.GlobalSettings(), SoftwareRendering);
 
     private:

--- a/src/cascadia/TerminalSettingsEditor/RenderingViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/RenderingViewModel.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "RenderingViewModel.g.h"
+#include "Utils.h"
 #include "ViewModelHelpers.h"
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
@@ -12,6 +13,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         explicit RenderingViewModel(Model::CascadiaSettings settings) noexcept;
 
+        GETSET_BINDABLE_ENUM_SETTING(GraphicsAPI, winrt::Microsoft::Terminal::Control::GraphicsAPI, _settings.GlobalSettings().GraphicsAPI);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_settings.GlobalSettings(), ForceFullRepaintRendering);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_settings.GlobalSettings(), SoftwareRendering);
 

--- a/src/cascadia/TerminalSettingsEditor/RenderingViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/RenderingViewModel.idl
@@ -13,7 +13,7 @@ namespace Microsoft.Terminal.Settings.Editor
 
         IInspectable CurrentGraphicsAPI;
         Windows.Foundation.Collections.IObservableVector<Microsoft.Terminal.Settings.Editor.EnumEntry> GraphicsAPIList { get; };
-        PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, ForceFullRepaintRendering);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, DisablePartialInvalidation);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, SoftwareRendering);
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/RenderingViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/RenderingViewModel.idl
@@ -11,6 +11,8 @@ namespace Microsoft.Terminal.Settings.Editor
     {
         RenderingViewModel(Microsoft.Terminal.Settings.Model.CascadiaSettings settings);
 
+        IInspectable CurrentGraphicsAPI;
+        Windows.Foundation.Collections.IObservableVector<Microsoft.Terminal.Settings.Editor.EnumEntry> GraphicsAPIList { get; };
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, ForceFullRepaintRendering);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, SoftwareRendering);
     }

--- a/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
@@ -311,13 +311,13 @@
     <value>Die Terminalanwendung, die gestartet wird, wenn eine Befehlszeilenanwendung ohne vorhandene Sitzung gestartet wird, beispielsweise vom Startmenü oder über das Dialogfeld "Ausführen".</value>
     <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
-  <data name="Globals_ForceFullRepaint.Header" xml:space="preserve">
+  <data name="Globals_DisablePartialInvalidation.Header" xml:space="preserve">
     <value>Gesamten Bildschirm beim Anzeigen von Updates aktualisieren</value>
     <comment>Header for a control to toggle the "force full repaint" setting. When enabled, the app renders new content between screen frames.</comment>
   </data>
-  <data name="Globals_ForceFullRepaint.HelpText" xml:space="preserve">
+  <data name="Globals_DisablePartialInvalidation.HelpText" xml:space="preserve">
     <value>Wenn diese Option deaktiviert ist, rendert das Terminal die Aktualisierungen nur zwischen den Frames auf den Bildschirm.</value>
-    <comment>A description for what the "force full repaint" setting does. Presented near "Globals_ForceFullRepaint.Header".</comment>
+    <comment>A description for what the "force full repaint" setting does. Presented near "Globals_DisablePartialInvalidation.Header".</comment>
   </data>
   <data name="Globals_InitialCols.Text" xml:space="preserve">
     <value>Spalten</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
@@ -446,10 +446,6 @@
     <value>An das zuletzt verwendete Fenster auf diesem Desktop anhängen</value>
     <comment>An option to choose from for the "windowing behavior" setting. When selected, new instances open in the most recently used window on this virtual desktop.</comment>
   </data>
-  <data name="Globals_RenderingDisclaimer.Text" xml:space="preserve">
-    <value>Diese Einstellungen eignen sich möglicherweise für die Problembehandlung, Sie wirken sich jedoch auf die Leistung aus.</value>
-    <comment>A disclaimer presented at the top of a page.</comment>
-  </data>
   <data name="Globals_ShowTitlebar.Header" xml:space="preserve">
     <value>Titelleiste ausblenden (Neustart erforderlich)</value>
     <comment>Header for a control to toggle whether the title bar should be shown or not. Changing this setting requires the user to relaunch the app.</comment>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -328,6 +328,14 @@
   <data name="Globals_GraphicsAPI_Direct3d11.Text" xml:space="preserve">
     <value>Direct3D 11</value>
   </data>
+  <data name="Globals_DisablePartialInvalidation.Header" xml:space="preserve">
+    <value>Disable partial Swap Chain invalidation</value>
+    <comment>"Swap Chain" is an official technical term by Microsoft. This text is shown next to a toggle.</comment>
+  </data>
+  <data name="Globals_DisablePartialInvalidation.HelpText" xml:space="preserve">
+    <value>By default, the text renderer uses a FLIP_SEQUENTIAL Swap Chain and declares dirty rectangles via the Present1 API. When this setting is enabled, a FLIP_DISCARD Swap Chain will be used instead, and no dirty rectangles will be declared. Whether one or the other is better depends on your hardware and various other factors.</value>
+    <comment>{Locked="Present1","FLIP_DISCARD","FLIP_SEQUENTIAL"}</comment>
+  </data>
   <data name="Globals_SoftwareRendering.Header" xml:space="preserve">
     <value>Use software rendering (WARP)</value>
     <comment>{Locked="WARP"} WARP is the "Windows Advanced Rasterization Platform". This text is shown next to a toggle.</comment>
@@ -335,14 +343,6 @@
   <data name="Globals_SoftwareRendering.HelpText" xml:space="preserve">
     <value>When enabled, the terminal will use a software rasterizer (WARP). This setting should be left disabled under almost all circumstances.</value>
     <comment>{Locked="WARP"} WARP is the "Windows Advanced Rasterization Platform".</comment>
-  </data>
-  <data name="Globals_ForceFullRepaint.Header" xml:space="preserve">
-    <value>Disable partial Swap Chain invalidation</value>
-    <comment>"Swap Chain" is an official technical term by Microsoft. This text is shown next to a toggle.</comment>
-  </data>
-  <data name="Globals_ForceFullRepaint.HelpText" xml:space="preserve">
-    <value>By default, the text renderer uses a FLIP_SEQUENTIAL Swap Chain and declares dirty rectangles via the Present1 API. When this setting is enabled, a FLIP_DISCARD Swap Chain will be used instead, and no dirty rectangles will be declared. Whether one or the other is better depends on your hardware and various other factors.</value>
-    <comment>{Locked="Present1","FLIP_DISCARD","FLIP_SEQUENTIAL"}</comment>
   </data>
   <data name="Globals_InitialCols.Text" xml:space="preserve">
     <value>Columns</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -311,13 +311,38 @@
     <value>The terminal application that launches when a command-line application is run without an existing session, like from the Start Menu or Run dialog.</value>
     <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
+  <data name="Globals_GraphicsAPI.Header" xml:space="preserve">
+    <value>Graphics API</value>
+    <comment>This text is shown next to a list of choices.</comment>
+  </data>
+  <data name="Globals_GraphicsAPI.HelpText" xml:space="preserve">
+    <value>Direct3D 11 provides a more performant and feature-rich experience, whereas Direct2D is more stable. The default option "Automatic" will pick the API that best fits your graphics hardware. If you experience significant issues, consider using Direct2D.</value>
+  </data>
+  <data name="Globals_GraphicsAPI_Automatic.Text" xml:space="preserve">
+    <value>Automatic</value>
+    <comment>The default choice between multiple graphics APIs.</comment>
+  </data>
+  <data name="Globals_GraphicsAPI_Direct2d.Text" xml:space="preserve">
+    <value>Direct2D</value>
+  </data>
+  <data name="Globals_GraphicsAPI_Direct3d11.Text" xml:space="preserve">
+    <value>Direct3D 11</value>
+  </data>
+  <data name="Globals_SoftwareRendering.Header" xml:space="preserve">
+    <value>Use software rendering (WARP)</value>
+    <comment>{Locked="WARP"} WARP is the "Windows Advanced Rasterization Platform". This text is shown next to a toggle.</comment>
+  </data>
+  <data name="Globals_SoftwareRendering.HelpText" xml:space="preserve">
+    <value>When enabled, the terminal will use a software rasterizer (WARP). This setting should be left disabled under almost all circumstances.</value>
+    <comment>{Locked="WARP"} WARP is the "Windows Advanced Rasterization Platform".</comment>
+  </data>
   <data name="Globals_ForceFullRepaint.Header" xml:space="preserve">
-    <value>Redraw entire screen when display updates</value>
-    <comment>Header for a control to toggle the "force full repaint" setting. When enabled, the app renders new content between screen frames.</comment>
+    <value>Disable partial Swap Chain invalidation</value>
+    <comment>"Swap Chain" is an official technical term by Microsoft. This text is shown next to a toggle.</comment>
   </data>
   <data name="Globals_ForceFullRepaint.HelpText" xml:space="preserve">
-    <value>When disabled, the terminal will render only the updates to the screen between frames.</value>
-    <comment>A description for what the "force full repaint" setting does. Presented near "Globals_ForceFullRepaint.Header".</comment>
+    <value>By default, the text renderer uses a FLIP_SEQUENTIAL Swap Chain and declares dirty rectangles via the Present1 API. When this setting is enabled, a FLIP_DISCARD Swap Chain will be used instead, and no dirty rectangles will be declared. Whether one or the other is better depends on your hardware and various other factors.</value>
+    <comment>{Locked="Present1","FLIP_DISCARD","FLIP_SEQUENTIAL"}</comment>
   </data>
   <data name="Globals_InitialCols.Text" xml:space="preserve">
     <value>Columns</value>
@@ -446,10 +471,6 @@
     <value>Attach to the most recently used window on this desktop</value>
     <comment>An option to choose from for the "windowing behavior" setting. When selected, new instances open in the most recently used window on this virtual desktop.</comment>
   </data>
-  <data name="Globals_RenderingDisclaimer.Text" xml:space="preserve">
-    <value>These settings may be useful for troubleshooting an issue, however they will impact your performance.</value>
-    <comment>A disclaimer presented at the top of a page.</comment>
-  </data>
   <data name="Globals_ShowTitlebar.Header" xml:space="preserve">
     <value>Hide the title bar (requires relaunch)</value>
     <comment>Header for a control to toggle whether the title bar should be shown or not. Changing this setting requires the user to relaunch the app.</comment>
@@ -477,14 +498,6 @@
   <data name="Globals_SnapToGridOnResize.HelpText" xml:space="preserve">
     <value>When disabled, the window will resize smoothly.</value>
     <comment>A description for what the "snap to grid on resize" setting does. Presented near "Globals_SnapToGridOnResize.Header".</comment>
-  </data>
-  <data name="Globals_SoftwareRendering.Header" xml:space="preserve">
-    <value>Use software rendering</value>
-    <comment>Header for a control to toggle whether the terminal should use software to render content instead of the hardware.</comment>
-  </data>
-  <data name="Globals_SoftwareRendering.HelpText" xml:space="preserve">
-    <value>When enabled, the terminal will use the software renderer (a.k.a. WARP) instead of the hardware one.</value>
-    <comment>A description for what the "software rendering" setting does. Presented near "Globals_SoftwareRendering.Header".</comment>
   </data>
   <data name="Globals_StartOnUserLogin.Header" xml:space="preserve">
     <value>Launch on machine startup</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
@@ -446,10 +446,6 @@
     <value>Adjuntar a la ventana de uso más reciente en este escritorio</value>
     <comment>An option to choose from for the "windowing behavior" setting. When selected, new instances open in the most recently used window on this virtual desktop.</comment>
   </data>
-  <data name="Globals_RenderingDisclaimer.Text" xml:space="preserve">
-    <value>Esta configuración puede ser útil para solucionar un problema, pero afectará al rendimiento.</value>
-    <comment>A disclaimer presented at the top of a page.</comment>
-  </data>
   <data name="Globals_ShowTitlebar.Header" xml:space="preserve">
     <value>Ocultar la barra de título (requiere reiniciar)</value>
     <comment>Header for a control to toggle whether the title bar should be shown or not. Changing this setting requires the user to relaunch the app.</comment>

--- a/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
@@ -311,13 +311,13 @@
     <value>Aplicación de terminal que se inicia cuando se ejecuta una aplicación de línea de comandos sin una sesión existente, como en el menú Inicio o en el cuadro de diálogo Ejecutar.</value>
     <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
-  <data name="Globals_ForceFullRepaint.Header" xml:space="preserve">
+  <data name="Globals_DisablePartialInvalidation.Header" xml:space="preserve">
     <value>Redibujar toda la pantalla cuando se muestren actualizaciones</value>
     <comment>Header for a control to toggle the "force full repaint" setting. When enabled, the app renders new content between screen frames.</comment>
   </data>
-  <data name="Globals_ForceFullRepaint.HelpText" xml:space="preserve">
+  <data name="Globals_DisablePartialInvalidation.HelpText" xml:space="preserve">
     <value>Cuando está deshabilitada, el terminal representará solo las actualizaciones de la pantalla entre fotogramas.</value>
-    <comment>A description for what the "force full repaint" setting does. Presented near "Globals_ForceFullRepaint.Header".</comment>
+    <comment>A description for what the "force full repaint" setting does. Presented near "Globals_DisablePartialInvalidation.Header".</comment>
   </data>
   <data name="Globals_InitialCols.Text" xml:space="preserve">
     <value>Columnas</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
@@ -446,10 +446,6 @@
     <value>Attacher à la dernière fenêtre utilisée sur ce bureau</value>
     <comment>An option to choose from for the "windowing behavior" setting. When selected, new instances open in the most recently used window on this virtual desktop.</comment>
   </data>
-  <data name="Globals_RenderingDisclaimer.Text" xml:space="preserve">
-    <value>Ces paramètres permettent parfois de résoudre des problèmes, mais ont un impact sur la performance.</value>
-    <comment>A disclaimer presented at the top of a page.</comment>
-  </data>
   <data name="Globals_ShowTitlebar.Header" xml:space="preserve">
     <value>Masquer la barre de titre (redémarrage nécessaire)</value>
     <comment>Header for a control to toggle whether the title bar should be shown or not. Changing this setting requires the user to relaunch the app.</comment>

--- a/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
@@ -311,13 +311,13 @@
     <value>L’application Terminal qui se lance lorsqu’une application de ligne de commande est exécutée sans session existante, par exemple à partir du menu Démarrer ou de la boîte de dialogue Exécuter.</value>
     <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
-  <data name="Globals_ForceFullRepaint.Header" xml:space="preserve">
+  <data name="Globals_DisablePartialInvalidation.Header" xml:space="preserve">
     <value>Redessiner l’intégralité de l’écran entre chaque trame</value>
     <comment>Header for a control to toggle the "force full repaint" setting. When enabled, the app renders new content between screen frames.</comment>
   </data>
-  <data name="Globals_ForceFullRepaint.HelpText" xml:space="preserve">
+  <data name="Globals_DisablePartialInvalidation.HelpText" xml:space="preserve">
     <value>Une fois désactivé, le terminal n’affiche à l’écran que les modifications effectuées entre les trames.</value>
-    <comment>A description for what the "force full repaint" setting does. Presented near "Globals_ForceFullRepaint.Header".</comment>
+    <comment>A description for what the "force full repaint" setting does. Presented near "Globals_DisablePartialInvalidation.Header".</comment>
   </data>
   <data name="Globals_InitialCols.Text" xml:space="preserve">
     <value>Colonnes</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
@@ -446,10 +446,6 @@
     <value>Allega alla finestra usata più di recente su questo desktop</value>
     <comment>An option to choose from for the "windowing behavior" setting. When selected, new instances open in the most recently used window on this virtual desktop.</comment>
   </data>
-  <data name="Globals_RenderingDisclaimer.Text" xml:space="preserve">
-    <value>Queste impostazioni potrebbero essere utili per la risoluzione di un problema, ma influiranno sulle prestazioni.</value>
-    <comment>A disclaimer presented at the top of a page.</comment>
-  </data>
   <data name="Globals_ShowTitlebar.Header" xml:space="preserve">
     <value>Nascondi la barra del titolo (sarà necessario riavviare)</value>
     <comment>Header for a control to toggle whether the title bar should be shown or not. Changing this setting requires the user to relaunch the app.</comment>

--- a/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
@@ -311,13 +311,13 @@
     <value>L'applicazione terminale che viene avviata quando viene eseguita un'applicazione della riga di comando senza una sessione esistente, ad esempio dalla finestra di dialogo menu Start o Esegui.</value>
     <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
-  <data name="Globals_ForceFullRepaint.Header" xml:space="preserve">
+  <data name="Globals_DisablePartialInvalidation.Header" xml:space="preserve">
     <value>Ridisegna l'intero schermo durante la visualizzazione degli aggiornamenti</value>
     <comment>Header for a control to toggle the "force full repaint" setting. When enabled, the app renders new content between screen frames.</comment>
   </data>
-  <data name="Globals_ForceFullRepaint.HelpText" xml:space="preserve">
+  <data name="Globals_DisablePartialInvalidation.HelpText" xml:space="preserve">
     <value>Se disabilitato, il terminale eseguirà il rendering solo degli aggiornamenti sullo schermo tra i fotogrammi.</value>
-    <comment>A description for what the "force full repaint" setting does. Presented near "Globals_ForceFullRepaint.Header".</comment>
+    <comment>A description for what the "force full repaint" setting does. Presented near "Globals_DisablePartialInvalidation.Header".</comment>
   </data>
   <data name="Globals_InitialCols.Text" xml:space="preserve">
     <value>Colonne</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
@@ -446,10 +446,6 @@
     <value>このデスクトップで最近使用したウィンドウに接続する</value>
     <comment>An option to choose from for the "windowing behavior" setting. When selected, new instances open in the most recently used window on this virtual desktop.</comment>
   </data>
-  <data name="Globals_RenderingDisclaimer.Text" xml:space="preserve">
-    <value>これらの設定は問題のトラブルシューティングに役立つ場合がありますが、パフォーマンスに影響を与えます。</value>
-    <comment>A disclaimer presented at the top of a page.</comment>
-  </data>
   <data name="Globals_ShowTitlebar.Header" xml:space="preserve">
     <value>タイトル バーを非表示にする (再起動が必要)</value>
     <comment>Header for a control to toggle whether the title bar should be shown or not. Changing this setting requires the user to relaunch the app.</comment>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
@@ -311,13 +311,13 @@
     <value>[スタート] メニューや [ファイル名を指定して実行] ダイアログなど、既存のセッションなしでコマンドライン アプリケーションを実行したときに起動するターミナル アプリケーション。</value>
     <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
-  <data name="Globals_ForceFullRepaint.Header" xml:space="preserve">
+  <data name="Globals_DisablePartialInvalidation.Header" xml:space="preserve">
     <value>ディスプレイの更新時に画面全体を再描画する</value>
     <comment>Header for a control to toggle the "force full repaint" setting. When enabled, the app renders new content between screen frames.</comment>
   </data>
-  <data name="Globals_ForceFullRepaint.HelpText" xml:space="preserve">
+  <data name="Globals_DisablePartialInvalidation.HelpText" xml:space="preserve">
     <value>無効にすると、ターミナルはフレームとフレームの間において情報更新分のみレンダリングします。</value>
-    <comment>A description for what the "force full repaint" setting does. Presented near "Globals_ForceFullRepaint.Header".</comment>
+    <comment>A description for what the "force full repaint" setting does. Presented near "Globals_DisablePartialInvalidation.Header".</comment>
   </data>
   <data name="Globals_InitialCols.Text" xml:space="preserve">
     <value>列</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
@@ -311,13 +311,13 @@
     <value>시작 메뉴나 실행 대화 상자와 같이 기존 세션이 없으면 명령 줄 응용 프로그램을 실행하고 있는 터미널 응용 프로그램입니다.</value>
     <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
-  <data name="Globals_ForceFullRepaint.Header" xml:space="preserve">
+  <data name="Globals_DisablePartialInvalidation.Header" xml:space="preserve">
     <value>업데이트를 표시할 때 전체 화면 다시 그리기</value>
     <comment>Header for a control to toggle the "force full repaint" setting. When enabled, the app renders new content between screen frames.</comment>
   </data>
-  <data name="Globals_ForceFullRepaint.HelpText" xml:space="preserve">
+  <data name="Globals_DisablePartialInvalidation.HelpText" xml:space="preserve">
     <value>사용하지 않도록 설정하면 터미널이 프레임 간 화면 업데이트만 렌더링합니다.</value>
-    <comment>A description for what the "force full repaint" setting does. Presented near "Globals_ForceFullRepaint.Header".</comment>
+    <comment>A description for what the "force full repaint" setting does. Presented near "Globals_DisablePartialInvalidation.Header".</comment>
   </data>
   <data name="Globals_InitialCols.Text" xml:space="preserve">
     <value>열</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
@@ -446,10 +446,6 @@
     <value>이 데스크톱에서 가장 최근에 사용한 창에 첨부</value>
     <comment>An option to choose from for the "windowing behavior" setting. When selected, new instances open in the most recently used window on this virtual desktop.</comment>
   </data>
-  <data name="Globals_RenderingDisclaimer.Text" xml:space="preserve">
-    <value>이런 설정은 문제를 해결하는 데는 유용할 수 있지만 성능에 영향을 미칩니다.</value>
-    <comment>A disclaimer presented at the top of a page.</comment>
-  </data>
   <data name="Globals_ShowTitlebar.Header" xml:space="preserve">
     <value>제목 표시줄 숨기기(다시 시작해야 함)</value>
     <comment>Header for a control to toggle whether the title bar should be shown or not. Changing this setting requires the user to relaunch the app.</comment>

--- a/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
@@ -311,13 +311,13 @@
     <value>O aplicativo de terminal que é iniciado quando um aplicativo de linha de comando é executado sem uma sessão existente, como no menu iniciar ou na caixa de diálogo Executar.</value>
     <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
-  <data name="Globals_ForceFullRepaint.Header" xml:space="preserve">
+  <data name="Globals_DisablePartialInvalidation.Header" xml:space="preserve">
     <value>Redesenhar a tela inteira ao exibir atualizações</value>
     <comment>Header for a control to toggle the "force full repaint" setting. When enabled, the app renders new content between screen frames.</comment>
   </data>
-  <data name="Globals_ForceFullRepaint.HelpText" xml:space="preserve">
+  <data name="Globals_DisablePartialInvalidation.HelpText" xml:space="preserve">
     <value>Quando desabilitado, o terminal renderizará somente as atualizações na tela entre quadros.</value>
-    <comment>A description for what the "force full repaint" setting does. Presented near "Globals_ForceFullRepaint.Header".</comment>
+    <comment>A description for what the "force full repaint" setting does. Presented near "Globals_DisablePartialInvalidation.Header".</comment>
   </data>
   <data name="Globals_InitialCols.Text" xml:space="preserve">
     <value>Colunas</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
@@ -446,10 +446,6 @@
     <value>Anexar à última janela usada nesta área de trabalho</value>
     <comment>An option to choose from for the "windowing behavior" setting. When selected, new instances open in the most recently used window on this virtual desktop.</comment>
   </data>
-  <data name="Globals_RenderingDisclaimer.Text" xml:space="preserve">
-    <value>Essas configurações podem ser úteis para solucionar um problema, no entanto, elas impactarão seu desempenho.</value>
-    <comment>A disclaimer presented at the top of a page.</comment>
-  </data>
   <data name="Globals_ShowTitlebar.Header" xml:space="preserve">
     <value>Oculta a barra do título (requer reinicialização)</value>
     <comment>Header for a control to toggle whether the title bar should be shown or not. Changing this setting requires the user to relaunch the app.</comment>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
@@ -446,10 +446,6 @@
     <value>Äţŧαĉђ τǿ τħе mοѕт ѓěςęńτļγ ûѕєď ŵíñðοω øи тћϊѕ ďёšкτǿφ !!! !!! !!! !!! !!! !</value>
     <comment>An option to choose from for the "windowing behavior" setting. When selected, new instances open in the most recently used window on this virtual desktop.</comment>
   </data>
-  <data name="Globals_RenderingDisclaimer.Text" xml:space="preserve">
-    <value>Τћέŝė ѕëτтίņģš мâу ьê üѕēƒµľ ƒόґ τřóųьŀėѕĥбοτілġ ǻл іŝśü℮, нσώéνєŕ τĥêў ŵīŀł ΐmρåςť убŭя ρěгƒόґмåñĉę. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
-    <comment>A disclaimer presented at the top of a page.</comment>
-  </data>
   <data name="Globals_ShowTitlebar.Header" xml:space="preserve">
     <value>Ĥìđε тħê τīţĺё ъªř (ŗėqūΐŗêś яеľаϋŉčћ) !!! !!! !!! !!</value>
     <comment>Header for a control to toggle whether the title bar should be shown or not. Changing this setting requires the user to relaunch the app.</comment>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
@@ -311,13 +311,13 @@
     <value>Ťђě ţэřмīηãĺ ǻφφℓï¢ǻтΐбň ŧђáт łáůйčĥēś ẅĥэп ā сöмmǻńđ-ľіŉэ ăρρĺįċāτΐôⁿ ϊš яųñ шíţћöυţ ªņ ĕхϊŝŧĭñğ şěŝѕïŏπ, ŀĩĸė ƒѓом ţћĕ Ŝτáґт Μęπü бг Яųņ ďīäℓöğ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
-  <data name="Globals_ForceFullRepaint.Header" xml:space="preserve">
+  <data name="Globals_DisablePartialInvalidation.Header" xml:space="preserve">
     <value>Ŗёδѓªŵ еñţιŗę šĉřέëŋ шн℮й đĩşρℓâў υρďάţëš !!! !!! !!! !!!</value>
     <comment>Header for a control to toggle the "force full repaint" setting. When enabled, the app renders new content between screen frames.</comment>
   </data>
-  <data name="Globals_ForceFullRepaint.HelpText" xml:space="preserve">
+  <data name="Globals_DisablePartialInvalidation.HelpText" xml:space="preserve">
     <value>Щħ℮п đįѕāъĺèđ, ťђέ тèřмΐņäľ ωìľľ řεŉďęŗ όŉľŷ ŧђέ ŭρďăţзŝ τö ŧђë šсгèзņ вêţшзэŉ ƒяāméş. !!! !!! !!! !!! !!! !!! !!! !!! !</value>
-    <comment>A description for what the "force full repaint" setting does. Presented near "Globals_ForceFullRepaint.Header".</comment>
+    <comment>A description for what the "force full repaint" setting does. Presented near "Globals_DisablePartialInvalidation.Header".</comment>
   </data>
   <data name="Globals_InitialCols.Text" xml:space="preserve">
     <value>Ċσŀùмñѕ !!</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
@@ -446,10 +446,6 @@
     <value>Äţŧαĉђ τǿ τħе mοѕт ѓěςęńτļγ ûѕєď ŵíñðοω øи тћϊѕ ďёšкτǿφ !!! !!! !!! !!! !!! !</value>
     <comment>An option to choose from for the "windowing behavior" setting. When selected, new instances open in the most recently used window on this virtual desktop.</comment>
   </data>
-  <data name="Globals_RenderingDisclaimer.Text" xml:space="preserve">
-    <value>Τћέŝė ѕëτтίņģš мâу ьê üѕēƒµľ ƒόґ τřóųьŀėѕĥбοτілġ ǻл іŝśü℮, нσώéνєŕ τĥêў ŵīŀł ΐmρåςť убŭя ρěгƒόґмåñĉę. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
-    <comment>A disclaimer presented at the top of a page.</comment>
-  </data>
   <data name="Globals_ShowTitlebar.Header" xml:space="preserve">
     <value>Ĥìđε тħê τīţĺё ъªř (ŗėqūΐŗêś яеľаϋŉčћ) !!! !!! !!! !!</value>
     <comment>Header for a control to toggle whether the title bar should be shown or not. Changing this setting requires the user to relaunch the app.</comment>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
@@ -311,13 +311,13 @@
     <value>Ťђě ţэřмīηãĺ ǻφφℓï¢ǻтΐбň ŧђáт łáůйčĥēś ẅĥэп ā сöмmǻńđ-ľіŉэ ăρρĺįċāτΐôⁿ ϊš яųñ шíţћöυţ ªņ ĕхϊŝŧĭñğ şěŝѕïŏπ, ŀĩĸė ƒѓом ţћĕ Ŝτáґт Μęπü бг Яųņ ďīäℓöğ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
-  <data name="Globals_ForceFullRepaint.Header" xml:space="preserve">
+  <data name="Globals_DisablePartialInvalidation.Header" xml:space="preserve">
     <value>Ŗёδѓªŵ еñţιŗę šĉřέëŋ шн℮й đĩşρℓâў υρďάţëš !!! !!! !!! !!!</value>
     <comment>Header for a control to toggle the "force full repaint" setting. When enabled, the app renders new content between screen frames.</comment>
   </data>
-  <data name="Globals_ForceFullRepaint.HelpText" xml:space="preserve">
+  <data name="Globals_DisablePartialInvalidation.HelpText" xml:space="preserve">
     <value>Щħ℮п đįѕāъĺèđ, ťђέ тèřмΐņäľ ωìľľ řεŉďęŗ όŉľŷ ŧђέ ŭρďăţзŝ τö ŧђë šсгèзņ вêţшзэŉ ƒяāméş. !!! !!! !!! !!! !!! !!! !!! !!! !</value>
-    <comment>A description for what the "force full repaint" setting does. Presented near "Globals_ForceFullRepaint.Header".</comment>
+    <comment>A description for what the "force full repaint" setting does. Presented near "Globals_DisablePartialInvalidation.Header".</comment>
   </data>
   <data name="Globals_InitialCols.Text" xml:space="preserve">
     <value>Ċσŀùмñѕ !!</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
@@ -446,10 +446,6 @@
     <value>Äţŧαĉђ τǿ τħе mοѕт ѓěςęńτļγ ûѕєď ŵíñðοω øи тћϊѕ ďёšкτǿφ !!! !!! !!! !!! !!! !</value>
     <comment>An option to choose from for the "windowing behavior" setting. When selected, new instances open in the most recently used window on this virtual desktop.</comment>
   </data>
-  <data name="Globals_RenderingDisclaimer.Text" xml:space="preserve">
-    <value>Τћέŝė ѕëτтίņģš мâу ьê üѕēƒµľ ƒόґ τřóųьŀėѕĥбοτілġ ǻл іŝśü℮, нσώéνєŕ τĥêў ŵīŀł ΐmρåςť убŭя ρěгƒόґмåñĉę. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!</value>
-    <comment>A disclaimer presented at the top of a page.</comment>
-  </data>
   <data name="Globals_ShowTitlebar.Header" xml:space="preserve">
     <value>Ĥìđε тħê τīţĺё ъªř (ŗėqūΐŗêś яеľаϋŉčћ) !!! !!! !!! !!</value>
     <comment>Header for a control to toggle whether the title bar should be shown or not. Changing this setting requires the user to relaunch the app.</comment>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
@@ -311,13 +311,13 @@
     <value>Ťђě ţэřмīηãĺ ǻφφℓï¢ǻтΐбň ŧђáт łáůйčĥēś ẅĥэп ā сöмmǻńđ-ľіŉэ ăρρĺįċāτΐôⁿ ϊš яųñ шíţћöυţ ªņ ĕхϊŝŧĭñğ şěŝѕïŏπ, ŀĩĸė ƒѓом ţћĕ Ŝτáґт Μęπü бг Яųņ ďīäℓöğ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
-  <data name="Globals_ForceFullRepaint.Header" xml:space="preserve">
+  <data name="Globals_DisablePartialInvalidation.Header" xml:space="preserve">
     <value>Ŗёδѓªŵ еñţιŗę šĉřέëŋ шн℮й đĩşρℓâў υρďάţëš !!! !!! !!! !!!</value>
     <comment>Header for a control to toggle the "force full repaint" setting. When enabled, the app renders new content between screen frames.</comment>
   </data>
-  <data name="Globals_ForceFullRepaint.HelpText" xml:space="preserve">
+  <data name="Globals_DisablePartialInvalidation.HelpText" xml:space="preserve">
     <value>Щħ℮п đįѕāъĺèđ, ťђέ тèřмΐņäľ ωìľľ řεŉďęŗ όŉľŷ ŧђέ ŭρďăţзŝ τö ŧђë šсгèзņ вêţшзэŉ ƒяāméş. !!! !!! !!! !!! !!! !!! !!! !!! !</value>
-    <comment>A description for what the "force full repaint" setting does. Presented near "Globals_ForceFullRepaint.Header".</comment>
+    <comment>A description for what the "force full repaint" setting does. Presented near "Globals_DisablePartialInvalidation.Header".</comment>
   </data>
   <data name="Globals_InitialCols.Text" xml:space="preserve">
     <value>Ċσŀùмñѕ !!</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
@@ -311,13 +311,13 @@
     <value>Приложение терминала, запускаемое при запуске приложения командной строки без существующего сеанса, например из меню "Пуск" или из диалогового окна "Выполнить".</value>
     <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
-  <data name="Globals_ForceFullRepaint.Header" xml:space="preserve">
+  <data name="Globals_DisablePartialInvalidation.Header" xml:space="preserve">
     <value>Перерисовка всего экрана при обновлении дисплея</value>
     <comment>Header for a control to toggle the "force full repaint" setting. When enabled, the app renders new content between screen frames.</comment>
   </data>
-  <data name="Globals_ForceFullRepaint.HelpText" xml:space="preserve">
+  <data name="Globals_DisablePartialInvalidation.HelpText" xml:space="preserve">
     <value>Если этот параметр отключен, терминал будет отображать только обновления экрана между кадрами.</value>
-    <comment>A description for what the "force full repaint" setting does. Presented near "Globals_ForceFullRepaint.Header".</comment>
+    <comment>A description for what the "force full repaint" setting does. Presented near "Globals_DisablePartialInvalidation.Header".</comment>
   </data>
   <data name="Globals_InitialCols.Text" xml:space="preserve">
     <value>Столбцы</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
@@ -446,10 +446,6 @@
     <value>Присоединять к последнему использованному окну на этом рабочем столе</value>
     <comment>An option to choose from for the "windowing behavior" setting. When selected, new instances open in the most recently used window on this virtual desktop.</comment>
   </data>
-  <data name="Globals_RenderingDisclaimer.Text" xml:space="preserve">
-    <value>Эти параметры могут быть полезны для устранения проблемы, но они повлияют на вашу производительность.</value>
-    <comment>A disclaimer presented at the top of a page.</comment>
-  </data>
   <data name="Globals_ShowTitlebar.Header" xml:space="preserve">
     <value>Скрыть заголовок окна (требуется перезапуск)</value>
     <comment>Header for a control to toggle whether the title bar should be shown or not. Changing this setting requires the user to relaunch the app.</comment>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
@@ -311,13 +311,13 @@
     <value>当命令行应用程序在没有现有会话(例如从“开始菜单”或“运行”对话框)运行时启动的终端应用程序。</value>
     <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
-  <data name="Globals_ForceFullRepaint.Header" xml:space="preserve">
+  <data name="Globals_DisablePartialInvalidation.Header" xml:space="preserve">
     <value>显示内容更新时重绘整个屏幕</value>
     <comment>Header for a control to toggle the "force full repaint" setting. When enabled, the app renders new content between screen frames.</comment>
   </data>
-  <data name="Globals_ForceFullRepaint.HelpText" xml:space="preserve">
+  <data name="Globals_DisablePartialInvalidation.HelpText" xml:space="preserve">
     <value>禁用后，终端将仅在帧之间将更新呈现到屏幕。</value>
-    <comment>A description for what the "force full repaint" setting does. Presented near "Globals_ForceFullRepaint.Header".</comment>
+    <comment>A description for what the "force full repaint" setting does. Presented near "Globals_DisablePartialInvalidation.Header".</comment>
   </data>
   <data name="Globals_InitialCols.Text" xml:space="preserve">
     <value>列</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
@@ -446,10 +446,6 @@
     <value>附加到此桌面上最近使用的窗口</value>
     <comment>An option to choose from for the "windowing behavior" setting. When selected, new instances open in the most recently used window on this virtual desktop.</comment>
   </data>
-  <data name="Globals_RenderingDisclaimer.Text" xml:space="preserve">
-    <value>这些设置可能有助于解决问题，但会对性能产生影响。</value>
-    <comment>A disclaimer presented at the top of a page.</comment>
-  </data>
   <data name="Globals_ShowTitlebar.Header" xml:space="preserve">
     <value>隐藏标题栏（需要重新启动）</value>
     <comment>Header for a control to toggle whether the title bar should be shown or not. Changing this setting requires the user to relaunch the app.</comment>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
@@ -446,10 +446,6 @@
     <value>附加到此桌面最近使用的視窗</value>
     <comment>An option to choose from for the "windowing behavior" setting. When selected, new instances open in the most recently used window on this virtual desktop.</comment>
   </data>
-  <data name="Globals_RenderingDisclaimer.Text" xml:space="preserve">
-    <value>這些設定可能有助於解決問題，但會影響效能。</value>
-    <comment>A disclaimer presented at the top of a page.</comment>
-  </data>
   <data name="Globals_ShowTitlebar.Header" xml:space="preserve">
     <value>隱藏標題列 (需要重新啟動)</value>
     <comment>Header for a control to toggle whether the title bar should be shown or not. Changing this setting requires the user to relaunch the app.</comment>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
@@ -311,13 +311,13 @@
     <value>當執行命令列應用程式且不使用現有工作模式而啟動的終端機應用程式 (例如從 [開始] 功能表或 [執行] 對話方塊)。</value>
     <comment>A description to clarify that the dropdown choice for default terminal will tell the operating system which Terminal application (Windows Terminal, the preview build, the legacy inbox window, or a 3rd party one) to use when starting a command line tool like CMD or Powershell that does not already have a window.</comment>
   </data>
-  <data name="Globals_ForceFullRepaint.Header" xml:space="preserve">
+  <data name="Globals_DisablePartialInvalidation.Header" xml:space="preserve">
     <value>顯示更新時，重新繪製整個螢幕</value>
     <comment>Header for a control to toggle the "force full repaint" setting. When enabled, the app renders new content between screen frames.</comment>
   </data>
-  <data name="Globals_ForceFullRepaint.HelpText" xml:space="preserve">
+  <data name="Globals_DisablePartialInvalidation.HelpText" xml:space="preserve">
     <value>停用時，終端機只會轉譯框架間螢幕的更新。</value>
-    <comment>A description for what the "force full repaint" setting does. Presented near "Globals_ForceFullRepaint.Header".</comment>
+    <comment>A description for what the "force full repaint" setting does. Presented near "Globals_DisablePartialInvalidation.Header".</comment>
   </data>
   <data name="Globals_InitialCols.Text" xml:space="preserve">
     <value>欄</value>

--- a/src/cascadia/TerminalSettingsModel/EnumMappings.cpp
+++ b/src/cascadia/TerminalSettingsModel/EnumMappings.cpp
@@ -39,6 +39,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     DEFINE_ENUM_MAP(Microsoft::Terminal::Control::CopyFormat, CopyFormat);
     DEFINE_ENUM_MAP(Model::WindowingMode, WindowingMode);
     DEFINE_ENUM_MAP(Microsoft::Terminal::Core::MatchMode, MatchMode);
+    DEFINE_ENUM_MAP(Microsoft::Terminal::Control::GraphicsAPI, GraphicsAPI);
 
     // Profile Settings
     DEFINE_ENUM_MAP(Model::CloseOnExitMode, CloseOnExitMode);

--- a/src/cascadia/TerminalSettingsModel/EnumMappings.h
+++ b/src/cascadia/TerminalSettingsModel/EnumMappings.h
@@ -35,6 +35,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::Microsoft::Terminal::Control::CopyFormat> CopyFormat();
         static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, WindowingMode> WindowingMode();
         static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::Microsoft::Terminal::Core::MatchMode> MatchMode();
+        static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::Microsoft::Terminal::Control::GraphicsAPI> GraphicsAPI();
 
         // Profile Settings
         static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, CloseOnExitMode> CloseOnExitMode();

--- a/src/cascadia/TerminalSettingsModel/EnumMappings.idl
+++ b/src/cascadia/TerminalSettingsModel/EnumMappings.idl
@@ -17,6 +17,7 @@ namespace Microsoft.Terminal.Settings.Model
         static Windows.Foundation.Collections.IMap<String, Microsoft.Terminal.Control.CopyFormat> CopyFormat { get; };
         static Windows.Foundation.Collections.IMap<String, Microsoft.Terminal.Settings.Model.WindowingMode> WindowingMode { get; };
         static Windows.Foundation.Collections.IMap<String, Microsoft.Terminal.Core.MatchMode> MatchMode { get; };
+        static Windows.Foundation.Collections.IMap<String, Microsoft.Terminal.Control.GraphicsAPI> GraphicsAPI { get; };
 
         // Profile Settings
         static Windows.Foundation.Collections.IMap<String, Microsoft.Terminal.Settings.Model.CloseOnExitMode> CloseOnExitMode { get; };

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
@@ -222,13 +222,16 @@ const std::vector<winrt::Microsoft::Terminal::Settings::Model::SettingsLoadWarni
 // - the JsonObject representing this instance
 Json::Value GlobalAppSettings::ToJson()
 {
+    // These experimental options should be removed from the settings file if they're at their default value.
+    // This prevents them from sticking around forever, even if the user was just experimenting with them.
+    // One could consider this a workaround for the settings UI right now not having a "reset to default" button for these.
     if (_GraphicsAPI == Control::GraphicsAPI::Automatic)
     {
         _GraphicsAPI.reset();
     }
-    if (_ForceFullRepaintRendering == false)
+    if (_DisablePartialInvalidation == false)
     {
-        _ForceFullRepaintRendering.reset();
+        _DisablePartialInvalidation.reset();
     }
     if (_SoftwareRendering == false)
     {

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
@@ -220,8 +220,21 @@ const std::vector<winrt::Microsoft::Terminal::Settings::Model::SettingsLoadWarni
 // - <none>
 // Return Value:
 // - the JsonObject representing this instance
-Json::Value GlobalAppSettings::ToJson() const
+Json::Value GlobalAppSettings::ToJson()
 {
+    if (_GraphicsAPI == Control::GraphicsAPI::Automatic)
+    {
+        _GraphicsAPI.reset();
+    }
+    if (_ForceFullRepaintRendering == false)
+    {
+        _ForceFullRepaintRendering.reset();
+    }
+    if (_SoftwareRendering == false)
+    {
+        _SoftwareRendering.reset();
+    }
+
     Json::Value json{ Json::ValueType::objectValue };
 
     JsonUtils::SetValueForKey(json, DefaultProfileKey, _UnparsedDefaultProfile);

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.h
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.h
@@ -52,7 +52,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         void LayerJson(const Json::Value& json, const OriginTag origin);
         void LayerActionsFrom(const Json::Value& json, const OriginTag origin, const bool withKeybindings = true);
 
-        Json::Value ToJson() const;
+        Json::Value ToJson();
 
         const std::vector<SettingsLoadWarnings>& KeybindingsWarnings() const;
 

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
@@ -77,7 +77,7 @@ namespace Microsoft.Terminal.Settings.Model
         INHERITABLE_SETTING(LaunchMode, LaunchMode);
         INHERITABLE_SETTING(Boolean, SnapToGridOnResize);
         INHERITABLE_SETTING(Microsoft.Terminal.Control.GraphicsAPI, GraphicsAPI);
-        INHERITABLE_SETTING(Boolean, ForceFullRepaintRendering);
+        INHERITABLE_SETTING(Boolean, DisablePartialInvalidation);
         INHERITABLE_SETTING(Boolean, SoftwareRendering);
         INHERITABLE_SETTING(Boolean, UseBackgroundImageForWindow);
         INHERITABLE_SETTING(Boolean, ForceVTInput);

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
@@ -76,6 +76,7 @@ namespace Microsoft.Terminal.Settings.Model
         INHERITABLE_SETTING(FirstWindowPreference, FirstWindowPreference);
         INHERITABLE_SETTING(LaunchMode, LaunchMode);
         INHERITABLE_SETTING(Boolean, SnapToGridOnResize);
+        INHERITABLE_SETTING(Microsoft.Terminal.Control.GraphicsAPI, GraphicsAPI);
         INHERITABLE_SETTING(Boolean, ForceFullRepaintRendering);
         INHERITABLE_SETTING(Boolean, SoftwareRendering);
         INHERITABLE_SETTING(Boolean, UseBackgroundImageForWindow);

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -24,9 +24,9 @@ Author(s):
     X(hstring, WordDelimiters, "wordDelimiters", DEFAULT_WORD_DELIMITERS)                                                                                                                             \
     X(bool, CopyOnSelect, "copyOnSelect", false)                                                                                                                                                      \
     X(bool, FocusFollowMouse, "focusFollowMouse", false)                                                                                                                                              \
-    X(winrt::Microsoft::Terminal::Control::GraphicsAPI, GraphicsAPI, "experimental.rendering.graphicsAPI")                                                                                            \
-    X(bool, ForceFullRepaintRendering, "experimental.rendering.forceFullRepaint", false)                                                                                                              \
-    X(bool, SoftwareRendering, "experimental.rendering.software", false)                                                                                                                              \
+    X(winrt::Microsoft::Terminal::Control::GraphicsAPI, GraphicsAPI, "rendering.graphicsAPI")                                                                                                         \
+    X(bool, DisablePartialInvalidation, "rendering.disablePartialInvalidation", false)                                                                                                                \
+    X(bool, SoftwareRendering, "rendering.software", false)                                                                                                                                           \
     X(bool, UseBackgroundImageForWindow, "experimental.useBackgroundImageForWindow", false)                                                                                                           \
     X(bool, ForceVTInput, "experimental.input.forceVT", false)                                                                                                                                        \
     X(bool, TrimBlockSelection, "trimBlockSelection", true)                                                                                                                                           \

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -24,6 +24,7 @@ Author(s):
     X(hstring, WordDelimiters, "wordDelimiters", DEFAULT_WORD_DELIMITERS)                                                                                                                             \
     X(bool, CopyOnSelect, "copyOnSelect", false)                                                                                                                                                      \
     X(bool, FocusFollowMouse, "focusFollowMouse", false)                                                                                                                                              \
+    X(winrt::Microsoft::Terminal::Control::GraphicsAPI, GraphicsAPI, "experimental.rendering.graphicsAPI")                                                                                            \
     X(bool, ForceFullRepaintRendering, "experimental.rendering.forceFullRepaint", false)                                                                                                              \
     X(bool, SoftwareRendering, "experimental.rendering.software", false)                                                                                                                              \
     X(bool, UseBackgroundImageForWindow, "experimental.useBackgroundImageForWindow", false)                                                                                                           \

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
@@ -360,6 +360,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         _CopyOnSelect = globalSettings.CopyOnSelect();
         _CopyFormatting = globalSettings.CopyFormatting();
         _FocusFollowMouse = globalSettings.FocusFollowMouse();
+        _GraphicsAPI = globalSettings.GraphicsAPI();
         _ForceFullRepaintRendering = globalSettings.ForceFullRepaintRendering();
         _SoftwareRendering = globalSettings.SoftwareRendering();
         _UseBackgroundImageForWindow = globalSettings.UseBackgroundImageForWindow();

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
@@ -361,7 +361,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         _CopyFormatting = globalSettings.CopyFormatting();
         _FocusFollowMouse = globalSettings.FocusFollowMouse();
         _GraphicsAPI = globalSettings.GraphicsAPI();
-        _ForceFullRepaintRendering = globalSettings.ForceFullRepaintRendering();
+        _DisablePartialInvalidation = globalSettings.DisablePartialInvalidation();
         _SoftwareRendering = globalSettings.SoftwareRendering();
         _UseBackgroundImageForWindow = globalSettings.UseBackgroundImageForWindow();
         _ForceVTInput = globalSettings.ForceVTInput();

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.h
@@ -156,7 +156,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         INHERITABLE_SETTING(Model::TerminalSettings, bool, RetroTerminalEffect, false);
         INHERITABLE_SETTING(Model::TerminalSettings, Microsoft::Terminal::Control::GraphicsAPI, GraphicsAPI);
-        INHERITABLE_SETTING(Model::TerminalSettings, bool, ForceFullRepaintRendering, false);
+        INHERITABLE_SETTING(Model::TerminalSettings, bool, DisablePartialInvalidation, false);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, SoftwareRendering, false);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, UseBackgroundImageForWindow, false);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, ForceVTInput, false);

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.h
@@ -155,6 +155,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         INHERITABLE_SETTING(Model::TerminalSettings, Microsoft::Terminal::Control::TextAntialiasingMode, AntialiasingMode, Microsoft::Terminal::Control::TextAntialiasingMode::Grayscale);
 
         INHERITABLE_SETTING(Model::TerminalSettings, bool, RetroTerminalEffect, false);
+        INHERITABLE_SETTING(Model::TerminalSettings, Microsoft::Terminal::Control::GraphicsAPI, GraphicsAPI);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, ForceFullRepaintRendering, false);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, SoftwareRendering, false);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, UseBackgroundImageForWindow, false);

--- a/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
@@ -761,3 +761,12 @@ struct ::Microsoft::Terminal::Settings::Model::JsonUtils::ConversionTrait<::winr
         return "SelectionColor (#rrggbb, #rgb, #rrggbbaa, iNN)";
     }
 };
+
+JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Control::GraphicsAPI)
+{
+    JSON_MAPPINGS(3) = {
+        pair_type{ "automatic", ValueType::Automatic },
+        pair_type{ "direct2d", ValueType::Direct2D },
+        pair_type{ "direct3d11", ValueType::Direct3D11 },
+    };
+};

--- a/src/cascadia/UnitTests_SettingsModel/SerializationTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/SerializationTests.cpp
@@ -107,8 +107,6 @@ namespace SettingsModelUnitTests
                 "trimPaste": true,
 
                 "experimental.input.forceVT": false,
-                "experimental.rendering.forceFullRepaint": false,
-                "experimental.rendering.software": false,
 
                 "actions": []
             })" };

--- a/src/cascadia/inc/ControlProperties.h
+++ b/src/cascadia/inc/ControlProperties.h
@@ -73,6 +73,7 @@
     X(winrt::hstring, StartingDirectory)                                                                                                                 \
     X(winrt::Microsoft::Terminal::Control::ScrollbarState, ScrollState, winrt::Microsoft::Terminal::Control::ScrollbarState::Visible)                    \
     X(winrt::Microsoft::Terminal::Control::TextAntialiasingMode, AntialiasingMode, winrt::Microsoft::Terminal::Control::TextAntialiasingMode::Grayscale) \
+    X(winrt::Microsoft::Terminal::Control::GraphicsAPI, GraphicsAPI)                                                                                     \
     X(bool, ForceFullRepaintRendering, false)                                                                                                            \
     X(bool, SoftwareRendering, false)                                                                                                                    \
     X(bool, UseBackgroundImageForWindow, false)                                                                                                          \

--- a/src/cascadia/inc/ControlProperties.h
+++ b/src/cascadia/inc/ControlProperties.h
@@ -74,7 +74,7 @@
     X(winrt::Microsoft::Terminal::Control::ScrollbarState, ScrollState, winrt::Microsoft::Terminal::Control::ScrollbarState::Visible)                    \
     X(winrt::Microsoft::Terminal::Control::TextAntialiasingMode, AntialiasingMode, winrt::Microsoft::Terminal::Control::TextAntialiasingMode::Grayscale) \
     X(winrt::Microsoft::Terminal::Control::GraphicsAPI, GraphicsAPI)                                                                                     \
-    X(bool, ForceFullRepaintRendering, false)                                                                                                            \
+    X(bool, DisablePartialInvalidation, false)                                                                                                           \
     X(bool, SoftwareRendering, false)                                                                                                                    \
     X(bool, UseBackgroundImageForWindow, false)                                                                                                          \
     X(bool, ShowMarks, false)                                                                                                                            \

--- a/src/cppwinrt.build.pre.props
+++ b/src/cppwinrt.build.pre.props
@@ -9,7 +9,6 @@
   <Import Project="..\common.openconsole.props" Condition="'$(OpenConsoleDir)'==''" />
 
   <PropertyGroup Label="Globals">
-    <CppWinRTHeapEnforcement>AnyValueHereWillDisableTheOptOut</CppWinRTHeapEnforcement>
     <CppWinRTEnabled>true</CppWinRTEnabled>
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <DefaultLanguage>en-US</DefaultLanguage>

--- a/src/renderer/atlas/AtlasEngine.api.cpp
+++ b/src/renderer/atlas/AtlasEngine.api.cpp
@@ -427,7 +427,7 @@ void AtlasEngine::SetSoftwareRendering(bool enable) noexcept
     }
 }
 
-void AtlasEngine::SetForceFullRepaintRendering(bool enable) noexcept
+void AtlasEngine::SetDisablePartialInvalidation(bool enable) noexcept
 {
     if (_api.s->target->disablePresent1 != enable)
     {

--- a/src/renderer/atlas/AtlasEngine.api.cpp
+++ b/src/renderer/atlas/AtlasEngine.api.cpp
@@ -316,31 +316,16 @@ CATCH_RETURN()
 
 #pragma endregion
 
-#pragma region DxRenderer
-
-HRESULT AtlasEngine::Enable() noexcept
-{
-    return S_OK;
-}
+#pragma region getter
 
 [[nodiscard]] std::wstring_view AtlasEngine::GetPixelShaderPath() noexcept
 {
     return _api.s->misc->customPixelShaderPath;
 }
 
-[[nodiscard]] std::wstring_view AtlasEngine::GetPixelShaderImagePath() noexcept
-{
-    return _api.s->misc->customPixelShaderImagePath;
-}
-
 [[nodiscard]] bool AtlasEngine::GetRetroTerminalEffect() const noexcept
 {
     return _api.s->misc->useRetroTerminalEffect;
-}
-
-[[nodiscard]] float AtlasEngine::GetScaling() const noexcept
-{
-    return static_cast<f32>(_api.s->font->dpi) / static_cast<f32>(USER_DEFAULT_SCREEN_DPI);
 }
 
 [[nodiscard]] Microsoft::Console::Types::Viewport AtlasEngine::GetViewportInCharacters(const Types::Viewport& viewInPixels) const noexcept
@@ -356,6 +341,10 @@ HRESULT AtlasEngine::Enable() noexcept
     assert(_api.s->font->cellSize.y != 0);
     return Types::Viewport::FromDimensions(viewInCharacters.Origin(), { viewInCharacters.Width() * _api.s->font->cellSize.x, viewInCharacters.Height() * _api.s->font->cellSize.y });
 }
+
+#pragma endregion
+
+#pragma region setter
 
 void AtlasEngine::SetAntialiasingMode(const D2D1_TEXT_ANTIALIAS_MODE antialiasingMode) noexcept
 {
@@ -379,10 +368,6 @@ void AtlasEngine::EnableTransparentBackground(const bool isTransparent) noexcept
         _api.enableTransparentBackground = isTransparent;
         _resolveTransparencySettings();
     }
-}
-
-void AtlasEngine::SetForceFullRepaintRendering(bool enable) noexcept
-{
 }
 
 [[nodiscard]] HRESULT AtlasEngine::SetHwnd(const HWND hwnd) noexcept
@@ -436,9 +421,25 @@ void AtlasEngine::SetSelectionBackground(const COLORREF color, const float alpha
 
 void AtlasEngine::SetSoftwareRendering(bool enable) noexcept
 {
-    if (_api.s->target->useSoftwareRendering != enable)
+    if (_api.s->target->useWARP != enable)
     {
-        _api.s.write()->target.write()->useSoftwareRendering = enable;
+        _api.s.write()->target.write()->useWARP = enable;
+    }
+}
+
+void AtlasEngine::SetForceFullRepaintRendering(bool enable) noexcept
+{
+    if (_api.s->target->disablePresent1 != enable)
+    {
+        _api.s.write()->target.write()->disablePresent1 = enable;
+    }
+}
+
+void AtlasEngine::SetGraphicsAPI(GraphicsAPI graphicsAPI) noexcept
+{
+    if (_api.s->target->graphicsAPI != graphicsAPI)
+    {
+        _api.s.write()->target.write()->graphicsAPI = graphicsAPI;
     }
 }
 

--- a/src/renderer/atlas/AtlasEngine.cpp
+++ b/src/renderer/atlas/AtlasEngine.cpp
@@ -550,7 +550,7 @@ void AtlasEngine::_handleSettingsUpdate()
 
     if (targetChanged)
     {
-        // target->useSoftwareRendering affects the selection of our IDXGIAdapter which requires us to reset _p.dxgi.
+        // target->useWARP affects the selection of our IDXGIAdapter which requires us to reset _p.dxgi.
         // This will indirectly also recreate the backend, when AtlasEngine::_recreateAdapter() detects this change.
         _p.dxgi = {};
     }

--- a/src/renderer/atlas/AtlasEngine.h
+++ b/src/renderer/atlas/AtlasEngine.h
@@ -57,30 +57,28 @@ namespace Microsoft::Console::Render::Atlas
         [[nodiscard]] HRESULT GetFontSize(_Out_ til::size* pFontSize) noexcept override;
         [[nodiscard]] HRESULT IsGlyphWideByFont(std::wstring_view glyph, _Out_ bool* pResult) noexcept override;
         [[nodiscard]] HRESULT UpdateTitle(std::wstring_view newTitle) noexcept override;
-
-        // DxRenderer - getter
-        HRESULT Enable() noexcept override;
-        [[nodiscard]] std::wstring_view GetPixelShaderPath() noexcept override;
-        [[nodiscard]] std::wstring_view GetPixelShaderImagePath() noexcept override;
-        [[nodiscard]] bool GetRetroTerminalEffect() const noexcept override;
-        [[nodiscard]] float GetScaling() const noexcept override;
-        [[nodiscard]] Types::Viewport GetViewportInCharacters(const Types::Viewport& viewInPixels) const noexcept override;
-        [[nodiscard]] Types::Viewport GetViewportInPixels(const Types::Viewport& viewInCharacters) const noexcept override;
-        // DxRenderer - setter
-        void SetAntialiasingMode(D2D1_TEXT_ANTIALIAS_MODE antialiasingMode) noexcept override;
-        void SetCallback(std::function<void(HANDLE)> pfn) noexcept override;
-        void EnableTransparentBackground(const bool isTransparent) noexcept override;
-        void SetForceFullRepaintRendering(bool enable) noexcept override;
-        [[nodiscard]] HRESULT SetHwnd(HWND hwnd) noexcept override;
-        void SetPixelShaderPath(std::wstring_view value) noexcept override;
-        void SetPixelShaderImagePath(std::wstring_view value) noexcept override;
-        void SetRetroTerminalEffect(bool enable) noexcept override;
-        void SetSelectionBackground(COLORREF color, float alpha = 0.5f) noexcept override;
-        void SetSoftwareRendering(bool enable) noexcept override;
-        void SetWarningCallback(std::function<void(HRESULT)> pfn) noexcept override;
-        [[nodiscard]] HRESULT SetWindowSize(til::size pixels) noexcept override;
-        [[nodiscard]] HRESULT UpdateFont(const FontInfoDesired& pfiFontInfoDesired, FontInfo& fiFontInfo, const std::unordered_map<std::wstring_view, uint32_t>& features, const std::unordered_map<std::wstring_view, float>& axes) noexcept override;
         void UpdateHyperlinkHoveredId(uint16_t hoveredId) noexcept override;
+
+        // getter
+        [[nodiscard]] std::wstring_view GetPixelShaderPath() noexcept;
+        [[nodiscard]] bool GetRetroTerminalEffect() const noexcept;
+        [[nodiscard]] Types::Viewport GetViewportInCharacters(const Types::Viewport& viewInPixels) const noexcept;
+        [[nodiscard]] Types::Viewport GetViewportInPixels(const Types::Viewport& viewInCharacters) const noexcept;
+        // setter
+        void SetAntialiasingMode(D2D1_TEXT_ANTIALIAS_MODE antialiasingMode) noexcept;
+        void SetCallback(std::function<void(HANDLE)> pfn) noexcept;
+        void EnableTransparentBackground(const bool isTransparent) noexcept;
+        [[nodiscard]] HRESULT SetHwnd(HWND hwnd) noexcept;
+        void SetPixelShaderPath(std::wstring_view value) noexcept;
+        void SetPixelShaderImagePath(std::wstring_view value) noexcept;
+        void SetRetroTerminalEffect(bool enable) noexcept;
+        void SetSelectionBackground(COLORREF color, float alpha = 0.5f) noexcept;
+        void SetSoftwareRendering(bool enable) noexcept;
+        void SetForceFullRepaintRendering(bool enable) noexcept;
+        void SetGraphicsAPI(GraphicsAPI graphicsAPI) noexcept;
+        void SetWarningCallback(std::function<void(HRESULT)> pfn) noexcept;
+        [[nodiscard]] HRESULT SetWindowSize(til::size pixels) noexcept;
+        [[nodiscard]] HRESULT UpdateFont(const FontInfoDesired& pfiFontInfoDesired, FontInfo& fiFontInfo, const std::unordered_map<std::wstring_view, uint32_t>& features, const std::unordered_map<std::wstring_view, float>& axes) noexcept;
 
     private:
         // AtlasEngine.cpp

--- a/src/renderer/atlas/AtlasEngine.h
+++ b/src/renderer/atlas/AtlasEngine.h
@@ -74,7 +74,7 @@ namespace Microsoft::Console::Render::Atlas
         void SetRetroTerminalEffect(bool enable) noexcept;
         void SetSelectionBackground(COLORREF color, float alpha = 0.5f) noexcept;
         void SetSoftwareRendering(bool enable) noexcept;
-        void SetForceFullRepaintRendering(bool enable) noexcept;
+        void SetDisablePartialInvalidation(bool enable) noexcept;
         void SetGraphicsAPI(GraphicsAPI graphicsAPI) noexcept;
         void SetWarningCallback(std::function<void(HRESULT)> pfn) noexcept;
         [[nodiscard]] HRESULT SetWindowSize(til::size pixels) noexcept;

--- a/src/renderer/atlas/AtlasEngine.r.cpp
+++ b/src/renderer/atlas/AtlasEngine.r.cpp
@@ -134,7 +134,7 @@ void AtlasEngine::_recreateAdapter()
     DXGI_ADAPTER_DESC1 desc{};
 
     {
-        const auto useSoftwareRendering = _p.s->target->useSoftwareRendering;
+        const auto useWARP = _p.s->target->useWARP;
         UINT index = 0;
 
         do
@@ -142,13 +142,13 @@ void AtlasEngine::_recreateAdapter()
             THROW_IF_FAILED(_p.dxgi.factory->EnumAdapters1(index++, adapter.put()));
             THROW_IF_FAILED(adapter->GetDesc1(&desc));
 
-            // If useSoftwareRendering is false we exit during the first iteration. Using the default adapter (index 0)
+            // If useWARP is false we exit during the first iteration. Using the default adapter (index 0)
             // is the right thing to do under most circumstances, unless you _really_ want to get your hands dirty.
             // The alternative is to track the window rectangle in respect to all IDXGIOutputs and select the right
             // IDXGIAdapter, while also considering the "graphics preference" override in the windows settings app, etc.
             //
-            // If useSoftwareRendering is true we search until we find the first WARP adapter (usually the last adapter).
-        } while (useSoftwareRendering && WI_IsFlagClear(desc.Flags, DXGI_ADAPTER_FLAG_SOFTWARE));
+            // If useWARP is true we search until we find the first WARP adapter (usually the last adapter).
+        } while (useWARP && WI_IsFlagClear(desc.Flags, DXGI_ADAPTER_FLAG_SOFTWARE));
     }
 
     if (memcmp(&_p.dxgi.adapterLuid, &desc.AdapterLuid, sizeof(LUID)) != 0)
@@ -166,7 +166,8 @@ void AtlasEngine::_recreateBackend()
     // HWND, IWindow, or composition surface at a time. --> Destroy it while we still have the old device.
     _destroySwapChain();
 
-    auto d2dMode = ATLAS_DEBUG_FORCE_D2D_MODE;
+    auto graphicsAPI = _p.s->target->graphicsAPI;
+
     auto deviceFlags =
         D3D11_CREATE_DEVICE_SINGLETHREADED
 #ifndef NDEBUG
@@ -182,8 +183,14 @@ void AtlasEngine::_recreateBackend()
 
     if (WI_IsFlagSet(_p.dxgi.adapterFlags, DXGI_ADAPTER_FLAG_SOFTWARE))
     {
+        // If we're using WARP we don't want to disable those optimizations of course.
         WI_ClearFlag(deviceFlags, D3D11_CREATE_DEVICE_PREVENT_INTERNAL_THREADING_OPTIMIZATIONS);
-        d2dMode = true;
+
+        // I'm not sure whether Direct2D is actually faster on WARP, but it's definitely better tested.
+        if (graphicsAPI == GraphicsAPI::Automatic)
+        {
+            graphicsAPI = GraphicsAPI::Direct2D;
+        }
     }
 
     wil::com_ptr<ID3D11Device> device0;
@@ -202,17 +209,16 @@ void AtlasEngine::_recreateBackend()
 
 #pragma warning(suppress : 26496) // The variable 'hr' does not change after construction, mark it as const (con.4).
     auto hr = D3D11CreateDevice(
-        /* pAdapter */ _p.dxgi.adapter.get(),
-        /* DriverType */ D3D_DRIVER_TYPE_UNKNOWN,
-        /* Software */ nullptr,
-        /* Flags */ deviceFlags,
-        /* pFeatureLevels */ featureLevels.data(),
-        /* FeatureLevels */ gsl::narrow_cast<UINT>(featureLevels.size()),
-        /* SDKVersion */ D3D11_SDK_VERSION,
-        /* ppDevice */ device0.put(),
-        /* pFeatureLevel */ &featureLevel,
+        /* pAdapter           */ _p.dxgi.adapter.get(),
+        /* DriverType         */ D3D_DRIVER_TYPE_UNKNOWN,
+        /* Software           */ nullptr,
+        /* Flags              */ deviceFlags,
+        /* pFeatureLevels     */ featureLevels.data(),
+        /* FeatureLevels      */ gsl::narrow_cast<UINT>(featureLevels.size()),
+        /* SDKVersion         */ D3D11_SDK_VERSION,
+        /* ppDevice           */ device0.put(),
+        /* pFeatureLevel      */ &featureLevel,
         /* ppImmediateContext */ deviceContext0.put());
-
 #ifndef NDEBUG
     if (hr == DXGI_ERROR_SDK_COMPONENT_MISSING)
     {
@@ -222,15 +228,15 @@ void AtlasEngine::_recreateBackend()
         WI_ClearFlag(deviceFlags, D3D11_CREATE_DEVICE_DEBUG);
 
         hr = D3D11CreateDevice(
-            /* pAdapter */ _p.dxgi.adapter.get(),
-            /* DriverType */ D3D_DRIVER_TYPE_UNKNOWN,
-            /* Software */ nullptr,
-            /* Flags */ deviceFlags,
-            /* pFeatureLevels */ featureLevels.data(),
-            /* FeatureLevels */ gsl::narrow_cast<UINT>(featureLevels.size()),
-            /* SDKVersion */ D3D11_SDK_VERSION,
-            /* ppDevice */ device0.put(),
-            /* pFeatureLevel */ &featureLevel,
+            /* pAdapter           */ _p.dxgi.adapter.get(),
+            /* DriverType         */ D3D_DRIVER_TYPE_UNKNOWN,
+            /* Software           */ nullptr,
+            /* Flags              */ deviceFlags,
+            /* pFeatureLevels     */ featureLevels.data(),
+            /* FeatureLevels      */ gsl::narrow_cast<UINT>(featureLevels.size()),
+            /* SDKVersion         */ D3D11_SDK_VERSION,
+            /* ppDevice           */ device0.put(),
+            /* pFeatureLevel      */ &featureLevel,
             /* ppImmediateContext */ deviceContext0.put());
     }
 #endif
@@ -252,37 +258,45 @@ void AtlasEngine::_recreateBackend()
     }
 #endif
 
-    if (featureLevel < D3D_FEATURE_LEVEL_10_0)
+    if (graphicsAPI == GraphicsAPI::Automatic)
     {
-        d2dMode = true;
-    }
-    else if (featureLevel < D3D_FEATURE_LEVEL_11_0)
-    {
-        D3D11_FEATURE_DATA_D3D10_X_HARDWARE_OPTIONS options{};
-        // I'm assuming if `CheckFeatureSupport` fails, it'll leave `options` untouched which will result in `d2dMode |= true`.
-        std::ignore = device->CheckFeatureSupport(D3D11_FEATURE_D3D10_X_HARDWARE_OPTIONS, &options, sizeof(options));
-        d2dMode |= !options.ComputeShaders_Plus_RawAndStructuredBuffers_Via_Shader_4_x;
+        if (featureLevel < D3D_FEATURE_LEVEL_10_0)
+        {
+            graphicsAPI = GraphicsAPI::Direct2D;
+        }
+        else if (featureLevel < D3D_FEATURE_LEVEL_11_0)
+        {
+            D3D11_FEATURE_DATA_D3D10_X_HARDWARE_OPTIONS options{};
+            // I'm assuming if `CheckFeatureSupport` fails, it'll leave `options` untouched which will result in `d2dMode |= true`.
+            std::ignore = device->CheckFeatureSupport(D3D11_FEATURE_D3D10_X_HARDWARE_OPTIONS, &options, sizeof(options));
+            if (!options.ComputeShaders_Plus_RawAndStructuredBuffers_Via_Shader_4_x)
+            {
+                graphicsAPI = GraphicsAPI::Direct2D;
+            }
+        }
     }
 
     _p.device = std::move(device);
     _p.deviceContext = std::move(deviceContext);
 
-    if (d2dMode)
+    switch (graphicsAPI)
     {
+    case GraphicsAPI::Direct2D:
         _b = std::make_unique<BackendD2D>();
-    }
-    else
-    {
+        _hackIsBackendD2D = true;
+        break;
+    default:
         _b = std::make_unique<BackendD3D>(_p);
+        _hackIsBackendD2D = false;
+        break;
     }
 
     // This ensures that the backends redraw their entire viewports whenever a new swap chain is created,
     // EVEN IF we got called when no actual settings changed (i.e. rendering failure, etc.).
     _p.MarkAllAsDirty();
 
-    const auto hackWantsBuiltinGlyphs = _p.s->font->builtinGlyphs && !d2dMode;
+    const auto hackWantsBuiltinGlyphs = _p.s->font->builtinGlyphs && !_hackIsBackendD2D;
     _hackTriggerRedrawAll = _hackWantsBuiltinGlyphs != hackWantsBuiltinGlyphs;
-    _hackIsBackendD2D = d2dMode;
     _hackWantsBuiltinGlyphs = hackWantsBuiltinGlyphs;
 }
 
@@ -330,7 +344,7 @@ void AtlasEngine::_createSwapChain()
         // more "intelligent" composition and display updates to occur like Panel Self Refresh
         // (PSR) which requires dirty rectangles (Present1 API) to work correctly.
         // We were asked by DWM folks to use DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL for this reason (PSR).
-        .SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL,
+        .SwapEffect = _p.s->target->disablePresent1 ? DXGI_SWAP_EFFECT_FLIP_DISCARD : DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL,
         // If our background is opaque we can enable "independent" flips by setting DXGI_ALPHA_MODE_IGNORE.
         // As our swap chain won't have to compose with DWM anymore it reduces the display latency dramatically.
         .AlphaMode = _p.s->target->useAlpha ? DXGI_ALPHA_MODE_PREMULTIPLIED : DXGI_ALPHA_MODE_IGNORE,
@@ -458,44 +472,36 @@ void AtlasEngine::_present()
         return;
     }
 
-    if constexpr (!ATLAS_DEBUG_SHOW_DIRTY)
+    if (!ATLAS_DEBUG_SHOW_DIRTY && !_p.s->target->disablePresent1 && memcmp(&dirtyRect, &fullRect, sizeof(RECT)) != 0)
     {
-        if (memcmp(&dirtyRect, &fullRect, sizeof(RECT)) != 0)
+        params.DirtyRectsCount = 1;
+        params.pDirtyRects = &dirtyRect;
+
+        if (_p.scrollOffset)
         {
-            params.DirtyRectsCount = 1;
-            params.pDirtyRects = &dirtyRect;
+            const auto offsetInPx = _p.scrollOffset * _p.s->font->cellSize.y;
+            const auto width = _p.s->targetSize.x;
+            // We don't use targetSize.y here, because "height" refers to the bottom coordinate of the last text row
+            // in the buffer. We then add the "offsetInPx" (which is negative when scrolling text upwards) and thus
+            // end up with a "bottom" value that is the bottom of the last row of text that we haven't invalidated.
+            const auto height = _p.s->viewportCellCount.y * _p.s->font->cellSize.y;
+            const auto top = std::max(0, offsetInPx);
+            const auto bottom = height + std::min(0, offsetInPx);
 
-            if (_p.scrollOffset)
-            {
-                const auto offsetInPx = _p.scrollOffset * _p.s->font->cellSize.y;
-                const auto width = _p.s->targetSize.x;
-                // We don't use targetSize.y here, because "height" refers to the bottom coordinate of the last text row
-                // in the buffer. We then add the "offsetInPx" (which is negative when scrolling text upwards) and thus
-                // end up with a "bottom" value that is the bottom of the last row of text that we haven't invalidated.
-                const auto height = _p.s->viewportCellCount.y * _p.s->font->cellSize.y;
-                const auto top = std::max(0, offsetInPx);
-                const auto bottom = height + std::min(0, offsetInPx);
+            scrollRect = { 0, top, width, bottom };
+            scrollOffset = { 0, offsetInPx };
 
-                scrollRect = { 0, top, width, bottom };
-                scrollOffset = { 0, offsetInPx };
-
-                params.pScrollRect = &scrollRect;
-                params.pScrollOffset = &scrollOffset;
-            }
+            params.pScrollRect = &scrollRect;
+            params.pScrollOffset = &scrollOffset;
         }
     }
 
-    if constexpr (Feature_AtlasEnginePresentFallback::IsEnabled())
+    auto hr = _p.swapChain.swapChain->Present1(1, 0, &params);
+    if (Feature_AtlasEnginePresentFallback::IsEnabled() && FAILED(hr) && params.DirtyRectsCount != 0)
     {
-        if (FAILED_LOG(_p.swapChain.swapChain->Present1(1, 0, &params)))
-        {
-            THROW_IF_FAILED(_p.swapChain.swapChain->Present(1, 0));
-        }
+        hr = _p.swapChain.swapChain->Present(1, 0);
     }
-    else
-    {
-        THROW_IF_FAILED(_p.swapChain.swapChain->Present1(1, 0, &params));
-    }
+    THROW_IF_FAILED(hr);
 
     _p.swapChain.waitForPresentation = true;
 }

--- a/src/renderer/atlas/Backend.h
+++ b/src/renderer/atlas/Backend.h
@@ -30,9 +30,6 @@ namespace Microsoft::Console::Render::Atlas
     // This helps with benchmarking the application as it'll run beyond display refresh rate.
 #define ATLAS_DEBUG_DISABLE_FRAME_LATENCY_WAITABLE_OBJECT 0
 
-    // Forces the use of Direct2D for text rendering (= BackendD2D).
-#define ATLAS_DEBUG_FORCE_D2D_MODE 0
-
     // Adds an artificial delay before every render pass. In milliseconds.
 #define ATLAS_DEBUG_RENDER_DELAY 0
 

--- a/src/renderer/atlas/common.h
+++ b/src/renderer/atlas/common.h
@@ -311,11 +311,20 @@ namespace Microsoft::Console::Render::Atlas
         DWRITE_SCRIPT_ANALYSIS analysis;
     };
 
+    enum class GraphicsAPI
+    {
+        Automatic,
+        Direct2D,
+        Direct3D11,
+    };
+
     struct TargetSettings
     {
         HWND hwnd = nullptr;
         bool useAlpha = false;
-        bool useSoftwareRendering = false;
+        bool useWARP = false;
+        bool disablePresent1 = false;
+        GraphicsAPI graphicsAPI = GraphicsAPI::Automatic;
     };
 
     enum class AntialiasingMode : u8

--- a/src/renderer/base/RenderEngineBase.cpp
+++ b/src/renderer/base/RenderEngineBase.cpp
@@ -77,6 +77,10 @@ void RenderEngineBase::WaitUntilCanRender() noexcept
     Sleep(8);
 }
 
+void RenderEngineBase::UpdateHyperlinkHoveredId(const uint16_t /*hoveredId*/) noexcept
+{
+}
+
 // Routine Description:
 // - Notifies us that we're about to circle the buffer, giving us a chance to
 //   force a repaint before the buffer contents are lost.

--- a/src/renderer/inc/IRenderEngine.hpp
+++ b/src/renderer/inc/IRenderEngine.hpp
@@ -90,33 +90,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] virtual HRESULT GetFontSize(_Out_ til::size* pFontSize) noexcept = 0;
         [[nodiscard]] virtual HRESULT IsGlyphWideByFont(std::wstring_view glyph, _Out_ bool* pResult) noexcept = 0;
         [[nodiscard]] virtual HRESULT UpdateTitle(std::wstring_view newTitle) noexcept = 0;
-
-        // The following functions used to be specific to the DxRenderer and they should
-        // be abstracted away and integrated into the above or simply get removed.
-
-        // DxRenderer - getter
-        virtual HRESULT Enable() noexcept { return S_OK; }
-        [[nodiscard]] virtual std::wstring_view GetPixelShaderPath() noexcept { return {}; }
-        [[nodiscard]] virtual std::wstring_view GetPixelShaderImagePath() noexcept { return {}; }
-        [[nodiscard]] virtual bool GetRetroTerminalEffect() const noexcept { return false; }
-        [[nodiscard]] virtual float GetScaling() const noexcept { return 1; }
-        [[nodiscard]] virtual Types::Viewport GetViewportInCharacters(const Types::Viewport& viewInPixels) const noexcept { return Types::Viewport::Empty(); }
-        [[nodiscard]] virtual Types::Viewport GetViewportInPixels(const Types::Viewport& viewInCharacters) const noexcept { return Types::Viewport::Empty(); }
-        // DxRenderer - setter
-        virtual void SetAntialiasingMode(const D2D1_TEXT_ANTIALIAS_MODE antialiasingMode) noexcept {}
-        virtual void SetCallback(std::function<void(HANDLE)> pfn) noexcept {}
-        virtual void EnableTransparentBackground(const bool isTransparent) noexcept {}
-        virtual void SetForceFullRepaintRendering(bool enable) noexcept {}
-        [[nodiscard]] virtual HRESULT SetHwnd(const HWND hwnd) noexcept { return E_NOTIMPL; }
-        virtual void SetPixelShaderPath(std::wstring_view value) noexcept {}
-        virtual void SetPixelShaderImagePath(std::wstring_view value) noexcept {}
-        virtual void SetRetroTerminalEffect(bool enable) noexcept {}
-        virtual void SetSelectionBackground(const COLORREF color, const float alpha = 0.5f) noexcept {}
-        virtual void SetSoftwareRendering(bool enable) noexcept {}
-        virtual void SetWarningCallback(std::function<void(HRESULT)> pfn) noexcept {}
-        [[nodiscard]] virtual HRESULT SetWindowSize(const til::size pixels) noexcept { return E_NOTIMPL; }
-        [[nodiscard]] virtual HRESULT UpdateFont(const FontInfoDesired& pfiFontInfoDesired, FontInfo& fiFontInfo, const std::unordered_map<std::wstring_view, uint32_t>& features, const std::unordered_map<std::wstring_view, float>& axes) noexcept { return E_NOTIMPL; }
-        virtual void UpdateHyperlinkHoveredId(const uint16_t hoveredId) noexcept {}
+        virtual void UpdateHyperlinkHoveredId(const uint16_t hoveredId) noexcept = 0;
     };
 }
 #pragma warning(pop)

--- a/src/renderer/inc/RenderEngineBase.hpp
+++ b/src/renderer/inc/RenderEngineBase.hpp
@@ -46,6 +46,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT InvalidateFlush(_In_ const bool circled, _Out_ bool* const pForcePaint) noexcept override;
 
         void WaitUntilCanRender() noexcept override;
+        void UpdateHyperlinkHoveredId(const uint16_t hoveredId) noexcept override;
 
     protected:
         [[nodiscard]] virtual HRESULT _DoUpdateTitle(const std::wstring_view newTitle) noexcept = 0;

--- a/src/renderer/uia/UiaRenderer.hpp
+++ b/src/renderer/uia/UiaRenderer.hpp
@@ -30,7 +30,7 @@ namespace Microsoft::Console::Render
         // Only one UiaEngine may present information at a time.
         // This ensures that an automation client isn't overwhelmed
         // by events when there are multiple TermControls
-        [[nodiscard]] HRESULT Enable() noexcept override;
+        [[nodiscard]] HRESULT Enable() noexcept;
         [[nodiscard]] HRESULT Disable() noexcept;
 
         // IRenderEngine Members

--- a/src/renderer/wddmcon/WddmConRenderer.hpp
+++ b/src/renderer/wddmcon/WddmConRenderer.hpp
@@ -19,7 +19,7 @@ namespace Microsoft::Console::Render
         // Used to release device resources so that another instance of
         // conhost can render to the screen (i.e. only one DirectX
         // application may control the screen at a time.)
-        [[nodiscard]] HRESULT Enable() noexcept override;
+        [[nodiscard]] HRESULT Enable() noexcept;
         [[nodiscard]] HRESULT Disable() noexcept;
 
         til::rect GetDisplaySize() noexcept;


### PR DESCRIPTION
This implements `SetForceFullRepaintRendering` and adds a new
`SetGraphicsAPI` function. The former toggles `Present1` on and off
and the latter allows users to explicitly request Direct2D/3D.

On top of these changes I did a minor cleanup of the interface,
because now that DxRenderer is gone we don't need all that anymore.

Closes #14254
Closes #16747

## Validation Steps Performed
* Toggling Direct2D on/off changes colored ligature support ✅
* Toggling Present1 on/off can be observed in a debugger ✅
* Toggling WARP on/off changes GPU metrics ✅