### PR TITLE
Re-implement previewing, with the new TSF

### DIFF
--- a/src/cascadia/TerminalApp/ActionPreviewHandlers.cpp
+++ b/src/cascadia/TerminalApp/ActionPreviewHandlers.cpp
@@ -50,6 +50,7 @@ namespace winrt::TerminalApp::implementation
         {
         case ShortcutAction::SetColorScheme:
         case ShortcutAction::AdjustOpacity:
+        case ShortcutAction::SendInput:
         {
             _RunRestorePreviews();
             break;
@@ -140,6 +141,24 @@ namespace winrt::TerminalApp::implementation
         });
     }
 
+    void TerminalPage::_PreviewSendInput(const Settings::Model::SendInputArgs& args)
+    {
+        const auto backup = _restorePreviewFuncs.empty();
+
+        _ApplyToActiveControls([&](const auto& control) {
+            const auto& str{ args.Input() };
+            control.PreviewInput(str);
+
+            if (backup)
+            {
+                _restorePreviewFuncs.emplace_back([=]() {
+                    // On dismiss:
+                    control.PreviewInput(L"");
+                });
+            }
+        });
+    }
+
     void TerminalPage::_PreviewAction(const Settings::Model::ActionAndArgs& args)
     {
         switch (args.Action())
@@ -149,6 +168,9 @@ namespace winrt::TerminalApp::implementation
             break;
         case ShortcutAction::AdjustOpacity:
             _PreviewAdjustOpacity(args.Args().try_as<AdjustOpacityArgs>());
+            break;
+        case ShortcutAction::SendInput:
+            _PreviewSendInput(args.Args().try_as<SendInputArgs>());
             break;
         }
 

--- a/src/cascadia/TerminalApp/ActionPreviewHandlers.cpp
+++ b/src/cascadia/TerminalApp/ActionPreviewHandlers.cpp
@@ -153,7 +153,7 @@ namespace winrt::TerminalApp::implementation
             {
                 _restorePreviewFuncs.emplace_back([=]() {
                     // On dismiss:
-                    control.PreviewInput(L"");
+                    control.PreviewInput(hstring{});
                 });
             }
         });

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -484,6 +484,7 @@ namespace winrt::TerminalApp::implementation
         void _RunRestorePreviews();
         void _PreviewColorScheme(const Microsoft::Terminal::Settings::Model::SetColorSchemeArgs& args);
         void _PreviewAdjustOpacity(const Microsoft::Terminal::Settings::Model::AdjustOpacityArgs& args);
+        void _PreviewSendInput(const Microsoft::Terminal::Settings::Model::SendInputArgs& args);
 
         winrt::Microsoft::Terminal::Settings::Model::ActionAndArgs _lastPreviewedAction{ nullptr };
         std::vector<std::function<void()>> _restorePreviewFuncs{};

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -2893,4 +2893,10 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         return _clickedOnMark(_contextMenuBufferPosition,
                               [](const ::MarkExtents& m) -> bool { return !m.HasOutput(); });
     }
+
+    void ControlCore::PreviewInput(std::wstring_view input)
+    {
+        _terminal->PreviewText(input);
+    }
+
 }

--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -257,6 +257,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         bool ShouldShowSelectCommand();
         bool ShouldShowSelectOutput();
 
+        void PreviewInput(std::wstring_view input);
+
         RUNTIME_SETTING(float, Opacity, _settings->Opacity());
         RUNTIME_SETTING(float, FocusedOpacity, FocusedAppearance().Opacity());
         RUNTIME_SETTING(bool, UseAcrylic, _settings->UseAcrylic());

--- a/src/cascadia/TerminalControl/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalControl/Resources/en-US/Resources.resw
@@ -316,4 +316,8 @@ Please either install the missing font or choose another one.</value>
     <value>invalid</value>
     <comment>This brief message is displayed when a regular expression is invalid.</comment>
   </data>
+  <data name="PreviewTextAnnouncement" xml:space="preserve">
+    <value>Suggested input: {0}</value>
+    <comment>{Locked="{0}"} {0} will be replaced with a string of input that is suggested for the user to input</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -732,7 +732,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::SendInput(const winrt::hstring& wstr)
     {
         // Dismiss any previewed input.
-        PreviewInput(L"");
+        PreviewInput(hstring{});
 
         // only broadcast if there's an actual listener. Saves the overhead of some object creation.
         if (StringSent)
@@ -3678,7 +3678,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                 automationPeer.RaiseNotificationEvent(
                     AutomationNotificationKind::ItemAdded,
                     AutomationNotificationProcessing::All,
-                    winrt::hstring{ fmt::format(std::wstring_view{ RS_(L"PreviewTextAnnouncement") }, text.c_str()) },
+                    winrt::hstring{ fmt::format(std::wstring_view{ RS_(L"PreviewTextAnnouncement") }, text) },
                     L"PreviewTextAnnouncement" /* unique name for this group of notifications */);
             }
         }

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -3670,6 +3670,18 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::PreviewInput(const winrt::hstring& text)
     {
         get_self<ControlCore>(_core)->PreviewInput(text);
+
+        if (!text.empty())
+        {
+            if (auto automationPeer{ FrameworkElementAutomationPeer::FromElement(*this) })
+            {
+                automationPeer.RaiseNotificationEvent(
+                    AutomationNotificationKind::ItemAdded,
+                    AutomationNotificationProcessing::All,
+                    winrt::hstring{ fmt::format(std::wstring_view{ RS_(L"PreviewTextAnnouncement") }, text.c_str()) },
+                    L"PreviewTextAnnouncement" /* unique name for this group of notifications */);
+            }
+        }
     }
 
     void TermControl::AddMark(const Control::ScrollMark& mark)

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -731,6 +731,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - <none>
     void TermControl::SendInput(const winrt::hstring& wstr)
     {
+        // Dismiss any previewed input.
+        PreviewInput(L"");
+
         // only broadcast if there's an actual listener. Saves the overhead of some object creation.
         if (StringSent)
         {
@@ -3659,6 +3662,11 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     uint64_t TermControl::OwningHwnd()
     {
         return _core.OwningHwnd();
+    }
+
+    void TermControl::PreviewInput(const winrt::hstring& text)
+    {
+        get_self<ControlCore>(_core)->PreviewInput(text);
     }
 
     void TermControl::AddMark(const Control::ScrollMark& mark)

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -73,6 +73,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         Windows::Foundation::Size CharacterDimensions() const;
         Windows::Foundation::Size MinimumSize();
         float SnapDimensionToGrid(const bool widthOrHeight, const float dimension);
+        void PreviewInput(const winrt::hstring& text);
 
         Windows::Foundation::Point CursorPositionInDips();
 

--- a/src/cascadia/TerminalControl/TermControl.idl
+++ b/src/cascadia/TerminalControl/TermControl.idl
@@ -127,6 +127,7 @@ namespace Microsoft.Terminal.Control
         CommandHistoryContext CommandHistory();
 
         void AdjustOpacity(Single Opacity, Boolean relative);
+        void PreviewInput(String text);
 
         // You'd think this should just be "Opacity", but UIElement already
         // defines an "Opacity", which we're actually not setting at all. We're

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -1598,7 +1598,7 @@ void Terminal::PreviewText(std::wstring_view input)
         return;
     }
 
-    // When we're previewing suggestions, they might be preceeded with DEL
+    // When we're previewing suggestions, they might be preceded with DEL
     // characters to backspace off the old command.
     //
     // But also, in the case of something like pwsh, there might be MORE "ghost"

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -1607,20 +1607,19 @@ void Terminal::PreviewText(std::wstring_view input)
     //
     // We need to trim off the leading DELs, then pad out the rest of the line
     // to cover any other ghost text.
-    std::wstring_view view{ input };
     // Where do the DELs end?
-    const auto strBegin = view.find_first_not_of(L"\x7f");
+    const auto strBegin = input.find_first_not_of(L"\x7f");
     if (strBegin != std::wstring::npos)
     {
         // Trim them off.
-        view = view.substr(strBegin);
+        input = input.substr(strBegin);
     }
     // How many spaces do we need, so that the preview exactly covers the entire
     // prompt, all the way to the end of the viewport?
     const auto bufferWidth = _GetMutableViewport().Width();
     const auto cursorX = _activeBuffer().GetCursor().GetPosition().x;
-    const auto expectedLenTillEnd = strBegin + (bufferWidth - cursorX);
-    std::wstring preview{ view };
+    const auto expectedLenTillEnd = strBegin + (static_cast<size_t>(bufferWidth) - static_cast<size_t>(cursorX));
+    std::wstring preview{ input };
     const auto originalSize{ preview.size() };
     if (expectedLenTillEnd > originalSize)
     {

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -1593,6 +1593,7 @@ void Terminal::PreviewText(std::wstring_view input)
     if (input.empty())
     {
         snippetPreview.text = L"";
+        snippetPreview.cursorPos = 0;
         snippetPreview.attributes.clear();
         _activeBuffer().NotifyPaintFrame();
         return;

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -246,6 +246,7 @@ public:
     const size_t GetTaskbarProgress() const noexcept;
 
     void ColorSelection(const TextAttribute& attr, winrt::Microsoft::Terminal::Core::MatchMode matchMode);
+    void PreviewText(std::wstring_view input);
 
 #pragma region TextSelection
     // These methods are defined in TerminalSelection.cpp

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -722,6 +722,7 @@ void Renderer::_PaintBufferOutput(_In_ IRenderEngine* const pEngine)
     // relative to the entire buffer.
     const auto view = _pData->GetViewport();
     const auto compositionRow = _compositionCache ? _compositionCache->absoluteOrigin.y : -1;
+    const auto& activeComposition = _pData->GetActiveComposition();
 
     // This is effectively the number of cells on the visible screen that need to be redrawn.
     // The origin is always 0, 0 because it represents the screen itself, not the underlying buffer.
@@ -753,7 +754,6 @@ void Renderer::_PaintBufferOutput(_In_ IRenderEngine* const pEngine)
 
         // Retrieve the text buffer so we can read information out of it.
         auto& buffer = _pData->GetTextBuffer();
-
         // Now walk through each row of text that we need to redraw.
         for (auto row = redraw.Top(); row < redraw.BottomExclusive(); row++)
         {
@@ -772,14 +772,14 @@ void Renderer::_PaintBufferOutput(_In_ IRenderEngine* const pEngine)
                 scratch.CopyFrom(r);
                 rowBackup = &scratch;
 
-                std::wstring_view text{ _pData->GetActiveComposition().text };
+                std::wstring_view text{ activeComposition.text };
                 RowWriteState state{
                     .columnLimit = r.GetReadableColumnCount(),
                     .columnEnd = _compositionCache->absoluteOrigin.x,
                 };
 
                 size_t off = 0;
-                for (const auto& range : _pData->GetActiveComposition().attributes)
+                for (const auto& range : activeComposition.attributes)
                 {
                     const auto len = range.len;
                     auto attr = range.attr;
@@ -1245,17 +1245,18 @@ void Renderer::_prepareNewComposition()
 
         auto& buffer = _pData->GetTextBuffer();
         auto& scratch = buffer.GetScratchpadRow();
+        const auto& activeComposition = _pData->GetActiveComposition();
 
-        std::wstring_view text{ _pData->GetActiveComposition().text };
+        std::wstring_view text{ activeComposition.text };
         RowWriteState state{
             .columnLimit = buffer.GetRowByOffset(line.top).GetReadableColumnCount(),
         };
 
-        state.text = text.substr(0, _pData->GetActiveComposition().cursorPos);
+        state.text = text.substr(0, activeComposition.cursorPos);
         scratch.ReplaceText(state);
         const auto cursorOffset = state.columnEnd;
 
-        state.text = text.substr(_pData->GetActiveComposition().cursorPos);
+        state.text = text.substr(activeComposition.cursorPos);
         state.columnBegin = state.columnEnd;
         scratch.ReplaceText(state);
 

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -772,14 +772,14 @@ void Renderer::_PaintBufferOutput(_In_ IRenderEngine* const pEngine)
                 scratch.CopyFrom(r);
                 rowBackup = &scratch;
 
-                std::wstring_view text{ _pData->activeComposition.text };
+                std::wstring_view text{ _pData->GetActiveComposition().text };
                 RowWriteState state{
                     .columnLimit = r.GetReadableColumnCount(),
                     .columnEnd = _compositionCache->absoluteOrigin.x,
                 };
 
                 size_t off = 0;
-                for (const auto& range : _pData->activeComposition.attributes)
+                for (const auto& range : _pData->GetActiveComposition().attributes)
                 {
                     const auto len = range.len;
                     auto attr = range.attr;
@@ -1225,7 +1225,7 @@ void Renderer::_invalidateOldComposition() const
 // so that _PaintBufferOutput() actually gets a chance to draw it.
 void Renderer::_prepareNewComposition()
 {
-    if (_pData->activeComposition.text.empty())
+    if (_pData->GetActiveComposition().text.empty())
     {
         return;
     }
@@ -1246,16 +1246,16 @@ void Renderer::_prepareNewComposition()
         auto& buffer = _pData->GetTextBuffer();
         auto& scratch = buffer.GetScratchpadRow();
 
-        std::wstring_view text{ _pData->activeComposition.text };
+        std::wstring_view text{ _pData->GetActiveComposition().text };
         RowWriteState state{
             .columnLimit = buffer.GetRowByOffset(line.top).GetReadableColumnCount(),
         };
 
-        state.text = text.substr(0, _pData->activeComposition.cursorPos);
+        state.text = text.substr(0, _pData->GetActiveComposition().cursorPos);
         scratch.ReplaceText(state);
         const auto cursorOffset = state.columnEnd;
 
-        state.text = text.substr(_pData->activeComposition.cursorPos);
+        state.text = text.substr(_pData->GetActiveComposition().cursorPos);
         state.columnBegin = state.columnEnd;
         scratch.ReplaceText(state);
 

--- a/src/renderer/inc/IRenderData.hpp
+++ b/src/renderer/inc/IRenderData.hpp
@@ -79,7 +79,7 @@ namespace Microsoft::Console::Render
         // Ideally this would not be stored on an interface, however ideally IRenderData should not be an interface in the first place.
         // This is because we should have only 1 way how to represent render data across the codebase anyway, and it should
         // be by-value in a struct so that we can snapshot it and release the terminal lock as quickly as possible.
-        const Composition& GetActiveComposition()
+        const Composition& GetActiveComposition() const noexcept
         {
             return !snippetPreview.text.empty() ? snippetPreview : tsfPreview;
         }

--- a/src/renderer/inc/IRenderData.hpp
+++ b/src/renderer/inc/IRenderData.hpp
@@ -79,6 +79,12 @@ namespace Microsoft::Console::Render
         // Ideally this would not be stored on an interface, however ideally IRenderData should not be an interface in the first place.
         // This is because we should have only 1 way how to represent render data across the codebase anyway, and it should
         // be by-value in a struct so that we can snapshot it and release the terminal lock as quickly as possible.
-        Composition activeComposition;
+        const Composition& GetActiveComposition()
+        {
+            return !snippetPreview.text.empty() ? snippetPreview : tsfPreview;
+        }
+
+        Composition tsfPreview;
+        Composition snippetPreview;
     };
 }

--- a/src/tsf/Implementation.cpp
+++ b/src/tsf/Implementation.cpp
@@ -144,9 +144,9 @@ void Implementation::Unfocus(IDataProvider* provider)
             renderData->UnlockConsole();
         });
 
-        if (!renderData->activeComposition.text.empty())
+        if (!renderData->tsfPreview.text.empty())
         {
-            auto& comp = renderData->activeComposition;
+            auto& comp = renderData->tsfPreview;
             comp.text.clear();
             comp.attributes.clear();
             renderer->NotifyPaintFrame();
@@ -570,7 +570,7 @@ void Implementation::_doCompositionUpdate(TfEditCookie ec)
                 renderData->UnlockConsole();
             });
 
-            auto& comp = renderData->activeComposition;
+            auto& comp = renderData->tsfPreview;
             comp.text = std::move(activeComposition);
             comp.attributes = std::move(activeCompositionRanges);
             // The code block above that calculates the `cursorPos` will clamp it to a positive number.


### PR DESCRIPTION
This adds support for previewing snippets, again. This time, with the new TSF implementation. Leonard pointed me in the right direction with this - he's the one who suggested to have a second `Composition` just for previews like this. 

Then we do some tricky magic to make it work when we're using commandlines from shell integration, or you've got the ghost text from powershell, etc. Then we visualize the control codes, just so they aren't just U+FFFE diamonds. 

Closes #12861
