### PR TITLE
Update Microsoft.Windows.CppWinRT to 2.0.240405.15

### DIFF
--- a/dep/nuget/packages.config
+++ b/dep/nuget/packages.config
@@ -4,7 +4,7 @@
   <!-- Native packages -->
   <package id="Microsoft.Internal.PGO-Helpers.Cpp" version="0.2.34" targetFramework="native" />
   <package id="Microsoft.Taef" version="10.60.210621002" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.230207.1" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.240405.15" targetFramework="native" />
   <package id="Microsoft.Internal.Windows.Terminal.ThemeHelpers" version="0.7.230706001" targetFramework="native" />
   <package id="Microsoft.VisualStudio.Setup.Configuration.Native" version="2.3.2262" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.UI.Xaml" version="2.8.4" targetFramework="native" />

--- a/scratch/ScratchIslandApp/SampleApp/packages.config
+++ b/scratch/ScratchIslandApp/SampleApp/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.Toolkit.Win32.UI.XamlApplication" version="6.1.3" targetFramework="native" />
   <package id="Microsoft.UI.Xaml" version="2.7.3" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.230207.1" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.240405.15" targetFramework="native" />
 </packages>

--- a/scratch/ScratchIslandApp/WindowExe/packages.config
+++ b/scratch/ScratchIslandApp/WindowExe/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.230207.1" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.240405.15" targetFramework="native" />
   <package id="Microsoft.Toolkit.Win32.UI.XamlApplication" version="6.1.3" targetFramework="native" />
   <package id="Microsoft.UI.Xaml" version="2.7.3" targetFramework="native" />
 </packages>

--- a/src/common.nugetversions.props
+++ b/src/common.nugetversions.props
@@ -4,7 +4,7 @@
   <Import Condition="'$(PgoTarget)' == 'true' And ('$(Platform)'=='x64' or '$(Platform)'=='arm64') And '$(PGOBuildMode)'!='' And Exists('$(SolutionDir)\build\PGO\Terminal.PGO.props')" Project="$(SolutionDir)\build\PGO\Terminal.PGO.props" />
 
   <!-- CppWinrt -->
-  <Import Project="$(MSBuildThisFileDirectory)..\packages\Microsoft.Windows.CppWinRT.2.0.230207.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="'$(TerminalCppWinrt)' == 'true' and Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Windows.CppWinRT.2.0.230207.1\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Import Project="$(MSBuildThisFileDirectory)..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props" Condition="'$(TerminalCppWinrt)' == 'true' and Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Windows.CppWinRT.2.0.230207.1\build\native\Microsoft.Windows.CppWinRT.props')" />
 
   <!-- TAEF -->
   <PropertyGroup>

--- a/src/common.nugetversions.targets
+++ b/src/common.nugetversions.targets
@@ -41,7 +41,7 @@
     <Import Condition="'$(PgoTarget)' == 'true' And ('$(Platform)'=='x64' or '$(Platform)'=='arm64') And '$(PGOBuildMode)'!='' and Exists('$(PkgMicrosoft_PGO_Helpers_Cpp)\build\Microsoft.PGO-Helpers.Cpp.targets')" Project="$(PkgMicrosoft_PGO_Helpers_Cpp)\build\Microsoft.PGO-Helpers.Cpp.targets" />
 
     <!-- CppWinrt -->
-    <Import Project="$(MSBuildThisFileDirectory)..\packages\Microsoft.Windows.CppWinRT.2.0.230207.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="'$(TerminalCppWinrt)' == 'true' and Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Windows.CppWinRT.2.0.230207.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="$(MSBuildThisFileDirectory)..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets" Condition="'$(TerminalCppWinrt)' == 'true' and Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Windows.CppWinRT.2.0.230207.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
 
     <!-- TAEF -->
     <Import Project="$(MSBuildThisFileDirectory)..\packages\Microsoft.Taef.10.60.210621002\build\Microsoft.Taef.targets" Condition="'$(TerminalTAEF)' == 'true' and Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Taef.10.60.210621002\build\Microsoft.Taef.targets')" />
@@ -76,8 +76,8 @@
     <Error Condition="'$(PgoTarget)' == 'true' And ('$(Platform)'=='x64' or '$(Platform)'=='arm64') And '$(PGOBuildMode)'!='' AND !Exists('$(PkgMicrosoft_PGO_Helpers_Cpp)\build\Microsoft.PGO-Helpers.Cpp.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(PkgMicrosoft_PGO_Helpers_Cpp)\build\Microsoft.PGO-Helpers.Cpp.targets))" />
 
     <!-- CppWinrt -->
-    <Error Condition="'$(TerminalCppWinrt)' == 'true' AND !Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Windows.CppWinRT.2.0.230207.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(MSBuildThisFileDirectory)..\packages\Microsoft.Windows.CppWinRT.2.0.230207.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
-    <Error Condition="'$(TerminalCppWinrt)' == 'true' AND !Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Windows.CppWinRT.2.0.230207.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(MSBuildThisFileDirectory)..\packages\Microsoft.Windows.CppWinRT.2.0.230207.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="'$(TerminalCppWinrt)' == 'true' AND !Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(MSBuildThisFileDirectory)..\packages\Microsoft.Windows.CppWinRT.2.0.230207.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="'$(TerminalCppWinrt)' == 'true' AND !Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(MSBuildThisFileDirectory)..\packages\Microsoft.Windows.CppWinRT.2.0.230207.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
 
     <!-- TAEF -->
     <Error Condition="'$(TerminalTAEF)' == 'true' AND !Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Taef.10.60.210621002\build\Microsoft.Taef.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(MSBuildThisFileDirectory)..\packages\Microsoft.Taef.10.60.210621002\build\Microsoft.Taef.targets'))" />


### PR DESCRIPTION
## changes
- Remove references to stale winmd files to fix incremental builds
- Use latest upload/download actions
- Fix build following dependabot updates
- Revert "Bump actions/upload-artifact from 3 to 4
- Bump actions/stale from 6 to 9
- Bump actions/checkout from 3 to 4
- Create dependabot.yml
- TDBuild - updating localized resource files.
- Update build.yml for Azure Pipelines
- CppWinRTAddXamlReferences to not use outputs as inputs
- User/dmachaj/slim source location
- Update pool
- Allow delegates to be created with weak reference + lambda
- Update GitHub action LLVM version to 17.0.5
- Allow resume_agile to be stored in a variable
- Add resume_agile to allow coroutine to resume in any apartment
- Improve GCC compatibility
- Support for std::span for winrt::array_view and winrt::com_array
- Allow classic COM interfaces with get_self 
- Fix source location test failure resulting from newer compiler
- Clarify contributing guide
- Fix workflow trigger
- Update open source docs
- Update readme
- Update issue template to use cpp instead of rust
- Add UTF-8 path support
- Disable MSYS2 mingw32 CI due to running out of memory
- Remove explicitly setting PreferredToolArchitecture, since VS 2022 handles this more comprehensively
- Remove ARM OneBranch build workaround
- Add capture support for unconventional result types
- Move official build pipelines to OneBranch
- Fix flakey clock and line-number tests
- Use safe DLL loading (avoid current directory) 
- Compliance and test cleanup
- Expose configuring /nomidl.
- Create pipeline to sync mirror repo
- Update README.md
- Stack usage reduction in apartment switching, and lifetime fixes
- Reduce stack consumption if unable to switch to apartment_context
- Fix unreliable clock epoch tests
- to_hstring for IStringable
- Add a clang-specific impl->projection conversion operator
