### PR TITLE
Remove some unused/obsolete XtermEngine code

### DIFF
--- a/src/renderer/vt/XtermEngine.cpp
+++ b/src/renderer/vt/XtermEngine.cpp
@@ -81,20 +81,6 @@ XtermEngine::XtermEngine(_In_ wil::unique_hfile hPipe,
         _clearedAllThisFrame = true;
         _firstPaint = false;
     }
-    else
-    {
-        std::span<const til::rect> dirty;
-        RETURN_IF_FAILED(GetDirtyArea(dirty));
-
-        // If we have 0 or 1 dirty pieces in the area, set as appropriate.
-        auto dirtyView = dirty.empty() ? Viewport::Empty() : Viewport::FromExclusive(til::at(dirty, 0));
-
-        // If there's more than 1, union them all up with the 1 we already have.
-        for (size_t i = 1; i < dirty.size(); ++i)
-        {
-            dirtyView = Viewport::Union(dirtyView, Viewport::FromExclusive(til::at(dirty, i)));
-        }
-    }
 
     return S_OK;
 }
@@ -246,7 +232,6 @@ XtermEngine::XtermEngine(_In_ wil::unique_hfile hPipe,
     auto hr = S_OK;
     const auto originalPos = _lastText;
     _trace.TraceMoveCursor(_lastText, coord);
-    auto performedSoftWrap = false;
     if (coord.x != _lastText.x || coord.y != _lastText.y)
     {
         if (coord.x == 0 && coord.y == 0)
@@ -272,7 +257,6 @@ XtermEngine::XtermEngine(_In_ wil::unique_hfile hPipe,
 
             if (previousLineWrapped)
             {
-                performedSoftWrap = true;
                 _trace.TraceWrapped();
                 hr = S_OK;
             }


### PR DESCRIPTION
## Summary of the Pull Request

The dirty view calculation in the `XtermEngine::StartPaint` method was
originally used to detect a full frame paint that would require a clear
screen, but that code was removed as part of PR #4741, making this
calculation obsolete.

The `performedSoftWrap` variable in the `XtermEngine::_MoveCursor`
method was assumedly a remanent of some WIP code that was mistakenly
committed in PR #5181. The variable was never actually used.

## Validation Steps Performed

All the unit tests still pass and nothing seems obviously broken in
manual testing.

## PR Checklist
- [x] Closes #17280
