### PR TITLE
Fix window style under minimized state

### DIFF
--- a/src/cascadia/TerminalApp/MinMaxCloseControl.cpp
+++ b/src/cascadia/TerminalApp/MinMaxCloseControl.cpp
@@ -116,6 +116,9 @@ namespace winrt::TerminalApp::implementation
 
         switch (visualState)
         {
+        case WindowVisualState::WindowVisualStateIconified:
+            // Iconified (aka minimized) state should preserve the active window styling
+            break;
         case WindowVisualState::WindowVisualStateMaximized:
             VisualStateManager::GoToState(MaximizeButton(), L"WindowStateMaximized", false);
 
@@ -124,9 +127,7 @@ namespace winrt::TerminalApp::implementation
             CloseButton().Height(maximizedHeight);
             MaximizeToolTip().Text(RS_(L"WindowRestoreDownButtonToolTip"));
             break;
-
         case WindowVisualState::WindowVisualStateNormal:
-        case WindowVisualState::WindowVisualStateIconified:
         default:
             VisualStateManager::GoToState(MaximizeButton(), L"WindowStateNormal", false);
 


### PR DESCRIPTION
Closes: #13961

This PR changes the window styling we use under the minimized state. We now retain the active window styling so the content's height doesn't change when switching between minimized and maximized states.

## Validation Steps Performed
- Open Terminal and go into Maximized mode.
- Click on the Minimize button.
- No `SizeChanged` event in `ControlCore`.
- Click on the WT icon in the taskbar to restore it.
- No `SizeChanged` event in `ControlCore`.