### PR TITLE
build: switch to ESRP v5, which supports managed identities

### DIFF
--- a/.github/actions/spelling/allow/microsoft.txt
+++ b/.github/actions/spelling/allow/microsoft.txt
@@ -1,6 +1,8 @@
 ACLs
 ADMINS
 advapi
+akv
+AKV
 altform
 altforms
 appendwttlogging

--- a/build/pipelines/ob-nightly.yml
+++ b/build/pipelines/ob-nightly.yml
@@ -30,6 +30,13 @@ extends:
     buildTerminal: true
     pgoBuildMode: Optimize
     codeSign: true
+    signingIdentity:
+      serviceName: $(SigningServiceName)
+      appId: $(SigningAppId)
+      tenantId: $(SigningTenantId)
+      akvName: $(SigningAKVName)
+      authCertName: $(SigningAuthCertName)
+      signCertName: $(SigningSignCertName)
     publishSymbolsToPublic: true
     publishVpackToWindows: false
     symbolExpiryTime: 15

--- a/build/pipelines/ob-release.yml
+++ b/build/pipelines/ob-release.yml
@@ -78,6 +78,13 @@ extends:
     buildConfigurations: ${{ parameters.buildConfigurations }}
     buildPlatforms: ${{ parameters.buildPlatforms }}
     codeSign: true
+    signingIdentity:
+      serviceName: $(SigningServiceName)
+      appId: $(SigningAppId)
+      tenantId: $(SigningTenantId)
+      akvName: $(SigningAKVName)
+      authCertName: $(SigningAuthCertName)
+      signCertName: $(SigningSignCertName)
     terminalInternalPackageVersion: ${{ parameters.terminalInternalPackageVersion }}
     publishSymbolsToPublic: ${{ parameters.publishSymbolsToPublic }}
     publishVpackToWindows: ${{ parameters.publishVpackToWindows }}

--- a/build/pipelines/templates-v2/job-build-package-wpf.yml
+++ b/build/pipelines/templates-v2/job-build-package-wpf.yml
@@ -27,6 +27,9 @@ parameters:
   - name: publishArtifacts
     type: boolean
     default: true
+  - name: signingIdentity
+    type: object
+    default: {}
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -97,10 +100,15 @@ jobs:
       flattenFolders: true
 
   - ${{ if eq(parameters.codeSign, true) }}:
-    - task: EsrpCodeSigning@3
+    - task: EsrpCodeSigning@5
       displayName: Submit *.nupkg to ESRP for code signing
       inputs:
-        ConnectedServiceName: 9d6d2960-0793-4d59-943e-78dcb434840a
+        ConnectedServiceName: ${{ parameters.signingIdentity.serviceName }}
+        AppRegistrationClientId: ${{ parameters.signingIdentity.appId }}
+        AppRegistrationTenantId: ${{ parameters.signingIdentity.tenantId }}
+        AuthAKVName: ${{ parameters.signingIdentity.akvName }}
+        AuthCertName: ${{ parameters.signingIdentity.authCertName }}
+        AuthSignCertName: ${{ parameters.signingIdentity.signCertName }}
         FolderPath: $(Build.ArtifactStagingDirectory)/nupkg
         Pattern: '*.nupkg'
         UseMinimatch: true

--- a/build/pipelines/templates-v2/job-build-project.yml
+++ b/build/pipelines/templates-v2/job-build-project.yml
@@ -65,6 +65,9 @@ parameters:
   - name: removeAllNonSignedFiles
     type: boolean
     default: false
+  - name: signingIdentity
+    type: object
+    default: {}
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -235,10 +238,15 @@ jobs:
 
     # Code-sign everything we just put together.
     # We run the signing in Terminal.BinDir, because all of the signing batches are relative to the final architecture/configuration output folder.
-    - task: EsrpCodeSigning@3
+    - task: EsrpCodeSigning@5
       displayName: Submit Signing Request
       inputs:
-        ConnectedServiceName: 9d6d2960-0793-4d59-943e-78dcb434840a
+        ConnectedServiceName: ${{ parameters.signingIdentity.serviceName }}
+        AppRegistrationClientId: ${{ parameters.signingIdentity.appId }}
+        AppRegistrationTenantId: ${{ parameters.signingIdentity.tenantId }}
+        AuthAKVName: ${{ parameters.signingIdentity.akvName }}
+        AuthCertName: ${{ parameters.signingIdentity.authCertName }}
+        AuthSignCertName: ${{ parameters.signingIdentity.signCertName }}
         FolderPath: '$(Terminal.BinDir)'
         signType: batchSigning
         batchSignPolicyFile: '$(Build.SourcesDirectory)/ESRPSigningConfig.json'

--- a/build/pipelines/templates-v2/job-merge-msix-into-bundle.yml
+++ b/build/pipelines/templates-v2/job-merge-msix-into-bundle.yml
@@ -32,6 +32,9 @@ parameters:
   - name: afterBuildSteps
     type: stepList
     default: []
+  - name: signingIdentity
+    type: object
+    default: {}
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -94,10 +97,15 @@ jobs:
     displayName: Create msixbundle
 
   - ${{ if eq(parameters.codeSign, true) }}:
-    - task: EsrpCodeSigning@3
+    - task: EsrpCodeSigning@5
       displayName: Submit *.msixbundle to ESRP for code signing
       inputs:
-        ConnectedServiceName: 9d6d2960-0793-4d59-943e-78dcb434840a
+        ConnectedServiceName: ${{ parameters.signingIdentity.serviceName }}
+        AppRegistrationClientId: ${{ parameters.signingIdentity.appId }}
+        AppRegistrationTenantId: ${{ parameters.signingIdentity.tenantId }}
+        AuthAKVName: ${{ parameters.signingIdentity.akvName }}
+        AuthCertName: ${{ parameters.signingIdentity.authCertName }}
+        AuthSignCertName: ${{ parameters.signingIdentity.signCertName }}
         FolderPath: $(System.ArtifactsDirectory)\bundle
         Pattern: $(BundleStemName)*.msixbundle
         UseMinimatch: true

--- a/build/pipelines/templates-v2/job-package-conpty.yml
+++ b/build/pipelines/templates-v2/job-package-conpty.yml
@@ -27,6 +27,9 @@ parameters:
   - name: publishArtifacts
     type: boolean
     default: true
+  - name: signingIdentity
+    type: object
+    default: {}
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -82,10 +85,15 @@ jobs:
       versionEnvVar: XES_PACKAGEVERSIONNUMBER
 
   - ${{ if eq(parameters.codeSign, true) }}:
-    - task: EsrpCodeSigning@3
+    - task: EsrpCodeSigning@5
       displayName: Submit *.nupkg to ESRP for code signing
       inputs:
-        ConnectedServiceName: 9d6d2960-0793-4d59-943e-78dcb434840a
+        ConnectedServiceName: ${{ parameters.signingIdentity.serviceName }}
+        AppRegistrationClientId: ${{ parameters.signingIdentity.appId }}
+        AppRegistrationTenantId: ${{ parameters.signingIdentity.tenantId }}
+        AuthAKVName: ${{ parameters.signingIdentity.akvName }}
+        AuthCertName: ${{ parameters.signingIdentity.authCertName }}
+        AuthSignCertName: ${{ parameters.signingIdentity.signCertName }}
         FolderPath: $(Build.ArtifactStagingDirectory)/nupkg
         Pattern: '*.nupkg'
         UseMinimatch: true

--- a/build/pipelines/templates-v2/pipeline-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-full-release-build.yml
@@ -33,7 +33,7 @@ parameters:
       - arm64
   - name: codeSign
     type: boolean
-    default: true
+    default: false
   - name: generateSbom
     type: boolean
     default: true

--- a/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
@@ -60,6 +60,9 @@ parameters:
   - name: extraPublishJobs
     type: object
     default: []
+  - name: signingIdentity
+    type: object
+    default: {}
 
 resources:
   repositories:
@@ -125,6 +128,7 @@ extends:
               generateSbom: false # this is handled by onebranch
               removeAllNonSignedFiles: true # appease the overlords
               codeSign: ${{ parameters.codeSign }}
+              signingIdentity: ${{ parameters.signingIdentity }}
               beforeBuildSteps: # Right before we build, lay down the universal package and localizations
                 - task: PkgESSetupBuild@12
                   displayName: Package ES - Setup Build
@@ -161,6 +165,7 @@ extends:
                 generateSbom: false # this is handled by onebranch
                 removeAllNonSignedFiles: true # appease the overlords
                 codeSign: ${{ parameters.codeSign }}
+                signingIdentity: ${{ parameters.signingIdentity }}
                 beforeBuildSteps:
                   - task: PkgESSetupBuild@12
                     displayName: Package ES - Setup Build
@@ -214,6 +219,7 @@ extends:
                 buildPlatforms: ${{ parameters.buildPlatforms }}
                 generateSbom: false # Handled by onebranch
                 codeSign: ${{ parameters.codeSign }}
+                signingIdentity: ${{ parameters.signingIdentity }}
                 afterBuildSteps:
                   # This directory has to exist, even if we aren't using createvpack, because the Guardian rules demand it.
                   - pwsh: |-
@@ -241,6 +247,7 @@ extends:
                 buildPlatforms: ${{ parameters.buildPlatforms }}
                 generateSbom: false # this is handled by onebranch
                 codeSign: ${{ parameters.codeSign }}
+                signingIdentity: ${{ parameters.signingIdentity }}
 
           - ${{ if eq(parameters.buildWPF, true) }}:
             - template: ./build/pipelines/templates-v2/job-build-package-wpf.yml@self
@@ -258,6 +265,7 @@ extends:
                 buildPlatforms: ${{ parameters.buildPlatforms }}
                 generateSbom: false # this is handled by onebranch
                 codeSign: ${{ parameters.codeSign }}
+                signingIdentity: ${{ parameters.signingIdentity }}
 
       - stage: Publish
         displayName: Publish


### PR DESCRIPTION
This required me to push a bunch more parameters through the build pipeline, but it gave me the opportunity to define them as variables that can be set at queue time.