### PR TITLE
Some schema updates for 1.21

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -1506,7 +1506,7 @@
                 "$ref": "#/$defs/ShortcutAction"
               },
               "minItems": 1,
-              "description": "A list of foo bar actions."
+              "description": "A list of other actions."
             }
           }
         }

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -1501,10 +1501,12 @@
               "const": "multipleActions"
             },
             "actions": {
-              "$ref": "#/$defs/ShortcutAction",
               "type": "array",
+              "items": {
+                "$ref": "#/$defs/ShortcutAction"
+              },
               "minItems": 1,
-              "description": "A list of other actions."
+              "description": "A list of foo bar actions."
             }
           }
         }
@@ -1891,6 +1893,14 @@
       ],
       "type": "string"
     },
+    "IconStyle": {
+      "enum": [
+        "default",
+        "hidden",
+        "monochrome"
+      ],
+      "type": "string"
+    },
     "ThemeColor": {
       "description": "A special kind of color for use in themes. Can be an #rrggbb color, #rrggbbaa color, or a special value. 'accent' is evaluated as the user's selected Accent color in the OS, and 'terminalBackground' will be evaluated as the background color of the active terminal pane.",
       "oneOf": [
@@ -1928,6 +1938,10 @@
         "showCloseButton": {
           "description": "Controls the visibility of the close button on the tab",
           "$ref": "#/$defs/ShowCloseButton"
+        },
+        "iconStyle": {
+          "description": "Controls the appearance of a tab's icon",
+          "$ref": "#/$defs/IconStyle"
         }
       }
     },
@@ -2064,6 +2078,9 @@
             },
             {
               "$ref": "#/$defs/SwitchToTabAction"
+            },
+            {
+              "$ref": "#/$defs/ScrollToMarkAction"
             },
             {
               "$ref": "#/$defs/MoveFocusAction"
@@ -2215,7 +2232,15 @@
         "commands": {
           "description": "List of commands to execute",
           "items": {
-            "$ref": "#/$defs/Keybinding/properties/command"
+            "type": "object",
+            "properties": {
+              "command": {
+                "$ref": "#/$defs/Keybinding/properties/command"
+              },
+              "name": {
+                "$ref": "#/$defs/Keybinding/properties/name"
+              }
+            }
           },
           "minItems": 1,
           "type": "array"
@@ -2776,9 +2801,14 @@
             "type": "string"
           }
         },
-        "experimental.autoMarkPrompts": {
+        "autoMarkPrompts": {
           "default": false,
           "description": "When set to true, prompts will automatically be marked.",
+          "type": "boolean"
+        },
+        "experimental.autoMarkPrompts": {
+          "deprecated": true,
+          "description": "This has been replaced by autoMarkPrompts in 1.21",
           "type": "boolean"
         },
         "experimental.retroTerminalEffect": {
@@ -2786,8 +2816,18 @@
           "type": "boolean"
         },
         "experimental.showMarksOnScrollbar": {
+          "deprecated": true,
+          "description": "This has been replaced by showMarksOnScrollbar in 1.21",
+          "type": "boolean"
+        },
+        "showMarksOnScrollbar": {
           "default": false,
           "description": "When set to true, marks added to the buffer via the addMark action will appear on the scrollbar.",
+          "type": "boolean"
+        },
+        "experimental.rightClickContextMenu": {
+          "default": false,
+          "description": "When set to true, right-clicking on the terminal will show a context menu. When set to false, right-click will copy",
           "type": "boolean"
         },
         "experimental.repositionCursorWithMouse": {


### PR DESCRIPTION
Noticed all these while prepping for Build:

* Promotes the stabilized features out of `experimental.`
* fixes a bug where a nested command with a `name` would match to a `renameWindow` action, instead of a command. 
* Adds the tab theme icon style
* fixes a bug where `ScrollToMarkAction` wasn't in the list of possible args, so they would incorrectly get flagged as `moveTab` 
* outright adds `experimental.rightClickContextMenu` which was missing (?)