### PR TITLE
Fix hyperlinks using an extra character at the end

### DIFF
--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -522,6 +522,10 @@ std::wstring Terminal::GetHyperlinkAtBufferPosition(const til::point bufferPos)
     // Case 2 - Step 2: get the auto-detected hyperlink
     if (result.has_value() && result->value == _hyperlinkPatternId)
     {
+        // GetPlainText works with inclusive coordinates, but interval's stop
+        // point is (horizontally) exclusive, so let's just update it.
+        result->stop.x--;
+
         return _activeBuffer().GetPlainText(result->start, result->stop);
     }
     return {};


### PR DESCRIPTION
Closes: #17323 

## Validation Steps Performed
- Run `echo Hello ^(https://github.com/microsoft/terminal^)` in cmd.
- Ctrl+click on the URL opens `https://github.com/microsoft/terminal` in the browser.
- Hovering over the url in the terminal shows `https://github.com/microsoft/terminal` in the hover UI.
