### PR TITLE
build: add a caching copy of the CI pipeline

### DIFF
--- a/build/pipelines/ci-caching.yml
+++ b/build/pipelines/ci-caching.yml
@@ -64,12 +64,6 @@ stages:
             buildEverything: true
             keepAllExpensiveBuildOutputs: false
 
-  - stage: CodeHealth
-    displayName: Code Health
-    dependsOn: []
-    jobs:
-      - template: ./templates-v2/job-check-code-format.yml
-
   - ${{ each platform in parameters.buildPlatforms }}:
     - stage: Build_${{ platform }}
       displayName: Build ${{ platform }}
@@ -100,10 +94,3 @@ stages:
               platform: ${{ platform }}
               # The tests might be run more than once; log one artifact per attempt.
               outputArtifactStem: -$(System.JobAttempt)
-
-  - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-    - stage: CodeIndexer
-      displayName: GitHub CodeNav Indexer
-      dependsOn: []
-      jobs:
-        - template: ./templates-v2/job-index-github-codenav.yml

--- a/build/pipelines/ci-caching.yml
+++ b/build/pipelines/ci-caching.yml
@@ -1,0 +1,109 @@
+trigger:
+  batch: true
+#  branches:
+#    include:
+#      - main
+#      - feature/*
+#      - gh-readonly-queue/*
+#  paths:
+#    exclude:
+#      - doc/*
+#      - samples/*
+#      - tools/*
+
+#pr:
+#  branches:
+#    include:
+#      - main
+#      - feature/*
+#  paths:
+#    exclude:
+#      - doc/*
+#      - samples/*
+#      - tools/*
+
+variables:
+  - name: runCodesignValidationInjectionBG
+    value: false
+
+#     0.0.yyMM.dd##
+#     0.0.1904.0900
+name: 0.0.$(Date:yyMM).$(Date:dd)$(Rev:rr)
+
+parameters:
+  - name: auditMode
+    displayName: "Build in Audit Mode (x64)"
+    type: boolean
+    default: true
+  - name: runTests
+    displayName: "Run Tests"
+    type: boolean
+    default: true
+  - name: buildPlatforms
+    type: object
+    default:
+      - x64
+      - x86
+      - arm64
+
+stages:
+  - ${{ if eq(parameters.auditMode, true) }}:
+    - stage: Audit_x64
+      displayName: Audit Mode
+      dependsOn: []
+      jobs:
+        - template: ./templates-v2/job-build-project.yml
+          parameters:
+            pool:
+              ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+                name: SHINE-OSS-L
+              ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+                name: SHINE-INT-L
+            buildPlatforms: [x64]
+            buildConfigurations: [AuditMode]
+            buildEverything: true
+            keepAllExpensiveBuildOutputs: false
+
+  - stage: CodeHealth
+    displayName: Code Health
+    dependsOn: []
+    jobs:
+      - template: ./templates-v2/job-check-code-format.yml
+
+  - ${{ each platform in parameters.buildPlatforms }}:
+    - stage: Build_${{ platform }}
+      displayName: Build ${{ platform }}
+      dependsOn: []
+      jobs:
+        - template: ./templates-v2/job-build-project.yml
+          parameters:
+            pool:
+              ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+                name: SHINE-OSS-L
+              ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+                name: SHINE-INT-L
+            buildPlatforms:
+              - ${{ platform }}
+            buildConfigurations: [Release]
+            buildEverything: true
+            keepAllExpensiveBuildOutputs: false
+
+    - ${{ if eq(parameters.runTests, true) }}:
+      - stage: Test_${{ platform }}
+        displayName: Test ${{ platform }}
+        dependsOn:
+          - Build_${{ platform }}
+        condition: succeeded()
+        jobs:
+          - template: ./templates-v2/job-test-project.yml
+            parameters:
+              platform: ${{ platform }}
+              # The tests might be run more than once; log one artifact per attempt.
+              outputArtifactStem: -$(System.JobAttempt)
+
+  - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+    - stage: CodeIndexer
+      displayName: GitHub CodeNav Indexer
+      dependsOn: []
+      jobs:
+        - template: ./templates-v2/job-index-github-codenav.yml


### PR DESCRIPTION
This is a place for @dfederm to work, but I couldn't create the pipeline definition without first creating the yml file _in main_. Thanks SFI.