### PR TITLE
Don't right-click paste on a click that also activates the window

### DIFF
--- a/src/cascadia/TerminalControl/ControlInteractivity.cpp
+++ b/src/cascadia/TerminalControl/ControlInteractivity.cpp
@@ -237,6 +237,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                                               const unsigned int pointerUpdateKind,
                                               const uint64_t timestamp,
                                               const ::Microsoft::Terminal::Core::ControlKeyStates modifiers,
+                                              const bool thisClickFocused,
                                               const Core::Point pixelPosition)
     {
         const auto terminalPosition = _getTerminalPosition(til::point{ pixelPosition });
@@ -309,8 +310,12 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                 auto contextArgs = winrt::make<ContextMenuRequestedEventArgs>(til::point{ pixelPosition }.to_winrt_point());
                 ContextMenuRequested.raise(*this, contextArgs);
             }
-            else
+            else if (!thisClickFocused)
             {
+                // GH#15803: Don't do this if this click activated our terminal
+                // window. We don't want right-click activations of the window
+                // to immediately paste the clipboard.
+
                 // Try to copy the text and clear the selection
                 const auto successfulCopy = CopySelectionToClipboard(shiftEnabled, nullptr);
                 _core->ClearSelection();

--- a/src/cascadia/TerminalControl/ControlInteractivity.h
+++ b/src/cascadia/TerminalControl/ControlInteractivity.h
@@ -55,6 +55,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                             const unsigned int pointerUpdateKind,
                             const uint64_t timestamp,
                             const ::Microsoft::Terminal::Core::ControlKeyStates modifiers,
+                            const bool thisClickFocused,
                             const Core::Point pixelPosition);
         void TouchPressed(const Core::Point contactPoint);
 

--- a/src/cascadia/TerminalControl/ControlInteractivity.idl
+++ b/src/cascadia/TerminalControl/ControlInteractivity.idl
@@ -40,6 +40,7 @@ namespace Microsoft.Terminal.Control
                             UInt32 pointerUpdateKind,
                             UInt64 timestamp,
                             Microsoft.Terminal.Core.ControlKeyStates modifiers,
+                            Boolean thisClickFocused,
                             Microsoft.Terminal.Core.Point pixelPosition);
         void TouchPressed(Microsoft.Terminal.Core.Point contactPoint);
 

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1550,7 +1550,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // again to bring it up.
         InputPane::GetForCurrentView().TryShow();
 
-        if (!_focused)
+        const bool thisClickFocused = !_focused;
+
+        if (thisClickFocused)
         {
             Focus(FocusState::Pointer);
         }
@@ -1572,6 +1574,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                                           TermControl::GetPointerUpdateKind(point),
                                           point.Timestamp(),
                                           ControlKeyStates{ args.KeyModifiers() },
+                                          thisClickFocused,
                                           _toTerminalOrigin(cursorPosition).to_core_point());
         }
 

--- a/src/cascadia/UnitTests_Control/ControlInteractivityTests.cpp
+++ b/src/cascadia/UnitTests_Control/ControlInteractivityTests.cpp
@@ -319,6 +319,7 @@ namespace ControlUnitTests
                                       WM_LBUTTONDOWN, //pointerUpdateKind
                                       0, // timestamp
                                       modifiers,
+                                      false,
                                       cursorPosition0.to_core_point());
         Log::Comment(L"Verify that there's not yet a selection");
 
@@ -367,6 +368,7 @@ namespace ControlUnitTests
                                       WM_LBUTTONDOWN, //pointerUpdateKind
                                       0, // timestamp
                                       modifiers,
+                                      false,
                                       cursorPosition3.to_core_point());
         Log::Comment(L"Verify that there's now no selection");
         VERIFY_IS_FALSE(core->HasSelection());
@@ -419,6 +421,7 @@ namespace ControlUnitTests
                                       WM_LBUTTONDOWN, //pointerUpdateKind
                                       0, // timestamp
                                       modifiers,
+                                      false,
                                       cursorPosition0.to_core_point());
 
         Log::Comment(L"Verify that there's not yet a selection");
@@ -568,6 +571,7 @@ namespace ControlUnitTests
                                       WM_LBUTTONDOWN, //pointerUpdateKind
                                       0, // timestamp
                                       modifiers,
+                                      false,
                                       cursorPosition0.to_core_point());
 
         Log::Comment(L"Verify that there's not yet a selection");
@@ -613,6 +617,7 @@ namespace ControlUnitTests
                                       WM_LBUTTONDOWN, //pointerUpdateKind
                                       0, // timestamp
                                       modifiers,
+                                      false,
                                       cursorPosition0.to_core_point());
 
         Log::Comment(L"Verify that there's not yet a selection");
@@ -731,6 +736,7 @@ namespace ControlUnitTests
                                       WM_LBUTTONDOWN, //pointerUpdateKind
                                       0, // timestamp
                                       modifiers,
+                                      false,
                                       cursorPosition0.to_core_point());
         Log::Comment(L"Verify that there's not yet a selection");
 
@@ -782,6 +788,7 @@ namespace ControlUnitTests
                                       WM_LBUTTONDOWN, //pointerUpdateKind
                                       0, // timestamp
                                       modifiers,
+                                      false,
                                       cursorPosition0.to_core_point());
 
         Log::Comment(L"Verify that there's not yet a selection");
@@ -936,6 +943,7 @@ namespace ControlUnitTests
                                       WM_LBUTTONDOWN, //pointerUpdateKind
                                       0, // timestamp
                                       modifiers,
+                                      false,
                                       cursorPosition0.to_core_point());
     }
 
@@ -985,6 +993,7 @@ namespace ControlUnitTests
                                       WM_LBUTTONDOWN, //pointerUpdateKind
                                       0, // timestamp
                                       modifiers,
+                                      false,
                                       cursorPosition0.to_core_point());
         VERIFY_ARE_EQUAL(0u, expectedOutput.size(), L"Validate we drained all the expected output");
 
@@ -1001,6 +1010,7 @@ namespace ControlUnitTests
                                       WM_LBUTTONDOWN, //pointerUpdateKind
                                       0, // timestamp
                                       modifiers,
+                                      false,
                                       cursorPosition1.to_core_point());
         VERIFY_ARE_EQUAL(0u, expectedOutput.size(), L"Validate we drained all the expected output");
 
@@ -1016,6 +1026,7 @@ namespace ControlUnitTests
                                       WM_LBUTTONDOWN, //pointerUpdateKind
                                       0, // timestamp
                                       modifiers,
+                                      false,
                                       cursorPosition0.to_core_point());
         // Flush it out.
         conn->WriteInput(L"sentinel");
@@ -1033,6 +1044,7 @@ namespace ControlUnitTests
                                       WM_LBUTTONDOWN, //pointerUpdateKind
                                       0, // timestamp
                                       modifiers,
+                                      false,
                                       cursorPosition1.to_core_point());
 
         Log::Comment(L" --- Resize the terminal to be 10 columns wider ---");
@@ -1047,6 +1059,7 @@ namespace ControlUnitTests
                                       WM_LBUTTONDOWN, //pointerUpdateKind
                                       0, // timestamp
                                       modifiers,
+                                      false,
                                       cursorPosition1.to_core_point());
         VERIFY_ARE_EQUAL(0u, expectedOutput.size(), L"Validate we drained all the expected output");
     }

--- a/src/tools/scratch/main.cpp
+++ b/src/tools/scratch/main.cpp
@@ -2,9 +2,12 @@
 // Licensed under the MIT license.
 
 #include <windows.h>
+#include <stdio.h>
 
 // This wmain exists for help in writing scratch programs while debugging.
 int __cdecl wmain(int /*argc*/, WCHAR* /*argv[]*/)
 {
+
+    wprintf(L"Hello \n goodbye \n");
     return 0;
 }


### PR DESCRIPTION
Doing so would automatically paste the clipboard. If an app was there waiting for input (like the VS debug console), then we'd immediately paste into it. This caused minor dsat, as it could unknowingly close the terminal (again, in the case of the vs debug console).

Closes #15803
