### PR TITLE
Fix schema and user defaults from Action ID change

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2519,7 +2519,6 @@
         },
         "keybindings": {
           "description": "A list of keychords bound to action IDs",
-          "deprecated": true,
           "items": {
             "$ref": "#/$defs/Keybinding"
           },

--- a/src/cascadia/TerminalSettingsModel/userDefaults.json
+++ b/src/cascadia/TerminalSettingsModel/userDefaults.json
@@ -23,7 +23,7 @@
     },
     "keybindings":
     [
-        { "id": "Terminal.CopySelectedText", "keys": "ctrl+c" },
+        { "id": "Terminal.CopyToClipboard", "keys": "ctrl+c" },
         { "id": "Terminal.PasteFromClipboard", "keys": "ctrl+v" },
         { "id": "Terminal.DuplicatePaneAuto", "keys": "alt+shift+d" }
     ]


### PR DESCRIPTION
- Remove the `deprecated` flag for the `keybindings` array now that we have re-added that
- Update `userDefaults` to use the correct ID for the `Copy` command
