### PR TITLE
build: move ESRP to a parameterized subtask which takes signingId

### DIFF
--- a/build/pipelines/templates-v2/job-build-package-wpf.yml
+++ b/build/pipelines/templates-v2/job-build-package-wpf.yml
@@ -100,36 +100,32 @@ jobs:
       flattenFolders: true
 
   - ${{ if eq(parameters.codeSign, true) }}:
-    - task: EsrpCodeSigning@5
-      displayName: Submit *.nupkg to ESRP for code signing
-      inputs:
-        ConnectedServiceName: ${{ parameters.signingIdentity.serviceName }}
-        AppRegistrationClientId: ${{ parameters.signingIdentity.appId }}
-        AppRegistrationTenantId: ${{ parameters.signingIdentity.tenantId }}
-        AuthAKVName: ${{ parameters.signingIdentity.akvName }}
-        AuthCertName: ${{ parameters.signingIdentity.authCertName }}
-        AuthSignCertName: ${{ parameters.signingIdentity.signCertName }}
-        FolderPath: $(Build.ArtifactStagingDirectory)/nupkg
-        Pattern: '*.nupkg'
-        UseMinimatch: true
-        signConfigType: inlineSignParams
-        inlineOperation: >-
-          [
-              {
-                  "KeyCode": "CP-401405",
-                  "OperationCode": "NuGetSign",
-                  "Parameters": {},
-                  "ToolName": "sign",
-                  "ToolVersion": "1.0"
-              },
-              {
-                  "KeyCode": "CP-401405",
-                  "OperationCode": "NuGetVerify",
-                  "Parameters": {},
-                  "ToolName": "sign",
-                  "ToolVersion": "1.0"
-              }
-          ]
+    - template: steps-esrp-signing.yml
+      parameters:
+        displayName: Submit *.nupkg to ESRP for code signing
+        signingIdentity: ${{ parameters.signingIdentity }}
+        inputs:
+          FolderPath: $(Build.ArtifactStagingDirectory)/nupkg
+          Pattern: '*.nupkg'
+          UseMinimatch: true
+          signConfigType: inlineSignParams
+          inlineOperation: >-
+            [
+                {
+                    "KeyCode": "CP-401405",
+                    "OperationCode": "NuGetSign",
+                    "Parameters": {},
+                    "ToolName": "sign",
+                    "ToolVersion": "1.0"
+                },
+                {
+                    "KeyCode": "CP-401405",
+                    "OperationCode": "NuGetVerify",
+                    "Parameters": {},
+                    "ToolName": "sign",
+                    "ToolVersion": "1.0"
+                }
+            ]
 
   - ${{ if eq(parameters.generateSbom, true) }}:
     - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0

--- a/build/pipelines/templates-v2/job-build-project.yml
+++ b/build/pipelines/templates-v2/job-build-project.yml
@@ -242,18 +242,14 @@ jobs:
 
     # Code-sign everything we just put together.
     # We run the signing in Terminal.BinDir, because all of the signing batches are relative to the final architecture/configuration output folder.
-    - task: EsrpCodeSigning@5
-      displayName: Submit Signing Request
-      inputs:
-        ConnectedServiceName: ${{ parameters.signingIdentity.serviceName }}
-        AppRegistrationClientId: ${{ parameters.signingIdentity.appId }}
-        AppRegistrationTenantId: ${{ parameters.signingIdentity.tenantId }}
-        AuthAKVName: ${{ parameters.signingIdentity.akvName }}
-        AuthCertName: ${{ parameters.signingIdentity.authCertName }}
-        AuthSignCertName: ${{ parameters.signingIdentity.signCertName }}
-        FolderPath: '$(Terminal.BinDir)'
-        signType: batchSigning
-        batchSignPolicyFile: '$(Build.SourcesDirectory)/ESRPSigningConfig.json'
+    - template: steps-esrp-signing.yml
+      parameters:
+        displayName: Submit Signing Request
+        signingIdentity: ${{ parameters.signingIdentity }}
+        inputs:
+          FolderPath: '$(Terminal.BinDir)'
+          signType: batchSigning
+          batchSignPolicyFile: '$(Build.SourcesDirectory)/ESRPSigningConfig.json'
 
     # We only need to re-pack the MSIX if we actually signed, so this can stay in the codeSign conditional
     - ${{ if or(parameters.buildTerminal, parameters.buildEverything) }}:

--- a/build/pipelines/templates-v2/job-merge-msix-into-bundle.yml
+++ b/build/pipelines/templates-v2/job-merge-msix-into-bundle.yml
@@ -97,45 +97,41 @@ jobs:
     displayName: Create msixbundle
 
   - ${{ if eq(parameters.codeSign, true) }}:
-    - task: EsrpCodeSigning@5
-      displayName: Submit *.msixbundle to ESRP for code signing
-      inputs:
-        ConnectedServiceName: ${{ parameters.signingIdentity.serviceName }}
-        AppRegistrationClientId: ${{ parameters.signingIdentity.appId }}
-        AppRegistrationTenantId: ${{ parameters.signingIdentity.tenantId }}
-        AuthAKVName: ${{ parameters.signingIdentity.akvName }}
-        AuthCertName: ${{ parameters.signingIdentity.authCertName }}
-        AuthSignCertName: ${{ parameters.signingIdentity.signCertName }}
-        FolderPath: $(System.ArtifactsDirectory)\bundle
-        Pattern: $(BundleStemName)*.msixbundle
-        UseMinimatch: true
-        signConfigType: inlineSignParams
-        inlineOperation: >-
-          [
-              {
-                  "KeyCode": "Dynamic",
-                  "CertTemplateName": "WINMSAPP1ST",
-                  "CertSubjectName": "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
-                  "OperationCode": "SigntoolSign",
-                  "Parameters": {
-                      "OpusName": "Microsoft",
-                      "OpusInfo": "http://www.microsoft.com",
-                      "FileDigest": "/fd \"SHA256\"",
-                      "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                  },
-                  "ToolName": "sign",
-                  "ToolVersion": "1.0"
-              },
-              {
-                  "KeyCode": "Dynamic",
-                  "CertTemplateName": "WINMSAPP1ST",
-                  "CertSubjectName": "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
-                  "OperationCode": "SigntoolVerify",
-                  "Parameters": {},
-                  "ToolName": "sign",
-                  "ToolVersion": "1.0"
-              }
-          ]
+    - template: steps-esrp-signing.yml
+      parameters:
+        displayName: Submit *.msixbundle to ESRP for code signing
+        signingIdentity: ${{ parameters.signingIdentity }}
+        inputs:
+          FolderPath: $(System.ArtifactsDirectory)\bundle
+          Pattern: $(BundleStemName)*.msixbundle
+          UseMinimatch: true
+          signConfigType: inlineSignParams
+          inlineOperation: >-
+            [
+                {
+                    "KeyCode": "Dynamic",
+                    "CertTemplateName": "WINMSAPP1ST",
+                    "CertSubjectName": "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
+                    "OperationCode": "SigntoolSign",
+                    "Parameters": {
+                        "OpusName": "Microsoft",
+                        "OpusInfo": "http://www.microsoft.com",
+                        "FileDigest": "/fd \"SHA256\"",
+                        "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                    },
+                    "ToolName": "sign",
+                    "ToolVersion": "1.0"
+                },
+                {
+                    "KeyCode": "Dynamic",
+                    "CertTemplateName": "WINMSAPP1ST",
+                    "CertSubjectName": "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
+                    "OperationCode": "SigntoolVerify",
+                    "Parameters": {},
+                    "ToolName": "sign",
+                    "ToolVersion": "1.0"
+                }
+            ]
 
   - ${{ if eq(parameters.generateSbom, true) }}:
     - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0

--- a/build/pipelines/templates-v2/job-package-conpty.yml
+++ b/build/pipelines/templates-v2/job-package-conpty.yml
@@ -85,36 +85,32 @@ jobs:
       versionEnvVar: XES_PACKAGEVERSIONNUMBER
 
   - ${{ if eq(parameters.codeSign, true) }}:
-    - task: EsrpCodeSigning@5
-      displayName: Submit *.nupkg to ESRP for code signing
-      inputs:
-        ConnectedServiceName: ${{ parameters.signingIdentity.serviceName }}
-        AppRegistrationClientId: ${{ parameters.signingIdentity.appId }}
-        AppRegistrationTenantId: ${{ parameters.signingIdentity.tenantId }}
-        AuthAKVName: ${{ parameters.signingIdentity.akvName }}
-        AuthCertName: ${{ parameters.signingIdentity.authCertName }}
-        AuthSignCertName: ${{ parameters.signingIdentity.signCertName }}
-        FolderPath: $(Build.ArtifactStagingDirectory)/nupkg
-        Pattern: '*.nupkg'
-        UseMinimatch: true
-        signConfigType: inlineSignParams
-        inlineOperation: >-
-          [
-              {
-                  "KeyCode": "CP-401405",
-                  "OperationCode": "NuGetSign",
-                  "Parameters": {},
-                  "ToolName": "sign",
-                  "ToolVersion": "1.0"
-              },
-              {
-                  "KeyCode": "CP-401405",
-                  "OperationCode": "NuGetVerify",
-                  "Parameters": {},
-                  "ToolName": "sign",
-                  "ToolVersion": "1.0"
-              }
-          ]
+    - template: steps-esrp-signing.yml
+      parameters:
+        displayName: Submit *.nupkg to ESRP for code signing
+        signingIdentity: ${{ parameters.signingIdentity }}
+        inputs:
+          FolderPath: $(Build.ArtifactStagingDirectory)/nupkg
+          Pattern: '*.nupkg'
+          UseMinimatch: true
+          signConfigType: inlineSignParams
+          inlineOperation: >-
+            [
+                {
+                    "KeyCode": "CP-401405",
+                    "OperationCode": "NuGetSign",
+                    "Parameters": {},
+                    "ToolName": "sign",
+                    "ToolVersion": "1.0"
+                },
+                {
+                    "KeyCode": "CP-401405",
+                    "OperationCode": "NuGetVerify",
+                    "Parameters": {},
+                    "ToolName": "sign",
+                    "ToolVersion": "1.0"
+                }
+            ]
 
   - ${{ if eq(parameters.generateSbom, true) }}:
     - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0

--- a/build/pipelines/templates-v2/steps-esrp-signing.yml
+++ b/build/pipelines/templates-v2/steps-esrp-signing.yml
@@ -1,0 +1,22 @@
+parameters:
+  - name: displayName
+    type: string
+    default: ESRP Code Signing
+  - name: inputs
+    type: object
+    default: {}
+  - name: signingIdentity
+    type: object
+    default: {}
+
+steps:
+  - task: EsrpCodeSigning@5
+    displayName: ${{ parameters.displayName }}
+    inputs:
+      ConnectedServiceName: ${{ parameters.signingIdentity.serviceName }}
+      AppRegistrationClientId: ${{ parameters.signingIdentity.appId }}
+      AppRegistrationTenantId: ${{ parameters.signingIdentity.tenantId }}
+      AuthAKVName: ${{ parameters.signingIdentity.akvName }}
+      AuthCertName: ${{ parameters.signingIdentity.authCertName }}
+      AuthSignCertName: ${{ parameters.signingIdentity.signCertName }}
+      ${{ insert }}: ${{ parameters.inputs }}


### PR DESCRIPTION
This centralized all our ESRP calls in one file, which will make it easier in the future when we are invariable required to change how we call it again.