### PR TITLE
Use float instead of double by default

### DIFF
--- a/src/cascadia/TerminalApp/ActionPreviewHandlers.cpp
+++ b/src/cascadia/TerminalApp/ActionPreviewHandlers.cpp
@@ -127,7 +127,7 @@ namespace winrt::TerminalApp::implementation
             auto originalOpacity{ control.BackgroundOpacity() };
 
             // Apply the new opacity
-            control.AdjustOpacity(args.Opacity() / 100.0, args.Relative());
+            control.AdjustOpacity(args.Opacity() / 100.0f, args.Relative());
 
             if (backup)
             {

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -286,7 +286,7 @@ namespace winrt::TerminalApp::implementation
             _SplitPane(terminalTab,
                        realArgs.SplitDirection(),
                        // This is safe, we're already filtering so the value is (0, 1)
-                       ::base::saturated_cast<float>(realArgs.SplitSize()),
+                       realArgs.SplitSize(),
                        _MakePane(realArgs.ContentArgs(), duplicateFromTab));
             args.Handled(true);
         }
@@ -1247,7 +1247,7 @@ namespace winrt::TerminalApp::implementation
             if (const auto& realArgs = args.ActionArgs().try_as<AdjustOpacityArgs>())
             {
                 const auto res = _ApplyToActiveControls([&](auto& control) {
-                    control.AdjustOpacity(realArgs.Opacity() / 100.0, realArgs.Relative());
+                    control.AdjustOpacity(realArgs.Opacity() / 100.0f, realArgs.Relative());
                 });
                 args.Handled(res);
             }

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -151,7 +151,7 @@ Pane::BuildStartupState Pane::BuildStartupActions(uint32_t currentId, uint32_t n
         // When creating a pane the split size is the size of the new pane
         // and not position.
         const auto splitDirection = _splitState == SplitState::Horizontal ? SplitDirection::Down : SplitDirection::Right;
-        const auto splitSize = (kind != BuildStartupKind::None && _IsLeaf() ? .5 : 1. - _desiredSplitPosition);
+        const auto splitSize = (kind != BuildStartupKind::None && _IsLeaf() ? 0.5f : 1.0f - _desiredSplitPosition);
         SplitPaneArgs args{ SplitType::Manual, splitDirection, splitSize, terminalArgs };
         actionAndArgs.Args(args);
 
@@ -1595,12 +1595,12 @@ void Pane::_CloseChildRoutine(const bool closeFirst)
     const auto splitWidth = _splitState == SplitState::Vertical;
 
     Size removedOriginalSize{
-        ::base::saturated_cast<float>(removedChild->_root.ActualWidth()),
-        ::base::saturated_cast<float>(removedChild->_root.ActualHeight())
+        static_cast<float>(removedChild->_root.ActualWidth()),
+        static_cast<float>(removedChild->_root.ActualHeight())
     };
     Size remainingOriginalSize{
-        ::base::saturated_cast<float>(remainingChild->_root.ActualWidth()),
-        ::base::saturated_cast<float>(remainingChild->_root.ActualHeight())
+        static_cast<float>(remainingChild->_root.ActualWidth()),
+        static_cast<float>(remainingChild->_root.ActualHeight())
     };
 
     // Remove both children from the grid
@@ -1902,7 +1902,7 @@ void Pane::_SetupEntranceAnimation()
     //   looks bad.
     _secondChild->_root.Background(_themeResources.unfocusedBorderBrush);
 
-    const auto [firstSize, secondSize] = _CalcChildrenSizes(::base::saturated_cast<float>(totalSize));
+    const auto [firstSize, secondSize] = _CalcChildrenSizes(static_cast<float>(totalSize));
 
     // This is safe to capture this, because it's only being called in the
     // context of this method (not on another thread)

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1947,8 +1947,8 @@ namespace winrt::TerminalApp::implementation
         layout.LaunchMode({ mode });
 
         // Only save the content size because the tab size will be added on load.
-        const auto contentWidth = ::base::saturated_cast<float>(_tabContent.ActualWidth());
-        const auto contentHeight = ::base::saturated_cast<float>(_tabContent.ActualHeight());
+        const auto contentWidth = static_cast<float>(_tabContent.ActualWidth());
+        const auto contentHeight = static_cast<float>(_tabContent.ActualHeight());
         const winrt::Windows::Foundation::Size windowSize{ contentWidth, contentHeight };
 
         layout.InitialSize(windowSize);
@@ -2358,8 +2358,8 @@ namespace winrt::TerminalApp::implementation
         {
             return;
         }
-        const auto contentWidth = ::base::saturated_cast<float>(_tabContent.ActualWidth());
-        const auto contentHeight = ::base::saturated_cast<float>(_tabContent.ActualHeight());
+        const auto contentWidth = static_cast<float>(_tabContent.ActualWidth());
+        const auto contentHeight = static_cast<float>(_tabContent.ActualHeight());
         const winrt::Windows::Foundation::Size availableSpace{ contentWidth, contentHeight };
 
         const auto realSplitType = activeTab->PreCalculateCanSplit(splitDirection, splitSize, availableSpace);

--- a/src/cascadia/TerminalApp/TitlebarControl.cpp
+++ b/src/cascadia/TerminalApp/TitlebarControl.cpp
@@ -44,12 +44,12 @@ namespace winrt::TerminalApp::implementation
         });
     }
 
-    double TitlebarControl::CaptionButtonWidth()
+    float TitlebarControl::CaptionButtonWidth()
     {
         // Divide by three, since we know there are only three buttons. When
         // Windows 12 comes along and adds another, we can update this /s
-        static auto width{ MinMaxCloseControl().ActualWidth() / 3.0 };
-        return width;
+        const auto minMaxCloseWidth = MinMaxCloseControl().ActualWidth();
+        return static_cast<float>(minMaxCloseWidth) / 3.0f;
     }
 
     IInspectable TitlebarControl::Content()

--- a/src/cascadia/TerminalApp/TitlebarControl.h
+++ b/src/cascadia/TerminalApp/TitlebarControl.h
@@ -15,7 +15,7 @@ namespace winrt::TerminalApp::implementation
         void PressButton(CaptionButton button);
         winrt::fire_and_forget ClickButton(CaptionButton button);
         void ReleaseButtons();
-        double CaptionButtonWidth();
+        float CaptionButtonWidth();
 
         IInspectable Content();
         void Content(IInspectable content);

--- a/src/cascadia/TerminalApp/TitlebarControl.idl
+++ b/src/cascadia/TerminalApp/TitlebarControl.idl
@@ -27,7 +27,7 @@ namespace TerminalApp
         void PressButton(CaptionButton button);
         void ClickButton(CaptionButton button);
         void ReleaseButtons();
-        Double CaptionButtonWidth { get; };
+        Single CaptionButtonWidth { get; };
 
         IInspectable Content;
         Windows.UI.Xaml.Controls.Border DragBar { get; };

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -677,7 +677,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         }
     }
 
-    void ControlCore::AdjustOpacity(const double adjustment)
+    void ControlCore::AdjustOpacity(const float adjustment)
     {
         if (adjustment == 0)
         {
@@ -694,11 +694,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - focused (default == true): Whether the window is focused or unfocused.
     // Return Value:
     // - <none>
-    void ControlCore::_setOpacity(const double opacity, bool focused)
+    void ControlCore::_setOpacity(const float opacity, bool focused)
     {
-        const auto newOpacity = std::clamp(opacity,
-                                           0.0,
-                                           1.0);
+        const auto newOpacity = std::clamp(opacity, 0.0f, 1.0f);
 
         if (newOpacity == Opacity())
         {
@@ -713,7 +711,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         _runtimeFocusedOpacity = focused ? newOpacity : _runtimeFocusedOpacity;
 
         // Manually turn off acrylic if they turn off transparency.
-        _runtimeUseAcrylic = newOpacity < 1.0 && _settings->UseAcrylic();
+        _runtimeUseAcrylic = newOpacity < 1.0f && _settings->UseAcrylic();
 
         // Update the renderer as well. It might need to fall back from
         // cleartype -> grayscale if the BG is transparent / acrylic.
@@ -881,7 +879,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // Method Description:
     // - Updates the appearance of the current terminal.
     // - INVARIANT: This method can only be called if the caller DOES NOT HAVE writing lock on the terminal.
-    void ControlCore::ApplyAppearance(const bool& focused)
+    void ControlCore::ApplyAppearance(const bool focused)
     {
         const auto lock = _terminal->LockForWriting();
         const auto& newAppearance{ focused ? _settings->FocusedAppearance() : _settings->UnfocusedAppearance() };
@@ -900,10 +898,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             // Incase EnableUnfocusedAcrylic is disabled and Focused Acrylic is set to true,
             // the terminal should ignore the unfocused opacity from settings.
             // The Focused Opacity from settings should be ignored if overridden at runtime.
-            bool useFocusedRuntimeOpacity = focused || (!_settings->EnableUnfocusedAcrylic() && UseAcrylic());
-            double newOpacity = useFocusedRuntimeOpacity ?
-                                    FocusedOpacity() :
-                                    newAppearance->Opacity();
+            const auto useFocusedRuntimeOpacity = focused || (!_settings->EnableUnfocusedAcrylic() && UseAcrylic());
+            const auto newOpacity = useFocusedRuntimeOpacity ? FocusedOpacity() : newAppearance->Opacity();
             _setOpacity(newOpacity, focused);
 
             // No need to update Acrylic if UnfocusedAcrylic is disabled
@@ -1422,8 +1418,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     {
         const auto fontSize = _actualFont.GetSize();
         return {
-            ::base::saturated_cast<float>(fontSize.width),
-            ::base::saturated_cast<float>(fontSize.height)
+            static_cast<float>(fontSize.width),
+            static_cast<float>(fontSize.height)
         };
     }
 
@@ -2350,7 +2346,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         return _settings->HasUnfocusedAppearance();
     }
 
-    void ControlCore::AdjustOpacity(const double opacityAdjust, const bool relative)
+    void ControlCore::AdjustOpacity(const float opacityAdjust, const bool relative)
     {
         if (relative)
         {

--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -91,7 +91,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void Detach();
 
         void UpdateSettings(const Control::IControlSettings& settings, const IControlAppearance& newAppearance);
-        void ApplyAppearance(const bool& focused);
+        void ApplyAppearance(const bool focused);
         Control::IControlSettings Settings();
         Control::IControlAppearance FocusedAppearance() const;
         Control::IControlAppearance UnfocusedAppearance() const;
@@ -136,7 +136,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void LostFocus();
 
         void ToggleShaderEffects();
-        void AdjustOpacity(const double adjustment);
+        void AdjustOpacity(const float adjustment);
         void ResumeRendering();
 
         void SetHoveredCell(Core::Point terminalPosition);
@@ -243,7 +243,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         hstring ReadEntireBuffer() const;
         Control::CommandHistoryContext CommandHistory() const;
 
-        void AdjustOpacity(const double opacity, const bool relative);
+        void AdjustOpacity(const float opacity, const bool relative);
 
         void WindowVisibilityChanged(const bool showOrHide);
 
@@ -258,8 +258,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         bool ShouldShowSelectCommand();
         bool ShouldShowSelectOutput();
 
-        RUNTIME_SETTING(double, Opacity, _settings->Opacity());
-        RUNTIME_SETTING(double, FocusedOpacity, FocusedAppearance().Opacity());
+        RUNTIME_SETTING(float, Opacity, _settings->Opacity());
+        RUNTIME_SETTING(float, FocusedOpacity, FocusedAppearance().Opacity());
         RUNTIME_SETTING(bool, UseAcrylic, _settings->UseAcrylic());
 
         // -------------------------------- WinRT Events ---------------------------------
@@ -399,7 +399,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void _updateAntiAliasingMode();
         void _connectionOutputHandler(const hstring& hstr);
         void _updateHoveredCell(const std::optional<til::point> terminalPosition);
-        void _setOpacity(const double opacity, const bool focused = true);
+        void _setOpacity(const float opacity, const bool focused = true);
 
         bool _isBackgroundTransparent();
         void _focusChanged(bool focused);

--- a/src/cascadia/TerminalControl/ControlCore.idl
+++ b/src/cascadia/TerminalControl/ControlCore.idl
@@ -88,7 +88,7 @@ namespace Microsoft.Terminal.Control
 
         Windows.Foundation.Size FontSize { get; };
         UInt16 FontWeight { get; };
-        Double Opacity { get; };
+        Single Opacity { get; };
         Boolean UseAcrylic { get; };
 
         Boolean TryMarkModeKeybinding(Int16 vkey,
@@ -149,7 +149,7 @@ namespace Microsoft.Terminal.Control
         String ReadEntireBuffer();
         CommandHistoryContext CommandHistory();
 
-        void AdjustOpacity(Double Opacity, Boolean relative);
+        void AdjustOpacity(Single Opacity, Boolean relative);
         void WindowVisibilityChanged(Boolean showOrHide);
 
         void ColorSelection(SelectionColor fg, SelectionColor bg, Microsoft.Terminal.Core.MatchMode matchMode);

--- a/src/cascadia/TerminalControl/ControlInteractivity.h
+++ b/src/cascadia/TerminalControl/ControlInteractivity.h
@@ -78,7 +78,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                         const Core::Point pixelPosition,
                         const Control::MouseButtonState state);
 
-        void UpdateScrollbar(const double newValue);
+        void UpdateScrollbar(const float newValue);
 
 #pragma endregion
 
@@ -110,8 +110,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         std::unique_ptr<::Microsoft::Console::Render::UiaEngine> _uiaEngine;
 
         winrt::com_ptr<ControlCore> _core{ nullptr };
-        unsigned int _rowsToScroll;
-        double _internalScrollbarPosition{ 0.0 };
+        UINT _rowsToScroll = 3;
+        float _internalScrollbarPosition = 0;
 
         // If this is set, then we assume we are in the middle of panning the
         //      viewport via touch input.

--- a/src/cascadia/TerminalControl/ControlInteractivity.idl
+++ b/src/cascadia/TerminalControl/ControlInteractivity.idl
@@ -64,7 +64,7 @@ namespace Microsoft.Terminal.Control
                            Microsoft.Terminal.Core.Point pixelPosition,
                            MouseButtonState state);
 
-        void UpdateScrollbar(Double newValue);
+        void UpdateScrollbar(Single newValue);
 
         Boolean ManglePathsForWsl { get; };
 

--- a/src/cascadia/TerminalControl/EventArgs.h
+++ b/src/cascadia/TerminalControl/EventArgs.h
@@ -133,12 +133,12 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     struct TransparencyChangedEventArgs : public TransparencyChangedEventArgsT<TransparencyChangedEventArgs>
     {
     public:
-        TransparencyChangedEventArgs(const double opacity) :
+        TransparencyChangedEventArgs(const float opacity) :
             _Opacity(opacity)
         {
         }
 
-        WINRT_PROPERTY(double, Opacity);
+        WINRT_PROPERTY(float, Opacity);
     };
 
     struct UpdateSearchResultsEventArgs : public UpdateSearchResultsEventArgsT<UpdateSearchResultsEventArgs>

--- a/src/cascadia/TerminalControl/EventArgs.idl
+++ b/src/cascadia/TerminalControl/EventArgs.idl
@@ -75,7 +75,7 @@ namespace Microsoft.Terminal.Control
 
     runtimeclass TransparencyChangedEventArgs
     {
-        Double Opacity { get; };
+        Single Opacity { get; };
     }
 
     enum SearchState

--- a/src/cascadia/TerminalControl/HwndTerminal.cpp
+++ b/src/cascadia/TerminalControl/HwndTerminal.cpp
@@ -1090,9 +1090,9 @@ til::rect HwndTerminal::GetPadding() const noexcept
     return {};
 }
 
-double HwndTerminal::GetScaleFactor() const noexcept
+float HwndTerminal::GetScaleFactor() const noexcept
 {
-    return static_cast<double>(_currentDpi) / static_cast<double>(USER_DEFAULT_SCREEN_DPI);
+    return static_cast<float>(_currentDpi) / static_cast<float>(USER_DEFAULT_SCREEN_DPI);
 }
 
 void HwndTerminal::ChangeViewport(const til::inclusive_rect& NewWindow)

--- a/src/cascadia/TerminalControl/HwndTerminal.hpp
+++ b/src/cascadia/TerminalControl/HwndTerminal.hpp
@@ -146,7 +146,7 @@ private:
     // Inherited via IControlAccessibilityInfo
     til::size GetFontSize() const noexcept override;
     til::rect GetBounds() const noexcept override;
-    double GetScaleFactor() const noexcept override;
+    float GetScaleFactor() const noexcept override;
     void ChangeViewport(const til::inclusive_rect& NewWindow) override;
     HRESULT GetHostUiaProvider(IRawElementProviderSimple** provider) noexcept override;
     til::rect GetPadding() const noexcept override;

--- a/src/cascadia/TerminalControl/IControlAppearance.idl
+++ b/src/cascadia/TerminalControl/IControlAppearance.idl
@@ -7,12 +7,12 @@ namespace Microsoft.Terminal.Control
     {
         Microsoft.Terminal.Core.Color SelectionBackground { get; };
         String BackgroundImage { get; };
-        Double BackgroundImageOpacity { get; };
+        Single BackgroundImageOpacity { get; };
         Windows.UI.Xaml.Media.Stretch BackgroundImageStretchMode { get; };
         Windows.UI.Xaml.HorizontalAlignment BackgroundImageHorizontalAlignment { get; };
         Windows.UI.Xaml.VerticalAlignment BackgroundImageVerticalAlignment { get; };
         // IntenseIsBold and IntenseIsBright are in Core Appearance
-        Double Opacity { get; };
+        Single Opacity { get; };
         Boolean UseAcrylic { get; };
 
         // Experimental settings

--- a/src/cascadia/TerminalControl/InteractivityAutomationPeer.cpp
+++ b/src/cascadia/TerminalControl/InteractivityAutomationPeer.cpp
@@ -169,14 +169,14 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         return _controlPadding;
     }
 
-    double InteractivityAutomationPeer::GetScaleFactor() const noexcept
+    float InteractivityAutomationPeer::GetScaleFactor() const noexcept
     {
-        return DisplayInformation::GetForCurrentView().RawPixelsPerViewPixel();
+        return static_cast<float>(DisplayInformation::GetForCurrentView().RawPixelsPerViewPixel());
     }
 
     void InteractivityAutomationPeer::ChangeViewport(const til::inclusive_rect& NewWindow)
     {
-        _interactivity->UpdateScrollbar(NewWindow.top);
+        _interactivity->UpdateScrollbar(static_cast<float>(NewWindow.top));
     }
 #pragma endregion
 

--- a/src/cascadia/TerminalControl/InteractivityAutomationPeer.h
+++ b/src/cascadia/TerminalControl/InteractivityAutomationPeer.h
@@ -66,7 +66,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         virtual til::size GetFontSize() const noexcept override;
         virtual til::rect GetBounds() const noexcept override;
         virtual til::rect GetPadding() const noexcept override;
-        virtual double GetScaleFactor() const noexcept override;
+        virtual float GetScaleFactor() const noexcept override;
         virtual void ChangeViewport(const til::inclusive_rect& NewWindow) override;
         virtual HRESULT GetHostUiaProvider(IRawElementProviderSimple** provider) override;
 #pragma endregion

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -779,10 +779,12 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         _interactivity.UpdateSettings();
         if (_automationPeer)
         {
-            _automationPeer.SetControlPadding(Core::Padding{ newMargin.Left,
-                                                             newMargin.Top,
-                                                             newMargin.Right,
-                                                             newMargin.Bottom });
+            _automationPeer.SetControlPadding(Core::Padding{
+                static_cast<float>(newMargin.Left),
+                static_cast<float>(newMargin.Top),
+                static_cast<float>(newMargin.Right),
+                static_cast<float>(newMargin.Bottom),
+            });
         }
 
         _showMarksInScrollbar = settings.ShowMarks();
@@ -1050,10 +1052,12 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             if (const auto& interactivityAutoPeer{ _interactivity.OnCreateAutomationPeer() })
             {
                 const auto margins{ SwapChainPanel().Margin() };
-                const Core::Padding padding{ margins.Left,
-                                             margins.Top,
-                                             margins.Right,
-                                             margins.Bottom };
+                const Core::Padding padding{
+                    static_cast<float>(margins.Left),
+                    static_cast<float>(margins.Top),
+                    static_cast<float>(margins.Right),
+                    static_cast<float>(margins.Bottom),
+                };
                 _automationPeer = winrt::make<implementation::TermControlAutomationPeer>(get_strong(), padding, interactivityAutoPeer);
                 return _automationPeer;
             }
@@ -1254,10 +1258,12 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         {
             _automationPeer.UpdateControlBounds();
             const auto margins{ GetPadding() };
-            _automationPeer.SetControlPadding(Core::Padding{ margins.Left,
-                                                             margins.Top,
-                                                             margins.Right,
-                                                             margins.Bottom });
+            _automationPeer.SetControlPadding(Core::Padding{
+                static_cast<float>(margins.Left),
+                static_cast<float>(margins.Top),
+                static_cast<float>(margins.Right),
+                static_cast<float>(margins.Bottom),
+            });
         }
 
         // Likewise, run the event handlers outside of lock (they could
@@ -1903,7 +1909,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         }
 
         const auto newValue = args.NewValue();
-        _interactivity.UpdateScrollbar(newValue);
+        _interactivity.UpdateScrollbar(static_cast<float>(newValue));
 
         // User input takes priority over terminal events so cancel
         // any pending scroll bar update if the user scrolls.
@@ -2451,14 +2457,14 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // If the settings have negative or zero row or column counts, ignore those counts.
         // (The lower TerminalCore layer also has upper bounds as well, but at this layer
         //  we may eventually impose different ones depending on how many pixels we can address.)
-        const auto cols = ::base::saturated_cast<float>(std::max(commandlineCols > 0 ?
-                                                                     commandlineCols :
-                                                                     settings.InitialCols(),
-                                                                 1));
-        const auto rows = ::base::saturated_cast<float>(std::max(commandlineRows > 0 ?
-                                                                     commandlineRows :
-                                                                     settings.InitialRows(),
-                                                                 1));
+        const auto cols = static_cast<float>(std::max(commandlineCols > 0 ?
+                                                          commandlineCols :
+                                                          settings.InitialCols(),
+                                                      1));
+        const auto rows = static_cast<float>(std::max(commandlineRows > 0 ?
+                                                          commandlineRows :
+                                                          settings.InitialRows(),
+                                                      1));
 
         const winrt::Windows::Foundation::Size initialSize{ cols, rows };
 
@@ -2763,14 +2769,14 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         // Convert text buffer cursor position to client coordinate position
         // within the window. This point is in _pixels_
-        const double clientCursorPosX = terminalPos.x * fontSize.Width;
-        const double clientCursorPosY = terminalPos.y * fontSize.Height;
+        const auto clientCursorPosX = terminalPos.x * fontSize.Width;
+        const auto clientCursorPosY = terminalPos.y * fontSize.Height;
 
         // Get scale factor for view
-        const double scaleFactor = SwapChainPanel().CompositionScaleX();
+        const auto scaleFactor = SwapChainPanel().CompositionScaleX();
 
-        const double clientCursorInDipsX = clientCursorPosX / scaleFactor;
-        const double clientCursorInDipsY = clientCursorPosY / scaleFactor;
+        const auto clientCursorInDipsX = clientCursorPosX / scaleFactor;
+        const auto clientCursorInDipsY = clientCursorPosY / scaleFactor;
 
         auto padding{ GetPadding() };
         til::point relativeToOrigin{ til::math::rounding,
@@ -3504,7 +3510,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         _core.ColorScheme(scheme);
     }
 
-    void TermControl::AdjustOpacity(const double opacity, const bool relative)
+    void TermControl::AdjustOpacity(const float opacity, const bool relative)
     {
         _core.AdjustOpacity(opacity, relative);
     }
@@ -3513,7 +3519,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     //   defines an "Opacity", which we're actually not setting at all. We're
     //   not overriding or changing _that_ value. Callers that want the opacity
     //   set by the settings should call this instead.
-    double TermControl::BackgroundOpacity() const
+    float TermControl::BackgroundOpacity() const
     {
         return _core.Opacity();
     }
@@ -3646,7 +3652,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                                                           cursorPos.y * fontSize.Height };
 
         // Get scale factor for view
-        const double scaleFactor = DisplayInformation::GetForCurrentView().RawPixelsPerViewPixel();
+        const auto scaleFactor = DisplayInformation::GetForCurrentView().RawPixelsPerViewPixel();
 
         // Adjust to DIPs
         const til::point clientCursorInDips{ til::math::rounding, clientCursorPos.X / scaleFactor, clientCursorPos.Y / scaleFactor };

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -100,7 +100,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         bool BracketedPasteEnabled() const noexcept;
 
-        double BackgroundOpacity() const;
+        float BackgroundOpacity() const;
 
         uint64_t OwningHwnd();
         void OwningHwnd(uint64_t owner);
@@ -171,7 +171,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         winrt::Microsoft::Terminal::Core::Scheme ColorScheme() const noexcept;
         void ColorScheme(const winrt::Microsoft::Terminal::Core::Scheme& scheme) const noexcept;
 
-        void AdjustOpacity(const double opacity, const bool relative);
+        void AdjustOpacity(const float opacity, const bool relative);
 
         bool RawWriteKeyEvent(const WORD vkey, const WORD scanCode, const winrt::Microsoft::Terminal::Core::ControlKeyStates modifiers, const bool keyDown);
         bool RawWriteChar(const wchar_t character, const WORD scanCode, const winrt::Microsoft::Terminal::Core::ControlKeyStates modifiers);

--- a/src/cascadia/TerminalControl/TermControl.idl
+++ b/src/cascadia/TerminalControl/TermControl.idl
@@ -126,13 +126,13 @@ namespace Microsoft.Terminal.Control
         String ReadEntireBuffer();
         CommandHistoryContext CommandHistory();
 
-        void AdjustOpacity(Double Opacity, Boolean relative);
+        void AdjustOpacity(Single Opacity, Boolean relative);
 
         // You'd think this should just be "Opacity", but UIElement already
         // defines an "Opacity", which we're actually not setting at all. We're
         // not overriding or changing _that_ value. Callers that want the
         // opacity set by the settings should call this instead.
-        Double BackgroundOpacity { get; };
+        Single BackgroundOpacity { get; };
 
         CursorDisplayState CursorVisibility;
 

--- a/src/cascadia/TerminalCore/ICoreAppearance.idl
+++ b/src/cascadia/TerminalCore/ICoreAppearance.idl
@@ -59,10 +59,10 @@ namespace Microsoft.Terminal.Core
     // Same thing here, but with padding. Can't use Windows.UI.Thickness, so
     // we'll declare our own.
     struct Padding {
-        Double Left;
-        Double Top;
-        Double Right;
-        Double Bottom;
+        Single Left;
+        Single Top;
+        Single Right;
+        Single Bottom;
     };
 
     // This is a projection of Microsoft::Terminal::Core::ControlKeyStates,

--- a/src/cascadia/TerminalSettingsEditor/Appearances.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.cpp
@@ -537,7 +537,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     void AppearanceViewModel::SetBackgroundImageOpacityFromPercentageValue(double percentageValue)
     {
-        BackgroundImageOpacity(winrt::Microsoft::Terminal::UI::Converters::PercentageValueToPercentage(percentageValue));
+        BackgroundImageOpacity(static_cast<float>(percentageValue) / 100.0f);
     }
 
     void AppearanceViewModel::SetBackgroundImagePath(winrt::hstring path)

--- a/src/cascadia/TerminalSettingsEditor/Appearances.idl
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.idl
@@ -91,7 +91,7 @@ namespace Microsoft.Terminal.Settings.Editor
         OBSERVABLE_PROJECTED_APPEARANCE_SETTING(Microsoft.Terminal.Core.CursorStyle, CursorShape);
         OBSERVABLE_PROJECTED_APPEARANCE_SETTING(UInt32, CursorHeight);
         OBSERVABLE_PROJECTED_APPEARANCE_SETTING(String, BackgroundImagePath);
-        OBSERVABLE_PROJECTED_APPEARANCE_SETTING(Double, BackgroundImageOpacity);
+        OBSERVABLE_PROJECTED_APPEARANCE_SETTING(Single, BackgroundImageOpacity);
         OBSERVABLE_PROJECTED_APPEARANCE_SETTING(Windows.UI.Xaml.Media.Stretch, BackgroundImageStretchMode);
         OBSERVABLE_PROJECTED_APPEARANCE_SETTING(Microsoft.Terminal.Settings.Model.ConvergedAlignment, BackgroundImageAlignment);
         OBSERVABLE_PROJECTED_APPEARANCE_SETTING(Microsoft.Terminal.Settings.Model.IntenseStyle, IntenseTextStyle);

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
@@ -49,7 +49,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         void SetAcrylicOpacityPercentageValue(double value)
         {
-            Opacity(winrt::Microsoft::Terminal::UI::Converters::PercentageValueToPercentage(value));
+            Opacity(static_cast<float>(value) / 100.0f);
         };
 
         void SetPadding(double value)

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
@@ -95,7 +95,7 @@ namespace Microsoft.Terminal.Settings.Editor
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Windows.Foundation.IReference<Microsoft.Terminal.Core.Color>, TabColor);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, SuppressApplicationTitle);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, UseAcrylic);
-        OBSERVABLE_PROJECTED_PROFILE_SETTING(Double, Opacity);
+        OBSERVABLE_PROJECTED_PROFILE_SETTING(Single, Opacity);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Microsoft.Terminal.Control.ScrollbarState, ScrollState);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(String, Padding);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(String, Commandline);

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -630,12 +630,12 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     struct SplitPaneArgs : public SplitPaneArgsT<SplitPaneArgs>
     {
         SplitPaneArgs() = default;
-        SplitPaneArgs(SplitType splitMode, SplitDirection direction, double size, const Model::INewContentArgs& terminalArgs) :
+        SplitPaneArgs(SplitType splitMode, SplitDirection direction, float size, const Model::INewContentArgs& terminalArgs) :
             _SplitMode{ splitMode },
             _SplitDirection{ direction },
             _SplitSize{ size },
             _ContentArgs{ terminalArgs } {};
-        SplitPaneArgs(SplitDirection direction, double size, const Model::INewContentArgs& terminalArgs) :
+        SplitPaneArgs(SplitDirection direction, float size, const Model::INewContentArgs& terminalArgs) :
             _SplitDirection{ direction },
             _SplitSize{ size },
             _ContentArgs{ terminalArgs } {};
@@ -648,7 +648,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         ACTION_ARG(Model::SplitDirection, SplitDirection, SplitDirection::Automatic);
         WINRT_PROPERTY(Model::INewContentArgs, ContentArgs, nullptr);
         ACTION_ARG(SplitType, SplitMode, SplitType::Manual);
-        ACTION_ARG(double, SplitSize, .5);
+        ACTION_ARG(float, SplitSize, .5);
 
         static constexpr std::string_view SplitKey{ "split" };
         static constexpr std::string_view SplitModeKey{ "splitMode" };

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -648,7 +648,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         ACTION_ARG(Model::SplitDirection, SplitDirection, SplitDirection::Automatic);
         WINRT_PROPERTY(Model::INewContentArgs, ContentArgs, nullptr);
         ACTION_ARG(SplitType, SplitMode, SplitType::Manual);
-        ACTION_ARG(float, SplitSize, .5);
+        ACTION_ARG(float, SplitSize, 0.5f);
 
         static constexpr std::string_view SplitKey{ "split" };
         static constexpr std::string_view SplitModeKey{ "splitMode" };

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -230,15 +230,15 @@ namespace Microsoft.Terminal.Settings.Model
 
     [default_interface] runtimeclass SplitPaneArgs : IActionArgs
     {
-        SplitPaneArgs(SplitType splitMode, SplitDirection split, Double size, INewContentArgs contentArgs);
-        SplitPaneArgs(SplitDirection split, Double size, INewContentArgs contentArgs);
+        SplitPaneArgs(SplitType splitMode, SplitDirection split, Single size, INewContentArgs contentArgs);
+        SplitPaneArgs(SplitDirection split, Single size, INewContentArgs contentArgs);
         SplitPaneArgs(SplitDirection split, INewContentArgs contentArgs);
         SplitPaneArgs(SplitType splitMode);
 
         SplitDirection SplitDirection { get; };
         INewContentArgs ContentArgs { get; };
         SplitType SplitMode { get; };
-        Double SplitSize { get; };
+        Single SplitSize { get; };
     };
 
     [default_interface] runtimeclass OpenSettingsArgs : IActionArgs

--- a/src/cascadia/TerminalSettingsModel/AppearanceConfig.cpp
+++ b/src/cascadia/TerminalSettingsModel/AppearanceConfig.cpp
@@ -53,7 +53,7 @@ Json::Value AppearanceConfig::ToJson() const
     JsonUtils::SetValueForKey(json, BackgroundKey, _Background);
     JsonUtils::SetValueForKey(json, SelectionBackgroundKey, _SelectionBackground);
     JsonUtils::SetValueForKey(json, CursorColorKey, _CursorColor);
-    JsonUtils::SetValueForKey(json, OpacityKey, _Opacity, JsonUtils::OptionalConverter<double, IntAsFloatPercentConversionTrait>{});
+    JsonUtils::SetValueForKey(json, OpacityKey, _Opacity, JsonUtils::OptionalConverter<float, IntAsFloatPercentConversionTrait>{});
     if (HasDarkColorSchemeName() || HasLightColorSchemeName())
     {
         // check if the setting is coming from the UI, if so grab the ColorSchemeName until the settings UI is fixed.
@@ -95,7 +95,7 @@ void AppearanceConfig::LayerJson(const Json::Value& json)
     JsonUtils::GetValueForKey(json, CursorColorKey, _CursorColor);
 
     JsonUtils::GetValueForKey(json, LegacyAcrylicTransparencyKey, _Opacity);
-    JsonUtils::GetValueForKey(json, OpacityKey, _Opacity, JsonUtils::OptionalConverter<double, IntAsFloatPercentConversionTrait>{});
+    JsonUtils::GetValueForKey(json, OpacityKey, _Opacity, JsonUtils::OptionalConverter<float, IntAsFloatPercentConversionTrait>{});
     if (json["colorScheme"].isString())
     {
         // to make the UI happy, set ColorSchemeName.

--- a/src/cascadia/TerminalSettingsModel/AppearanceConfig.h
+++ b/src/cascadia/TerminalSettingsModel/AppearanceConfig.h
@@ -40,7 +40,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         INHERITABLE_NULLABLE_SETTING(Model::IAppearanceConfig, Microsoft::Terminal::Core::Color, Background, nullptr);
         INHERITABLE_NULLABLE_SETTING(Model::IAppearanceConfig, Microsoft::Terminal::Core::Color, SelectionBackground, nullptr);
         INHERITABLE_NULLABLE_SETTING(Model::IAppearanceConfig, Microsoft::Terminal::Core::Color, CursorColor, nullptr);
-        INHERITABLE_SETTING(Model::IAppearanceConfig, double, Opacity, 1.0);
+        INHERITABLE_SETTING(Model::IAppearanceConfig, float, Opacity, 1.0f);
 
         INHERITABLE_SETTING(Model::IAppearanceConfig, hstring, DarkColorSchemeName, L"Campbell");
         INHERITABLE_SETTING(Model::IAppearanceConfig, hstring, LightColorSchemeName, L"Campbell");

--- a/src/cascadia/TerminalSettingsModel/IAppearanceConfig.idl
+++ b/src/cascadia/TerminalSettingsModel/IAppearanceConfig.idl
@@ -45,7 +45,7 @@ namespace Microsoft.Terminal.Settings.Model
         INHERITABLE_APPEARANCE_SETTING(String, BackgroundImagePath);
         String ExpandedBackgroundImagePath { get; };
 
-        INHERITABLE_APPEARANCE_SETTING(Double, BackgroundImageOpacity);
+        INHERITABLE_APPEARANCE_SETTING(Single, BackgroundImageOpacity);
         INHERITABLE_APPEARANCE_SETTING(Windows.UI.Xaml.Media.Stretch, BackgroundImageStretchMode);
         INHERITABLE_APPEARANCE_SETTING(ConvergedAlignment, BackgroundImageAlignment);
 
@@ -54,7 +54,7 @@ namespace Microsoft.Terminal.Settings.Model
         INHERITABLE_APPEARANCE_SETTING(String, PixelShaderImagePath);
         INHERITABLE_APPEARANCE_SETTING(IntenseStyle, IntenseTextStyle);
         INHERITABLE_APPEARANCE_SETTING(Microsoft.Terminal.Core.AdjustTextMode, AdjustIndistinguishableColors);
-        INHERITABLE_APPEARANCE_SETTING(Double, Opacity);
+        INHERITABLE_APPEARANCE_SETTING(Single, Opacity);
         INHERITABLE_APPEARANCE_SETTING(Boolean, UseAcrylic);
     };
 }

--- a/src/cascadia/TerminalSettingsModel/JsonUtils.h
+++ b/src/cascadia/TerminalSettingsModel/JsonUtils.h
@@ -729,7 +729,7 @@ namespace Microsoft::Terminal::Settings::Model::JsonUtils
             return json.isNumeric();
         }
 
-        Json::Value ToJson(const float& val)
+        Json::Value ToJson(const float val)
         {
             return val;
         }
@@ -753,7 +753,7 @@ namespace Microsoft::Terminal::Settings::Model::JsonUtils
             return json.isNumeric();
         }
 
-        Json::Value ToJson(const double& val)
+        Json::Value ToJson(const double val)
         {
             return val;
         }

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -121,7 +121,7 @@ Author(s):
 #define MTSM_APPEARANCE_SETTINGS(X)                                                                                                                                \
     X(Core::CursorStyle, CursorShape, "cursorShape", Core::CursorStyle::Bar)                                                                                       \
     X(uint32_t, CursorHeight, "cursorHeight", DEFAULT_CURSOR_HEIGHT)                                                                                               \
-    X(double, BackgroundImageOpacity, "backgroundImageOpacity", 1.0)                                                                                               \
+    X(float, BackgroundImageOpacity, "backgroundImageOpacity", 1.0f)                                                                                               \
     X(winrt::Windows::UI::Xaml::Media::Stretch, BackgroundImageStretchMode, "backgroundImageStretchMode", winrt::Windows::UI::Xaml::Media::Stretch::UniformToFill) \
     X(bool, RetroTerminalEffect, "experimental.retroTerminalEffect", false)                                                                                        \
     X(hstring, PixelShaderPath, "experimental.pixelShaderPath")                                                                                                    \

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.h
@@ -121,7 +121,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         INHERITABLE_SETTING(Model::TerminalSettings, guid, SessionId);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, EnableUnfocusedAcrylic, false);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, UseAcrylic, false);
-        INHERITABLE_SETTING(Model::TerminalSettings, double, Opacity, UseAcrylic() ? 0.5 : 1.0);
+        INHERITABLE_SETTING(Model::TerminalSettings, float, Opacity, UseAcrylic() ? 0.5f : 1.0f);
         INHERITABLE_SETTING(Model::TerminalSettings, hstring, Padding, DEFAULT_PADDING);
         INHERITABLE_SETTING(Model::TerminalSettings, hstring, FontFace, DEFAULT_FONT_FACE);
         INHERITABLE_SETTING(Model::TerminalSettings, float, FontSize, DEFAULT_FONT_SIZE);
@@ -136,7 +136,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         INHERITABLE_SETTING(Model::TerminalSettings, Model::ColorScheme, AppliedColorScheme);
         INHERITABLE_SETTING(Model::TerminalSettings, hstring, BackgroundImage);
-        INHERITABLE_SETTING(Model::TerminalSettings, double, BackgroundImageOpacity, 1.0);
+        INHERITABLE_SETTING(Model::TerminalSettings, float, BackgroundImageOpacity, 1.0f);
 
         INHERITABLE_SETTING(Model::TerminalSettings, winrt::Windows::UI::Xaml::Media::Stretch, BackgroundImageStretchMode, winrt::Windows::UI::Xaml::Media::Stretch::UniformToFill);
         INHERITABLE_SETTING(Model::TerminalSettings, winrt::Windows::UI::Xaml::HorizontalAlignment, BackgroundImageHorizontalAlignment, winrt::Windows::UI::Xaml::HorizontalAlignment::Center);

--- a/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
@@ -353,11 +353,11 @@ struct ::Microsoft::Terminal::Settings::Model::JsonUtils::ConversionTrait<::winr
     }
 };
 
-struct IntAsFloatPercentConversionTrait : ::Microsoft::Terminal::Settings::Model::JsonUtils::ConversionTrait<double>
+struct IntAsFloatPercentConversionTrait : ::Microsoft::Terminal::Settings::Model::JsonUtils::ConversionTrait<float>
 {
-    double FromJson(const Json::Value& json)
+    float FromJson(const Json::Value& json)
     {
-        return ::base::saturated_cast<double>(json.asUInt()) / 100.0;
+        return static_cast<float>(json.asUInt()) / 100.0f;
     }
 
     bool CanConvert(const Json::Value& json)
@@ -370,9 +370,9 @@ struct IntAsFloatPercentConversionTrait : ::Microsoft::Terminal::Settings::Model
         return value >= 0 && value <= 100;
     }
 
-    Json::Value ToJson(const double& val)
+    Json::Value ToJson(const float val)
     {
-        return std::clamp(::base::saturated_cast<uint32_t>(std::round(val * 100.0)), 0u, 100u);
+        return std::clamp(::base::saturated_cast<uint32_t>(std::round(val * 100.0f)), 0u, 100u);
     }
 
     std::string TypeDescription() const

--- a/src/cascadia/UnitTests_Control/ControlCoreTests.cpp
+++ b/src/cascadia/UnitTests_Control/ControlCoreTests.cpp
@@ -137,14 +137,14 @@ namespace ControlUnitTests
         VERIFY_IS_NOT_NULL(core);
 
         // A callback to make sure that we're raising TransparencyChanged events
-        auto expectedOpacity = 0.5;
+        auto expectedOpacity = 0.5f;
         auto opacityCallback = [&](auto&&, Control::TransparencyChangedEventArgs args) mutable {
             VERIFY_ARE_EQUAL(expectedOpacity, args.Opacity());
             VERIFY_ARE_EQUAL(expectedOpacity, core->Opacity());
             // The Settings object's opacity shouldn't be changed
-            VERIFY_ARE_EQUAL(0.5, settings->Opacity());
+            VERIFY_ARE_EQUAL(0.5f, settings->Opacity());
 
-            if (expectedOpacity < 1.0)
+            if (expectedOpacity < 1.0f)
             {
                 VERIFY_IS_TRUE(settings->UseAcrylic());
                 VERIFY_IS_TRUE(core->_settings->UseAcrylic());
@@ -153,7 +153,7 @@ namespace ControlUnitTests
             // GH#603: Adjusting opacity shouldn't change whether or not we
             // requested acrylic.
 
-            auto expectedUseAcrylic = expectedOpacity < 1.0;
+            auto expectedUseAcrylic = expectedOpacity < 1.0f;
             VERIFY_IS_TRUE(core->_settings->UseAcrylic());
             VERIFY_ARE_EQUAL(expectedUseAcrylic, core->UseAcrylic());
         };
@@ -166,39 +166,39 @@ namespace ControlUnitTests
         VERIFY_IS_TRUE(core->_initializedTerminal);
 
         Log::Comment(L"Increasing opacity till fully opaque");
-        expectedOpacity += 0.1; // = 0.6;
-        core->AdjustOpacity(0.1);
-        expectedOpacity += 0.1; // = 0.7;
-        core->AdjustOpacity(0.1);
-        expectedOpacity += 0.1; // = 0.8;
-        core->AdjustOpacity(0.1);
-        expectedOpacity += 0.1; // = 0.9;
-        core->AdjustOpacity(0.1);
-        expectedOpacity += 0.1; // = 1.0;
+        expectedOpacity += 0.1f; // = 0.6;
+        core->AdjustOpacity(0.1f);
+        expectedOpacity += 0.1f; // = 0.7;
+        core->AdjustOpacity(0.1f);
+        expectedOpacity += 0.1f; // = 0.8;
+        core->AdjustOpacity(0.1f);
+        expectedOpacity += 0.1f; // = 0.9;
+        core->AdjustOpacity(0.1f);
+        expectedOpacity += 0.1f; // = 1.0;
         // cast to float because floating point numbers are mean
-        VERIFY_ARE_EQUAL(1.0f, base::saturated_cast<float>(expectedOpacity));
-        core->AdjustOpacity(0.1);
+        VERIFY_ARE_EQUAL(1.0f, expectedOpacity);
+        core->AdjustOpacity(0.1f);
 
         Log::Comment(L"Increasing opacity more doesn't actually change it to be >1.0");
 
-        expectedOpacity = 1.0;
-        core->AdjustOpacity(0.1);
+        expectedOpacity = 1.0f;
+        core->AdjustOpacity(0.1f);
 
         Log::Comment(L"Decrease opacity");
-        expectedOpacity -= 0.25; // = 0.75;
-        core->AdjustOpacity(-0.25);
-        expectedOpacity -= 0.25; // = 0.5;
-        core->AdjustOpacity(-0.25);
-        expectedOpacity -= 0.25; // = 0.25;
-        core->AdjustOpacity(-0.25);
-        expectedOpacity -= 0.25; // = 0.05;
+        expectedOpacity -= 0.25f; // = 0.75;
+        core->AdjustOpacity(-0.25f);
+        expectedOpacity -= 0.25f; // = 0.5;
+        core->AdjustOpacity(-0.25f);
+        expectedOpacity -= 0.25f; // = 0.25;
+        core->AdjustOpacity(-0.25f);
+        expectedOpacity -= 0.25f; // = 0.05;
         // cast to float because floating point numbers are mean
-        VERIFY_ARE_EQUAL(0.0f, base::saturated_cast<float>(expectedOpacity));
-        core->AdjustOpacity(-0.25);
+        VERIFY_ARE_EQUAL(0.0f, expectedOpacity);
+        core->AdjustOpacity(-0.25f);
 
         Log::Comment(L"Decreasing opacity more doesn't actually change it to be < 0");
-        expectedOpacity = 0.0;
-        core->AdjustOpacity(-0.25);
+        expectedOpacity = 0.0f;
+        core->AdjustOpacity(-0.25f);
     }
 
     void ControlCoreTests::TestFreeAfterClose()

--- a/src/cascadia/UnitTests_Control/ControlInteractivityTests.cpp
+++ b/src/cascadia/UnitTests_Control/ControlInteractivityTests.cpp
@@ -140,14 +140,14 @@ namespace ControlUnitTests
         auto [core, interactivity] = _createCoreAndInteractivity(*settings, *conn);
 
         // A callback to make sure that we're raising TransparencyChanged events
-        auto expectedOpacity = 0.5;
+        auto expectedOpacity = 0.5f;
         auto opacityCallback = [&](auto&&, Control::TransparencyChangedEventArgs args) mutable {
             VERIFY_ARE_EQUAL(expectedOpacity, args.Opacity());
             VERIFY_ARE_EQUAL(expectedOpacity, core->Opacity());
             // The Settings object's opacity shouldn't be changed
-            VERIFY_ARE_EQUAL(0.5, settings->Opacity());
+            VERIFY_ARE_EQUAL(0.5f, settings->Opacity());
 
-            auto expectedUseAcrylic = expectedOpacity < 1.0 &&
+            auto expectedUseAcrylic = expectedOpacity < 1.0f &&
                                       (useAcrylic);
             VERIFY_ARE_EQUAL(useAcrylic, settings->UseAcrylic());
             VERIFY_ARE_EQUAL(expectedUseAcrylic, core->UseAcrylic());
@@ -162,10 +162,10 @@ namespace ControlUnitTests
         for (auto i = 0; i < 55; i++)
         {
             // each mouse wheel only adjusts opacity by .01
-            expectedOpacity += 0.01;
-            if (expectedOpacity >= 1.0)
+            expectedOpacity += 0.01f;
+            if (expectedOpacity >= 1.0f)
             {
-                expectedOpacity = 1.0;
+                expectedOpacity = 1.0f;
             }
 
             // The mouse location and buttons don't matter here.
@@ -180,10 +180,10 @@ namespace ControlUnitTests
         for (auto i = 0; i < 105; i++)
         {
             // each mouse wheel only adjusts opacity by .01
-            expectedOpacity -= 0.01;
-            if (expectedOpacity <= 0.0)
+            expectedOpacity -= 0.01f;
+            if (expectedOpacity <= 0.0f)
             {
-                expectedOpacity = 0.0;
+                expectedOpacity = 0.0f;
             }
 
             // The mouse location and buttons don't matter here.

--- a/src/cascadia/UnitTests_SettingsModel/CommandTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/CommandTests.cpp
@@ -156,7 +156,7 @@ namespace SettingsModelUnitTests
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
             VERIFY_ARE_EQUAL(SplitDirection::Right, realArgs.SplitDirection());
-            VERIFY_ARE_EQUAL(0.5, realArgs.SplitSize());
+            VERIFY_ARE_EQUAL(0.5f, realArgs.SplitSize());
         }
         {
             auto command = commands.Lookup(L"command2");
@@ -167,7 +167,7 @@ namespace SettingsModelUnitTests
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
             VERIFY_ARE_EQUAL(SplitDirection::Down, realArgs.SplitDirection());
-            VERIFY_ARE_EQUAL(0.5, realArgs.SplitSize());
+            VERIFY_ARE_EQUAL(0.5f, realArgs.SplitSize());
         }
         {
             auto command = commands.Lookup(L"command4");
@@ -178,7 +178,7 @@ namespace SettingsModelUnitTests
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
             VERIFY_ARE_EQUAL(SplitDirection::Automatic, realArgs.SplitDirection());
-            VERIFY_ARE_EQUAL(0.5, realArgs.SplitSize());
+            VERIFY_ARE_EQUAL(0.5f, realArgs.SplitSize());
         }
         {
             auto command = commands.Lookup(L"command5");
@@ -189,7 +189,7 @@ namespace SettingsModelUnitTests
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
             VERIFY_ARE_EQUAL(SplitDirection::Automatic, realArgs.SplitDirection());
-            VERIFY_ARE_EQUAL(0.5, realArgs.SplitSize());
+            VERIFY_ARE_EQUAL(0.5f, realArgs.SplitSize());
         }
         {
             auto command = commands.Lookup(L"command6");
@@ -211,7 +211,7 @@ namespace SettingsModelUnitTests
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
             VERIFY_ARE_EQUAL(SplitDirection::Right, realArgs.SplitDirection());
-            VERIFY_ARE_EQUAL(0.5, realArgs.SplitSize());
+            VERIFY_ARE_EQUAL(0.5f, realArgs.SplitSize());
         }
         {
             auto command = commands.Lookup(L"command8");
@@ -222,7 +222,7 @@ namespace SettingsModelUnitTests
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
             VERIFY_ARE_EQUAL(SplitDirection::Left, realArgs.SplitDirection());
-            VERIFY_ARE_EQUAL(0.5, realArgs.SplitSize());
+            VERIFY_ARE_EQUAL(0.5f, realArgs.SplitSize());
         }
         {
             auto command = commands.Lookup(L"command9");
@@ -233,7 +233,7 @@ namespace SettingsModelUnitTests
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
             VERIFY_ARE_EQUAL(SplitDirection::Up, realArgs.SplitDirection());
-            VERIFY_ARE_EQUAL(0.5, realArgs.SplitSize());
+            VERIFY_ARE_EQUAL(0.5f, realArgs.SplitSize());
         }
         {
             auto command = commands.Lookup(L"command10");
@@ -244,7 +244,7 @@ namespace SettingsModelUnitTests
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
             VERIFY_ARE_EQUAL(SplitDirection::Down, realArgs.SplitDirection());
-            VERIFY_ARE_EQUAL(0.5, realArgs.SplitSize());
+            VERIFY_ARE_EQUAL(0.5f, realArgs.SplitSize());
         }
     }
 
@@ -274,7 +274,7 @@ namespace SettingsModelUnitTests
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
             VERIFY_ARE_EQUAL(SplitDirection::Automatic, realArgs.SplitDirection());
-            VERIFY_ARE_EQUAL(0.25, realArgs.SplitSize());
+            VERIFY_ARE_EQUAL(0.25f, realArgs.SplitSize());
         }
     }
 

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -1423,7 +1423,7 @@ void IslandWindow::_doSlideAnimation(const uint32_t dropdownDuration, const bool
     {
         const auto end = std::chrono::system_clock::now();
         const auto millis = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-        const auto dt = ::base::saturated_cast<double>(millis.count());
+        const auto dt = static_cast<double>(millis.count());
 
         if (dt > animationDuration)
         {

--- a/src/cascadia/inc/ControlProperties.h
+++ b/src/cascadia/inc/ControlProperties.h
@@ -19,10 +19,10 @@
 //  All of these settings are defined in IControlAppearance.
 #define CONTROL_APPEARANCE_SETTINGS(X)                                                                                                          \
     X(til::color, SelectionBackground, DEFAULT_FOREGROUND)                                                                                      \
-    X(double, Opacity, 1.0)                                                                                                                     \
+    X(float, Opacity, 1.0f)                                                                                                                     \
     X(bool, UseAcrylic, false)                                                                                                                  \
     X(winrt::hstring, BackgroundImage)                                                                                                          \
-    X(double, BackgroundImageOpacity, 1.0)                                                                                                      \
+    X(float, BackgroundImageOpacity, 1.0f)                                                                                                      \
     X(winrt::Windows::UI::Xaml::Media::Stretch, BackgroundImageStretchMode, winrt::Windows::UI::Xaml::Media::Stretch::UniformToFill)            \
     X(winrt::Windows::UI::Xaml::HorizontalAlignment, BackgroundImageHorizontalAlignment, winrt::Windows::UI::Xaml::HorizontalAlignment::Center) \
     X(winrt::Windows::UI::Xaml::VerticalAlignment, BackgroundImageVerticalAlignment, winrt::Windows::UI::Xaml::VerticalAlignment::Center)       \

--- a/src/types/IControlAccessibilityInfo.h
+++ b/src/types/IControlAccessibilityInfo.h
@@ -27,7 +27,7 @@ namespace Microsoft::Console::Types
         virtual til::size GetFontSize() const noexcept = 0;
         virtual til::rect GetBounds() const noexcept = 0;
         virtual til::rect GetPadding() const noexcept = 0;
-        virtual double GetScaleFactor() const noexcept = 0;
+        virtual float GetScaleFactor() const noexcept = 0;
         virtual void ChangeViewport(const til::inclusive_rect& NewWindow) = 0;
         virtual HRESULT GetHostUiaProvider(IRawElementProviderSimple** provider) = 0;
 

--- a/src/types/TermControlUiaProvider.cpp
+++ b/src/types/TermControlUiaProvider.cpp
@@ -145,7 +145,7 @@ til::rect TermControlUiaProvider::GetPadding() const noexcept
     return _controlInfo->GetPadding();
 }
 
-double TermControlUiaProvider::GetScaleFactor() const noexcept
+float TermControlUiaProvider::GetScaleFactor() const noexcept
 {
     return _controlInfo->GetScaleFactor();
 }

--- a/src/types/TermControlUiaProvider.hpp
+++ b/src/types/TermControlUiaProvider.hpp
@@ -45,7 +45,7 @@ namespace Microsoft::Terminal
 
         til::size GetFontSize() const noexcept;
         til::rect GetPadding() const noexcept;
-        double GetScaleFactor() const noexcept;
+        float GetScaleFactor() const noexcept;
         void ChangeViewport(const til::inclusive_rect& NewWindow) override;
 
     protected:


### PR DESCRIPTION
While `double` is probably generally preferable for UI code,
our application is essentially a complex wrapper wrapper around
DWrite, D2D and D3D, all of which use `float` exclusively.

Of course it also uses XAML, but that one uses `float` for roughly
1/3rd of its API functions, so I'm not sure what it prefers.
Additionally, it's mostly a coincidence that we use WinUI/XAML for
Windows Terminal whereas DWrite/D2D/D3D are effectively essential.
This is demonstrated by the fact that we have a `HwndTerminal`,
while there's no alternative to e.g. D3D on Windows.

The goal of this PR is that DIP based calculations never end up
mixing `float` and `double`. This PR also changes opacity-related
values to `float` because I felt like that fits the theme.