### PR TITLE
Warn when using old MacType versions

### DIFF
--- a/src/cascadia/TerminalControl/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalControl/Resources/en-US/Resources.resw
@@ -219,7 +219,7 @@ Please either install the missing font or choose another one.</value>
   </data>
   <data name="RendererErrorMacType" xml:space="preserve">
     <value>Your version of MacType is incompatible with this application. Please update to version 2023.5.31 or later.</value>
-    <comment>{Locked="2023.5.31"}</comment>
+    <comment>{Locked="2023.5.31","MacType"}</comment>
   </data>
   <data name="RendererErrorOther" xml:space="preserve">
     <value>Renderer encountered an unexpected error: {0:#010x} {1}</value>

--- a/src/cascadia/TerminalControl/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalControl/Resources/en-US/Resources.resw
@@ -217,6 +217,10 @@ Please either install the missing font or choose another one.</value>
     <value>Unable to find the following fonts: {0}. Please either install them or choose different fonts.</value>
     <comment>{Locked="{0}"} This is a warning dialog shown when the user selects a font that isn't installed.</comment>
   </data>
+  <data name="RendererErrorMacType" xml:space="preserve">
+    <value>Your version of MacType is incompatible with this application. Please update to version 2023.5.31 or later.</value>
+    <comment>{Locked="2023.5.31"}</comment>
+  </data>
   <data name="RendererErrorOther" xml:space="preserve">
     <value>Renderer encountered an unexpected error: {0:#010x} {1}</value>
     <comment>{Locked="{0:#010x}","{1}"} {0:#010x} is a placeholder for a Windows error code (e.g. 0x88985002). {1} is the corresponding message.</comment>

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1143,6 +1143,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         case DWRITE_E_NOFONT:
             message = winrt::hstring{ fmt::format(std::wstring_view{ RS_(L"RendererErrorFontNotFound") }, parameter) };
             break;
+        case ATLAS_ENGINE_ERROR_MAC_TYPE:
+            message = RS_(L"RendererErrorMacType");
+            break;
         default:
         {
             wchar_t buf[512];

--- a/src/renderer/atlas/BackendD3D.cpp
+++ b/src/renderer/atlas/BackendD3D.cpp
@@ -875,7 +875,9 @@ void BackendD3D::_resizeGlyphAtlas(const RenderingPayload& p, const u16 u, const
 //   https://github.com/snowie2000/mactype/pull/938
 // This results in crashes. Not a lot of them, but enough to constantly show up.
 // The issue was fixed in the MacType v1.2023.5.31 release, the only one in 2023.
-bool BackendD3D::_checkMacTypeVersion(const RenderingPayload& p) noexcept
+//
+// Please feel free to remove this check in a few years.
+bool BackendD3D::_checkMacTypeVersion(const RenderingPayload& p)
 {
 #ifdef _WIN64
     static constexpr auto name = L"MacType64.Core.dll";
@@ -914,15 +916,14 @@ bool BackendD3D::_checkMacTypeVersion(const RenderingPayload& p) noexcept
         return false;
     }
 
-    const DWORD v1_2023 = MAKELONG(2023, 1);
-    const auto bad = info->dwFileVersionMS < v1_2023;
+    const auto faulty = info->dwFileVersionMS < (1 << 16 | 2023);
 
-    if (bad && p.warningCallback)
+    if (faulty && p.warningCallback)
     {
         p.warningCallback(ATLAS_ENGINE_ERROR_MAC_TYPE, {});
     }
 
-    return bad;
+    return faulty;
 }
 
 BackendD3D::QuadInstance& BackendD3D::_getLastQuad() noexcept

--- a/src/renderer/atlas/BackendD3D.cpp
+++ b/src/renderer/atlas/BackendD3D.cpp
@@ -37,6 +37,7 @@ TIL_FAST_MATH_BEGIN
 #pragma warning(disable : 26459) // You called an STL function '...' with a raw pointer parameter at position '...' that may be unsafe [...].
 #pragma warning(disable : 26481) // Don't use pointer arithmetic. Use span instead (bounds.1).
 #pragma warning(disable : 26482) // Only index into arrays using constant expressions (bounds.2).
+#pragma warning(disable : 26490) // Don't use reinterpret_cast (type.1).
 
 // Initializing large arrays can be very costly compared to how cheap some of these functions are.
 #define ALLOW_UNINITIALIZED_BEGIN _Pragma("warning(push)") _Pragma("warning(disable : 26494)")

--- a/src/renderer/atlas/BackendD3D.h
+++ b/src/renderer/atlas/BackendD3D.h
@@ -204,7 +204,7 @@ namespace Microsoft::Console::Render::Atlas
         void _d2dEndDrawing();
         ATLAS_ATTR_COLD void _resetGlyphAtlas(const RenderingPayload& p);
         ATLAS_ATTR_COLD void _resizeGlyphAtlas(const RenderingPayload& p, u16 u, u16 v);
-        static bool _checkMacTypeVersion(const RenderingPayload& p) noexcept;
+        static bool _checkMacTypeVersion(const RenderingPayload& p);
         QuadInstance& _getLastQuad() noexcept;
         QuadInstance& _appendQuad();
         ATLAS_ATTR_COLD void _bumpInstancesSize();

--- a/src/renderer/atlas/BackendD3D.h
+++ b/src/renderer/atlas/BackendD3D.h
@@ -204,6 +204,7 @@ namespace Microsoft::Console::Render::Atlas
         void _d2dEndDrawing();
         ATLAS_ATTR_COLD void _resetGlyphAtlas(const RenderingPayload& p);
         ATLAS_ATTR_COLD void _resizeGlyphAtlas(const RenderingPayload& p, u16 u, u16 v);
+        static bool _checkMacTypeVersion(const RenderingPayload& p) noexcept;
         QuadInstance& _getLastQuad() noexcept;
         QuadInstance& _appendQuad();
         ATLAS_ATTR_COLD void _bumpInstancesSize();

--- a/src/renderer/atlas/common.h
+++ b/src/renderer/atlas/common.h
@@ -53,6 +53,8 @@ namespace Microsoft::Console::Render::Atlas
     // My best effort of replicating __attribute__((cold)) from gcc/clang.
 #define ATLAS_ATTR_COLD __declspec(noinline)
 
+#define ATLAS_ENGINE_ERROR_MAC_TYPE MAKE_HRESULT(SEVERITY_SUCCESS, FACILITY_ITF, 'MT')
+
     template<typename T>
     struct vec2
     {


### PR DESCRIPTION
This adds a check for whether MacType is injected and whether it's
a known bad version (pre-2023). In that case we avoid calling the
known faulty `ID2D1Device4` interface. We could avoid it in general to
fix the issue without a warning (it's only a very mild optimization),
but on the other hand, the bug that MacType has is a very serious one
and it's probably better overall to suggest users to update.

See: https://github.com/snowie2000/mactype/pull/938

## Validation Steps Performed
* MacType 2021.1-RC1 results in a warning and no crash ✅
* MacType 2023.5.31 results in no warning ✅