### PR TITLE
AtlasEngine: Improve robustness against weird font sizes

### DIFF
--- a/src/renderer/atlas/AtlasEngine.api.cpp
+++ b/src/renderer/atlas/AtlasEngine.api.cpp
@@ -636,7 +636,7 @@ void AtlasEngine::_resolveFontMetrics(const FontInfoDesired& fontInfoDesired, Fo
     const auto& faceName = fontInfoDesired.GetFaceName();
     const auto requestedFamily = fontInfoDesired.GetFamily();
     auto requestedWeight = fontInfoDesired.GetWeight();
-    auto fontSize = fontInfoDesired.GetFontSize();
+    auto fontSize = std::clamp(fontInfoDesired.GetFontSize(), 1.0f, 100.0f);
     auto requestedSize = fontInfoDesired.GetEngineSize();
 
     if (!requestedSize.height)

--- a/src/renderer/atlas/BackendD2D.cpp
+++ b/src/renderer/atlas/BackendD2D.cpp
@@ -39,18 +39,28 @@ void BackendD2D::Render(RenderingPayload& p)
     }
 
     _renderTarget->BeginDraw();
+    try
+    {
 #if ATLAS_DEBUG_SHOW_DIRTY || ATLAS_DEBUG_DUMP_RENDER_TARGET
-    // Invalidating the render target helps with spotting Present1() bugs.
-    _renderTarget->Clear();
+        // Invalidating the render target helps with spotting Present1() bugs.
+        _renderTarget->Clear();
 #endif
-    _drawBackground(p);
-    _drawCursorPart1(p);
-    _drawText(p);
-    _drawCursorPart2(p);
-    _drawSelection(p);
+        _drawBackground(p);
+        _drawCursorPart1(p);
+        _drawText(p);
+        _drawCursorPart2(p);
+        _drawSelection(p);
 #if ATLAS_DEBUG_SHOW_DIRTY
-    _debugShowDirty(p);
+        _debugShowDirty(p);
 #endif
+    }
+    catch (...)
+    {
+        // In case an exception is thrown for some reason between BeginDraw() and EndDraw()
+        // we still technically need to call EndDraw() before releasing any resources.
+        LOG_IF_FAILED(_renderTarget->EndDraw());
+        throw;
+    }
     THROW_IF_FAILED(_renderTarget->EndDraw());
 
 #if ATLAS_DEBUG_DUMP_RENDER_TARGET

--- a/src/renderer/atlas/BackendD3D.cpp
+++ b/src/renderer/atlas/BackendD3D.cpp
@@ -184,6 +184,16 @@ BackendD3D::BackendD3D(const RenderingPayload& p)
 #endif
 }
 
+BackendD3D::~BackendD3D()
+{
+    // In case an exception is thrown for some reason between BeginDraw() and EndDraw()
+    // we still technically need to call EndDraw() before releasing any resources.
+    if (_d2dBeganDrawing)
+    {
+        LOG_IF_FAILED(_d2dRenderTarget->EndDraw());
+    }
+}
+
 void BackendD3D::ReleaseResources() noexcept
 {
     _renderTargetView.reset();

--- a/src/renderer/atlas/BackendD3D.cpp
+++ b/src/renderer/atlas/BackendD3D.cpp
@@ -184,12 +184,14 @@ BackendD3D::BackendD3D(const RenderingPayload& p)
 #endif
 }
 
+#pragma warning(suppress : 26432) // If you define or delete any default operation in the type '...', define or delete them all (c.21).
 BackendD3D::~BackendD3D()
 {
     // In case an exception is thrown for some reason between BeginDraw() and EndDraw()
     // we still technically need to call EndDraw() before releasing any resources.
     if (_d2dBeganDrawing)
     {
+#pragma warning(suppress : 26447) // The function is declared 'noexcept' but calls function '...' which may throw exceptions (f.6).
         LOG_IF_FAILED(_d2dRenderTarget->EndDraw());
     }
 }

--- a/src/renderer/atlas/BackendD3D.h
+++ b/src/renderer/atlas/BackendD3D.h
@@ -13,6 +13,7 @@ namespace Microsoft::Console::Render::Atlas
     struct BackendD3D : IBackend
     {
         BackendD3D(const RenderingPayload& p);
+        ~BackendD3D() override;
 
         void ReleaseResources() noexcept override;
         void Render(RenderingPayload& payload) override;

--- a/src/renderer/atlas/common.h
+++ b/src/renderer/atlas/common.h
@@ -404,9 +404,9 @@ namespace Microsoft::Console::Render::Atlas
         til::generational<CursorSettings> cursor;
         til::generational<MiscellaneousSettings> misc;
         // Size of the viewport / swap chain in pixel.
-        u16x2 targetSize{ 1, 1 };
+        u16x2 targetSize{ 0, 0 };
         // Size of the portion of the text buffer that we're drawing on the screen.
-        u16x2 viewportCellCount{ 1, 1 };
+        u16x2 viewportCellCount{ 0, 0 };
         // The position of the viewport inside the text buffer (in cells).
         u16x2 viewportOffset{ 0, 0 };
     };


### PR DESCRIPTION
This clamps the font sizes between 1 and 100. Additionally, it fixes
a warning that I randomly noticed when reproducing the issue: D2D
complained that `EndDraw` must be called before releasing resources.
Finally, this fixes a crash when the terminal size is exactly (1,1)
cells, which happened because the initial (invalid) size was (1,1) too.

This doesn't fully fix all font-size related issues, but that's
currently difficult to achieve, as for instance the swap chain size
isn't actually based on the window size, nay, it's based on the cell
size multiplied by the cell count. So if the cell size is egregiously
large then we get a swap chain size that's larger than the display and
potentially larger than what the GPU supports which results in errors.

Closes #17227