### PR TITLE
Fix typing multiple emojis on Windows 10

### DIFF
--- a/src/tsf/Implementation.cpp
+++ b/src/tsf/Implementation.cpp
@@ -500,6 +500,8 @@ void Implementation::_doCompositionUpdate(TfEditCookie ec)
                 ULONG len = bufCap;
                 THROW_IF_FAILED(range->GetText(ec, TF_TF_MOVESTART, buf, len, &len));
 
+                // Since we can't un-finalize finalized text, we only finalize text that's at the start of the document.
+                // In other words, don't put text that's in the middle between two active compositions into the finalized string.
                 if (!composing && !activeCompositionEncountered)
                 {
                     finalizedString.append(buf, len);

--- a/src/tsf/Implementation.cpp
+++ b/src/tsf/Implementation.cpp
@@ -436,6 +436,7 @@ void Implementation::_doCompositionUpdate(TfEditCookie ec)
     std::wstring finalizedString;
     std::wstring activeComposition;
     til::small_vector<Render::CompositionRange, 2> activeCompositionRanges;
+    bool activeCompositionEncountered = false;
 
     const GUID* guids[] = { &GUID_PROP_COMPOSING, &GUID_PROP_ATTRIBUTE };
     wil::com_ptr<ITfReadOnlyProperty> props;
@@ -499,7 +500,7 @@ void Implementation::_doCompositionUpdate(TfEditCookie ec)
                 ULONG len = bufCap;
                 THROW_IF_FAILED(range->GetText(ec, TF_TF_MOVESTART, buf, len, &len));
 
-                if (!composing)
+                if (!composing && !activeCompositionEncountered)
                 {
                     finalizedString.append(buf, len);
                 }
@@ -518,6 +519,8 @@ void Implementation::_doCompositionUpdate(TfEditCookie ec)
 
             const auto attr = _textAttributeFromAtom(atom);
             activeCompositionRanges.emplace_back(totalLen, attr);
+
+            activeCompositionEncountered |= composing;
         }
     }
 

--- a/src/tsf/Implementation.cpp
+++ b/src/tsf/Implementation.cpp
@@ -436,7 +436,6 @@ void Implementation::_doCompositionUpdate(TfEditCookie ec)
     std::wstring finalizedString;
     std::wstring activeComposition;
     til::small_vector<Render::CompositionRange, 2> activeCompositionRanges;
-    bool firstRange = true;
 
     const GUID* guids[] = { &GUID_PROP_COMPOSING, &GUID_PROP_ATTRIBUTE };
     wil::com_ptr<ITfReadOnlyProperty> props;
@@ -500,7 +499,7 @@ void Implementation::_doCompositionUpdate(TfEditCookie ec)
                 ULONG len = bufCap;
                 THROW_IF_FAILED(range->GetText(ec, TF_TF_MOVESTART, buf, len, &len));
 
-                if (!composing && firstRange)
+                if (!composing)
                 {
                     finalizedString.append(buf, len);
                 }
@@ -519,8 +518,6 @@ void Implementation::_doCompositionUpdate(TfEditCookie ec)
 
             const auto attr = _textAttributeFromAtom(atom);
             activeCompositionRanges.emplace_back(totalLen, attr);
-
-            firstRange = false;
         }
     }
 


### PR DESCRIPTION
On Windows 10 Emojis don't finish composition until the Emoji picker
panel is closed. Each emoji is thus its own composition range.
`firstRange` thus caused only the first emoji to finish composition.
The end result was that all remaining emojis would stay around
forever, with the user entirely unable to clear them.

## Validation Steps Performed
* Windows 10 VM
* Open Emoji picker (Win+.)
* Press and hold Enter on any Emoji
* Press Esc to finish the composition
* All of the Emoji can be backspaced / deleted