### PR TITLE
Update so that cursor size/type/isblinkingallowed get restored when switching back to main buffer from alt buffer

### DIFF
--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -514,6 +514,9 @@ bool AdaptDispatch::CursorSaveState()
     savedCursorState.IsOriginModeRelative = _modes.test(Mode::Origin);
     savedCursorState.Attributes = attributes;
     savedCursorState.TermOutput = _termOutput;
+    savedCursorState.CursorType = textBuffer.GetCursor().GetType();
+    savedCursorState.IsBlinkingAllowed = textBuffer.GetCursor().IsBlinkingAllowed();
+    savedCursorState.Size = textBuffer.GetCursor().GetSize();
 
     return true;
 }
@@ -535,6 +538,11 @@ bool AdaptDispatch::CursorRestoreState()
 
     // We can then restore the position with a standard CUP operation.
     CursorPosition(savedCursorState.Row, savedCursorState.Column);
+
+    Cursor& cursor = _api.GetTextBuffer().GetCursor();
+    cursor.SetBlinkingAllowed(savedCursorState.IsBlinkingAllowed);
+    cursor.SetType(savedCursorState.CursorType);
+    cursor.SetSize(savedCursorState.Size);
 
     // If the delayed wrap flag was set when the cursor was saved, we need to restore that now.
     if (savedCursorState.IsDelayedEOLWrap)

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -193,6 +193,9 @@ namespace Microsoft::Console::VirtualTerminal
             bool IsOriginModeRelative = false;
             TextAttribute Attributes = {};
             TerminalOutput TermOutput = {};
+            ULONG Size = 0;
+            bool IsBlinkingAllowed = false;
+            CursorType CursorType = CursorType::Legacy;
         };
         struct Offset
         {


### PR DESCRIPTION
## Summary of the Pull Request

When switching to a application that uses the alt buffer,  the cursor continues to use the alt buffer applications cursor type when switched back to the main buffer.

I think that this is from this logic in Terminal::UseMainScreenBuffer().
https://github.com/microsoft/terminal/blob/378b6594bd94cf3b27f4e309a11efe25d83de0d9/src/cascadia/TerminalCore/TerminalApi.cpp#L276-L287

Based on these comments,  I made the updates in AdaptDispatch::CursorRestoreState where it looked like it was restoring the cursor position.
https://github.com/microsoft/terminal/blob/378b6594bd94cf3b27f4e309a11efe25d83de0d9/src/cascadia/TerminalCore/TerminalApi.cpp#L271-L275
https://github.com/e82eric/terminal/blob/91fed9ca3c7b9a89612a7ab9569330a642684a84/src/terminal/adapter/adaptDispatch.cpp#L540

![BlockCursor](https://github.com/microsoft/terminal/assets/811029/7d7940e4-ecb6-4baf-ab00-f120f1e874d8)

## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
