### PR TITLE
Add a close button to the Snippets pane

### DIFF
--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -935,4 +935,10 @@
   <data name="ActionSaveFailedToast.Title" xml:space="preserve">
     <value>Action save failed</value>
   </data>
+  <data name="CloseSnippetsPaneButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Close pane</value>
+  </data>
+  <data name="CloseSnippetsPaneButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Close pane</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/SnippetsPaneContent.cpp
+++ b/src/cascadia/TerminalApp/SnippetsPaneContent.cpp
@@ -138,6 +138,11 @@ namespace winrt::TerminalApp::implementation
             _runCommand(taskVM->Command());
         }
     }
+    void SnippetsPaneContent::_closePaneClick(const Windows::Foundation::IInspectable& /*sender*/,
+                                              const Windows::UI::Xaml::RoutedEventArgs&)
+    {
+        Close();
+    }
 
     // Called when one of the items in the list is tapped, or enter/space is
     // pressed on it while focused. Notably, this isn't the Tapped event - it

--- a/src/cascadia/TerminalApp/SnippetsPaneContent.cpp
+++ b/src/cascadia/TerminalApp/SnippetsPaneContent.cpp
@@ -106,7 +106,7 @@ namespace winrt::TerminalApp::implementation
 
     winrt::WUX::Media::Brush SnippetsPaneContent::BackgroundBrush()
     {
-        static const auto key = winrt::box_value(L"UnfocusedBorderBrush");
+        static const auto key = winrt::box_value(L"SettingsUiTabBrush");
         return ThemeLookup(WUX::Application::Current().Resources(),
                            _settings.GlobalSettings().CurrentTheme().RequestedTheme(),
                            key)

--- a/src/cascadia/TerminalApp/SnippetsPaneContent.h
+++ b/src/cascadia/TerminalApp/SnippetsPaneContent.h
@@ -55,6 +55,7 @@ namespace winrt::TerminalApp::implementation
         winrt::Windows::Foundation::Collections::IObservableVector<TerminalApp::FilteredTask> _allTasks{ nullptr };
 
         void _runCommandButtonClicked(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs&);
+        void _closePaneClick(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs&);
         void _filterTextChanged(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
 
         void _updateFilteredCommands();

--- a/src/cascadia/TerminalApp/SnippetsPaneContent.xaml
+++ b/src/cascadia/TerminalApp/SnippetsPaneContent.xaml
@@ -232,7 +232,7 @@
                        x:Uid="SnippetPaneTitle"
                        HorizontalAlignment="Left"
                        FontSize="24" />
-            <Button HorizontalAlignment="Right">
+            <Button x:Uid="CloseSnippetsPaneButton" HorizontalAlignment="Right" Click="_closePaneClick">
 
                 <Button.Content>
                     <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"

--- a/src/cascadia/TerminalApp/SnippetsPaneContent.xaml
+++ b/src/cascadia/TerminalApp/SnippetsPaneContent.xaml
@@ -225,11 +225,22 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <TextBlock x:Name="_title"
-                   x:Uid="SnippetPaneTitle"
-                   Grid.Row="0"
-                   Margin="4"
-                   FontSize="24" />
+        <Grid Grid.Row="0"
+              Margin="4"
+              HorizontalAlignment="Stretch">
+            <TextBlock x:Name="_title"
+                       x:Uid="SnippetPaneTitle"
+                       HorizontalAlignment="Left"
+                       FontSize="24" />
+            <Button HorizontalAlignment="Right">
+
+                <Button.Content>
+                    <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                              FontSize="12"
+                              Glyph="&#xE8BB;" />
+                </Button.Content>
+            </Button>
+        </Grid>
 
         <TextBlock Grid.Row="1"
                    Margin="8,16,8,8"

--- a/src/cascadia/TerminalApp/SnippetsPaneContent.xaml
+++ b/src/cascadia/TerminalApp/SnippetsPaneContent.xaml
@@ -232,7 +232,9 @@
                        x:Uid="SnippetPaneTitle"
                        HorizontalAlignment="Left"
                        FontSize="24" />
-            <Button x:Uid="CloseSnippetsPaneButton" HorizontalAlignment="Right" Click="_closePaneClick">
+            <Button x:Uid="CloseSnippetsPaneButton"
+                    HorizontalAlignment="Right"
+                    Click="_closePaneClick">
 
                 <Button.Content>
                     <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -4687,7 +4687,10 @@ namespace winrt::TerminalApp::implementation
         {
             const auto themeBrush{ tabRowBg.Evaluate(res, terminalBrush, true) };
             bgColor = ThemeColor::ColorFromBrush(themeBrush);
-            TitlebarBrush(themeBrush);
+            // If the tab content returned nullptr for the terminalBrush, we
+            // _don't_ want to use it as the tab row background. We want to just
+            // use the default tab row background.
+            TitlebarBrush(themeBrush ? themeBrush : backgroundSolidBrush);
         }
         else
         {

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -3321,7 +3321,7 @@ namespace winrt::TerminalApp::implementation
                         return true;
                     }
                     return false;
-                    });
+                });
                 // Bail out if we already found one.
                 if (found)
                 {

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -3311,18 +3311,22 @@ namespace winrt::TerminalApp::implementation
             // Prevent the user from opening a bunch of snippets panes.
             //
             // Look at the focused tab, and if it already has one, then just focus it.
-            const bool found = _GetFocusedTab().try_as<TerminalTab>()->GetRootPane()->WalkTree([](const auto& p) -> bool {
-                if (const auto& snippets{ p->GetContent().try_as<SnippetsPaneContent>() })
-                {
-                    snippets->Focus(FocusState::Programmatic);
-                    return true;
-                }
-                return false;
-            });
-            // Bail out if we already found one.
-            if (found)
+            if (const auto& focusedTab{ _GetFocusedTab() })
             {
-                return nullptr;
+                const auto rootPane{ focusedTab.try_as<TerminalTab>()->GetRootPane() };
+                const bool found = rootPane == nullptr ? false : rootPane->WalkTree([](const auto& p) -> bool {
+                    if (const auto& snippets{ p->GetContent().try_as<SnippetsPaneContent>() })
+                    {
+                        snippets->Focus(FocusState::Programmatic);
+                        return true;
+                    }
+                    return false;
+                    });
+                // Bail out if we already found one.
+                if (found)
+                {
+                    return nullptr;
+                }
             }
 
             const auto& tasksContent{ winrt::make_self<SnippetsPaneContent>() };


### PR DESCRIPTION
As discussed in the bug bash. It should be closable with a button. 

This also changes the tab color to match the Settings tabs.

This also fixes a crash where dragging just a snippets pane out to it's own window would crash. 