### PR TITLE
Update the version of nuget in CI

### DIFF
--- a/build/pipelines/templates-v2/steps-ensure-nuget-version.yml
+++ b/build/pipelines/templates-v2/steps-ensure-nuget-version.yml
@@ -1,5 +1,5 @@
 steps:
 - task: NuGetToolInstaller@1
-  displayName: Use NuGet 6.6.1
+  displayName: Use NuGet 6.10.1
   inputs:
-    versionSpec: 6.6.1
+    versionSpec: 6.10.1

--- a/build/pipelines/templates-v2/steps-ensure-nuget-version.yml
+++ b/build/pipelines/templates-v2/steps-ensure-nuget-version.yml
@@ -1,5 +1,5 @@
 steps:
 - task: NuGetToolInstaller@1
-  displayName: Use NuGet 6.10.1
+  displayName: Use NuGet 6.6.2
   inputs:
-    versionSpec: 6.10.1
+    versionSpec: 6.6.2


### PR DESCRIPTION
From 6.6.1 to ~6.10.1~ **6.6.2**. Error message in [this build](https://dev.azure.com/ms/terminal/_build/results?buildId=589101&view=logs&jobId=36a6dfee-ce90-551f-03ae-d3d23ce5d56b&j=3c1e980d-f764-593c-e9f8-7ee26362779d&t=eaa78dea-0bc2-55c8-d6a2-aed4f1df31f3) in #17476 seems to suggest that this version of nuget isn't available in the agents anymore.
