### PR TITLE
Automatically enable AdjustIndistinguishableColors if High Contrast mode enabled

### DIFF
--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -655,6 +655,11 @@ namespace winrt::TerminalApp::implementation
                globals.MinimizeToNotificationArea();
     }
 
+    void AppLogic::SetHighContrast(bool highContrast)
+    {
+        _settings.HighContrastMode(highContrast);
+    }
+
     bool AppLogic::AllowHeadless()
     {
         if (!_loadedInitialSettings)

--- a/src/cascadia/TerminalApp/AppLogic.h
+++ b/src/cascadia/TerminalApp/AppLogic.h
@@ -65,6 +65,7 @@ namespace winrt::TerminalApp::implementation
         bool IsolatedMode();
         bool AllowHeadless();
         bool RequestsTrayIcon();
+        void SetHighContrast(bool highContrast);
 
         TerminalApp::TerminalWindow CreateNewWindow();
 

--- a/src/cascadia/TerminalApp/AppLogic.idl
+++ b/src/cascadia/TerminalApp/AppLogic.idl
@@ -45,6 +45,7 @@ namespace TerminalApp
         Boolean IsolatedMode { get; };
         Boolean AllowHeadless { get; };
         Boolean RequestsTrayIcon { get; };
+        void SetHighContrast(Boolean highContrast);
 
         FindTargetWindowResult FindTargetWindow(String[] args);
 

--- a/src/cascadia/TerminalApp/TerminalPaneContent.cpp
+++ b/src/cascadia/TerminalApp/TerminalPaneContent.cpp
@@ -340,11 +340,13 @@ namespace winrt::TerminalApp::implementation
         RestartTerminalRequested.raise(*this, nullptr);
     }
 
-    void TerminalPaneContent::UpdateSettings(const CascadiaSettings& /*settings*/)
+    void TerminalPaneContent::UpdateSettings(const CascadiaSettings& settings)
     {
-        if (const auto& settings{ _cache.TryLookup(_profile) })
+        if (const auto& cachedSettings{ _cache.TryLookup(_profile) })
         {
-            _control.UpdateControlSettings(settings.DefaultSettings(), settings.UnfocusedSettings());
+            auto cachedDefaultSettings = cachedSettings.DefaultSettings();
+            cachedDefaultSettings.HighContrastMode(settings.HighContrastMode());
+            _control.UpdateControlSettings(cachedDefaultSettings, cachedSettings.UnfocusedSettings());
         }
     }
 

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -829,6 +829,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         _cellHeight = CSSLengthPercentage::FromString(_settings->CellHeight().c_str());
         _runtimeOpacity = std::nullopt;
         _runtimeFocusedOpacity = std::nullopt;
+        _terminal->SetHighContrastInfo(settings.HighContrastMode());
 
         // Manually turn off acrylic if they turn off transparency.
         _runtimeUseAcrylic = _settings->Opacity() < 1.0 && _settings->UseAcrylic();

--- a/src/cascadia/TerminalControl/ControlSettings.h
+++ b/src/cascadia/TerminalControl/ControlSettings.h
@@ -26,6 +26,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         CONTROL_SETTINGS(SETTINGS_GEN)
 #undef SETTINGS_GEN
 
+        WINRT_PROPERTY(bool, HighContrastMode, false);
+
     private:
         winrt::com_ptr<ControlAppearance> _unfocusedAppearance{ nullptr };
         winrt::com_ptr<ControlAppearance> _focusedAppearance{ nullptr };

--- a/src/cascadia/TerminalControl/IControlSettings.idl
+++ b/src/cascadia/TerminalControl/IControlSettings.idl
@@ -66,5 +66,8 @@ namespace Microsoft.Terminal.Control
         Boolean UseBackgroundImageForWindow { get; };
         Boolean RightClickContextMenu { get; };
         Boolean RepositionCursorWithMouse { get; };
+
+        // Non-serialized settings
+        Boolean HighContrastMode;
     };
 }

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -320,7 +320,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         };
         bool _InitializeTerminal(const InitializeReason reason);
         winrt::fire_and_forget _restoreInBackground();
-        void _SetFontSize(int fontSize);
         void _TappedHandler(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Input::TappedRoutedEventArgs& e);
         void _KeyDownHandler(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Input::KeyRoutedEventArgs& e);
         void _KeyUpHandler(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Input::KeyRoutedEventArgs& e);
@@ -348,8 +347,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         void _SwapChainSizeChanged(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::SizeChangedEventArgs& e);
         void _SwapChainScaleChanged(const Windows::UI::Xaml::Controls::SwapChainPanel& sender, const Windows::Foundation::IInspectable& args);
-
-        void _TerminalTabColorChanged(const std::optional<til::color> color);
 
         void _ScrollPositionChanged(const IInspectable& sender, const Control::ScrollPositionChangedArgs& args);
 

--- a/src/cascadia/TerminalCore/ICoreAppearance.idl
+++ b/src/cascadia/TerminalCore/ICoreAppearance.idl
@@ -23,7 +23,9 @@ namespace Microsoft.Terminal.Core
     {
         Never,
         Indexed,
-        Always
+        Always,
+        AutomaticIndexed,
+        AutomaticAlways
     };
 
     // TerminalCore declares its own Color struct to avoid depending

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -139,7 +139,22 @@ void Terminal::UpdateAppearance(const ICoreAppearance& appearance)
     renderSettings.SetRenderMode(RenderSettings::Mode::IntenseIsBold, appearance.IntenseIsBold());
     renderSettings.SetRenderMode(RenderSettings::Mode::IntenseIsBright, appearance.IntenseIsBright());
 
-    switch (appearance.AdjustIndistinguishableColors())
+    // If we're in high contrast mode and AIC is set to Automatic Indexed/Always,
+    // fallback to Indexed/Always respectively.
+    const auto deducedAIC = [this, &appearance]() {
+        const auto initialAIC = appearance.AdjustIndistinguishableColors();
+        switch (initialAIC)
+        {
+        case AdjustTextMode::AutomaticIndexed:
+            return _highContrastMode ? AdjustTextMode::Indexed : AdjustTextMode::Never;
+        case AdjustTextMode::AutomaticAlways:
+            return _highContrastMode ? AdjustTextMode::Always : AdjustTextMode::Never;
+        default:
+            return initialAIC;
+        }
+    }();
+
+    switch (deducedAIC)
     {
     case AdjustTextMode::Always:
         renderSettings.SetRenderMode(RenderSettings::Mode::IndexedDistinguishableColors, false);
@@ -205,6 +220,11 @@ void Terminal::UpdateAppearance(const ICoreAppearance& appearance)
     // workaround to force the control to redraw any scrollbar marks whose color
     // may have changed.
     _NotifyScrollEvent();
+}
+
+void Terminal::SetHighContrastInfo(bool hc)
+{
+    _highContrastMode = hc;
 }
 
 void Terminal::SetCursorStyle(const DispatchTypes::CursorStyle cursorStyle)

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -92,6 +92,7 @@ public:
 
     void UpdateSettings(winrt::Microsoft::Terminal::Core::ICoreSettings settings);
     void UpdateAppearance(const winrt::Microsoft::Terminal::Core::ICoreAppearance& appearance);
+    void SetHighContrastInfo(bool hc);
     void SetFontInfo(const FontInfo& fontInfo);
     void SetCursorStyle(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::CursorStyle cursorStyle);
     void EraseScrollback();
@@ -366,6 +367,7 @@ private:
     size_t _hyperlinkPatternId = 0;
 
     std::wstring _workingDirectory;
+    bool _highContrastMode = false;
 
     // This default fake font value is only used to check if the font is a raster font.
     // Otherwise, the font is changed to a real value with the renderer via TriggerFontChange.

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -863,6 +863,14 @@
     <value>Always</value>
     <comment>An option to choose from for the "adjust indistinguishable colors" setting. When selected, we will adjust the text colors for visibility.</comment>
   </data>
+<data name="Profile_AdjustIndistinguishableColorsAutomaticIndexed.Content" xml:space="preserve">
+    <value>When High Contrast is enabled, only for colors in the color scheme</value>
+    <comment>An option to choose from for the "adjust indistinguishable colors" setting. When selected, we will adjust the text colors for visibility only when the colors are part of this profile's color scheme's color table if and only if high contrast mode is enabled.</comment>
+  </data>
+	<data name="Profile_AdjustIndistinguishableColorsAutomaticAlways.Content" xml:space="preserve">
+    <value>When High Contrast Mode is enabled, all colors</value>
+    <comment>An option to choose from for the "adjust indistinguishable colors" setting. When selected, we will adjust the text colors for visibility if and only if high contrast mode is enabled.</comment>
+  </data>
   <data name="Profile_CursorShapeBar.Content" xml:space="preserve">
     <value>Bar ( ┃ )</value>
     <comment>{Locked="┃"} An option to choose from for the "cursor shape" setting. When selected, the cursor will look like a vertical bar. The character in the parentheses is used to show what it looks like.</comment>

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -53,6 +53,16 @@ std::string_view Model::implementation::LoadStringResource(int resourceID)
     return { reinterpret_cast<const char*>(ptr), sz };
 }
 
+bool CascadiaSettings::HighContrastMode()
+{
+    return _highContrastMode;
+}
+
+void CascadiaSettings::HighContrastMode(bool value)
+{
+    _highContrastMode = value;
+}
+
 winrt::hstring CascadiaSettings::Hash() const noexcept
 {
     return _hash;

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
@@ -112,6 +112,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         static winrt::hstring ApplicationDisplayName();
         static winrt::hstring ApplicationVersion();
         static bool IsPortableMode();
+        static bool HighContrastMode();
+        static void HighContrastMode(bool value);
         static void ExportFile(winrt::hstring path, winrt::hstring content);
 
         CascadiaSettings() noexcept = default;
@@ -155,6 +157,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         static const std::filesystem::path& _settingsPath();
         static const std::filesystem::path& _releaseSettingsPath();
         static winrt::hstring _calculateHash(std::string_view settings, const FILETIME& lastWriteTime);
+        static bool _highContrastMode;
 
         winrt::com_ptr<implementation::Profile> _createNewProfile(const std::wstring_view& name) const;
         Model::Profile _getProfileForCommandLine(const winrt::hstring& commandLine) const;

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.idl
@@ -16,6 +16,7 @@ namespace Microsoft.Terminal.Settings.Model
         static String SettingsPath { get; };
         static String DefaultSettingsPath { get; };
         static Boolean IsPortableMode { get; };
+        static Boolean HighContrastMode;
 
         static String ApplicationDisplayName { get; };
         static String ApplicationVersion { get; };

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.h
@@ -173,6 +173,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         INHERITABLE_SETTING(Model::TerminalSettings, bool, ReloadEnvironmentVariables, true);
 
+        WINRT_PROPERTY(bool, HighContrastMode, false);
+
     private:
         std::optional<std::array<Microsoft::Terminal::Core::Color, COLOR_TABLE_SIZE>> _ColorTable;
         std::span<Microsoft::Terminal::Core::Color> _getColorTableImpl();

--- a/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
@@ -35,10 +35,12 @@ JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Core::CursorStyle)
 // - Helper for converting a user-specified adjustTextMode value to its corresponding enum
 JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Core::AdjustTextMode)
 {
-    JSON_MAPPINGS(3) = {
+    JSON_MAPPINGS(5) = {
         pair_type{ "never", ValueType::Never },
         pair_type{ "indexed", ValueType::Indexed },
         pair_type{ "always", ValueType::Always },
+        pair_type{ "automaticIndexed", ValueType::AutomaticIndexed },
+        pair_type{ "automaticAlways", ValueType::AutomaticAlways },
     };
 
     // Override mapping parser to add boolean parsing

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -1506,7 +1506,7 @@ void AppHost::_handleSendContent(const winrt::Windows::Foundation::IInspectable&
 // Bubble the update settings request up to the emperor. We're being called on
 // the Window thread, but the Emperor needs to update the settings on the _main_
 // thread.
-void AppHost::_requestUpdateSettings()
+void AppHost::_requestUpdateSettings(bool highContrastEnabled)
 {
-    UpdateSettingsRequested.raise();
+    UpdateSettingsRequested.raise(highContrastEnabled);
 }

--- a/src/cascadia/WindowsTerminal/AppHost.h
+++ b/src/cascadia/WindowsTerminal/AppHost.h
@@ -32,7 +32,7 @@ public:
 
     static void s_DisplayMessageBox(const winrt::TerminalApp::ParseCommandlineResult& message);
 
-    til::event<winrt::delegate<void()>> UpdateSettingsRequested;
+    til::event<winrt::delegate<void(bool)>> UpdateSettingsRequested;
 
 private:
     std::unique_ptr<IslandWindow> _window;
@@ -146,7 +146,7 @@ private:
     void _handleAttach(const winrt::Windows::Foundation::IInspectable& sender,
                        winrt::Microsoft::Terminal::Remoting::AttachRequest args);
 
-    void _requestUpdateSettings();
+    void _requestUpdateSettings(bool highContrastEnabled);
 
     // Page -> us -> monarch
     void _handleReceiveContent(const winrt::Windows::Foundation::IInspectable& sender,

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -749,6 +749,8 @@ long IslandWindow::_calculateTotalSize(const bool isWidth, const long clientSize
             // themes, color schemes that might depend on the OS theme
             if (param == L"ImmersiveColorSet")
             {
+                bool updateSettings = false;
+
                 // GH#15732: Don't update the settings, unless the theme
                 // _actually_ changed. ImmersiveColorSet gets sent more often
                 // than just on a theme change. It notably gets sent when the PC
@@ -757,7 +759,28 @@ long IslandWindow::_calculateTotalSize(const bool isWidth, const long clientSize
                 if (isCurrentlyDark != _currentSystemThemeIsDark)
                 {
                     _currentSystemThemeIsDark = isCurrentlyDark;
-                    UpdateSettingsRequested.raise();
+                    updateSettings = true;
+                }
+
+                bool isCurrentlyHighContrast = []() {
+                    HIGHCONTRAST hc = { 0 };
+                    hc.cbSize = sizeof(HIGHCONTRAST);
+                    if (SystemParametersInfo(SPI_GETHIGHCONTRAST, sizeof(hc), &hc, 0))
+                    {
+                        return (bool)(hc.dwFlags & HCF_HIGHCONTRASTON);
+                    }
+                    return false;
+                }();
+
+                if (isCurrentlyHighContrast != _currentHighContrastModeState)
+                {
+                    _currentHighContrastModeState = isCurrentlyHighContrast;
+                    updateSettings = true;
+                }
+
+                if (updateSettings)
+                {
+                    UpdateSettingsRequested.raise(_currentHighContrastModeState);
                 }
             }
         }

--- a/src/cascadia/WindowsTerminal/IslandWindow.h
+++ b/src/cascadia/WindowsTerminal/IslandWindow.h
@@ -87,7 +87,7 @@ public:
 
     til::event<winrt::delegate<void()>> WindowMoved;
     til::event<winrt::delegate<void(bool)>> WindowVisibilityChanged;
-    til::event<winrt::delegate<void()>> UpdateSettingsRequested;
+    til::event<winrt::delegate<void(bool)>> UpdateSettingsRequested;
 
 protected:
     void ForceResize()
@@ -118,6 +118,7 @@ protected:
     RECT _rcWorkBeforeFullscreen{};
     UINT _dpiBeforeFullscreen{ 96 };
     bool _currentSystemThemeIsDark{ true };
+    bool _currentHighContrastModeState{ false };
 
     void _coldInitialize();
     void _warmInitialize();

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -850,9 +850,10 @@ winrt::fire_and_forget WindowEmperor::_windowIsQuakeWindowChanged(winrt::Windows
     co_await wil::resume_foreground(this->_dispatcher);
     _checkWindowsForNotificationIcon();
 }
-winrt::fire_and_forget WindowEmperor::_windowRequestUpdateSettings()
+winrt::fire_and_forget WindowEmperor::_windowRequestUpdateSettings(bool highContrastEnabled)
 {
     // We MUST be on the main thread to update the settings. We will crash when trying to enumerate fragment extensions otherwise.
     co_await wil::resume_foreground(this->_dispatcher);
+    _app.Logic().SetHighContrastMode();
     _app.Logic().ReloadSettings();
 }

--- a/src/cascadia/WindowsTerminal/WindowEmperor.h
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.h
@@ -62,7 +62,7 @@ private:
     void _numberOfWindowsChanged(const winrt::Windows::Foundation::IInspectable&, const winrt::Windows::Foundation::IInspectable&);
 
     winrt::fire_and_forget _windowIsQuakeWindowChanged(winrt::Windows::Foundation::IInspectable sender, winrt::Windows::Foundation::IInspectable args);
-    winrt::fire_and_forget _windowRequestUpdateSettings();
+    winrt::fire_and_forget _windowRequestUpdateSettings(bool highContrastEnabled);
 
     void _createMessageWindow();
 

--- a/src/cascadia/WindowsTerminal/WindowThread.cpp
+++ b/src/cascadia/WindowsTerminal/WindowThread.cpp
@@ -31,7 +31,7 @@ void WindowThread::CreateHost()
                                         _manager,
                                         _peasant);
 
-    _UpdateSettingsRequestedToken = _host->UpdateSettingsRequested([this]() { UpdateSettingsRequested.raise(); });
+    _UpdateSettingsRequestedToken = _host->UpdateSettingsRequested([this](bool highContrastEnabled) { UpdateSettingsRequested.raise(highContrastEnabled); });
 
     winrt::init_apartment(winrt::apartment_type::single_threaded);
 
@@ -111,7 +111,7 @@ bool WindowThread::KeepWarm()
         // state transitions. In this case, the window is actually being woken up.
         if (msg.message == AppHost::WM_REFRIGERATE)
         {
-            _UpdateSettingsRequestedToken = _host->UpdateSettingsRequested([this]() { UpdateSettingsRequested.raise(); });
+            _UpdateSettingsRequestedToken = _host->UpdateSettingsRequested([this](bool highContrastEnabled) { UpdateSettingsRequested.raise(highContrastEnabled); });
             // Re-initialize the host here, on the window thread
             _host->Initialize();
             return true;

--- a/src/cascadia/WindowsTerminal/WindowThread.h
+++ b/src/cascadia/WindowsTerminal/WindowThread.h
@@ -25,7 +25,7 @@ public:
 
     uint64_t PeasantID();
 
-    til::event<winrt::delegate<void()>> UpdateSettingsRequested;
+    til::event<winrt::delegate<void(bool)>> UpdateSettingsRequested;
 
 private:
     winrt::Microsoft::Terminal::Remoting::Peasant _peasant{ nullptr };

--- a/src/cascadia/inc/ControlProperties.h
+++ b/src/cascadia/inc/ControlProperties.h
@@ -13,7 +13,7 @@
     X(uint32_t, CursorHeight, DEFAULT_CURSOR_HEIGHT)                                                                      \
     X(bool, IntenseIsBold)                                                                                                \
     X(bool, IntenseIsBright, true)                                                                                        \
-    X(winrt::Microsoft::Terminal::Core::AdjustTextMode, AdjustIndistinguishableColors, winrt::Microsoft::Terminal::Core::AdjustTextMode::Never)
+    X(winrt::Microsoft::Terminal::Core::AdjustTextMode, AdjustIndistinguishableColors, winrt::Microsoft::Terminal::Core::AdjustTextMode::AutomaticIndexed)
 
 // --------------------------- Control Appearance ---------------------------
 //  All of these settings are defined in IControlAppearance.


### PR DESCRIPTION
## Summary of the Pull Request
If High Contrast mode is enabled in the OS settings, we now automatically enable `adjustIndistinguishableColors`. To accomplish this, a new `AutomaticAlways` and `AutomaticIndexed` value is added to `adjustIndistinguishableColors`. When these are chosen, color nudging doesn't occur in regular contrast sessions, but we interpret the value as `Always` and `Indexed` respectively.

The new default value is `AutomaticIndexed`. Meaning that regular contrast sessions will see no difference in behavior. However, if they switch to high contrast mode, Windows Terminal will interpret the value as `Indexed` at runtime. This was chosen because `Always` is more performance intensive.
  
## References and Relevant Issues
#12999

## Detailed Description of the Pull Request / Additional comments
The order of events is as follows:
1. `IslandWindow` receives a `WM_SETTINGCHANGE` event where we check if High Contrast mode was enabled
2. When that's the case, we raise a `UpdateSettingsRequested` with a `bool HighContrast` parameter
3. That parameter is stored in `CascadiaSettings` as a `static bool HighContrast`
4. `TerminalPaneContent` goes through the `UpdateSettings` process. However, now we stuff the `CascadiaSettings::HighContrastMode` value into the `TerminalSettings`, then tell the control to update its settings
5. Stuff `HighContrastMode` in the `Terminal` object we're updating
6. When `Terminal` updates its appearance, we evaluate `AutomaticIndexed` and `AutomaticAlways` as non-automatic values, then update the render settings appropriately.

## Validation Steps Performed
⚠️ _full feature is yet to be tested_ ⚠️
Individual components have been tested, however, including...
- Using the WM_SETTINGCHANGE event to get the High Contrast setting value and storing it in `CascadiaSettings`
- Evaluating the `adjustIndistinguishableColors` `AutomaticX` values as `X` at runtime