### PR TITLE
Increase usage of fmt and FMT_COMPILE

### DIFF
--- a/src/inc/LibraryIncludes.h
+++ b/src/inc/LibraryIncludes.h
@@ -29,7 +29,6 @@
 #include <filesystem>
 #include <fstream>
 #include <functional>
-#include <iomanip>
 #include <iterator>
 #include <list>
 #include <map>
@@ -44,7 +43,6 @@
 #include <set>
 #include <shared_mutex>
 #include <span>
-#include <sstream>
 #include <stdexcept>
 #include <string_view>
 #include <string>

--- a/src/inc/til/bitmap.h
+++ b/src/inc/til/bitmap.h
@@ -466,17 +466,12 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
 
             std::wstring to_string() const
             {
-                std::wstringstream wss;
-                wss << std::endl
-                    << L"Bitmap of size " << _sz.to_string() << " contains the following dirty regions:" << std::endl;
-                wss << L"Runs:" << std::endl;
-
+                auto str = fmt::format(FMT_COMPILE(L"Bitmap of size {} contains the following dirty regions:\nRuns:"), _sz.to_string());
                 for (auto& item : *this)
                 {
-                    wss << L"\t- " << item.to_string() << std::endl;
+                    fmt::format_to(std::back_inserter(str), FMT_COMPILE(L"\n\t- {}"), item.to_string());
                 }
-
-                return wss.str();
+                return str;
             }
 
         private:

--- a/src/inc/til/color.h
+++ b/src/inc/til/color.h
@@ -198,24 +198,17 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
 
         std::wstring to_string() const
         {
-            std::wstringstream wss;
-            wss << L"Color " << ToHexString(false);
-            return wss.str();
+            return ToHexString(false);
         }
+
         std::wstring ToHexString(const bool omitAlpha = false) const
         {
-            std::wstringstream wss;
-            wss << L"#" << std::uppercase << std::setfill(L'0') << std::hex;
-            // Force the compiler to promote from byte to int. Without it, the
-            // stringstream will try to write the components as chars
-            wss << std::setw(2) << static_cast<int>(r);
-            wss << std::setw(2) << static_cast<int>(g);
-            wss << std::setw(2) << static_cast<int>(b);
-            if (!omitAlpha)
+            auto str = fmt::format(FMT_COMPILE(L"#{:02X}{:02X}{:02X}{:02X}"), r, g, b, a);
+            if (omitAlpha)
             {
-                wss << std::setw(2) << static_cast<int>(a);
+                str.resize(7);
             }
-            return wss.str();
+            return str;
         }
     };
 #pragma warning(pop)

--- a/src/inc/til/env.h
+++ b/src/inc/til/env.h
@@ -86,7 +86,6 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
                 inline constexpr wil::zwstring_view system_env_var_root{ LR"(SYSTEM\CurrentControlSet\Control\Session Manager\Environment)" };
                 inline constexpr wil::zwstring_view user_env_var_root{ LR"(Environment)" };
                 inline constexpr wil::zwstring_view user_volatile_env_var_root{ LR"(Volatile Environment)" };
-                inline constexpr wil::zwstring_view user_volatile_session_env_var_root_pattern{ LR"(Volatile Environment\{0:d})" };
             };
         };
 
@@ -472,7 +471,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
             // not processing autoexec.bat
             get_vars_from_registry(HKEY_CURRENT_USER, til::details::vars::reg::user_env_var_root);
             get_vars_from_registry(HKEY_CURRENT_USER, til::details::vars::reg::user_volatile_env_var_root);
-            get_vars_from_registry(HKEY_CURRENT_USER, fmt::format(til::details::vars::reg::user_volatile_session_env_var_root_pattern, NtCurrentTeb()->ProcessEnvironmentBlock->SessionId));
+            get_vars_from_registry(HKEY_CURRENT_USER, fmt::format(FMT_COMPILE(LR"(Volatile Environment\{})"), NtCurrentTeb()->ProcessEnvironmentBlock->SessionId));
         }
 
         std::wstring to_string() const

--- a/src/interactivity/win32/uiaTextRange.cpp
+++ b/src/interactivity/win32/uiaTextRange.cpp
@@ -60,14 +60,6 @@ IFACEMETHODIMP UiaTextRange::Clone(_Outptr_result_maybenull_ ITextRangeProvider*
     *ppRetVal = nullptr;
     RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(ppRetVal, *this));
 
-#if defined(_DEBUG) && defined(UiaTextRangeBase_DEBUG_MSGS)
-    OutputDebugString(L"Clone\n");
-    std::wstringstream ss;
-    ss << _id << L" cloned to " << (static_cast<UiaTextRangeBase*>(*ppRetVal))->_id;
-    std::wstring str = ss.str();
-    OutputDebugString(str.c_str());
-    OutputDebugString(L"\n");
-#endif
     // TODO GitHub #1914: Re-attach Tracing to UIA Tree
     // tracing
     /*ApiMsgClone apiMsg;

--- a/src/interactivity/win32/windowproc.cpp
+++ b/src/interactivity/win32/windowproc.cpp
@@ -721,9 +721,7 @@ using namespace Microsoft::Console::Types;
     {
         try
         {
-            std::wstringstream wss;
-            wss << std::setfill(L'0') << std::setw(8) << wParam;
-            auto wstr = wss.str();
+            const auto wstr = fmt::format(FMT_COMPILE(L"{:08X}"), wParam);
             LoadKeyboardLayout(wstr.c_str(), KLF_ACTIVATE);
         }
         catch (...)

--- a/src/renderer/atlas/pch.h
+++ b/src/renderer/atlas/pch.h
@@ -50,5 +50,9 @@
 #include <base/numerics/safe_math.h>
 #pragma warning(pop)
 
+// {fmt}, a C++20-compatible formatting library
+#include <fmt/format.h>
+#include <fmt/compile.h>
+
 #include <til.h>
 #include <til/bit.h>

--- a/src/types/UiaTracing.cpp
+++ b/src/types/UiaTracing.cpp
@@ -65,29 +65,14 @@ UiaTracing::~UiaTracing() noexcept
 
 std::wstring UiaTracing::_getValue(const ScreenInfoUiaProviderBase& siup) noexcept
 {
-    std::wstringstream stream;
-    stream << "_id: " << siup.GetId();
-    return stream.str();
+    return fmt::format(FMT_COMPILE(L"_id:{}"), siup.GetId());
 }
 
 std::wstring UiaTracing::_getValue(const UiaTextRangeBase& utr) noexcept
-try
 {
     const auto start = utr.GetEndpoint(TextPatternRangeEndpoint_Start);
     const auto end = utr.GetEndpoint(TextPatternRangeEndpoint_End);
-
-    std::wstringstream stream;
-    stream << " _id: " << utr.GetId();
-    stream << " _start: { " << start.x << ", " << start.y << " }";
-    stream << " _end: { " << end.x << ", " << end.y << " }";
-    stream << " _degenerate: " << utr.IsDegenerate();
-    stream << " _wordDelimiters: " << utr._wordDelimiters;
-    stream << " content: " << utr._getTextValue();
-    return stream.str();
-}
-catch (...)
-{
-    return {};
+    return fmt::format(FMT_COMPILE(L"_id:{} _start:{},{} _end:{},{} _degenerate:{} _wordDelimiters:{} content:{}"), utr.GetId(), start.x, start.y, end.x, end.y, utr.IsDegenerate(), utr._wordDelimiters, utr._getTextValue());
 }
 
 std::wstring UiaTracing::_getValue(const TextPatternRangeEndpoint endpoint) noexcept
@@ -485,7 +470,7 @@ void UiaTracing::TextProvider::get_ProviderOptions(const ScreenInfoUiaProviderBa
     EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
-        auto getOptions = [options]() {
+        static constexpr auto getOptions = [](ProviderOptions options) {
             switch (options)
             {
             case ProviderOptions_ServerSideProvider:
@@ -499,7 +484,7 @@ void UiaTracing::TextProvider::get_ProviderOptions(const ScreenInfoUiaProviderBa
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::get_ProviderOptions",
             TraceLoggingValue(_getValue(siup).c_str(), "base"),
-            TraceLoggingValue(getOptions(), "providerOptions"),
+            TraceLoggingValue(getOptions(options), "providerOptions"),
             TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
             TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
@@ -510,7 +495,7 @@ void UiaTracing::TextProvider::GetPatternProvider(const ScreenInfoUiaProviderBas
     EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
-        auto getPattern = [patternId]() {
+        static constexpr auto getPattern = [](PATTERNID patternId) {
             switch (patternId)
             {
             case UIA_TextPatternId:
@@ -524,7 +509,7 @@ void UiaTracing::TextProvider::GetPatternProvider(const ScreenInfoUiaProviderBas
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::get_ProviderOptions",
             TraceLoggingValue(_getValue(siup).c_str(), "base"),
-            TraceLoggingValue(getPattern(), "patternId"),
+            TraceLoggingValue(getPattern(patternId), "patternId"),
             TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
             TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
@@ -535,7 +520,7 @@ void UiaTracing::TextProvider::GetPropertyValue(const ScreenInfoUiaProviderBase&
     EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
-        auto getProperty = [propertyId]() {
+        static constexpr auto getProperty = [](PROPERTYID propertyId) {
             switch (propertyId)
             {
             case UIA_ControlTypePropertyId:
@@ -565,7 +550,7 @@ void UiaTracing::TextProvider::GetPropertyValue(const ScreenInfoUiaProviderBase&
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::GetPropertyValue",
             TraceLoggingValue(_getValue(siup).c_str(), "base"),
-            TraceLoggingValue(getProperty(), "propertyId"),
+            TraceLoggingValue(getProperty(propertyId), "propertyId"),
             TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
             TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
@@ -677,17 +662,15 @@ void UiaTracing::TextProvider::RangeFromPoint(const ScreenInfoUiaProviderBase& s
     EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
-        auto getPoint = [point]() {
-            std::wstringstream stream;
-            stream << "{ " << point.x << ", " << point.y << " }";
-            return stream.str();
+        static constexpr auto getPoint = [](const UiaPoint& point) {
+            return fmt::format(FMT_COMPILE(L"{},{}"), (float)point.x, (float)point.y);
         };
 
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::RangeFromPoint",
             TraceLoggingValue(_getValue(siup).c_str(), "base"),
-            TraceLoggingValue(getPoint().c_str(), "uiaPoint"),
+            TraceLoggingValue(getPoint(point).c_str(), "uiaPoint"),
             TraceLoggingValue(_getValue(result).c_str(), "result (utr)"),
             TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
             TraceLoggingKeyword(TIL_KEYWORD_TRACE));
@@ -714,7 +697,7 @@ void UiaTracing::TextProvider::get_SupportedTextSelection(const ScreenInfoUiaPro
     EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
-        auto getResult = [result]() {
+        static constexpr auto getResult = [](SupportedTextSelection result) {
             switch (result)
             {
             case SupportedTextSelection_Single:
@@ -728,7 +711,7 @@ void UiaTracing::TextProvider::get_SupportedTextSelection(const ScreenInfoUiaPro
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::get_SupportedTextSelection",
             TraceLoggingValue(_getValue(siup).c_str(), "base"),
-            TraceLoggingValue(getResult(), "result"),
+            TraceLoggingValue(getResult(result), "result"),
             TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
             TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }

--- a/src/types/utils.cpp
+++ b/src/types/utils.cpp
@@ -93,14 +93,7 @@ GUID Utils::CreateGuid()
 // - a string representation of the color
 std::string Utils::ColorToHexString(const til::color color)
 {
-    std::stringstream ss;
-    ss << "#" << std::uppercase << std::setfill('0') << std::hex;
-    // Force the compiler to promote from byte to int. Without it, the
-    // stringstream will try to write the components as chars
-    ss << std::setw(2) << static_cast<int>(color.r);
-    ss << std::setw(2) << static_cast<int>(color.g);
-    ss << std::setw(2) << static_cast<int>(color.b);
-    return ss.str();
+    return fmt::format(FMT_COMPILE("#{:02X}{:02X}{:02X}"), color.r, color.g, color.b);
 }
 
 // Function Description:
@@ -809,7 +802,7 @@ std::tuple<std::wstring, std::wstring> Utils::MangleStartingDirectoryForWSL(std:
                 }
 
                 return {
-                    fmt::format(LR"("{}" --cd "{}" {})", executablePath.native(), mangledDirectory, arguments),
+                    fmt::format(FMT_COMPILE(LR"("{}" --cd "{}" {})"), executablePath.native(), mangledDirectory, arguments),
                     std::wstring{}
                 };
             }


### PR DESCRIPTION
This is a rather simple PR overall. It mostly touches either test
or tracing code. Only a few changes affect the actual runtime.

The goal of this changeset is to get rid of the `double` format tables
in the OpenConsole build by using `FMT_COMPILE` everywhere.