### PR TITLE
Backport session persistence fixes in #17211 and #17268

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1898,7 +1898,10 @@ namespace winrt::TerminalApp::implementation
 
     void TerminalPage::PersistState()
     {
-        if (_startupState != StartupState::Initialized)
+        // This method may be called for a window even if it hasn't had a tab yet or lost all of them.
+        // We shouldn't persist such windows.
+        const auto tabCount = _tabs.Size();
+        if (_startupState != StartupState::Initialized || tabCount == 0)
         {
             return;
         }
@@ -1914,7 +1917,7 @@ namespace winrt::TerminalApp::implementation
 
         // if the focused tab was not the last tab, restore that
         auto idx = _GetFocusedTabIndex();
-        if (idx && idx != _tabs.Size() - 1)
+        if (idx && idx != tabCount - 1)
         {
             ActionAndArgs action;
             action.Action(ShortcutAction::SwitchToTab);

--- a/src/cascadia/TerminalApp/TerminalWindow.cpp
+++ b/src/cascadia/TerminalApp/TerminalWindow.cpp
@@ -263,7 +263,7 @@ namespace winrt::TerminalApp::implementation
         AppLogic::Current()->NotifyRootInitialized();
     }
 
-    void TerminalWindow::Quit()
+    void TerminalWindow::PersistState()
     {
         if (_root)
         {

--- a/src/cascadia/TerminalApp/TerminalWindow.h
+++ b/src/cascadia/TerminalApp/TerminalWindow.h
@@ -73,7 +73,7 @@ namespace winrt::TerminalApp::implementation
 
         void Create();
 
-        void Quit();
+        void PersistState();
 
         winrt::fire_and_forget UpdateSettings(winrt::TerminalApp::SettingsLoadEventArgs args);
 

--- a/src/cascadia/TerminalApp/TerminalWindow.idl
+++ b/src/cascadia/TerminalApp/TerminalWindow.idl
@@ -62,7 +62,7 @@ namespace TerminalApp
         Boolean ShouldImmediatelyHandoffToElevated();
         void HandoffToElevated();
 
-        void Quit();
+        void PersistState();
 
         Windows.UI.Xaml.UIElement GetRoot();
 

--- a/src/cascadia/TerminalConnection/ConptyConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConptyConnection.cpp
@@ -193,8 +193,6 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         _inPipe{ hIn },
         _outPipe{ hOut }
     {
-        _sessionId = Utils::CreateGuid();
-
         THROW_IF_FAILED(ConptyPackPseudoConsole(hServerProcess, hRef, hSig, &_hPC));
         _piClient.hProcess = hClientProcess;
 

--- a/src/cascadia/TerminalConnection/ConptyConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConptyConnection.cpp
@@ -186,13 +186,15 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
                                        const HANDLE hRef,
                                        const HANDLE hServerProcess,
                                        const HANDLE hClientProcess,
-                                       TERMINAL_STARTUP_INFO startupInfo) :
+                                       const TERMINAL_STARTUP_INFO& startupInfo) :
         _rows{ 25 },
         _cols{ 80 },
         _guid{ Utils::CreateGuid() },
         _inPipe{ hIn },
         _outPipe{ hOut }
     {
+        _sessionId = Utils::CreateGuid();
+
         THROW_IF_FAILED(ConptyPackPseudoConsole(hServerProcess, hRef, hSig, &_hPC));
         _piClient.hProcess = hClientProcess;
 

--- a/src/cascadia/TerminalConnection/ConptyConnection.h
+++ b/src/cascadia/TerminalConnection/ConptyConnection.h
@@ -19,7 +19,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
                          const HANDLE hRef,
                          const HANDLE hServerProcess,
                          const HANDLE hClientProcess,
-                         TERMINAL_STARTUP_INFO startupInfo);
+                         const TERMINAL_STARTUP_INFO& startupInfo);
 
         ConptyConnection() noexcept = default;
         void Initialize(const Windows::Foundation::Collections::ValueSet& settings);

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -1190,13 +1190,16 @@ winrt::fire_and_forget AppHost::_QuitRequested(const winrt::Windows::Foundation:
     co_await wil::resume_foreground(_windowLogic.GetRoot().Dispatcher());
 
     const auto strongThis = weakThis.lock();
-    // GH #16235: If we don't have a window logic, we're already refrigerating, and won't have our _window either.
-    if (!strongThis || _windowLogic == nullptr)
+    if (!strongThis)
     {
         co_return;
     }
 
-    _windowLogic.Quit();
+    if (_appLogic && _windowLogic && _appLogic.ShouldUsePersistedLayout())
+    {
+        _windowLogic.PersistState();
+    }
+
     PostQuitMessage(0);
 }
 


### PR DESCRIPTION
As the title says, this backports the changes in #17211 and #17268:
* `PersistState` being called when the window is closed
  (as opposed to closing the tab). The settings check was missing.
* Avoid persisting windows with 0 tabs (= last tab gets closed).