### PR TITLE
Use the full buffer width for the VT viewport

### DIFF
--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -2461,8 +2461,10 @@ void SCREEN_INFORMATION::UpdateBottom()
 // - the virtual terminal viewport
 Viewport SCREEN_INFORMATION::GetVirtualViewport() const noexcept
 {
-    const auto newTop = _virtualBottom - _viewport.Height() + 1;
-    return Viewport::FromDimensions({ _viewport.Left(), newTop }, _viewport.Dimensions());
+    const auto viewportHeight = _viewport.Height();
+    const auto bufferWidth = _textBuffer->GetSize().Width();
+    const auto top = std::max(0, _virtualBottom - viewportHeight + 1);
+    return Viewport::FromExclusive({ 0, top, bufferWidth, top + viewportHeight });
 }
 
 // Method Description:


### PR DESCRIPTION
That's a weird one I found while working on #17445...
The `_viewport` in conhost is basically the section of the buffer that
gets render on the screen. The `_viewport.Left()` is effectively the
horizontal scrolling position. I don't think we should use that for
the VT viewport. This PR changes it so that the VT viewport always
spans the full width of the buffer. This makes it possible to address
the full width of the buffer with CUP sequences.

Part of #14000