### PR TITLE
Enable the check for the jailbreak filter

### DIFF
--- a/src/features.xml
+++ b/src/features.xml
@@ -90,6 +90,9 @@
         <name>Feature_TerminalChatJailbreakFilter</name>
         <description>If enabled, we check if the provided Azure OpenAI LLM uses a jailbreak filter.</description>
         <stage>AlwaysDisabled</stage>
+        <alwaysEnabledBrandingTokens>
+            <brandingToken>Canary</brandingToken>
+        </alwaysEnabledBrandingTokens>
     </feature>
 
     <feature>


### PR DESCRIPTION
One of the DSB requirements for Terminal AI was the check for a jailbreak filter. The code for this merged a while back and was put behind a velocity flag, this PR turns it on.