### PR TITLE
Replace 'it'll' with 'it will' to adhere to Microsoft Style Guidelines

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -990,7 +990,7 @@
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
   </data>
   <data name="Profile_Elevate.HelpText" xml:space="preserve">
-    <value>If enabled, the profile will open in an Admin terminal window automatically. If the current window is already running as admin, it'll open in this window.</value>
+    <value>If enabled, the profile will open in an Admin terminal window automatically. If the current window is already running as admin, it will open in this window.</value>
     <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">


### PR DESCRIPTION
## Summary of the Pull Request

## References and Relevant Issues
Fixes "Align 'Run this profile as Administrator' Settings Description with Microsoft Style Guidelines" #16946 
## Detailed Description of the Pull Request / Additional comments
Expanded the contraction "it'll" to "it will" on line 993 of `src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw`
## Validation Steps Performed
N/A

## PR Checklist
- [X] Closes #16946
- [ ] Tests added/passed
   - No tests were added
- [ ] Documentation updated
   - No documentation was updated
- [ ] Schema updated (if necessary)
   - No schema was updated