### PR TITLE
Fix more PDP ploc related issues

### DIFF
--- a/build/scripts/Copy-ContextMenuResourcesToCascadiaPackage.ps1
+++ b/build/scripts/Copy-ContextMenuResourcesToCascadiaPackage.ps1
@@ -41,6 +41,7 @@ ForEach ($pair in $Languages.GetEnumerator()) {
 	$writerSettings = [System.Xml.XmlWriterSettings]::new()
 	$writerSettings.NewLineChars = "`r`n"
 	$writerSettings.Indent = $true
+	$writerSettings.Encoding = [System.Text.UTF8Encoding]::new($false) # suppress the BOM
 	$writer = [System.Xml.XmlWriter]::Create($ResPath, $writerSettings)
 	$XmlDocument.Save($writer)
 	$writer.Flush()

--- a/build/scripts/Generate-PseudoLocalizations.ps1
+++ b/build/scripts/Generate-PseudoLocalizations.ps1
@@ -9,6 +9,7 @@ Get-ChildItem -Recurse -Directory -Filter qps-ploc*
         $writerSettings = [System.Xml.XmlWriterSettings]::new()
         $writerSettings.NewLineChars = "`r`n"
         $writerSettings.Indent = $true
+        $writerSettings.Encoding = [System.Text.UTF8Encoding]::new($false) # suppress the BOM
         $writer = [System.Xml.XmlWriter]::Create($target, $writerSettings)
         $ploc.Save($writer)
         $writer.Flush()

--- a/tools/ConvertTo-PseudoLocalization.ps1
+++ b/tools/ConvertTo-PseudoLocalization.ps1
@@ -61,19 +61,20 @@ $content.Load($Path)
 
 function GetPseudoLocalization([string]$key, [string]$value, [string]$comment) {
     $placeholders = @{}
+    $placeholderChar = 0xE000
 
-    if ($comment -match '.*\{Locked=?([^}]*)\}.*') {
-        $locked = $Matches[1] ?? ''
+    # Iterate through all {Locked=...} comments and replace locked
+    # words with placeholders from the Unicode Private Use Area.
+    foreach ($m in [regex]::Matches($comment, '\{Locked=?([^}]*)\}')) {
+        $locked = $m.Groups[1].Value
 
         # Skip {Locked} and {Locked=qps-ploc} entries
-        if ((($locked -eq '') -or $locked.Contains('qps-ploc'))) {
+        if (($locked -eq '') -or $locked.Contains('qps-ploc')) {
             return $value
         }
 
         $lockedList = $locked -split ','
-        $placeholderChar = 0xE000
 
-        # Replaced all locked words with placeholders from the Unicode Private Use Area
         foreach ($locked in $lockedList) {
             if ($locked.StartsWith('"') -and $locked.EndsWith('"')) {
                 $locked = $locked.Substring(1, $locked.Length - 2)

--- a/tools/ConvertTo-PseudoLocalization.ps1
+++ b/tools/ConvertTo-PseudoLocalization.ps1
@@ -95,10 +95,6 @@ function GetPseudoLocalization([string]$key, [string]$value, [string]$comment) {
     $hash = [System.BitConverter]::ToInt32($hash)
     $rng = [System.Random]::new($hash)
 
-    if ($key -eq 'NoticeFontNotFound') {
-        $value = $value
-    }
-
     $lines = $value -split '\r?\n'
     $lines = $lines | ForEach-Object {
         # Replace all characters with pseudo-localized characters


### PR DESCRIPTION
This fixes some more issues not properly covered by #17526:
* Fixed `_locComment_text` comments being effectively ignored.
* Fixed line splitting of comments (CRLF vs LF).
* Fixed BOM suppression.
* Fixed support for having multiple `{Locked=...}` comments.