### PR TITLE
Add descriptions to commands (namely, snippets)

### DIFF
--- a/src/cascadia/TerminalApp/SuggestionsControl.cpp
+++ b/src/cascadia/TerminalApp/SuggestionsControl.cpp
@@ -1172,7 +1172,6 @@ namespace winrt::TerminalApp::implementation
         _anchor = anchor;
         _space = space;
 
-        // const til::size actualSize{ til::math::rounding, ActualWidth(), ActualHeight() };
         // Is there space in the window below the cursor to open the menu downwards?
         const bool canOpenDownwards = (_anchor.Y + characterHeight + ActualHeight()) < space.Height;
         _setDirection(canOpenDownwards ? TerminalApp::SuggestionsDirection::TopDown :
@@ -1192,10 +1191,8 @@ namespace winrt::TerminalApp::implementation
         const auto clampedX = std::clamp(proposedX, 0, maxX);
 
         // Create a thickness for the new margins. This will set the left, then
-        // we'll go update the top.
-        auto newMargin = Windows::UI::Xaml::ThicknessHelper::FromLengths(clampedX, 0, 0, 0);
-        Margin(newMargin);
-
+        // we'll go update the top separately
+        Margin(Windows::UI::Xaml::ThicknessHelper::FromLengths(clampedX, 0, 0, 0));
         _recalculateTopMargin();
 
         _searchBox().Text(filter);

--- a/src/cascadia/TerminalApp/SuggestionsControl.cpp
+++ b/src/cascadia/TerminalApp/SuggestionsControl.cpp
@@ -1168,7 +1168,7 @@ namespace winrt::TerminalApp::implementation
                                               til::size{ 0, 0 };
         _descriptionsBackdrop().Measure(actualSize.to_winrt_size());
         const til::size descriptionDesiredSize = _descriptionsBackdrop().Visibility() == Visibility::Visible ?
-                                                     til::size{ til::math::rounding, _descriptionsBackdrop().DesiredSize().Width, _descriptionsBackdrop().DesiredSize().Height + 12.0f } :
+                                                     til::size{ til::math::rounding, _descriptionsBackdrop().DesiredSize().Width, _descriptionsBackdrop().DesiredSize().Height } :
                                                      til::size{ 0, 0 };
 
         // Now, position vertically.

--- a/src/cascadia/TerminalApp/SuggestionsControl.cpp
+++ b/src/cascadia/TerminalApp/SuggestionsControl.cpp
@@ -1256,22 +1256,23 @@ namespace winrt::TerminalApp::implementation
 
         // Create a thickness for the new margins
         auto newMargin = Windows::UI::Xaml::ThicknessHelper::FromLengths(clampedX, 0, 0, 0);
-        // Now, position vertically.
-        if (_direction == TerminalApp::SuggestionsDirection::TopDown)
-        {
-            // The control should open right below the cursor, with the list
-            // extending below. This is easy, we can just use the cursor as the
-            // origin (more or less)
-            newMargin.Top = (_anchor.Y /* - descriptionSize.height*/);
-        }
-        else
-        {
-            // Position at the cursor. The suggestions UI itself will maintain
-            // its own offset such that it's always above its origin
-            // NO newMargin.Top = (_anchor.Y - actualSize.height /* - descriptionSize.height*/);
-            newMargin.Top = (_anchor.Y - actualSize.height - descriptionSize.height);
-        }
+        // // Now, position vertically.
+        // if (_direction == TerminalApp::SuggestionsDirection::TopDown)
+        // {
+        //     // The control should open right below the cursor, with the list
+        //     // extending below. This is easy, we can just use the cursor as the
+        //     // origin (more or less)
+        //     newMargin.Top = (_anchor.Y /* - descriptionSize.height*/);
+        // }
+        // else
+        // {
+        //     // Position at the cursor. The suggestions UI itself will maintain
+        //     // its own offset such that it's always above its origin
+        //     // NO newMargin.Top = (_anchor.Y - actualSize.height /* - descriptionSize.height*/);
+        //     newMargin.Top = (_anchor.Y - actualSize.height - descriptionSize.height);
+        // }
         Margin(newMargin);
+        _recalculateTopMargin();
 
         _searchBox().Text(filter);
 

--- a/src/cascadia/TerminalApp/SuggestionsControl.cpp
+++ b/src/cascadia/TerminalApp/SuggestionsControl.cpp
@@ -1164,8 +1164,12 @@ namespace winrt::TerminalApp::implementation
 
         til::size actualSize{ til::math::rounding, ActualWidth(), ActualHeight() };
         const til::size descriptionSize = _descriptionsBackdrop().Visibility() == Visibility::Visible ?
-                                              til::size{ til::math::rounding, _descriptionsBackdrop().ActualWidth(), _descriptionsBackdrop().ActualHeight() } :
+                                              til::size{ til::math::rounding, _descriptionsBackdrop().ActualWidth(), _descriptionsBackdrop().ActualHeight() + 12.0 } :
                                               til::size{ 0, 0 };
+        _descriptionsBackdrop().Measure(actualSize.to_winrt_size());
+        const til::size descriptionDesiredSize = _descriptionsBackdrop().Visibility() == Visibility::Visible ?
+                                                     til::size{ til::math::rounding, _descriptionsBackdrop().DesiredSize().Width, _descriptionsBackdrop().DesiredSize().Height + 12.0f } :
+                                                     til::size{ 0, 0 };
 
         // Now, position vertically.
         if (_direction == TerminalApp::SuggestionsDirection::TopDown)
@@ -1201,9 +1205,12 @@ namespace winrt::TerminalApp::implementation
             backdropHeight;
             const auto descriptionHeight = descriptionSize.height;
             descriptionHeight;
+            const auto descriptionDesiredHeight = descriptionDesiredSize.height;
+            descriptionDesiredHeight;
             //const auto marginTop = (_anchor.Y - backdropHeight - descriptionHeight);
             // const auto marginTop = (_anchor.Y - actualHeight - descriptionHeight);
-            const auto marginTop = (_anchor.Y - backdropHeight - descriptionHeight - 12);
+            // const auto marginTop = (_anchor.Y - backdropHeight - descriptionHeight);
+            const auto marginTop = (_anchor.Y - backdropHeight - descriptionDesiredHeight);
 
             currentMargin.Top = marginTop;
         }

--- a/src/cascadia/TerminalApp/SuggestionsControl.cpp
+++ b/src/cascadia/TerminalApp/SuggestionsControl.cpp
@@ -1172,10 +1172,9 @@ namespace winrt::TerminalApp::implementation
         _anchor = anchor;
         _space = space;
 
-        const til::size actualSize{ til::math::rounding, ActualWidth(), ActualHeight() };
-        const til::size descriptionSize{ til::math::rounding, _descriptionsBackdrop().ActualWidth(), _descriptionsBackdrop().ActualHeight() };
+        // const til::size actualSize{ til::math::rounding, ActualWidth(), ActualHeight() };
         // Is there space in the window below the cursor to open the menu downwards?
-        const bool canOpenDownwards = (_anchor.Y + characterHeight + actualSize.height) < space.Height;
+        const bool canOpenDownwards = (_anchor.Y + characterHeight + ActualHeight()) < space.Height;
         _setDirection(canOpenDownwards ? TerminalApp::SuggestionsDirection::TopDown :
                                          TerminalApp::SuggestionsDirection::BottomUp);
         // Set the anchor below by a character height
@@ -1189,7 +1188,7 @@ namespace winrt::TerminalApp::implementation
         const auto proposedX = gsl::narrow_cast<int>(_anchor.X - 40);
         // If the control is too wide to fit in the window, clamp it fit inside
         // the window.
-        const auto maxX = gsl::narrow_cast<int>(space.Width - actualSize.width);
+        const auto maxX = gsl::narrow_cast<int>(space.Width - ActualWidth());
         const auto clampedX = std::clamp(proposedX, 0, maxX);
 
         // Create a thickness for the new margins. This will set the left, then

--- a/src/cascadia/TerminalApp/SuggestionsControl.cpp
+++ b/src/cascadia/TerminalApp/SuggestionsControl.cpp
@@ -1124,15 +1124,37 @@ namespace winrt::TerminalApp::implementation
     void SuggestionsControl::_setDirection(TerminalApp::SuggestionsDirection direction)
     {
         _direction = direction;
+
+        auto backdrop = _backdrop();
+        auto descriptionsBackdrop = _descriptionsBackdrop();
+        // _listAndDescriptionStack().Children().Clear();
+        auto kids{ _listAndDescriptionStack().Children() };
+
         if (_direction == TerminalApp::SuggestionsDirection::TopDown)
         {
             Controls::Grid::SetRow(_searchBox(), 0);
-            Controls::Grid::SetRow(_descriptionsBackdrop(), 2);
+
+            // _listAndDescriptionStack().Children().Append(backdrop);
+            // _listAndDescriptionStack().Children().Append(descriptionsBackdrop);
+
+            uint32_t index;
+            if (kids.IndexOf(backdrop, index))
+            {
+                kids.Move(index, 0);
+            }
         }
         else // BottomUp
         {
             Controls::Grid::SetRow(_searchBox(), 4);
-            Controls::Grid::SetRow(_descriptionsBackdrop(), 0);
+
+            uint32_t index;
+            if (kids.IndexOf(descriptionsBackdrop, index))
+            {
+                kids.Move(index, 0);
+            }
+
+            // _listAndDescriptionStack().Children().Append(descriptionsBackdrop);
+            // _listAndDescriptionStack().Children().Append(backdrop);
         }
     }
 
@@ -1179,8 +1201,9 @@ namespace winrt::TerminalApp::implementation
             backdropHeight;
             const auto descriptionHeight = descriptionSize.height;
             descriptionHeight;
-            // const auto marginTop = (_anchor.Y - backdropHeight - descriptionHeight);
-            const auto marginTop = (_anchor.Y - actualHeight - descriptionHeight);
+            //const auto marginTop = (_anchor.Y - backdropHeight - descriptionHeight);
+            // const auto marginTop = (_anchor.Y - actualHeight - descriptionHeight);
+            const auto marginTop = (_anchor.Y - backdropHeight - descriptionHeight - 12);
 
             currentMargin.Top = marginTop;
         }

--- a/src/cascadia/TerminalApp/SuggestionsControl.cpp
+++ b/src/cascadia/TerminalApp/SuggestionsControl.cpp
@@ -106,9 +106,6 @@ namespace winrt::TerminalApp::implementation
             // stays "attached" to the cursor.
             if (Visibility() == Visibility::Visible && _direction == TerminalApp::SuggestionsDirection::BottomUp)
             {
-                // auto m = this->Margin();
-                // m.Top = (_anchor.Y - ActualHeight());
-                // this->Margin(m);
                 this->_recalculateTopMargin();
             }
         });

--- a/src/cascadia/TerminalApp/SuggestionsControl.h
+++ b/src/cascadia/TerminalApp/SuggestionsControl.h
@@ -99,6 +99,8 @@ namespace winrt::TerminalApp::implementation
         void _close();
         void _dismissPalette();
 
+        void _recalculateTopMargin();
+
         void _filterTextChanged(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
         void _previewKeyDownHandler(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Input::KeyRoutedEventArgs& e);
         void _keyUpHandler(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Input::KeyRoutedEventArgs& e);
@@ -110,7 +112,8 @@ namespace winrt::TerminalApp::implementation
 
         void _listItemClicked(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Controls::ItemClickEventArgs& e);
         void _listItemSelectionChanged(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Controls::SelectionChangedEventArgs& e);
-        void _selectedCommandChanged(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
+        winrt::fire_and_forget _selectedCommandChanged(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
+        winrt::fire_and_forget _openTooltip(Microsoft::Terminal::Settings::Model::Command cmd);
 
         void _moveBackButtonClicked(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs&);
         void _updateCurrentNestedCommands(const winrt::Microsoft::Terminal::Settings::Model::Command& parentCommand);
@@ -122,7 +125,6 @@ namespace winrt::TerminalApp::implementation
         Windows::Foundation::Collections::IVector<winrt::TerminalApp::FilteredCommand> _commandsToFilter();
         std::wstring _getTrimmedInput();
         uint32_t _getNumVisibleItems();
-
         friend class TerminalAppLocalTests::TabTests;
     };
 }

--- a/src/cascadia/TerminalApp/SuggestionsControl.h
+++ b/src/cascadia/TerminalApp/SuggestionsControl.h
@@ -112,7 +112,7 @@ namespace winrt::TerminalApp::implementation
 
         void _listItemClicked(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Controls::ItemClickEventArgs& e);
         void _listItemSelectionChanged(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Controls::SelectionChangedEventArgs& e);
-        winrt::fire_and_forget _selectedCommandChanged(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
+        void _selectedCommandChanged(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
         winrt::fire_and_forget _openTooltip(Microsoft::Terminal::Settings::Model::Command cmd);
 
         void _moveBackButtonClicked(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs&);

--- a/src/cascadia/TerminalApp/SuggestionsControl.h
+++ b/src/cascadia/TerminalApp/SuggestionsControl.h
@@ -112,7 +112,7 @@ namespace winrt::TerminalApp::implementation
         void _listItemClicked(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Controls::ItemClickEventArgs& e);
         void _listItemSelectionChanged(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Controls::SelectionChangedEventArgs& e);
         void _selectedCommandChanged(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
-        winrt::fire_and_forget _openTooltip(Microsoft::Terminal::Settings::Model::Command cmd);
+        void _openTooltip(Microsoft::Terminal::Settings::Model::Command cmd);
 
         void _moveBackButtonClicked(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs&);
         void _updateCurrentNestedCommands(const winrt::Microsoft::Terminal::Settings::Model::Command& parentCommand);

--- a/src/cascadia/TerminalApp/SuggestionsControl.xaml
+++ b/src/cascadia/TerminalApp/SuggestionsControl.xaml
@@ -111,15 +111,17 @@
         </Grid.ColumnDefinitions>
 
         <Grid.RowDefinitions>
-            <RowDefinition Height="8*" />
+            <RowDefinition Height="2*" />
+            <RowDefinition Height="7*" />
             <RowDefinition Height="2*" />
         </Grid.RowDefinitions>
 
         <Grid x:Name="_backdrop"
-              Grid.Row="0"
-              Grid.RowSpan="2"
+              Grid.Row="1"
+              Grid.RowSpan="1"
               Grid.Column="0"
               Grid.ColumnSpan="3"
+              MinWidth="300"
               MaxWidth="300"
               MaxHeight="300"
               Margin="0"
@@ -135,16 +137,16 @@
               Translation="0,0,32">
 
             <Grid.RowDefinitions>
+                <!--  0: Top-down _searchBox  -->
                 <RowDefinition Height="Auto" />
-                <!--  Top-down _searchBox  -->
+                <!--  1: Top-down ParentCommandName  -->
                 <RowDefinition Height="Auto" />
-                <!--  Top-down ParentCommandName  -->
+                <!--  2: Top-down UNUSED????????  -->
                 <RowDefinition Height="Auto" />
-                <!--  Top-down UNUSED????????  -->
+                <!--  3: _filteredActionsView  -->
                 <RowDefinition Height="*" />
-                <!--  _filteredActionsView  -->
+                <!--  4: bottom-up _searchBox  -->
                 <RowDefinition Height="Auto" />
-                <!--  bottom-up _searchBox  -->
             </Grid.RowDefinitions>
 
             <TextBox x:Name="_searchBox"
@@ -207,8 +209,55 @@
                       SelectionMode="Single"
                       Style="{StaticResource NoAnimationsPlease}" />
 
-        </Grid>
 
+        </Grid>
+        <!-- <Border Height="1" Grid.Row="1" /> -->
+        <Grid x:Name="_descriptionsBackdrop"
+              Grid.Row="0"
+              Grid.RowSpan="1"
+              Grid.Column="0"
+              Grid.ColumnSpan="3"
+              MaxWidth="300"
+              Margin="0,6,0,0"
+              Padding="0,4,0,0"
+              HorizontalAlignment="Stretch"
+              VerticalAlignment="Stretch"
+              Background="{ThemeResource FlyoutPresenterBackground}"
+              BorderBrush="{ThemeResource FlyoutBorderThemeBrush}"
+              BorderThickness="{ThemeResource FlyoutBorderThemeThickness}"
+              CornerRadius="{ThemeResource OverlayCornerRadius}"
+              PointerPressed="_backdropPointerPressed"
+              Shadow="{StaticResource SharedShadow}"
+              Translation="0,0,32">
+
+            <Grid.RowDefinitions>
+                <!--  0: descriptions view  -->
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <StackPanel x:Name="_descriptionsView"
+                        Grid.Row="0"
+                        Margin="8,0,8,8"
+                        Orientation="Vertical"
+                        Visibility="Collapsed">
+                <TextBlock x:Name="_descriptionTitle"
+                           FontSize="14"
+                           FontWeight="Bold"
+                           IsTextSelectionEnabled="True"
+                           TextWrapping="WrapWholeWords" />
+                <ScrollViewer MaxHeight="64"
+                              VerticalScrollBarVisibility="Visible"
+                              VerticalScrollMode="Enabled"
+                              Visibility="Visible">
+                    <!-- <TextBlock Text="Foo bar bax"
+                           TextWrapping="WrapWholeWords" />-->
+                    <TextBlock x:Name="_descriptionComment"
+                               IsTextSelectionEnabled="True"
+                               TextWrapping="WrapWholeWords" />
+                </ScrollViewer>
+            </StackPanel>
+
+        </Grid>
 
     </Grid>
 </UserControl>

--- a/src/cascadia/TerminalApp/SuggestionsControl.xaml
+++ b/src/cascadia/TerminalApp/SuggestionsControl.xaml
@@ -103,24 +103,9 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <Grid>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="2*" />
-            <ColumnDefinition Width="6*" />
-            <ColumnDefinition Width="2*" />
-        </Grid.ColumnDefinitions>
-
-        <Grid.RowDefinitions>
-            <RowDefinition Height="2*" />
-            <RowDefinition Height="7*" />
-            <RowDefinition Height="2*" />
-        </Grid.RowDefinitions>
-
+    <StackPanel x:Name="_listAndDescriptionStack"
+                Orientation="Vertical">
         <Grid x:Name="_backdrop"
-              Grid.Row="1"
-              Grid.RowSpan="1"
-              Grid.Column="0"
-              Grid.ColumnSpan="3"
               MinWidth="300"
               MaxWidth="300"
               MaxHeight="300"
@@ -211,14 +196,10 @@
 
 
         </Grid>
-        <!-- <Border Height="1" Grid.Row="1" /> -->
+
         <Grid x:Name="_descriptionsBackdrop"
-              Grid.Row="0"
-              Grid.RowSpan="1"
-              Grid.Column="0"
-              Grid.ColumnSpan="3"
               MaxWidth="300"
-              Margin="0,6,0,0"
+              Margin="0,6,0,6"
               Padding="0,4,0,0"
               HorizontalAlignment="Stretch"
               VerticalAlignment="Stretch"
@@ -259,5 +240,5 @@
 
         </Grid>
 
-    </Grid>
+    </StackPanel>
 </UserControl>

--- a/src/cascadia/TerminalApp/SuggestionsControl.xaml
+++ b/src/cascadia/TerminalApp/SuggestionsControl.xaml
@@ -230,8 +230,6 @@
                               VerticalScrollBarVisibility="Visible"
                               VerticalScrollMode="Enabled"
                               Visibility="Visible">
-                    <!-- <TextBlock Text="Foo bar bax"
-                           TextWrapping="WrapWholeWords" />-->
                     <TextBlock x:Name="_descriptionComment"
                                IsTextSelectionEnabled="True"
                                TextWrapping="WrapWholeWords" />

--- a/src/cascadia/TerminalSettingsModel/Command.cpp
+++ b/src/cascadia/TerminalSettingsModel/Command.cpp
@@ -355,7 +355,10 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         {
             JsonUtils::SetValueForKey(cmdJson, IconKey, _iconPath);
             JsonUtils::SetValueForKey(cmdJson, NameKey, _name);
-            JsonUtils::SetValueForKey(cmdJson, DescriptionKey, _Description);
+            if (!_Description.empty())
+            {
+                JsonUtils::SetValueForKey(cmdJson, DescriptionKey, _Description);
+            }
             if (!_ID.empty())
             {
                 JsonUtils::SetValueForKey(cmdJson, IDKey, _ID);

--- a/src/cascadia/TerminalSettingsModel/Command.cpp
+++ b/src/cascadia/TerminalSettingsModel/Command.cpp
@@ -38,6 +38,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         command->_keyMappings = _keyMappings;
         command->_iconPath = _iconPath;
         command->_IterateOn = _IterateOn;
+        command->_Description = _Description;
 
         command->_originalJson = _originalJson;
         command->_nestedCommand = _nestedCommand;
@@ -285,6 +286,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         auto nested = false;
         JsonUtils::GetValueForKey(json, IterateOnKey, result->_IterateOn);
+        JsonUtils::GetValueForKey(json, DescriptionKey, result->_Description);
 
         // For iterable commands, we'll make another pass at parsing them once
         // the json is patched. So ignore parsing sub-commands for now. Commands
@@ -439,6 +441,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         {
             JsonUtils::SetValueForKey(cmdJson, IconKey, _iconPath);
             JsonUtils::SetValueForKey(cmdJson, NameKey, _name);
+            JsonUtils::SetValueForKey(cmdJson, DescriptionKey, _Description);
             if (!_ID.empty())
             {
                 JsonUtils::SetValueForKey(cmdJson, IDKey, _ID);
@@ -666,8 +669,10 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         const auto parseElement = [&](const auto& element) {
             winrt::hstring completionText;
             winrt::hstring listText;
+            winrt::hstring tooltipText;
             JsonUtils::GetValueForKey(element, "CompletionText", completionText);
             JsonUtils::GetValueForKey(element, "ListItemText", listText);
+            JsonUtils::GetValueForKey(element, "ToolTip", tooltipText);
 
             auto args = winrt::make_self<SendInputArgs>(
                 winrt::hstring{ fmt::format(FMT_COMPILE(L"{:\x7f^{}}{}"),
@@ -679,8 +684,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
             auto c = winrt::make_self<Command>();
             c->_name = listText;
+            c->_Description = tooltipText;
             c->_ActionAndArgs = actionAndArgs;
-
             // Try to assign a sensible icon based on the result type. These are
             // roughly chosen to align with the icons in
             // https://github.com/PowerShell/PowerShellEditorServices/pull/1738

--- a/src/cascadia/TerminalSettingsModel/Command.h
+++ b/src/cascadia/TerminalSettingsModel/Command.h
@@ -38,6 +38,7 @@ static constexpr std::string_view ActionKey{ "command" };
 static constexpr std::string_view IterateOnKey{ "iterateOn" };
 static constexpr std::string_view CommandsKey{ "commands" };
 static constexpr std::string_view KeysKey{ "keys" };
+static constexpr std::string_view DescriptionKey{ "description" };
 
 namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 {
@@ -90,6 +91,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         WINRT_PROPERTY(ExpandCommandType, IterateOn, ExpandCommandType::None);
         WINRT_PROPERTY(Model::ActionAndArgs, ActionAndArgs);
         WINRT_PROPERTY(OriginTag, Origin);
+        WINRT_PROPERTY(winrt::hstring, Description, L"");
 
     private:
         Json::Value _originalJson;

--- a/src/cascadia/TerminalSettingsModel/Command.idl
+++ b/src/cascadia/TerminalSettingsModel/Command.idl
@@ -37,6 +37,9 @@ namespace Microsoft.Terminal.Settings.Model
 
         String Name { get; };
         String ID { get; };
+
+        String Description { get; };
+
         ActionAndArgs ActionAndArgs { get; };
         Microsoft.Terminal.Control.KeyChord Keys { get; };
         void RegisterKey(Microsoft.Terminal.Control.KeyChord keys);

--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -29,12 +29,14 @@ try
 
     _pProvider = pProvider;
     _pData = pData;
+    _pData->LockConsole();
     _start = pData->GetViewport().Origin();
     _end = _start;
     _blockRange = false;
     _wordDelimiters = wordDelimiters;
 
     UiaTracing::TextRange::Constructor(*this);
+    _pData->UnlockConsole();
     return S_OK;
 }
 CATCH_RETURN();

--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -29,14 +29,12 @@ try
 
     _pProvider = pProvider;
     _pData = pData;
-    _pData->LockConsole();
     _start = pData->GetViewport().Origin();
     _end = _start;
     _blockRange = false;
     _wordDelimiters = wordDelimiters;
 
     UiaTracing::TextRange::Constructor(*this);
-    _pData->UnlockConsole();
     return S_OK;
 }
 CATCH_RETURN();


### PR DESCRIPTION
This adds a `"description"` property to actions. Notably, the shell completion protocol (#3121) will now also populate that. 

The suggestions UI can then use those descriptions to display an additional tooltip with that information. 

TeachingTip was kinda an abject disaster last time I tried this, so this _isn't_ a TeachingTip. It's literally a text block. 

xlinks:
* #13000
* #15845 
* #14939 - the last abandoned attempt at this