### PR TITLE
Don't explode when duplicating a pane

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -3152,7 +3152,8 @@ namespace winrt::TerminalApp::implementation
                                                   TerminalConnection::ITerminalConnection existingConnection)
 
     {
-        if (const auto& newTerminalArgs{ contentArgs.try_as<NewTerminalArgs>() })
+        const auto& newTerminalArgs{ contentArgs.try_as<NewTerminalArgs>() };
+        if (contentArgs == nullptr || newTerminalArgs != nullptr || contentArgs.Type().empty())
         {
             // Terminals are of course special, and have to deal with debug taps, duplicating the tab, etc.
             return _MakeTerminalPane(newTerminalArgs, sourceTab, existingConnection);


### PR DESCRIPTION
I forgot to check here if the `INewContentArgs` were null or not. Pretty dumb mistake honestly.

Closes #17075
Closes #17076
