### PR TITLE
Add action for Quick Fix and key binding for Suggestions

### DIFF
--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -1461,7 +1461,19 @@ namespace winrt::TerminalApp::implementation
                 }
 
                 // Aggregate all the commands from the different sources that
-                // the user selected.
+                // the user selected. This is the order presented to the user
+
+                if (WI_IsFlagSet(source, SuggestionsSource::QuickFixes) &&
+                    context != nullptr &&
+                    context.QuickFixes() != nullptr)
+                {
+                    // \ue74c --> OEM icon
+                    const auto recentCommands = Command::HistoryToCommands(context.QuickFixes(), hstring{ L"" }, false, hstring{ L"\ue74c" });
+                    for (const auto& t : recentCommands)
+                    {
+                        commandsCollection.push_back(t);
+                    }
+                }
 
                 // Tasks are all the sendInput commands the user has saved in
                 // their settings file. Ask the ActionMap for those.
@@ -1482,18 +1494,6 @@ namespace winrt::TerminalApp::implementation
                 {
                     // \ue81c --> History icon
                     const auto recentCommands = Command::HistoryToCommands(context.History(), currentCommandline, false, hstring{ L"\ue81c" });
-                    for (const auto& t : recentCommands)
-                    {
-                        commandsCollection.push_back(t);
-                    }
-                }
-
-                if (WI_IsFlagSet(source, SuggestionsSource::QuickFixes) &&
-                    context != nullptr &&
-                    context.QuickFixes() != nullptr)
-                {
-                    // \ue74c --> OEM icon
-                    const auto recentCommands = Command::HistoryToCommands(context.QuickFixes(), hstring{ L"" }, false, hstring{ L"\ue74c" });
                     for (const auto& t : recentCommands)
                     {
                         commandsCollection.push_back(t);

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -1599,8 +1599,8 @@ namespace winrt::TerminalApp::implementation
     {
         if (const auto& control{ _GetActiveControl() })
         {
-            control.OpenQuickFixMenu();
+            const auto handled = control.OpenQuickFixMenu();
+            args.Handled(handled);
         }
-        args.Handled(true);
     }
 }

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -1593,4 +1593,14 @@ namespace winrt::TerminalApp::implementation
         _ShowAboutDialog();
         args.Handled(true);
     }
+
+    void TerminalPage::_HandleQuickFix(const IInspectable& /*sender*/,
+                                       const ActionEventArgs& args)
+    {
+        if (const auto& control{ _GetActiveControl() })
+        {
+            control.OpenQuickFixMenu();
+        }
+        args.Handled(true);
+    }
 }

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -3892,6 +3892,14 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         return std::max(CharacterDimensions().Width * 2.0 / 3.0, GetPadding().Left);
     }
 
+    void TermControl::OpenQuickFixMenu()
+    {
+        if (Feature_QuickFix::IsEnabled() && _core.QuickFixesAvailable())
+        {
+            QuickFixButton().Flyout().ShowAt(QuickFixButton());
+        }
+    }
+
     void TermControl::RefreshQuickFixMenu()
     {
         if (!Feature_QuickFix::IsEnabled())

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -3906,16 +3906,19 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     bool TermControl::OpenQuickFixMenu()
     {
-        if (Feature_QuickFix::IsEnabled() && _core.QuickFixesAvailable())
+        if constexpr (Feature_QuickFix::IsEnabled())
         {
-            // Expand the quick fix button if it's collapsed (looks nicer)
-            if (_quickFixButtonCollapsible)
+            if (_core.QuickFixesAvailable())
             {
-                VisualStateManager::GoToState(*this, StateNormal, false);
+                // Expand the quick fix button if it's collapsed (looks nicer)
+                if (_quickFixButtonCollapsible)
+                {
+                    VisualStateManager::GoToState(*this, StateNormal, false);
+                }
+                auto quickFixBtn = QuickFixButton();
+                quickFixBtn.Flyout().ShowAt(quickFixBtn);
+                return true;
             }
-            auto quickFixBtn = QuickFixButton();
-            quickFixBtn.Flyout().ShowAt(quickFixBtn);
-            return true;
         }
         return false;
     }

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -3907,7 +3907,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                     }
                 });
             }
-            QuickFixButton().Flyout().ShowAt(QuickFixButton());
+            auto quickFixBtn = QuickFixButton();
+            quickFixBtn.Flyout().ShowAt(quickFixBtn);
         }
     }
 

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -3940,7 +3940,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         const auto viewportBufferPosition = rd->GetViewport();
         const auto cursorBufferPosition = rd->GetCursorPosition();
         rd->UnlockConsole();
-        if (cursorBufferPosition.y < viewportBufferPosition.Top() || cursorBufferPosition.y > viewportBufferPosition.BottomExclusive())
+        if (cursorBufferPosition.y < viewportBufferPosition.Top() || cursorBufferPosition.y > viewportBufferPosition.BottomInclusive())
         {
             quickFixBtn.Visibility(Visibility::Collapsed);
             return;

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -3896,6 +3896,17 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     {
         if (Feature_QuickFix::IsEnabled() && _core.QuickFixesAvailable())
         {
+            // Expand the quick fix button if it's collapsed (looks nicer)
+            if (_quickFixButtonCollapsible)
+            {
+                VisualStateManager::GoToState(*this, StateNormal, false);
+                QuickFixButton().Flyout().Closing([weakThis = get_weak()](auto& /*sender*/, auto& /*args*/) {
+                    if (auto termCtrl = weakThis.get())
+                    {
+                        VisualStateManager::GoToState(*termCtrl, StateCollapsed, false);
+                    }
+                });
+            }
             QuickFixButton().Flyout().ShowAt(QuickFixButton());
         }
     }

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -182,6 +182,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void RawWriteString(const winrt::hstring& text);
 
         void ShowContextMenu();
+        void OpenQuickFixMenu();
         void RefreshQuickFixMenu();
         void ClearQuickFix();
 

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -182,7 +182,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void RawWriteString(const winrt::hstring& text);
 
         void ShowContextMenu();
-        void OpenQuickFixMenu();
+        bool OpenQuickFixMenu();
         void RefreshQuickFixMenu();
         void ClearQuickFix();
 

--- a/src/cascadia/TerminalControl/TermControl.idl
+++ b/src/cascadia/TerminalControl/TermControl.idl
@@ -149,6 +149,7 @@ namespace Microsoft.Terminal.Control
         Double QuickFixButtonCollapsedWidth { get; };
 
         void ShowContextMenu();
+        void OpenQuickFixMenu();
         void RefreshQuickFixMenu();
         void ClearQuickFix();
 

--- a/src/cascadia/TerminalControl/TermControl.idl
+++ b/src/cascadia/TerminalControl/TermControl.idl
@@ -149,7 +149,7 @@ namespace Microsoft.Terminal.Control
         Double QuickFixButtonCollapsedWidth { get; };
 
         void ShowContextMenu();
-        void OpenQuickFixMenu();
+        Boolean OpenQuickFixMenu();
         void RefreshQuickFixMenu();
         void ClearQuickFix();
 

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -1597,12 +1597,13 @@ void Terminal::ColorSelection(const TextAttribute& attr, winrt::Microsoft::Termi
 }
 
 // Method Description:
-// - Returns the position of the cursor relative to the active viewport
+// - Returns the position of the cursor relative to the visible viewport
 til::point Terminal::GetViewportRelativeCursorPosition() const noexcept
 {
     const auto absoluteCursorPosition{ GetCursorPosition() };
-    const auto viewport{ _GetMutableViewport() };
-    return absoluteCursorPosition - viewport.Origin();
+    const auto mutableViewport{ _GetMutableViewport() };
+    const auto relativeCursorPos = absoluteCursorPosition - mutableViewport.Origin();
+    return { relativeCursorPos.x, relativeCursorPos.y + _scrollOffset };
 }
 
 void Terminal::PreviewText(std::wstring_view input)

--- a/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
@@ -98,6 +98,7 @@ static constexpr std::string_view RestartConnectionKey{ "restartConnection" };
 static constexpr std::string_view ToggleBroadcastInputKey{ "toggleBroadcastInput" };
 static constexpr std::string_view OpenScratchpadKey{ "experimental.openScratchpad" };
 static constexpr std::string_view OpenAboutKey{ "openAbout" };
+static constexpr std::string_view QuickFixKey{ "quickFix" };
 
 static constexpr std::string_view ActionKey{ "action" };
 
@@ -438,6 +439,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                 { ShortcutAction::ToggleBroadcastInput, RS_(L"ToggleBroadcastInputCommandKey") },
                 { ShortcutAction::OpenScratchpad, RS_(L"OpenScratchpadKey") },
                 { ShortcutAction::OpenAbout, RS_(L"OpenAboutCommandKey") },
+                { ShortcutAction::QuickFix, RS_(L"QuickFixCommandKey") },
             };
         }();
 

--- a/src/cascadia/TerminalSettingsModel/AllShortcutActions.h
+++ b/src/cascadia/TerminalSettingsModel/AllShortcutActions.h
@@ -111,7 +111,8 @@
     ON_ALL_ACTIONS(RestartConnection)       \
     ON_ALL_ACTIONS(ToggleBroadcastInput)    \
     ON_ALL_ACTIONS(OpenScratchpad)          \
-    ON_ALL_ACTIONS(OpenAbout)
+    ON_ALL_ACTIONS(OpenAbout)               \
+    ON_ALL_ACTIONS(QuickFix)
 
 #define ALL_SHORTCUT_ACTIONS_WITH_ARGS             \
     ON_ALL_ACTIONS_WITH_ARGS(AdjustFontSize)       \

--- a/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
@@ -735,6 +735,6 @@
     <value>Save Snippet</value>
   </data>
   <data name="QuickFixCommandKey" xml:space="preserve">
-    <value>Quick fix</value>
+    <value>Open quick fix menu</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
@@ -734,4 +734,7 @@
   <data name="SaveSnippetNamePrefix" xml:space="preserve">
     <value>Save Snippet</value>
   </data>
+  <data name="QuickFixCommandKey" xml:space="preserve">
+    <value>Quick fix</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -447,6 +447,7 @@
         { "command": "restoreLastClosed", "id": "Terminal.RestoreLastClosed" },
         { "command": "openAbout", "id": "Terminal.OpenAboutDialog" },
         { "command": "experimental.openTasks", "id": "Terminal.OpenTasks" },
+        { "command": "quickFix", "id": "Terminal.QuickFix" },
         { "command": { "action": "showSuggestions", "source": "all"}, "id": "Terminal.Suggestions" },
 
         // Tab Management

--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -447,6 +447,7 @@
         { "command": "restoreLastClosed", "id": "Terminal.RestoreLastClosed" },
         { "command": "openAbout", "id": "Terminal.OpenAboutDialog" },
         { "command": "experimental.openTasks", "id": "Terminal.OpenTasks" },
+        { "command": "quickFix", "id": "Terminal.QuickFix" },
 
         // Tab Management
         // "command": "closeTab" is unbound by default.
@@ -639,6 +640,7 @@
         { "keys":"ctrl+shift+p", "id": "Terminal.ToggleCommandPalette" },
         { "keys":"win+sc(41)", "id": "Terminal.QuakeMode" },
         { "keys": "alt+space", "id": "Terminal.OpenSystemMenu" },
+        { "keys": "ctrl+period", "id": "Terminal.QuickFix" },
 
         // Tab Management
         // "command": "closeTab" is unbound by default.

--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -447,7 +447,7 @@
         { "command": "restoreLastClosed", "id": "Terminal.RestoreLastClosed" },
         { "command": "openAbout", "id": "Terminal.OpenAboutDialog" },
         { "command": "experimental.openTasks", "id": "Terminal.OpenTasks" },
-        { "command": "quickFix", "id": "Terminal.QuickFix" },
+        { "command": { "action": "showSuggestions", "source": "all"}, "id": "Terminal.Suggestions" },
 
         // Tab Management
         // "command": "closeTab" is unbound by default.
@@ -640,7 +640,7 @@
         { "keys":"ctrl+shift+p", "id": "Terminal.ToggleCommandPalette" },
         { "keys":"win+sc(41)", "id": "Terminal.QuakeMode" },
         { "keys": "alt+space", "id": "Terminal.OpenSystemMenu" },
-        { "keys": "ctrl+shift+period", "id": "Terminal.QuickFix" },
+        { "keys": "ctrl+shift+period", "id": "Terminal.Suggestions" },
 
         // Tab Management
         // "command": "closeTab" is unbound by default.

--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -640,7 +640,7 @@
         { "keys":"ctrl+shift+p", "id": "Terminal.ToggleCommandPalette" },
         { "keys":"win+sc(41)", "id": "Terminal.QuakeMode" },
         { "keys": "alt+space", "id": "Terminal.OpenSystemMenu" },
-        { "keys": "ctrl+period", "id": "Terminal.QuickFix" },
+        { "keys": "ctrl+shift+period", "id": "Terminal.QuickFix" },
 
         // Tab Management
         // "command": "closeTab" is unbound by default.


### PR DESCRIPTION
Adds a keybinding to open the quick fix menu, if one is available. When the action is used, we also open up the button (if it was collapsed) because that looks nice.

The `showSuggestions` action is bound to `ctrl+shift+period` by default to align with VS' "quick actions" feature and VS Code's "quick fix" feature. This was chosen over binding to `quickFix` because it's more helpful. The quick fix button is a route for users that prefer to use the mouse. If users want to add a keybinding to activate the `quickFix` button, they can do that now.

This PR also performs a bit of miscellaneous polish from the bug bash. This includes:
- the suggestions UI now presents quick fixes first
- scrolling may result in the button being drawn in the wrong place
   - The bug was tracked down this line: `TermControl::CursorPositionInDips()` --> `_core.CursorPosition()` --> `Terminal::GetViewportRelativeCursorPosition()`. The mutable viewport there does _not_ update when the user scrolls. Thus, the button would be drawn on the same position _on the screen_ even though we scrolled. To fix this, I include the `_scrollOffset` in the calculation. The only other place this function is used is with the suggestions UI, which does _not_ update the UIs position as we scroll (but if we're interested in doing that, we can now).

Closes #17377