### PR TITLE
Fix spurious clear-to-end sequence in buffer dumps

### DIFF
--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -2790,7 +2790,7 @@ void TextBuffer::Serialize(const wchar_t* destination) const
             // In other words, we can only skip \x1b[K = Erase in Line, if both the first/last attribute are the default attribute.
             static constexpr TextAttribute defaultAttr;
             const auto trimTrailingWhitespaces = it == last && lastCharX < newX;
-            const auto clearToEndOfLine = trimTrailingWhitespaces && beg->value != defaultAttr || beg->value != defaultAttr;
+            const auto clearToEndOfLine = trimTrailingWhitespaces && (beg->value != defaultAttr || last->value != defaultAttr);
 
             if (trimTrailingWhitespaces)
             {


### PR DESCRIPTION
I think I forgot to complete that section of the code...
The parentheses were missing and `beg` was repeated twice. The last
line in the comment above this explains what I intended it to be.

Closes #17365

## Validation Steps Performed
* In a new PowerShell tab
* Run ``"`e[999C`e[2D`e[42mfoo`e[m"``
* Newline until it scrolls
* Run it again
* Close and reopen
* The green "foo" is still green ✅