### PR TITLE
Fix lock warning during ReturnResponse

### DIFF
--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -22,8 +22,9 @@ TRACELOGGING_DEFINE_PROVIDER(g_hCTerminalCoreProvider,
 
 void Terminal::ReturnResponse(const std::wstring_view response)
 {
-    if (_pfnWriteInput)
+    if (_pfnWriteInput && !response.empty())
     {
+        const auto suspension = _readWriteLock.suspend();
         _pfnWriteInput(response);
     }
 }


### PR DESCRIPTION
As reported here:
https://github.com/microsoft/terminal/pull/16224#discussion_r1594849244

The underlying `WriteFile` call may block indefinitely and
we shouldn't hold the terminal lock during that period.