### PR TITLE
Support valid out-of-bounds access in utextAccess

### DIFF
--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -497,6 +497,10 @@ std::wstring Terminal::GetHyperlinkAtBufferPosition(const til::point bufferPos)
         result = GetHyperlinkIntervalFromViewportPosition(viewportPos);
         if (result.has_value())
         {
+            // GetPlainText and _ConvertToBufferCell work with inclusive coordinates, but interval's
+            // stop point is (horizontally) exclusive, so let's just update it.
+            result->stop.x--;
+
             result->start = _ConvertToBufferCell(result->start);
             result->stop = _ConvertToBufferCell(result->stop);
         }
@@ -522,10 +526,6 @@ std::wstring Terminal::GetHyperlinkAtBufferPosition(const til::point bufferPos)
     // Case 2 - Step 2: get the auto-detected hyperlink
     if (result.has_value() && result->value == _hyperlinkPatternId)
     {
-        // GetPlainText works with inclusive coordinates, but interval's stop
-        // point is (horizontally) exclusive, so let's just update it.
-        result->stop.x--;
-
         return _activeBuffer().GetPlainText(result->start, result->stop);
     }
     return {};


### PR DESCRIPTION
`utextAccess` apparently doesn't actually need to clamp the
`chunkOffset` to be in range of the current chunk. Also, I missed to
implement the part of the spec that says to leave the iterator on the
first/last chunk of the `UText` in case of an out-of-bounds index.

This PR fixes the issue by simply not returning early, doing a more
liberal clamp of the offset, and then checking whether it was in range.

As an aside, this also fixes a one-off bug when hovering URLs that
end on the very last cell of the viewport (or are cut off).

Closes #17343

## Validation Steps Performed
* Write an URL that wraps across the last 2 lines in the buffer
* Scroll 1 line up
* No assert ✅
* Hovering the URL shows the full, still visible parts of the URL ✅