### PR TITLE
Add clamping of initial rows and columns settings

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Launch.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Launch.xaml
@@ -183,6 +183,8 @@
                     <muxc:NumberBox x:Uid="Globals_InitialColsBox"
                                     Grid.Row="0"
                                     Grid.Column="1"
+                                    Minimum="1"
+                                    Maximum="999"
                                     VerticalAlignment="Center"
                                     Style="{StaticResource LaunchSizeNumberBoxStyle}"
                                     Value="{x:Bind ViewModel.InitialCols, Mode=TwoWay}" />
@@ -194,6 +196,8 @@
                     <muxc:NumberBox x:Uid="Globals_InitialRowsBox"
                                     Grid.Row="1"
                                     Grid.Column="1"
+                                    Minimum="1"
+                                    Maximum="999"
                                     VerticalAlignment="Center"
                                     Style="{StaticResource LaunchSizeNumberBoxStyle}"
                                     Value="{x:Bind ViewModel.InitialRows, Mode=TwoWay}" />

--- a/src/cascadia/TerminalSettingsEditor/Launch.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Launch.xaml
@@ -183,9 +183,9 @@
                     <muxc:NumberBox x:Uid="Globals_InitialColsBox"
                                     Grid.Row="0"
                                     Grid.Column="1"
-                                    Minimum="1"
-                                    Maximum="999"
                                     VerticalAlignment="Center"
+                                    Maximum="999"
+                                    Minimum="1"
                                     Style="{StaticResource LaunchSizeNumberBoxStyle}"
                                     Value="{x:Bind ViewModel.InitialCols, Mode=TwoWay}" />
                     <TextBlock x:Uid="Globals_InitialRows"
@@ -196,9 +196,9 @@
                     <muxc:NumberBox x:Uid="Globals_InitialRowsBox"
                                     Grid.Row="1"
                                     Grid.Column="1"
-                                    Minimum="1"
-                                    Maximum="999"
                                     VerticalAlignment="Center"
+                                    Maximum="999"
+                                    Minimum="1"
                                     Style="{StaticResource LaunchSizeNumberBoxStyle}"
                                     Value="{x:Bind ViewModel.InitialRows, Mode=TwoWay}" />
                 </Grid>

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
@@ -144,7 +144,7 @@ void GlobalAppSettings::LayerJson(const Json::Value& json, const OriginTag origi
     {
         this->InitialCols(std::clamp(this->InitialCols(), 1, 999));
     }
-    if (this->InitialRows() != std::clamp(this->InitialRows(), 1, 999))
+    if (this->HasInitialRows())
     {
         this->InitialRows(std::clamp(this->InitialRows(), 1, 999));
     }

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
@@ -133,7 +133,7 @@ void GlobalAppSettings::LayerJson(const Json::Value& json, const OriginTag origi
     JsonUtils::GetValueForKey(json, LegacyUseTabSwitcherModeKey, _TabSwitcherMode);
 
 #define GLOBAL_SETTINGS_LAYER_JSON(type, name, jsonKey, ...) \
-    JsonUtils::GetValueForKey(json, jsonKey, _##name);   
+    JsonUtils::GetValueForKey(json, jsonKey, _##name);
     MTSM_GLOBAL_SETTINGS(GLOBAL_SETTINGS_LAYER_JSON)
 #undef GLOBAL_SETTINGS_LAYER_JSON
 

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
@@ -133,14 +133,21 @@ void GlobalAppSettings::LayerJson(const Json::Value& json, const OriginTag origi
     JsonUtils::GetValueForKey(json, LegacyUseTabSwitcherModeKey, _TabSwitcherMode);
 
 #define GLOBAL_SETTINGS_LAYER_JSON(type, name, jsonKey, ...) \
-    JsonUtils::GetValueForKey(json, jsonKey, _##name);
+    JsonUtils::GetValueForKey(json, jsonKey, _##name);   
     MTSM_GLOBAL_SETTINGS(GLOBAL_SETTINGS_LAYER_JSON)
 #undef GLOBAL_SETTINGS_LAYER_JSON
 
     // GH#11975 We only want to allow sensible values and prevent crashes, so we are clamping those values
-    this->InitialCols(std::clamp(this->InitialCols(), 1, 999));
-    this->InitialRows(std::clamp(this->InitialRows(), 1, 999));
-
+    // We only want to assign if the value did change through clamping,
+    // otherwise we could end up setting defaults that get persisted
+    if (this->InitialCols() != std::clamp(this->InitialCols(), 1, 999))
+    {
+        this->InitialCols(std::clamp(this->InitialCols(), 1, 999));
+    }
+    if (this->InitialRows() != std::clamp(this->InitialRows(), 1, 999))
+    {
+        this->InitialRows(std::clamp(this->InitialRows(), 1, 999));
+    }
     LayerActionsFrom(json, origin, true);
 
     JsonUtils::GetValueForKey(json, LegacyReloadEnvironmentVariablesKey, _legacyReloadEnvironmentVariables);

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
@@ -140,7 +140,7 @@ void GlobalAppSettings::LayerJson(const Json::Value& json, const OriginTag origi
     // GH#11975 We only want to allow sensible values and prevent crashes, so we are clamping those values
     // We only want to assign if the value did change through clamping,
     // otherwise we could end up setting defaults that get persisted
-    if (this->InitialCols() != std::clamp(this->InitialCols(), 1, 999))
+    if (this->HasInitialCols())
     {
         this->InitialCols(std::clamp(this->InitialCols(), 1, 999));
     }

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
@@ -137,6 +137,10 @@ void GlobalAppSettings::LayerJson(const Json::Value& json, const OriginTag origi
     MTSM_GLOBAL_SETTINGS(GLOBAL_SETTINGS_LAYER_JSON)
 #undef GLOBAL_SETTINGS_LAYER_JSON
 
+    // GH#11975 We only want to allow sensible values and prevent crashes, so we are clamping those values
+    this->InitialCols(std::clamp(this->InitialCols(), 1, 999));
+    this->InitialRows(std::clamp(this->InitialRows(), 1, 999));
+
     LayerActionsFrom(json, origin, true);
 
     JsonUtils::GetValueForKey(json, LegacyReloadEnvironmentVariablesKey, _legacyReloadEnvironmentVariables);

--- a/src/cascadia/UnitTests_SettingsModel/DeserializationTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/DeserializationTests.cpp
@@ -1306,7 +1306,8 @@ namespace SettingsModelUnitTests
     {
         static constexpr std::string_view inputSettings{ R"({
             "initialCols" : 1000000,
-            "initialRows" : -1000000
+            "initialRows" : -1000000,
+            "profiles": [{ "name": "profile0" }]
         })" };
 
         const auto settings = createSettings(inputSettings);

--- a/src/cascadia/UnitTests_SettingsModel/DeserializationTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/DeserializationTests.cpp
@@ -47,6 +47,7 @@ namespace SettingsModelUnitTests
         TEST_METHOD(ValidateKeybindingsWarnings);
         TEST_METHOD(ValidateColorSchemeInCommands);
         TEST_METHOD(ValidateExecuteCommandlineWarning);
+        TEST_METHOD(TestClampingOfStartupColumnAndViewProperties);
         TEST_METHOD(TestTrailingCommas);
         TEST_METHOD(TestCommandsAndKeybindings);
         TEST_METHOD(TestNestedCommandWithoutName);
@@ -1299,6 +1300,19 @@ namespace SettingsModelUnitTests
         VERIFY_ARE_EQUAL(SettingsLoadWarnings::MissingRequiredParameter, settings->Warnings().GetAt(1));
         VERIFY_ARE_EQUAL(SettingsLoadWarnings::MissingRequiredParameter, settings->Warnings().GetAt(2));
         VERIFY_ARE_EQUAL(SettingsLoadWarnings::MissingRequiredParameter, settings->Warnings().GetAt(3));
+    }
+
+    void DeserializationTests::TestClampingOfStartupColumnAndViewProperties()
+    {
+        static constexpr std::string_view inputSettings{ R"({
+            "initialCols" : 1000000,
+            "initialRows" : -1000000
+        })" };
+
+        const auto settings = createSettings(inputSettings);
+
+        VERIFY_ARE_EQUAL(999, settings->GlobalSettings().InitialCols());
+        VERIFY_ARE_EQUAL(1, settings->GlobalSettings().InitialRows());
     }
 
     void DeserializationTests::TestTrailingCommas()


### PR DESCRIPTION
This clamps the initial rows and columns settings in two areas:
- When reading the JSON file
- In the settings dialogue

For consistency, I've also added a minimum value to the NumberBoxes even
though the default Minimum is 1. The Maximum and Minimum are taken from
the JSON Schema file (Min 1, Max 999).

Closes #11957
