### PR TITLE
Add more profile GUID tests

### DIFF
--- a/src/cascadia/UnitTests_SettingsModel/ProfileTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/ProfileTests.cpp
@@ -85,7 +85,7 @@ namespace SettingsModelUnitTests
                                               "name" : "profile4",
                                               "guid" : "{6239a42c-1de4-49a3-80bd-e8fdd045185c}"
                                               })" };
-        const std::string profileWithGuidFormatBUpperCase{ R"({
+        const std::string profileWithGuidUpperCaseFormatB{ R"({
                                               "name" : "profile4",
                                               "guid" : "{6239A42C-1DE4-49A3-80BD-E8FDD045185C}"
                                               })" };
@@ -99,15 +99,15 @@ namespace SettingsModelUnitTests
         //parseAndVerifyProfile(profileWithGuidFormatP, false);
 
         const auto parsedNullGuidProfile = parseAndVerifyProfile(profileWithNullGuid, true);
-        const auto parsedFormatBGuidProfile = parseAndVerifyProfile(profileWithGuidFormatB, true);
-        const auto parsedFormatBUpperCaseGuidProfile = parseAndVerifyProfile(profileWithGuidFormatBUpperCase, true);
+        const auto parsedGuidProfileFormatB = parseAndVerifyProfile(profileWithGuidFormatB, true);
+        const auto parsedGuidProfileUpperCaseFormatB = parseAndVerifyProfile(profileWithGuidUpperCaseFormatB, true);
 
         const winrt::guid nullGuid{};
         const winrt::guid cmdGuid = Utils::GuidFromString(L"{6239a42c-1de4-49a3-80bd-e8fdd045185c}");
 
         VERIFY_ARE_EQUAL(parsedNullGuidProfile->Guid(), nullGuid);
-        VERIFY_ARE_EQUAL(parsedFormatBGuidProfile->Guid(), cmdGuid);
-        VERIFY_ARE_EQUAL(parsedFormatBUpperCaseGuidProfile->Guid(), cmdGuid);
+        VERIFY_ARE_EQUAL(parsedGuidProfileFormatB->Guid(), cmdGuid);
+        VERIFY_ARE_EQUAL(parsedGuidProfileUpperCaseFormatB->Guid(), cmdGuid);
     }
 
     void ProfileTests::LayerProfileProperties()

--- a/src/cascadia/UnitTests_SettingsModel/ProfileTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/ProfileTests.cpp
@@ -68,7 +68,7 @@ namespace SettingsModelUnitTests
                                               "name" : "profile4",
                                               "guid" : "{6239A42C1DE449A380BDE8FDD045185C}"
                                               })" };
-        const std::string profileWithGuidInQoutes{ R"({
+        const std::string profileWithRawGuid{ R"({
                                               "name" : "profile4",
                                               "guid" : "6239a42c-1de4-49a3-80bd-e8fdd045185c"
                                               })" };
@@ -94,7 +94,7 @@ namespace SettingsModelUnitTests
         parseAndVerifyProfile(secondProfileWithoutGuid, false);
 
         // The following crash JSON parsing
-        //parseAndVerifyProfile(profileWithGuidInQoutes, false);
+        //parseAndVerifyProfile(profileWithRawGuid, false);
         //parseAndVerifyProfile(profileWithHyphenlessGuid, false);
         //parseAndVerifyProfile(profileWithGuidFormatP, false);
 

--- a/src/cascadia/UnitTests_SettingsModel/ProfileTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/ProfileTests.cpp
@@ -94,9 +94,9 @@ namespace SettingsModelUnitTests
         parseAndVerifyProfile(secondProfileWithoutGuid, false);
 
         // The following crash JSON parsing
-        //parseAndVerifyProfile(profileWithRawGuid, false);
-        //parseAndVerifyProfile(profileWithHyphenlessGuid, false);
-        //parseAndVerifyProfile(profileWithGuidFormatP, false);
+        VERIFY_THROWS(parseAndVerifyProfile(profileWithHyphenlessGuid, false), std::exception);
+        VERIFY_THROWS(parseAndVerifyProfile(profileWithRawGuid, false), std::exception);
+        VERIFY_THROWS(parseAndVerifyProfile(profileWithGuidFormatP, false), std::exception);
 
         const auto parsedNullGuidProfile = parseAndVerifyProfile(profileWithNullGuid, true);
         const auto parsedGuidProfileFormatB = parseAndVerifyProfile(profileWithGuidFormatB, true);

--- a/src/cascadia/UnitTests_SettingsModel/ProfileTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/ProfileTests.cpp
@@ -45,6 +45,15 @@ namespace SettingsModelUnitTests
         // this test that includes synthesizing GUIDS for profiles without GUIDs
         // set
 
+        const auto parseAndVerifyProfile = [](const std::string profile, const bool hasGuid) {
+            const auto profileAsJson = VerifyParseSucceeded(profile);
+            const auto profileParsed = implementation::Profile::FromJson(profileAsJson);
+
+            VERIFY_ARE_EQUAL(profileParsed->HasGuid(), hasGuid);
+            return profileParsed;
+        };
+
+        // Invalid GUID Values
         const std::string profileWithoutGuid{ R"({
                                               "name" : "profile0"
                                               })" };
@@ -55,37 +64,50 @@ namespace SettingsModelUnitTests
                                               "name" : "profile2",
                                               "guid" : null
                                               })" };
+        const std::string profileWithHyphenlessGuid{ R"({
+                                              "name" : "profile4",
+                                              "guid" : "{6239A42C1DE449A380BDE8FDD045185C}"
+                                              })" };
+        const std::string profileWithGuidInQoutes{ R"({
+                                              "name" : "profile4",
+                                              "guid" : "6239a42c-1de4-49a3-80bd-e8fdd045185c"
+                                              })" };
+        const std::string profileWithGuidFormatP{ R"({
+                                              "name" : "profile4",
+                                              "guid" : "(6239a42c-1de4-49a3-80bd-e8fdd045185c)\\"
+                                              })" };
+        // Valid GUIDs
         const std::string profileWithNullGuid{ R"({
                                               "name" : "profile3",
                                               "guid" : "{00000000-0000-0000-0000-000000000000}"
                                               })" };
-        const std::string profileWithGuid{ R"({
+        const std::string profileWithGuidFormatB{ R"({
                                               "name" : "profile4",
                                               "guid" : "{6239a42c-1de4-49a3-80bd-e8fdd045185c}"
                                               })" };
+        const std::string profileWithGuidFormatBUpperCase{ R"({
+                                              "name" : "profile4",
+                                              "guid" : "{6239A42C-1DE4-49A3-80BD-E8FDD045185C}"
+                                              })" };
 
-        const auto profile0Json = VerifyParseSucceeded(profileWithoutGuid);
-        const auto profile1Json = VerifyParseSucceeded(secondProfileWithoutGuid);
-        const auto profile2Json = VerifyParseSucceeded(profileWithNullForGuid);
-        const auto profile3Json = VerifyParseSucceeded(profileWithNullGuid);
-        const auto profile4Json = VerifyParseSucceeded(profileWithGuid);
+        parseAndVerifyProfile(profileWithoutGuid, false);
+        parseAndVerifyProfile(secondProfileWithoutGuid, false);
 
-        const auto profile0 = implementation::Profile::FromJson(profile0Json);
-        const auto profile1 = implementation::Profile::FromJson(profile1Json);
-        const auto profile2 = implementation::Profile::FromJson(profile2Json);
-        const auto profile3 = implementation::Profile::FromJson(profile3Json);
-        const auto profile4 = implementation::Profile::FromJson(profile4Json);
-        const winrt::guid cmdGuid = Utils::GuidFromString(L"{6239a42c-1de4-49a3-80bd-e8fdd045185c}");
+        // The following crash JSON parsing
+        //parseAndVerifyProfile(profileWithGuidInQoutes, false);
+        //parseAndVerifyProfile(profileWithHyphenlessGuid, false);
+        //parseAndVerifyProfile(profileWithGuidFormatP, false);
+
+        const auto parsedNullGuidProfile = parseAndVerifyProfile(profileWithNullGuid, true);
+        const auto parsedFormatBGuidProfile = parseAndVerifyProfile(profileWithGuidFormatB, true);
+        const auto parsedFormatBUpperCaseGuidProfile = parseAndVerifyProfile(profileWithGuidFormatBUpperCase, true);
+
         const winrt::guid nullGuid{};
+        const winrt::guid cmdGuid = Utils::GuidFromString(L"{6239a42c-1de4-49a3-80bd-e8fdd045185c}");
 
-        VERIFY_IS_FALSE(profile0->HasGuid());
-        VERIFY_IS_FALSE(profile1->HasGuid());
-        VERIFY_IS_FALSE(profile2->HasGuid());
-        VERIFY_IS_TRUE(profile3->HasGuid());
-        VERIFY_IS_TRUE(profile4->HasGuid());
-
-        VERIFY_ARE_EQUAL(profile3->Guid(), nullGuid);
-        VERIFY_ARE_EQUAL(profile4->Guid(), cmdGuid);
+        VERIFY_ARE_EQUAL(parsedNullGuidProfile->Guid(), nullGuid);
+        VERIFY_ARE_EQUAL(parsedFormatBGuidProfile->Guid(), cmdGuid);
+        VERIFY_ARE_EQUAL(parsedFormatBUpperCaseGuidProfile->Guid(), cmdGuid);
     }
 
     void ProfileTests::LayerProfileProperties()


### PR DESCRIPTION
## Summary of the Pull Request
Adding more profile GUID tests
## References and Relevant Issues
Closes #2119 
## Detailed Description of the Pull Request / Additional comments

Currently, there are formats that simply break GUID parsing (the commented out test cases). Should we catch that and treat it like a "null" GUID or should we generate a new GUID for those profiles?

## Validation Steps Performed

## PR Checklist
- [x] Closes #2119 
- [x] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
