### PR TITLE
Add a WT_SETTINGS_DIR env variable that portable profiles can use

### DIFF
--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -149,6 +149,11 @@ namespace winrt::TerminalApp::implementation
         _languageProfileNotifier = winrt::make_self<LanguageProfileNotifier>([this]() {
             _reloadSettings->Run();
         });
+
+        // Do this here, rather than at the top of main. This will prevent us from
+        // including this variable in the vars we serialize in the
+        // Remoting::CommandlineArgs up in HandleCommandlineArgs.
+        _setupFolderPathEnvVar();
     }
 
     // Method Description:
@@ -720,4 +725,14 @@ namespace winrt::TerminalApp::implementation
         return TerminalApp::ParseCommandlineResult{ winrt::to_hstring(_appArgs.GetExitMessage()), r };
     }
 
+    // Function Description
+    // * Adds a `WT_SETTINGS_PATH` env var to our own environment block, that
+    //   points at our settings directory. This allows portable installs to
+    //   refer to files in the portable install using %WT_SETTINGS_PATH%
+    void AppLogic::_setupFolderPathEnvVar()
+    {
+        std::wstring path{ CascadiaSettings::SettingsPath() };
+        auto folderPath = path.substr(0, path.find_last_of(L"\\"));
+        SetEnvironmentVariableW(L"WT_SETTINGS_PATH", folderPath.c_str());
+    }
 }

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -726,13 +726,13 @@ namespace winrt::TerminalApp::implementation
     }
 
     // Function Description
-    // * Adds a `WT_SETTINGS_PATH` env var to our own environment block, that
+    // * Adds a `WT_SETTINGS_DIR` env var to our own environment block, that
     //   points at our settings directory. This allows portable installs to
-    //   refer to files in the portable install using %WT_SETTINGS_PATH%
+    //   refer to files in the portable install using %WT_SETTINGS_DIR%
     void AppLogic::_setupFolderPathEnvVar()
     {
         std::wstring path{ CascadiaSettings::SettingsPath() };
         auto folderPath = path.substr(0, path.find_last_of(L"\\"));
-        SetEnvironmentVariableW(L"WT_SETTINGS_PATH", folderPath.c_str());
+        SetEnvironmentVariableW(L"WT_SETTINGS_DIR", folderPath.c_str());
     }
 }

--- a/src/cascadia/TerminalApp/AppLogic.h
+++ b/src/cascadia/TerminalApp/AppLogic.h
@@ -112,6 +112,8 @@ namespace winrt::TerminalApp::implementation
         void _RegisterSettingsChange();
         fire_and_forget _DispatchReloadSettings();
 
+        void _setupFolderPathEnvVar();
+
 #ifdef UNIT_TESTING
         friend class TerminalAppLocalTests::CommandlineTest;
 #endif

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -307,17 +307,6 @@ void WindowEmperor::_decrementWindowCount()
     }
 }
 
-// Function Description
-// * Adds a `WT_FOLDER_PATH` env var to our own environment block, that points
-//   at our parent directory. This allows portable installs to refer to files in
-//   the portable install using %WT_FOLDER_PATH%
-static void _setupFolderPathEnvVar()
-{
-    std::wstring path = wil::GetModuleFileNameW<std::wstring>();
-    auto folderPath = path.substr(0, path.find_last_of(L"\\"));
-    SetEnvironmentVariableW(L"WT_FOLDER_PATH", folderPath.c_str());
-}
-
 // Method Description:
 // - Set up all sorts of handlers now that we've determined that we're a process
 //   that will end up hosting the windows. These include:
@@ -331,11 +320,6 @@ static void _setupFolderPathEnvVar()
 // - <none>
 void WindowEmperor::_becomeMonarch()
 {
-    // Do this here, rather than at the top of main. This will prevent us from
-    // including this variable in the vars we serialize in the
-    // Remoting::CommandlineArgs up in HandleCommandlineArgs.
-    _setupFolderPathEnvVar();
-
     // Add a callback to the window manager so that when the Monarch wants a new
     // window made, they come to us
     _manager.RequestNewWindow([this](auto&&, const Remoting::WindowRequestedArgs& args) {


### PR DESCRIPTION
Basically, title. 

It'd be a neat idea for portable installs of the Terminal to reference files that are right there in the portable install.

This PR adds a `WT_SETTINGS_DIR` var to Terminal's own env block. This allows us to resolve profiles relative to our own settings folder. 

Closes #16295 