### PR TITLE
Fix persistence of handoff'd tabs

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1899,7 +1899,10 @@ namespace winrt::TerminalApp::implementation
 
     void TerminalPage::PersistState()
     {
-        if (_startupState != StartupState::Initialized)
+        // This method may be called for a window even if it hasn't had a tab yet or lost all of them.
+        // We shouldn't persist such windows.
+        const auto tabCount = _tabs.Size();
+        if (_startupState != StartupState::Initialized || tabCount == 0)
         {
             return;
         }
@@ -1915,7 +1918,7 @@ namespace winrt::TerminalApp::implementation
 
         // if the focused tab was not the last tab, restore that
         auto idx = _GetFocusedTabIndex();
-        if (idx && idx != _tabs.Size() - 1)
+        if (idx && idx != tabCount - 1)
         {
             ActionAndArgs action;
             action.Action(ShortcutAction::SwitchToTab);

--- a/src/cascadia/TerminalConnection/ConptyConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConptyConnection.cpp
@@ -180,12 +180,14 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
                                        const HANDLE hRef,
                                        const HANDLE hServerProcess,
                                        const HANDLE hClientProcess,
-                                       TERMINAL_STARTUP_INFO startupInfo) :
+                                       const TERMINAL_STARTUP_INFO& startupInfo) :
         _rows{ 25 },
         _cols{ 80 },
         _inPipe{ hIn },
         _outPipe{ hOut }
     {
+        _sessionId = Utils::CreateGuid();
+
         THROW_IF_FAILED(ConptyPackPseudoConsole(hServerProcess, hRef, hSig, &_hPC));
         _piClient.hProcess = hClientProcess;
 

--- a/src/cascadia/TerminalConnection/ConptyConnection.h
+++ b/src/cascadia/TerminalConnection/ConptyConnection.h
@@ -19,7 +19,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
                          const HANDLE hRef,
                          const HANDLE hServerProcess,
                          const HANDLE hClientProcess,
-                         TERMINAL_STARTUP_INFO startupInfo);
+                         const TERMINAL_STARTUP_INFO& startupInfo);
 
         ConptyConnection() noexcept = default;
         void Initialize(const Windows::Foundation::Collections::ValueSet& settings);


### PR DESCRIPTION
As it turns out, for handoff'd connections `Initialize` isn't called
and this meant the `_sessionId` was always null.
After this PR we still don't have a `_profileGuid` but that's probably
not a critical issue, since that's an inherent flaw with handoff.
It can only be solved in a robust manner if WT gets launched before the
console app is launched, but it's unlikely for that to ever happen.

## Validation Steps Performed
* Launch
* Register that version of WT as the default
* Close all tabs (Ctrl+Shift+W)
* `persistedWindowLayouts` is empty ✅
* Launch cmd/pwsh via handoff
* You get 1 window ✅
* Close the window (= press the X button)
* Launch
* You get 2 windows ✅