### PR TITLE
Raise the dupe bot's threshold to .8

### DIFF
--- a/.github/workflows/similarIssues.yml
+++ b/.github/workflows/similarIssues.yml
@@ -16,7 +16,7 @@ jobs:
           issueTitle: ${{ github.event.issue.title }}
           issueBody: ${{ github.event.issue.body }}
           repo: ${{ github.repository }}
-          similaritytolerance: "0.75"
+          similaritytolerance: "0.8"
   add-comment:
     needs: getSimilarIssues
     runs-on: ubuntu-latest


### PR DESCRIPTION
I was talking with @plante-msft this week at Build and we agreed that .75 is just a bit too chatty. .8 seems like it's a better threshold - sure, it'll miss a few of the harder edge cases, but it'll chime in less frequently when it's just wrong. 