### PR TITLE
Pass real server process handle to the terminal during handoff

### DIFF
--- a/src/host/srvinit.cpp
+++ b/src/host/srvinit.cpp
@@ -504,7 +504,15 @@ try
                                                                L"\\Reference",
                                                                FALSE));
 
-    const auto serverProcess = GetCurrentProcess();
+    // Give a copy of our own process handle to be tracked.
+    wil::unique_process_handle serverProcess;
+    RETURN_IF_WIN32_BOOL_FALSE(DuplicateHandle(GetCurrentProcess(),
+                                               GetCurrentProcess(),
+                                               GetCurrentProcess(),
+                                               serverProcess.addressof(),
+                                               SYNCHRONIZE,
+                                               FALSE,
+                                               0));
 
     ::Microsoft::WRL::ComPtr<ITerminalHandoff2> handoff;
 
@@ -585,7 +593,7 @@ try
                                                   outPipeTheirSide.get(),
                                                   signalPipeTheirSide.get(),
                                                   refHandle.get(),
-                                                  serverProcess,
+                                                  serverProcess.get(),
                                                   clientProcess.get(),
                                                   myStartupInfo));
 


### PR DESCRIPTION
## Validation Steps Performed
- Double-clicking a `.exe` opens the terminal.
- Open WT and run a few commands. Didn't see any problems.
