### PR TITLE
Fix !_noFlushOnEnd not flushing

### DIFF
--- a/src/renderer/vt/XtermEngine.cpp
+++ b/src/renderer/vt/XtermEngine.cpp
@@ -44,6 +44,10 @@ XtermEngine::XtermEngine(_In_ wil::unique_hfile hPipe,
         // have been reset in the EndPaint call. But since that's not going to
         // happen now, we need to reset it here, otherwise we may mistakenly skip
         // the flush on the next frame.
+        if (!_noFlushOnEnd)
+        {
+            _Flush();
+        }
         _noFlushOnEnd = false;
         return hr;
     }


### PR DESCRIPTION
This simply copies a bit more from `VtEngine::EndPaint`'s
`_noFlushOnEnd` handling which already seems to fix the linked issue.

Closes #17204