### PR TITLE
Fix crash when closing panes very quickly

### DIFF
--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -985,8 +985,13 @@ void Pane::_ContentLostFocusHandler(const winrt::Windows::Foundation::IInspectab
 // - <none>
 void Pane::Close()
 {
-    _setPaneContent(nullptr);
+    if (!_content)
+    {
+        return;
+    }
+
     // Fire our Closed event to tell our parent that we should be removed.
+    _setPaneContent(nullptr);
     Closed.raise(nullptr, nullptr);
 }
 
@@ -1430,7 +1435,7 @@ void Pane::_CloseChild(const bool closeFirst)
 
         // Reattach the TermControl to our grid.
         _root.Children().Append(_borderFirst);
-        const auto& control{ _content.GetRoot() };
+        const auto control = _content ? _content.GetRoot() : nullptr;
         _borderFirst.Child(control);
 
         // Make sure to set our _splitState before focusing the control. If you
@@ -1450,7 +1455,10 @@ void Pane::_CloseChild(const bool closeFirst)
         // focus our control now. This should trigger our own GotFocus event.
         if (usedToFocusClosedChildsTerminal || _lastActive)
         {
-            _content.Focus(FocusState::Programmatic);
+            if (_content)
+            {
+                _content.Focus(FocusState::Programmatic);
+            }
 
             // See GH#7252
             // Manually fire off the GotFocus event. Typically, this is done
@@ -1711,7 +1719,7 @@ void Pane::_SetupChildCloseHandlers()
 IPaneContent Pane::_takePaneContent()
 {
     _closeRequestedRevoker.revoke();
-    return std::move(_content);
+    return _content ? std::move(_content) : nullptr;
 }
 
 // This method safely sets the content of the Pane. It'll ensure to revoke and
@@ -2943,6 +2951,10 @@ void Pane::FinalizeConfigurationGivenDefault()
 // - Returns true if the pane or one of its descendants is read-only
 bool Pane::ContainsReadOnly() const
 {
+    if (!_content)
+    {
+        return false;
+    }
     return _IsLeaf() ? _content.ReadOnly() : (_firstChild->ContainsReadOnly() || _secondChild->ContainsReadOnly());
 }
 
@@ -2956,6 +2968,10 @@ bool Pane::ContainsReadOnly() const
 // - <none>
 void Pane::CollectTaskbarStates(std::vector<winrt::TerminalApp::TaskbarState>& states)
 {
+    if (!_content)
+    {
+        return;
+    }
     if (_IsLeaf())
     {
         auto tbState{ winrt::make<winrt::TerminalApp::implementation::TaskbarState>(_content.TaskbarState(),


### PR DESCRIPTION
#17358 introduced a bug where if you open/close panes very rapidly Terminal will crash. This was because `_content` was being set to `null` and then a `Close` event was being emitted, but several functions attempt to access the pane's `_content` as part of the close routine. For example, `TerminalTab` tries to update the `TaskbarProgress` every time a pane is closed and as part of that update sequence it queries the pane - which has `null` content now - for the taskbar progress, resulting in a crash. This PR fixes that crash.

Refs #17358 