### PR TITLE
onebranch: allow publish/package to run in :latest container

### DIFF
--- a/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
@@ -106,6 +106,11 @@ extends:
       - stage: Build
         displayName: Build
         dependsOn: []
+        variables:
+          # This was set by the parent build, but we need to override it to select a specific compiler version
+          - template: ./build/pipelines/templates-v2/variables-onebranch-config.yml@self
+            parameters:
+              containerVersion: 1.0.02566.28
         jobs:
           - template: ./build/pipelines/templates-v2/job-build-project.yml@self
             parameters:

--- a/build/pipelines/templates-v2/variables-onebranch-config.yml
+++ b/build/pipelines/templates-v2/variables-onebranch-config.yml
@@ -1,2 +1,7 @@
+parameters:
+  - name: containerVersion
+    type: string
+    default: latest
+
 variables:
-  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:1.0.02566.28'
+  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:${{ parameters.containerVersion }}'


### PR DESCRIPTION
We have to run in an older OneBranch Windows container image due to compiler bugs.

This change prevents us from having to wait for the container image to download for build legs that _aren't_ using the compiler.