### PR TITLE
Replace til::bit_cast with std::bit_cast

### DIFF
--- a/src/buffer/out/TextColor.cpp
+++ b/src/buffer/out/TextColor.cpp
@@ -202,7 +202,7 @@ COLORREF TextColor::GetColor(const std::array<COLORREF, TextColor::TABLE_SIZE>& 
             //    the result will be something like 0b00100000.
             // 5. Use BitScanForward (bsf) to find the index of the most significant 1 bit.
             const auto haystack = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(colorTable.data())); // 1.
-            const auto needle = _mm256_set1_epi32(til::bit_cast<int>(defaultColor)); // 2.
+            const auto needle = _mm256_set1_epi32(std::bit_cast<int>(defaultColor)); // 2.
             const auto result = _mm256_cmpeq_epi32(haystack, needle); // 3.
             const auto mask = _mm256_movemask_ps(_mm256_castsi256_ps(result)); // 4.
             unsigned long index;
@@ -219,7 +219,7 @@ COLORREF TextColor::GetColor(const std::array<COLORREF, TextColor::TABLE_SIZE>& 
             //   --> the index returned by _BitScanForward must be divided by 2.
             const auto haystack1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(colorTable.data() + 0));
             const auto haystack2 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(colorTable.data() + 4));
-            const auto needle = _mm_set1_epi32(til::bit_cast<int>(defaultColor));
+            const auto needle = _mm_set1_epi32(std::bit_cast<int>(defaultColor));
             const auto result1 = _mm_cmpeq_epi32(haystack1, needle);
             const auto result2 = _mm_cmpeq_epi32(haystack2, needle);
             const auto result = _mm_packs_epi32(result1, result2); // 3.5

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -2502,7 +2502,7 @@ void TextBuffer::_AppendRTFText(std::string& contentBuilder, const std::wstring_
         {
             // Windows uses unsigned wchar_t - RTF uses signed ones.
             // '?' is the fallback ascii character.
-            const auto codeUnitRTFStr = std::to_string(til::bit_cast<int16_t>(codeUnit));
+            const auto codeUnitRTFStr = std::to_string(std::bit_cast<int16_t>(codeUnit));
             fmt::format_to(std::back_inserter(contentBuilder), FMT_COMPILE("\\u{}?"), codeUnitRTFStr);
         }
     }

--- a/src/host/directio.cpp
+++ b/src/host/directio.cpp
@@ -306,8 +306,8 @@ CATCH_RETURN();
                         // Fill the 1 byte (AsciiChar) portion of the leading and trailing cells with each of the bytes returned.
                         // We have to be bit careful here not to directly write the CHARs, because CHARs are signed whereas wchar_t isn't
                         // and we don't want any sign-extension. We want a 1:1 copy instead, so cast it to an unsigned char first.
-                        in1.Char.UnicodeChar = til::bit_cast<uint8_t>(AsciiDbcs[0]);
-                        in2.Char.UnicodeChar = til::bit_cast<uint8_t>(AsciiDbcs[1]);
+                        in1.Char.UnicodeChar = std::bit_cast<uint8_t>(AsciiDbcs[0]);
+                        in2.Char.UnicodeChar = std::bit_cast<uint8_t>(AsciiDbcs[1]);
                     }
                     else
                     {
@@ -323,7 +323,7 @@ CATCH_RETURN();
                     // 2 byte UTF-16 character into. Give it a go.
                     CHAR asciiChar{};
                     ConvertToOem(codepage, &in1.Char.UnicodeChar, 1, &asciiChar, 1);
-                    in1.Char.UnicodeChar = til::bit_cast<uint8_t>(asciiChar);
+                    in1.Char.UnicodeChar = std::bit_cast<uint8_t>(asciiChar);
                 }
             }
         }

--- a/src/host/inputBuffer.cpp
+++ b/src/host/inputBuffer.cpp
@@ -434,7 +434,7 @@ try
                     {
                         // char is signed and assigning it to UnicodeChar would cause sign-extension.
                         // unsigned char doesn't have this problem.
-                        event.Event.KeyEvent.uChar.UnicodeChar = til::bit_cast<uint8_t>(ch);
+                        event.Event.KeyEvent.uChar.UnicodeChar = std::bit_cast<uint8_t>(ch);
                         OutEvents.push_back(event);
                     }
                     repeat--;

--- a/src/inc/consoletaeftemplates.hpp
+++ b/src/inc/consoletaeftemplates.hpp
@@ -61,7 +61,7 @@ namespace WEX::TestExecution
             return true;
         }
 
-        const auto nDiff = static_cast<std::make_signed_t<U>>(til::bit_cast<U>(a) - til::bit_cast<U>(b));
+        const auto nDiff = static_cast<std::make_signed_t<U>>(std::bit_cast<U>(a) - std::bit_cast<U>(b));
         const auto uDiff = static_cast<U>(nDiff < 0 ? -nDiff : nDiff);
         return uDiff <= 4;
     }

--- a/src/inc/til/bit.h
+++ b/src/inc/til/bit.h
@@ -5,20 +5,12 @@
 
 namespace til
 {
-    // bit_cast is a backport of the STL's std::bit_cast to C++17.
-    template<class To, class From, std::enable_if_t<std::conjunction_v<std::bool_constant<sizeof(To) == sizeof(From)>, std::is_trivially_copyable<To>, std::is_trivially_copyable<From>>, int> = 0>
-    [[nodiscard]] constexpr To bit_cast(const From& _Val) noexcept
-    {
-        // TODO: Replace til::bit_cast and __builtin_bit_cast with std::bit_cast
-        return __builtin_bit_cast(To, _Val);
-    }
-
     // When you cast a signed integer to an unsigned one, the compiler will use "sign extension"
     // so that -1 translates to all bits being set, no matter the size of the target type.
     // Sometimes you don't need or want that, which is when you can use this function.
     template<typename T>
     [[nodiscard]] constexpr auto as_unsigned(const T& v) noexcept
     {
-        return bit_cast<std::make_unsigned_t<T>>(v);
+        return std::bit_cast<std::make_unsigned_t<T>>(v);
     }
 }


### PR DESCRIPTION
The former was introduced when we were still using C++17.
We're using C++20 now so it's not needed anymore.