### PR TITLE
build: make the agent pool selection more robust

### DIFF
--- a/build/pipelines/ci-caching.yml
+++ b/build/pipelines/ci-caching.yml
@@ -55,10 +55,10 @@ stages:
         - template: ./templates-v2/job-build-project.yml
           parameters:
             pool:
-              ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-                name: SHINE-OSS-L
-              ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+              ${{ if eq(variables['System.CollectionId'], 'cb55739e-4afe-46a3-970f-1b49d8ee7564') }}:
                 name: SHINE-INT-L
+              ${{ else }}:
+                name: SHINE-OSS-L
             buildPlatforms: [x64]
             buildConfigurations: [AuditMode]
             buildEverything: true
@@ -72,10 +72,10 @@ stages:
         - template: ./templates-v2/job-build-project.yml
           parameters:
             pool:
-              ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-                name: SHINE-OSS-L
-              ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+              ${{ if eq(variables['System.CollectionId'], 'cb55739e-4afe-46a3-970f-1b49d8ee7564') }}:
                 name: SHINE-INT-L
+              ${{ else }}:
+                name: SHINE-OSS-L
             buildPlatforms:
               - ${{ platform }}
             buildConfigurations: [Release]

--- a/build/pipelines/ci.yml
+++ b/build/pipelines/ci.yml
@@ -55,10 +55,10 @@ stages:
         - template: ./templates-v2/job-build-project.yml
           parameters:
             pool:
-              ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-                name: SHINE-OSS-L
-              ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+              ${{ if eq(variables['System.CollectionId'], 'cb55739e-4afe-46a3-970f-1b49d8ee7564') }}:
                 name: SHINE-INT-L
+              ${{ else }}:
+                name: SHINE-OSS-L
             buildPlatforms: [x64]
             buildConfigurations: [AuditMode]
             buildEverything: true
@@ -78,10 +78,10 @@ stages:
         - template: ./templates-v2/job-build-project.yml
           parameters:
             pool:
-              ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-                name: SHINE-OSS-L
-              ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+              ${{ if eq(variables['System.CollectionId'], 'cb55739e-4afe-46a3-970f-1b49d8ee7564') }}:
                 name: SHINE-INT-L
+              ${{ else }}:
+                name: SHINE-OSS-L
             buildPlatforms:
               - ${{ platform }}
             buildConfigurations: [Release]

--- a/build/pipelines/fuzz.yml
+++ b/build/pipelines/fuzz.yml
@@ -24,10 +24,10 @@ stages:
       - template: ./templates-v2/job-build-project.yml
         parameters:
           pool:
-            ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-              name: SHINE-OSS-L
-            ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+            ${{ if eq(variables['System.CollectionId'], 'cb55739e-4afe-46a3-970f-1b49d8ee7564') }}:
               name: SHINE-INT-L
+            ${{ else }}:
+              name: SHINE-OSS-L
           buildPlatforms: [x64]
           buildConfigurations: [Fuzzing]
           buildEverything: true

--- a/build/pipelines/pgo.yml
+++ b/build/pipelines/pgo.yml
@@ -40,10 +40,10 @@ stages:
       - template: ./templates-v2/job-build-project.yml
         parameters:
           pool:
-            ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-              name: SHINE-OSS-L
-            ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+            ${{ if eq(variables['System.CollectionId'], 'cb55739e-4afe-46a3-970f-1b49d8ee7564') }}:
               name: SHINE-INT-L
+            ${{ else }}:
+              name: SHINE-OSS-L
           branding: ${{ parameters.branding }}
           buildPlatforms: ${{ parameters.buildPlatforms }}
           buildConfigurations: [Release]

--- a/build/pipelines/templates-v2/job-run-pgo-tests.yml
+++ b/build/pipelines/templates-v2/job-run-pgo-tests.yml
@@ -13,16 +13,16 @@ jobs:
     OutputBuildPlatform: ${{ parameters.buildPlatform }}
     Terminal.BinDir: $(Build.SourcesDirectory)/bin/$(OutputBuildPlatform)/$(BuildConfiguration)
   pool:
-    ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-      ${{ if ne(parameters.buildPlatform, 'ARM64') }}:
-        name: SHINE-OSS-Testing-x64
-      ${{ else }}:
-        name: SHINE-OSS-Testing-arm64
-    ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+    ${{ if eq(variables['System.CollectionId'], 'cb55739e-4afe-46a3-970f-1b49d8ee7564') }}:
       ${{ if ne(parameters.buildPlatform, 'ARM64') }}:
         name: SHINE-INT-Testing-x64
       ${{ else }}:
         name: SHINE-INT-Testing-arm64
+    ${{ else }}:
+      ${{ if ne(parameters.buildPlatform, 'ARM64') }}:
+        name: SHINE-OSS-Testing-x64
+      ${{ else }}:
+        name: SHINE-OSS-Testing-arm64
 
   steps:
   - checkout: self

--- a/build/pipelines/templates-v2/job-test-project.yml
+++ b/build/pipelines/templates-v2/job-test-project.yml
@@ -17,16 +17,16 @@ jobs:
       OutputBuildPlatform: ${{ parameters.platform }}
     Terminal.BinDir: $(Build.SourcesDirectory)/bin/$(OutputBuildPlatform)/$(BuildConfiguration)
   pool:
-    ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-      ${{ if ne(parameters.platform, 'ARM64') }}:
-        name: SHINE-OSS-Testing-x64
-      ${{ else }}:
-        name: SHINE-OSS-Testing-arm64
-    ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+    ${{ if eq(variables['System.CollectionId'], 'cb55739e-4afe-46a3-970f-1b49d8ee7564') }}:
       ${{ if ne(parameters.platform, 'ARM64') }}:
         name: SHINE-INT-Testing-x64
       ${{ else }}:
         name: SHINE-INT-Testing-arm64
+    ${{ else }}:
+      ${{ if ne(parameters.platform, 'ARM64') }}:
+        name: SHINE-OSS-Testing-x64
+      ${{ else }}:
+        name: SHINE-OSS-Testing-arm64
 
   steps:
   - checkout: self


### PR DESCRIPTION
We are no longer exclusively using one organization named "ms" and one organization not named "ms".

This change flips the sense of the organization comparison so the `OSS` agents can be used for every collection _except_ very specifically the Microsoft one. I also switched to using its ID.