### PR TITLE
Show parts of the scrollback on restore

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -1787,12 +1787,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             // * prints "  [Restored <date> <time>]  <spaces until end of line>  "
             // * resets the color ("\x1b[m")
             // * newlines
-            // * clears the screen ("\x1b[2J")
-            // The last step is necessary because we launch ConPTY without PSEUDOCONSOLE_INHERIT_CURSOR by default.
-            // This will cause ConPTY to emit a \x1b[2J sequence on startup to ensure it and the terminal are in-sync.
-            // If we didn't do a \x1b[2J ourselves as well, the user would briefly see the last state of the terminal,
-            // before it's quickly scrolled away once ConPTY has finished starting up, which looks weird.
-            message = fmt::format(FMT_COMPILE(L"\x1b[100;37m  [{} {} {}]\x1b[K\x1b[m\r\n\x1b[2J"), msg, date, time);
+            message = fmt::format(FMT_COMPILE(L"\x1b[100;37m  [{} {} {}]\x1b[K\x1b[m\r\n"), msg, date, time);
         }
 
         wchar_t buffer[32 * 1024];
@@ -1830,6 +1825,18 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             }
 
             _terminal->Write(message);
+
+            // Show 3 lines of scrollback to the user, so they know it's there. Otherwise, in particular with the well
+            // hidden touch scrollbars in WinUI 2 and later, there's no indication that there's something to scroll up to.
+            //
+            // We only show 3 lines because ConPTY doesn't know about our restored buffer contents initially,
+            // and so ReadConsole calls will return whitespace.
+            //
+            // We also avoid using actual newlines or similar here, because if we ever change our text buffer implementation
+            // to actually track the written contents, we don't want this to be part of the next buffer snapshot.
+            const auto cursorPosition = _terminal->GetCursorPosition();
+            const auto y = std::max(0, cursorPosition.y - 4);
+            _terminal->SetViewportPosition({ 0, y });
         }
     }
 


### PR DESCRIPTION
First, this makes use of `PSEUDOCONSOLE_INHERIT_CURSOR` to stop ConPTY from emitting a CSI 2 J on startup. Then, it uses `Terminal::SetViewportPosition` to fake-scroll the viewport down so that only 3 lines of scrollback are visible. It avoids printing actual newlines because if we later change the text buffer to actually track the written contents, we don't want those newlines to end up in the next buffer snapshot.

Closes #17274

## Validation Steps Performed
* Restore cmd multiple times
* There's always exactly 3 lines visible ✅