### PR TITLE
Add support for querying the character cell size

### DIFF
--- a/src/terminal/adapter/DispatchTypes.hpp
+++ b/src/terminal/adapter/DispatchTypes.hpp
@@ -589,6 +589,8 @@ namespace Microsoft::Console::VirtualTerminal::DispatchTypes
         IconifyWindow = 2,
         RefreshWindow = 7,
         ResizeWindowInCharacters = 8,
+        ReportTextSizeInPixels = 14,
+        ReportCharacterCellSize = 16,
         ReportTextSizeInCharacters = 18
     };
 

--- a/src/terminal/adapter/PageManager.cpp
+++ b/src/terminal/adapter/PageManager.cpp
@@ -52,6 +52,11 @@ void Page::SetAttributes(const TextAttribute& attr, ITerminalApi* api) const
     }
 }
 
+til::size Page::Size() const noexcept
+{
+    return { Width(), Height() };
+}
+
 til::CoordType Page::Top() const noexcept
 {
     // If we ever support vertical window panning, the page top won't

--- a/src/terminal/adapter/PageManager.hpp
+++ b/src/terminal/adapter/PageManager.hpp
@@ -26,6 +26,7 @@ namespace Microsoft::Console::VirtualTerminal
         Cursor& Cursor() const noexcept;
         const TextAttribute& Attributes() const noexcept;
         void SetAttributes(const TextAttribute& attr, ITerminalApi* api = nullptr) const;
+        til::size Size() const noexcept;
         til::CoordType Top() const noexcept;
         til::CoordType Bottom() const noexcept;
         til::CoordType Width() const noexcept;

--- a/src/terminal/adapter/SixelParser.hpp
+++ b/src/terminal/adapter/SixelParser.hpp
@@ -28,8 +28,8 @@ namespace Microsoft::Console::VirtualTerminal
     public:
         static constexpr VTInt DefaultConformance = 9;
 
-        static til::size CellSizeForLevel(const VTInt conformanceLevel) noexcept;
-        static size_t MaxColorsForLevel(const VTInt conformanceLevel) noexcept;
+        static til::size CellSizeForLevel(const VTInt conformanceLevel = DefaultConformance) noexcept;
+        static size_t MaxColorsForLevel(const VTInt conformanceLevel = DefaultConformance) noexcept;
 
         SixelParser(AdaptDispatch& dispatcher, const StateMachine& stateMachine, const VTInt conformanceLevel = DefaultConformance) noexcept;
         void SoftReset();

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -3377,10 +3377,23 @@ public:
 
     TEST_METHOD(WindowManipulationTypeTests)
     {
+        // Our pixel size reports are based on a virtual cell size of 10x20 pixels
+        // for compatibility with the VT240 and VT340 graphic terminals.
+        const auto cellSize = til::size{ 10, 20 };
+
         _testGetSet->PrepData();
-        _pDispatch->WindowManipulation(DispatchTypes::WindowManipulationType::ReportTextSizeInCharacters, NULL, NULL);
         const auto [textBuffer, viewport, _] = _testGetSet->GetBufferAndViewport();
-        const std::wstring expectedResponse = fmt::format(L"\033[8;{};{}t", viewport.height(), textBuffer.GetSize().Width());
+
+        _pDispatch->WindowManipulation(DispatchTypes::WindowManipulationType::ReportTextSizeInCharacters, NULL, NULL);
+        std::wstring expectedResponse = fmt::format(L"\033[8;{};{}t", viewport.height(), textBuffer.GetSize().Width());
+        _testGetSet->ValidateInputEvent(expectedResponse.c_str());
+
+        _pDispatch->WindowManipulation(DispatchTypes::WindowManipulationType::ReportTextSizeInPixels, NULL, NULL);
+        expectedResponse = fmt::format(L"\033[4;{};{}t", viewport.height() * cellSize.height, textBuffer.GetSize().Width() * cellSize.width);
+        _testGetSet->ValidateInputEvent(expectedResponse.c_str());
+
+        _pDispatch->WindowManipulation(DispatchTypes::WindowManipulationType::ReportCharacterCellSize, NULL, NULL);
+        expectedResponse = fmt::format(L"\033[6;{};{}t", cellSize.height, cellSize.width);
         _testGetSet->ValidateInputEvent(expectedResponse.c_str());
     }
 


### PR DESCRIPTION
This PR add supports for two query sequences that are used to determine
the pixel size of a character cell:

* `CSI 16 t` reports the pixel size of a character cell directly.
* `CSI 14 t` reports the pixel size of the text area, and when divided
  by the character size of the text area, you can get the character cell
  size indirectly (this method predates the introduction of `CSI 16 t`).

These queries are used by Sixel applications that want to fit an image
within specific text boundaries, so need to know how many cells would be
covered by a particular pixel size, or vice versa. Our implementation of
Sixel uses a virtual cell size that is always 10x20 (in order to emulate
the VT340 more accurately), so these queries shouldn't really be needed,
but some applications will fail to work without them.

## References and Relevant Issues

Sixel support was added to conhost in PR #17421.

## Validation Steps Performed

I've added some unit tests to verify that these queries are producing
the expected responses, and I've manually tested on [XtermDOOM] (which
uses `CSI 16 t`), and the [Notcurses] library (which uses `CSI 14 t`).

[XtermDOOM]: https://gitlab.com/AutumnMeowMeow/xtermdoom
[Notcurses]: https://github.com/dankamongmen/notcurses

## PR Checklist
- [x] Tests added/passed
