### PR TITLE
Dismiss a action preview when the next action isn't previewable

### DIFF
--- a/src/cascadia/TerminalApp/ActionPreviewHandlers.cpp
+++ b/src/cascadia/TerminalApp/ActionPreviewHandlers.cpp
@@ -172,6 +172,9 @@ namespace winrt::TerminalApp::implementation
         case ShortcutAction::SendInput:
             _PreviewSendInput(args.Args().try_as<SendInputArgs>());
             break;
+        default:
+            _EndPreview();
+            return;
         }
 
         // GH#9818 Other ideas for actions that could be preview-able:


### PR DESCRIPTION
This became much more obvious with the sendInput previewing. We would only dismiss previews if the following action was also previewable.

related: #15845 