### PR TITLE
Fix cursor invalidation when line renditions are used

### DIFF
--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -1178,8 +1178,8 @@ void Renderer::_invalidateCurrentCursor() const
     const auto view = buffer.GetSize();
     const auto coord = _currentCursorOptions.coordCursor;
 
-    const auto lineRendition = buffer.GetLineRendition(coord.y);
-    const auto cursorWidth = _pData->IsCursorDoubleWidth() ? 2 : 1;
+    const auto lineRendition = _currentCursorOptions.lineRendition;
+    const auto cursorWidth = _currentCursorOptions.fIsDoubleWidth ? 2 : 1;
 
     til::rect rect{ coord.x, coord.y, coord.x + cursorWidth, coord.y + 1 };
     rect = BufferToScreenLine(rect, lineRendition);


### PR DESCRIPTION
## Summary of the Pull Request

When the renderer calculates the invalidate region for the cursor, it
needs to take the line rendition into account. But it was using a
relative coordinate rather than absolute coordinate when looking up the
line rendition for the row, so the calculated region could easily be
incorrect.

With this PR we now use the line rendition that was already being cached
in the `CursorOptions` structure, so we avoid needing to look it up
anyway. Similarly I've replaced the `IsCursorDoubleWidth` lookup with
the value that was already cached in the `CursorOptions` structure.

## Validation Steps Performed

I've confirmed that the test case in issue #17226 is now working as
expected.

## PR Checklist
- [x] Closes #17226
