### PR TITLE
Clean up command history context passed to suggestions UI

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -2235,19 +2235,29 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         std::vector<winrt::hstring> commands;
         const auto bufferCommands{ textBuffer.Commands() };
-        for (const auto& commandInBuffer : bufferCommands)
-        {
-            const auto strEnd = commandInBuffer.find_last_not_of(UNICODE_SPACE);
+
+        auto trimToHstring = [](const auto& s) -> winrt::hstring {
+            const auto strEnd = s.find_last_not_of(UNICODE_SPACE);
             if (strEnd != std::string::npos)
             {
-                const auto trimmed = commandInBuffer.substr(0, strEnd + 1);
+                const auto trimmed = s.substr(0, strEnd + 1);
+                return winrt::hstring{ trimmed };
+            }
+            return winrt::hstring{ L"" };
+        };
 
-                commands.push_back(winrt::hstring{ trimmed });
+        for (const auto& commandInBuffer : bufferCommands)
+        {
+            if (const auto hstr {trimToHstring(commandInBuffer)} ; !hstr.empty() )
+            {
+                commands.push_back(hstr);
             }
         }
 
         auto context = winrt::make_self<CommandHistoryContext>(std::move(commands));
-        context->CurrentCommandline(winrt::hstring{ _terminal->CurrentCommand() });
+
+        const auto currentCommand = _terminal->CurrentCommand();
+        context->CurrentCommandline(trimToHstring(currentCommand));
 
         return *context;
     }

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -2246,19 +2246,28 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             return winrt::hstring{ L"" };
         };
 
+        const auto currentCommand = _terminal->CurrentCommand();
+        const auto trimmedCurrentCommand = trimToHstring(currentCommand);
+
         for (const auto& commandInBuffer : bufferCommands)
         {
-            if (const auto hstr {trimToHstring(commandInBuffer)} ; !hstr.empty() )
+            if (const auto hstr{ trimToHstring(commandInBuffer) };
+                (!hstr.empty() && hstr != trimmedCurrentCommand))
             {
                 commands.push_back(hstr);
             }
         }
 
+        // If the very last thing in the list of recent commands, is exacly the
+        // same as the current command, then let's not include it in the
+        // history. It's literally the thing the user has typed, RIGHT now.
+        if (commands.back() == trimmedCurrentCommand)
+        {
+            commands.pop_back();
+        }
+
         auto context = winrt::make_self<CommandHistoryContext>(std::move(commands));
-
-        const auto currentCommand = _terminal->CurrentCommand();
-        context->CurrentCommandline(trimToHstring(currentCommand));
-
+        context->CurrentCommandline(trimmedCurrentCommand);
         return *context;
     }
 

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -2258,7 +2258,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             }
         }
 
-        // If the very last thing in the list of recent commands, is exacly the
+        // If the very last thing in the list of recent commands, is exactly the
         // same as the current command, then let's not include it in the
         // history. It's literally the thing the user has typed, RIGHT now.
         if (!commands.empty() && commands.back() == trimmedCurrentCommand)

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -2261,7 +2261,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // If the very last thing in the list of recent commands, is exacly the
         // same as the current command, then let's not include it in the
         // history. It's literally the thing the user has typed, RIGHT now.
-        if (commands.back() == trimmedCurrentCommand)
+        if (!commands.empty() && commands.back() == trimmedCurrentCommand)
         {
             commands.pop_back();
         }

--- a/src/cascadia/UnitTests_Control/ControlCoreTests.cpp
+++ b/src/cascadia/UnitTests_Control/ControlCoreTests.cpp
@@ -543,8 +543,8 @@ namespace ControlUnitTests
         Log::Comment(L"Write 'Bar' to the command...");
         conn->WriteInput(L"Bar");
         {
-            DebugBreak();
             auto historyContext{ core->CommandHistory() };
+            // Bar shouldn't be in the history, it should be the current command
             VERIFY_ARE_EQUAL(1u, historyContext.History().Size());
             VERIFY_ARE_EQUAL(L"Bar", historyContext.CurrentCommandline());
         }
@@ -556,6 +556,7 @@ namespace ControlUnitTests
         {
             auto historyContext{ core->CommandHistory() };
             VERIFY_ARE_EQUAL(1u, historyContext.History().Size());
+            // The current commandline is now empty
             VERIFY_ARE_EQUAL(L"", historyContext.CurrentCommandline());
         }
     }

--- a/src/cascadia/UnitTests_Control/ControlCoreTests.cpp
+++ b/src/cascadia/UnitTests_Control/ControlCoreTests.cpp
@@ -21,7 +21,7 @@ namespace ControlUnitTests
     class ControlCoreTests
     {
         BEGIN_TEST_CLASS(ControlCoreTests)
-            // TEST_CLASS_PROPERTY(L"TestTimeout", L"0:0:10") // 10s timeout
+            TEST_CLASS_PROPERTY(L"TestTimeout", L"0:0:10") // 10s timeout
         END_TEST_CLASS()
 
         TEST_METHOD(ComPtrSettings);

--- a/src/cascadia/UnitTests_Control/ControlCoreTests.cpp
+++ b/src/cascadia/UnitTests_Control/ControlCoreTests.cpp
@@ -21,7 +21,7 @@ namespace ControlUnitTests
     class ControlCoreTests
     {
         BEGIN_TEST_CLASS(ControlCoreTests)
-            TEST_CLASS_PROPERTY(L"TestTimeout", L"0:0:10") // 10s timeout
+            // TEST_CLASS_PROPERTY(L"TestTimeout", L"0:0:10") // 10s timeout
         END_TEST_CLASS()
 
         TEST_METHOD(ComPtrSettings);
@@ -543,6 +543,7 @@ namespace ControlUnitTests
         Log::Comment(L"Write 'Bar' to the command...");
         conn->WriteInput(L"Bar");
         {
+            DebugBreak();
             auto historyContext{ core->CommandHistory() };
             VERIFY_ARE_EQUAL(1u, historyContext.History().Size());
             VERIFY_ARE_EQUAL(L"Bar", historyContext.CurrentCommandline());


### PR DESCRIPTION
This is fallout from #16937. 

* Typing a command then backspacing the chars then asking for suggestions would think the current commandline ended with spaces, making filtering very hard. 
* The currently typed command would _also_ appear in the command history, which isn't useful. 

I actually did TDD for this and wrote the test first, then confirmed again running through the build script, I wasn't hitting any of the earlier issues. 

Closes #17241
Closes #17243