### PR TITLE
Fix wrong CommandPallete access

### DIFF
--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -881,7 +881,10 @@ namespace winrt::TerminalApp::implementation
             }
         }
 
-        CommandPalette().Visibility(Visibility::Collapsed);
+        if (const auto p = CommandPaletteElement())
+        {
+            p.Visibility(Visibility::Collapsed);
+        }
         _UpdateTabView();
     }
 


### PR DESCRIPTION
Closes: #17032

We were wrongly calling the Ctor of CommandPalette which led to the creation of an uninitialized winrt command palette object, and then OnCreateAutomationPeer() was called on that. This seems to be the cause of #17032.

## Validation Steps Performed
- Open WT.
- Try to tear off a tab out of the tab headers view.
- WT doesn't crash.
