### PR TITLE
PowerShell menu completion parser thread-safety fix

### DIFF
--- a/src/cascadia/TerminalSettingsModel/Command.cpp
+++ b/src/cascadia/TerminalSettingsModel/Command.cpp
@@ -690,7 +690,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         auto data = winrt::to_string(json);
 
         std::string errs;
-        static std::unique_ptr<Json::CharReader> reader{ Json::CharReaderBuilder{}.newCharReader() };
+        std::unique_ptr<Json::CharReader> reader{ Json::CharReaderBuilder{}.newCharReader() };
         Json::Value root;
         if (!reader->parse(data.data(), data.data() + data.size(), &root, &errs))
         {


### PR DESCRIPTION
Fix Terminal crashing when experimental PowerShell menu completion is very quickly invoked multiple times.

`Command::ParsePowerShellMenuComplete` can be called from multiple threads, but it uses a `static` `Json::CharReader`, which cannot safely parse data from multiple threads at the same time. Removing `static` fixes the problem, since every function call gets its own `reader`.

Validation: Pressed Ctrl+Space quickly a few times with hardcoded huge JSON as the completion payload. Also shown at the end of the second video in #17220.

Closes #17220
