### PR TITLE
Fix a crash when closing panes

### DIFF
--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -248,7 +248,7 @@ private:
 
     std::optional<uint32_t> _id;
     std::weak_ptr<Pane> _parentChildPath{};
-
+    bool _closed{ false };
     bool _lastActive{ false };
     winrt::event_token _firstClosedToken{ 0 };
     winrt::event_token _secondClosedToken{ 0 };

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -739,7 +739,7 @@ namespace winrt::TerminalApp::implementation
             }
 
             // Clean read-only mode to prevent additional prompt if closing the pane triggers closing of a hosting tab
-            pane->WalkTree([](auto p) {
+            pane->WalkTree([](const auto& p) {
                 if (const auto control{ p->GetTerminalControl() })
                 {
                     if (control.ReadOnly())

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -3810,7 +3810,7 @@ namespace winrt::TerminalApp::implementation
             // recipe for disaster. We won't ever open up a tab in this window.
             newTerminalArgs.Elevate(false);
             const auto newPane = _MakePane(newTerminalArgs, nullptr, connection);
-            newPane->WalkTree([](auto pane) {
+            newPane->WalkTree([](const auto& pane) {
                 pane->FinalizeConfigurationGivenDefault();
             });
             _CreateNewTabFromPane(newPane);

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -952,6 +952,7 @@ namespace winrt::TerminalApp::implementation
             [this](auto&& sender, auto&&) {
                 if (const auto content{ sender.try_as<TerminalApp::IPaneContent>() })
                 {
+                    // Calling Close() while walking the tree is not safe, because Close() mutates the tree.
                     const auto pane = _rootPane->_FindPane([&](const auto& p) -> std::shared_ptr<Pane> {
                         if (p->GetContent() == content)
                         {

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -41,7 +41,7 @@ namespace winrt::TerminalApp::implementation
 
         auto firstId = _nextPaneId;
 
-        _rootPane->WalkTree([&](std::shared_ptr<Pane> pane) {
+        _rootPane->WalkTree([&](const auto& pane) {
             // update the IDs on each pane
             if (pane->_IsLeaf())
             {
@@ -203,7 +203,7 @@ namespace winrt::TerminalApp::implementation
     {
         ASSERT_UI_THREAD();
 
-        _rootPane->WalkTree([&](std::shared_ptr<Pane> pane) {
+        _rootPane->WalkTree([&](const auto& pane) {
             // Attach event handlers to each new pane
             _AttachEventHandlersToPane(pane);
             if (auto content = pane->GetContent())
@@ -275,7 +275,7 @@ namespace winrt::TerminalApp::implementation
         _UpdateHeaderControlMaxWidth();
 
         // Update the settings on all our panes.
-        _rootPane->WalkTree([&](auto pane) {
+        _rootPane->WalkTree([&](const auto& pane) {
             pane->UpdateSettings(settings);
             return false;
         });
@@ -534,7 +534,7 @@ namespace winrt::TerminalApp::implementation
 
         // Add the new event handlers to the new pane(s)
         // and update their ids.
-        pane->WalkTree([&](auto p) {
+        pane->WalkTree([&](const auto& p) {
             _AttachEventHandlersToPane(p);
             if (p->_IsLeaf())
             {
@@ -624,7 +624,7 @@ namespace winrt::TerminalApp::implementation
         // manually.
         _rootPane->Closed(_rootClosedToken);
         auto p = _rootPane;
-        p->WalkTree([](auto pane) {
+        p->WalkTree([](const auto& pane) {
             pane->Detached.raise(pane);
         });
 
@@ -650,7 +650,7 @@ namespace winrt::TerminalApp::implementation
 
         // Add the new event handlers to the new pane(s)
         // and update their ids.
-        pane->WalkTree([&](auto p) {
+        pane->WalkTree([&](const auto& p) {
             _AttachEventHandlersToPane(p);
             if (p->_IsLeaf())
             {
@@ -949,26 +949,19 @@ namespace winrt::TerminalApp::implementation
 
         events.CloseRequested = content.CloseRequested(
             winrt::auto_revoke,
-            [dispatcher, weakThis](auto sender, auto&&) -> winrt::fire_and_forget {
-                // Don't forget! this ^^^^^^^^ sender can't be a reference, this is a async callback.
-
-                // The lambda lives in the `std::function`-style container owned by `control`. That is, when the
-                // `control` gets destroyed the lambda struct also gets destroyed. In other words, we need to
-                // copy `weakThis` onto the stack, because that's the only thing that gets captured in coroutines.
-                // See: https://devblogs.microsoft.com/oldnewthing/20211103-00/?p=105870
-                const auto weakThisCopy = weakThis;
-                co_await wil::resume_foreground(dispatcher);
-                // Check if Tab's lifetime has expired
-                if (auto tab{ weakThisCopy.get() })
+            [this](auto&& sender, auto&&) {
+                if (const auto content{ sender.try_as<TerminalApp::IPaneContent>() })
                 {
-                    if (const auto content{ sender.try_as<TerminalApp::IPaneContent>() })
+                    const auto pane = _rootPane->_FindPane([&](const auto& p) -> std::shared_ptr<Pane> {
+                        if (p->GetContent() == content)
+                        {
+                            return p;
+                        }
+                        return {};
+                    });
+                    if (pane)
                     {
-                        tab->_rootPane->WalkTree([content](std::shared_ptr<Pane> pane) {
-                            if (pane->GetContent() == content)
-                            {
-                                pane->Close();
-                            }
-                        });
+                        pane->Close();
                     }
                 }
             });


### PR DESCRIPTION
Calling Close() from within WalkPanes is not safe. Simply using _FindPane is enough to fix this.

This PR also fixes another potential source of infinite recursion, and fixes panes being passed by-value into the callbacks.

Closes #17305

## Validation Steps Performed
* Split panes vertically 3 times
* `exit` the middle, the bottom and final one, in that order
* Doesn't crash ✅