### PR TITLE
Change SolidColorBrush to AcrylicBrush in MainPage.xaml

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -54,13 +54,21 @@
 
             </ResourceDictionary.MergedDictionaries>
 
-            <SolidColorBrush x:Key="NavigationViewExpandedPaneBackground"
-                             Color="Transparent" />
-            <SolidColorBrush x:Key="NavigationViewContentBackground"
-                             Color="Transparent" />
-
-            <Thickness x:Key="NavigationViewContentGridBorderThickness">0</Thickness>
-            <Thickness x:Key="NavigationViewMinimalContentGridBorderThickness">0</Thickness>
+            <AcrylicBrush x:Key="NavigationViewDefaultPaneBackground"
+                          BackgroundSource="Backdrop"
+                          FallbackColor="{ThemeResource SystemChromeMediumLowColor}"
+                          TintColor="{ThemeResource SystemChromeMediumColor}"
+                          TintOpacity="0.5" />
+            <AcrylicBrush x:Key="NavigationViewTopPaneBackground"
+                          BackgroundSource="Backdrop"
+                          FallbackColor="{ThemeResource SystemChromeMediumLowColor}"
+                          TintColor="{ThemeResource SystemChromeMediumColor}"
+                          TintOpacity="0.5" />
+            <AcrylicBrush x:Key="NavigationViewExpandedPaneBackground"
+                          BackgroundSource="HostBackdrop"
+                          FallbackColor="{ThemeResource SystemChromeMediumLowColor}"
+                          TintColor="{ThemeResource SystemChromeMediumColor}"
+                          TintOpacity="0.7" />
 
         </ResourceDictionary>
     </Page.Resources>


### PR DESCRIPTION
## Summary of the Pull Request
In the MainPage.xaml, change the SolidColorBrush to AcrylicBrush to be able to alter the color of the panel when it cannot be rendered

## References and Relevant Issues
- #9752 Original implementaion
- #12973 Modifying this change

## Detailed Description of the Pull Request / Additional comments
In #12973, we changed the way of rendering the panel to use a SolidColorBrush with a transparent background. However, when this cannot be rendered, it causes an error of overlapping. Therefore, this change is to revert this panel to the original implementation introduced in #9752, using AcrylicBrush and setting the color to 'SystemChromeMediumLowColor' when it cannot be rendered.

## Validation Steps Performed
1. Open the Windows terminal App
2. Set the width to <= 500px
3. Open the Settings tab 
4. Check that the background is not longer overlapping.

![image](https://github.com/microsoft/terminal/assets/40709873/c626cb41-d4af-4101-8d27-27390beb814c)


## PR Checklist
- [X] Closes #16906 
- [X] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
