### PR TITLE
Move to AzureFileCopy@6 for Managed Identity support

### DIFF
--- a/build/pipelines/templates-v2/job-deploy-to-azure-storage.yml
+++ b/build/pipelines/templates-v2/job-deploy-to-azure-storage.yml
@@ -80,7 +80,7 @@ jobs:
       Install-Module -Verbose -AllowClobber -Force Az.Accounts, Az.Storage, Az.Network, Az.Resources, Az.Compute
     displayName: Install Azure Module Dependencies
 
-  - task: AzureFileCopy@5
+  - task: AzureFileCopy@6
     displayName: Publish to Storage Account
     inputs:
       sourcePath: _out/*


### PR DESCRIPTION
This is required for us to move off Entra ID Application identity.