### PR TITLE
Fix conpty cursor movement detection on double-width lines

### DIFF
--- a/src/renderer/vt/invalidate.cpp
+++ b/src/renderer/vt/invalidate.cpp
@@ -75,7 +75,8 @@ CATCH_RETURN();
     }
     _skipCursor = false;
 
-    _cursorMoved = psrRegion->origin() != _lastText;
+    _cursorMoved = psrRegion->origin() != _lastCursorOrigin;
+    _lastCursorOrigin = psrRegion->origin();
     return S_OK;
 }
 

--- a/src/renderer/vt/vtrenderer.hpp
+++ b/src/renderer/vt/vtrenderer.hpp
@@ -111,6 +111,7 @@ namespace Microsoft::Console::Render
         til::pmr::bitmap _invalidMap;
 
         til::point _lastText;
+        til::point _lastCursorOrigin;
         til::point _scrollDelta;
 
         bool _clearedAllThisFrame;


### PR DESCRIPTION
When the VT render engine checks whether the cursor has moved in the
`InvalidateCursor` method, it does so by comparing the origin of the
given cursor region with the last text output coordinates. But these two
values are actually from different coordinate systems, and when on a
double-width line, the x text coordinate is half of the corresponding
screen coordinate. As a result, the movement detection is sometimes
incorrect.

This PR fixes the issue by adding another field to track the last cursor
origin in screen coordinates, so we have a meaningful value to compare
against.

## References and Relevant Issues

The previous cursor movement detection was added in PR #17194 to fix
issue #17117.

## Validation Steps Performed

I've confirmed that the test case from issue #17232 is now fixed, and
the test case from issue #17117 is still working as expected.

## PR Checklist
- [x] Closes #17232
