### PR TITLE
Add support for disabling nesting in the sinppets menu

### DIFF
--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -1360,7 +1360,7 @@ namespace winrt::TerminalApp::implementation
                 // their settings file. Ask the ActionMap for those.
                 if (WI_IsFlagSet(source, SuggestionsSource::Tasks))
                 {
-                    const auto tasks = _settings.GlobalSettings().ActionMap().FilterToSendInput(currentCommandline);
+                    const auto tasks = _settings.GlobalSettings().ActionMap().FilterToSendInput(currentCommandline, realArgs.Nesting());
                     for (const auto& t : tasks)
                     {
                         commandsCollection.push_back(t);

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -216,8 +216,9 @@ protected:                                                                  \
     X(CommandPaletteLaunchMode, LaunchMode, "launchMode", false, CommandPaletteLaunchMode::Action)
 
 ////////////////////////////////////////////////////////////////////////////////
-#define SUGGESTIONS_ARGS(X)                                                 \
-    X(SuggestionsSource, Source, "source", false, SuggestionsSource::Tasks) \
+#define SUGGESTIONS_ARGS(X)                                                       \
+    X(SuggestionsSource, Source, "source", false, SuggestionsSource::Tasks)       \
+    X(SuggestionsNesting, Nesting, "nesting", false, SuggestionsNesting::Enabled) \
     X(bool, UseCommandline, "useCommandline", false, false)
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -122,6 +122,12 @@ namespace Microsoft.Terminal.Settings.Model
         All = 0xffffffff,
     };
 
+    enum SuggestionsNesting
+    {
+        Disabled,
+        Enabled,
+    };
+
     interface INewContentArgs {
         String Type { get; };
         Boolean Equals(INewContentArgs other);
@@ -343,8 +349,9 @@ namespace Microsoft.Terminal.Settings.Model
     [default_interface] runtimeclass SuggestionsArgs : IActionArgs
     {
         SuggestionsArgs();
-        SuggestionsArgs(SuggestionsSource source, Boolean useCommandline);
+        SuggestionsArgs(SuggestionsSource source, SuggestionsNesting nesting, Boolean useCommandline);
         SuggestionsSource Source { get; };
+        SuggestionsNesting Nesting { get; };
         Boolean UseCommandline { get; };
     };
 

--- a/src/cascadia/TerminalSettingsModel/ActionMap.h
+++ b/src/cascadia/TerminalSettingsModel/ActionMap.h
@@ -83,7 +83,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         void ExpandCommands(const Windows::Foundation::Collections::IVectorView<Model::Profile>& profiles,
                             const Windows::Foundation::Collections::IMapView<winrt::hstring, Model::ColorScheme>& schemes);
 
-        winrt::Windows::Foundation::Collections::IVector<Model::Command> FilterToSendInput(winrt::hstring currentCommandline);
+        winrt::Windows::Foundation::Collections::IVector<Model::Command> FilterToSendInput(winrt::hstring currentCommandline, Model::SuggestionsNesting nesting);
 
     private:
         Model::Command _GetActionByID(const winrt::hstring& actionID) const;

--- a/src/cascadia/TerminalSettingsModel/ActionMap.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionMap.idl
@@ -22,7 +22,7 @@ namespace Microsoft.Terminal.Settings.Model
 
         IVector<Command> ExpandedCommands { get; };
 
-        IVector<Command> FilterToSendInput(String CurrentCommandline);
+        IVector<Command> FilterToSendInput(String CurrentCommandline, SuggestionsNesting nesting);
     };
 
     [default_interface] runtimeclass ActionMap : IActionMapView

--- a/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
@@ -510,6 +510,14 @@ JSON_FLAG_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::SuggestionsSourc
     };
 };
 
+JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::SuggestionsNesting)
+{
+    JSON_MAPPINGS(2) = {
+        pair_type{ "enabled", ValueType::Enabled },
+        pair_type{ "disabled", ValueType::Disabled },
+    };
+};
+
 JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::WindowingMode)
 {
     JSON_MAPPINGS(3) = {


### PR DESCRIPTION
Adds a `nesting` param to `showSuggestions`. The default remains `"enabled"`. We now also accept `"disabled"`, which will plop all the snippets into a single top-level list. This will make it easier for users to open suggestions based on what they've already typed at the commandline. e.g. type `gitco` at the commandline, and have that pre-filtered to the `git commit -m ""\u001b[D` snippet.

As spec'd in [Suggestions-UI.md](https://github.com/microsoft/terminal/blob/main/doc/specs/%231595%20-%20Suggestions%20UI/Suggestions-UI.md)


----

It's dangerous to go alone, take this:

```jsonc    
    "actions": 
    [
        {
            "command": 
            {
                "action": "showSuggestions",
                "nesting": "disabled",
                "source": "all",
                "useCommandline": true
            },
            "id": "User.showSuggestions.noNesting"
        },
    ],
    "keybindings": 
    [
        {
            "id": "User.showSuggestions.noNesting",
            "keys": "ctrl+shift+space"
        },
```