### PR TITLE
Make subsequent windows open in the foreground

### DIFF
--- a/src/cascadia/Remoting/WindowManager.cpp
+++ b/src/cascadia/Remoting/WindowManager.cpp
@@ -138,6 +138,7 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                 // commandline in an existing window, or a new one, but either way,
                 // this process doesn't need to make a new window.
 
+                AllowSetForegroundWindow(static_cast<DWORD>(_monarch.GetPID()));
                 return winrt::make<ProposeCommandlineResult>(false);
             }
             // Otherwise, we'll try to handle this ourselves.

--- a/src/cascadia/Remoting/WindowManager.cpp
+++ b/src/cascadia/Remoting/WindowManager.cpp
@@ -138,7 +138,7 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                 // commandline in an existing window, or a new one, but either way,
                 // this process doesn't need to make a new window.
 
-                AllowSetForegroundWindow(static_cast<DWORD>(_monarch.GetPID()));
+                LOG_IF_WIN32_BOOL_FALSE(AllowSetForegroundWindow(static_cast<DWORD>(_monarch.GetPID())));
                 return winrt::make<ProposeCommandlineResult>(false);
             }
             // Otherwise, we'll try to handle this ourselves.

--- a/src/cascadia/Remoting/WindowManager.cpp
+++ b/src/cascadia/Remoting/WindowManager.cpp
@@ -130,6 +130,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
             // We connected to a monarch instance, not us though. This won't hit
             // in isolated mode.
 
+            LOG_IF_FAILED(CoAllowSetForegroundWindow(winrt::get_unknown(_monarch), nullptr));
+
             // Send the commandline over to the monarch process
             if (_proposeToMonarch(args))
             {
@@ -138,7 +140,6 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                 // commandline in an existing window, or a new one, but either way,
                 // this process doesn't need to make a new window.
 
-                LOG_IF_WIN32_BOOL_FALSE(AllowSetForegroundWindow(static_cast<DWORD>(_monarch.GetPID())));
                 return winrt::make<ProposeCommandlineResult>(false);
             }
             // Otherwise, we'll try to handle this ourselves.


### PR DESCRIPTION
Sometimes subsequent WT windows open in the background behind other applications. This PR tries to fix it.

Refs #15895
Refs #15479

Mysterious bug (and annoying). There are even some discussions about happening to the first startup, not just subsequent ones. Sometimes the window may show up without animation too. So I don't think this is the final solution, but it did get solved on my computer, for now.

## Validation Steps Performed
0. Quit all WT windows if some.
1. Open File Explorer, click "Open in Terminal" in context menu.
2. Move the newly opened window and minimize it.
3. Back to step 1 and repeat several times.
4. All the windows should open in the foreground correctly (yet possibly without animation).