### PR TITLE
Fix qps-ploc generation for store translations

### DIFF
--- a/build/scripts/Generate-PseudoLocalizations.ps1
+++ b/build/scripts/Generate-PseudoLocalizations.ps1
@@ -1,5 +1,5 @@
-Get-ChildItem -Recurse -Filter *.resw
-    | Where-Object { $_.Directory.Name.StartsWith("qps-ploc") }
+Get-ChildItem -Recurse -Directory -Filter qps-ploc*
+    | Get-ChildItem -Include *.resw,*.xml
     | ForEach-Object {
         $source = Join-Path $_.Directory "../en-US/$($_.Name)"
         $target = $_

--- a/tools/ConvertTo-PseudoLocalization.ps1
+++ b/tools/ConvertTo-PseudoLocalization.ps1
@@ -59,92 +59,92 @@ $content = [System.Xml.XmlDocument]::new()
 $content.PreserveWhitespace = $true
 $content.Load($Path)
 
-function GetPseudoLocalization([string]$key, [string]$value) {
+function GetPseudoLocalization([string]$key, [string]$value, [string]$comment) {
+    $locked = $null
+    if ($comment -match '.*\{Locked=?([^}]*)\}.*') {
+        $locked = $Matches[1]
+    }
+
+    # Skip {Locked} and {Locked=qps-ploc} entries
+    if ($locked -and (($locked -eq '') -or $locked.Contains('qps-ploc'))) {
+        continue
+    }
+
+    $placeholders = @{}
+
+    if ($locked) {
+        $lockedList = $locked -split ','
+        $placeholderChar = 0xE000
+
+        # Replaced all locked words with placeholders from the Unicode Private Use Area
+        foreach ($locked in $lockedList) {
+            if ($locked.StartsWith('"') -and $locked.EndsWith('"')) {
+                $locked = $locked.Substring(1, $locked.Length - 2)
+                $locked = $locked.Replace('\"', '"')
+            }
+
+            $placeholder = "$([char]$placeholderChar)"
+            $placeholderChar++
+
+            $placeholders[$placeholder] = $locked
+            $value = $value.Replace($locked, $placeholder)
+        }
+    }
+
     # We can't rely on $key.GetHashCode() to be consistent across different runs,
     # because in the future PowerShell may enable UseRandomizedStringHashAlgorithm.
     $hash = [System.Text.Encoding]::UTF8.GetBytes($key)
     $hash = [System.Security.Cryptography.SHA1]::Create().ComputeHash($hash)
     $hash = [System.BitConverter]::ToInt32($hash)
-
-    # Replace all characters with pseudo-localized characters
     $rng = [System.Random]::new($hash)
-    $newValue = ''
-    foreach ($char in $value.ToCharArray()) {
-        if ($m = $mapping[$char]) {
-            $newValue += $m[$rng.Next(0, $mapping[$char].Length)]
-        }
-        else {
-            $newValue += $char
-        }
-    }
 
-    return $newValue
-}
-
-function PadPseudoLocalization([string]$value) {
-    # Add 40% padding to the end of the string
-    $paddingLength = [System.Math]::Round(0.4 * $value.Length)
-    $padding = ' !!!' * ($paddingLength / 4 + 1)
-    $value += $padding.Substring(0, $paddingLength)
-    return $value
-}
-
-if ($path.EndsWith(".resw")) {
-    foreach ($entry in $content.SelectNodes('//root/data')) {
-        $value = $entry.value
-        $comment = $entry.SelectSingleNode('comment')?.'#text' ?? ''
-        $placeholders = @{}
-
-        if ($comment.StartsWith('{Locked')) {
-            # Skip {Locked} and {Locked=qps-ploc} entries
-            if ($comment -match '\{Locked(\}|=[^}]*qps-ploc).*') {
-                continue
+    $lines = $value.Split("`n")
+    $lines = $lines | ForEach-Object {
+        # Replace all characters with pseudo-localized characters
+        $newValue = ''
+        foreach ($char in $_.ToCharArray()) {
+            if ($m = $mapping[$char]) {
+                $newValue += $m[$rng.Next(0, $mapping[$char].Length)]
             }
-
-            $lockedList = ($comment -replace '\{Locked=(.*?)\}.*', '$1') -split ','
-            $placeholderChar = 0xE000
-
-            # Replaced all locked words with placeholders from the Unicode Private Use Area
-            foreach ($locked in $lockedList) {
-                if ($locked.StartsWith('"') -and $locked.EndsWith('"')) {
-                    $locked = $locked.Substring(1, $locked.Length - 2)
-                    $locked = $locked.Replace('\"', '"')
-                }
-
-                $placeholder = "$([char]$placeholderChar)"
-                $placeholderChar++
-
-                $placeholders[$placeholder] = $locked
-                $value = $value.Replace($locked, $placeholder)
+            else {
+                $newValue += $char
             }
         }
-
-        $newValue = GetPseudoLocalization $entry.name $value
 
         # Replace all placeholders with their original values
         foreach ($kv in $placeholders.GetEnumerator()) {
             $newValue = $newValue.Replace($kv.Key, $kv.Value)
         }
 
-        $newValue = PadPseudoLocalization $newValue
-
-        $entry.value = $newValue
+        # Add 40% padding to the end of the string
+        $paddingLength = [System.Math]::Round(0.4 * $_.Length)
+        $padding = ' !!!' * ($paddingLength / 4 + 1)
+        $newValue + $padding.Substring(0, $paddingLength)
     }
-} elseif ($path.EndsWith(".xml")) {
-    foreach ($entry in $content.DocumentElement.SelectNodes('//*[@_locID]/text()')) {
-        $value = $entry.Value
-        if ($value.Trim().Length -eq 0) {
-            continue
-        }
+    return $lines -join "`n"
+}
 
-        $locID = $entry.ParentNode.GetAttribute('_locID')
-        $newValue = GetPseudoLocalization $locID $value
-        $newValue = PadPseudoLocalization $newValue
-        $entry.Value = $newValue
+if ($path.EndsWith(".resw")) {
+    foreach ($entry in $content.SelectNodes('/root/data')) {
+        $comment = $entry.SelectSingleNode('comment')?.'#text' ?? ''
+        $entry.value = GetPseudoLocalization $entry.name $entry.value $comment
+    }
+}
+elseif ($path.EndsWith(".xml")) {
+    foreach ($parent in $content.DocumentElement.SelectNodes('//*[@_locID]')) {
+        $locID = $parent.GetAttribute('_locID')
+        $comment = $parent.SelectSingleNode('comment()[contains(., "_locComment_text")]')?.'#text' ?? ''
+
+        foreach ($entry in $parent.SelectNodes('text()')) {
+            $value = $entry.Value
+            if ($value.Trim().Length -ne 0) {
+                $entry.Value = GetPseudoLocalization $locID $value $comment
+            }
+        }
     }
 
     # Remove all _locComment_text comments
-    foreach ($entry in $content.DocumentElement.SelectNodes('//*/comment()[contains(., "_locComment_text")]')) {
+    foreach ($entry in $content.DocumentElement.SelectNodes('//comment()[contains(., "_locComment_text")]')) {
         $null = $entry.ParentNode.RemoveChild($entry)
     }
 


### PR DESCRIPTION
* Modified `Generate-PseudoLocalizations.ps1` to find the .xml files.
  (As opposed to .resw for the other translations.)
* Added support for the new format by adding new XPath expressions,
  and stripping comments/attributes as needed.
* Fixed `PreserveWhitespace` during XML loading.
* Fixed compliance with PowerShell's strict mode.

## Validation Steps Performed
Ran it locally and compared the results. ✅