### PR TITLE
Stop parsing `saveSnippets` actions in json

### DIFF
--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -540,7 +540,7 @@ void AppCommandlineArgs::_buildFocusPaneParser()
 
 void AppCommandlineArgs::_buildSaveSnippetParser()
 {
-    _saveCommand = _app.add_subcommand("x-save-snippet", RS_A(L"SaveSnippetDesc"));
+    _saveCommand = _app.add_subcommand("x-save", RS_A(L"SaveSnippetDesc"));
 
     auto setupSubcommand = [this](auto* subcommand) {
         subcommand->add_option("--name,-n", _saveInputName, RS_A(L"SaveSnippetArgDesc"));

--- a/src/cascadia/TerminalApp/ShortcutActionDispatch.cpp
+++ b/src/cascadia/TerminalApp/ShortcutActionDispatch.cpp
@@ -44,6 +44,7 @@ namespace winrt::TerminalApp::implementation
         {
 #define ON_ALL_ACTIONS(id) ACTION_CASE(id);
             ALL_SHORTCUT_ACTIONS
+            INTERNAL_SHORTCUT_ACTIONS
 #undef ON_ALL_ACTIONS
         default:
             return false;

--- a/src/cascadia/TerminalApp/ShortcutActionDispatch.h
+++ b/src/cascadia/TerminalApp/ShortcutActionDispatch.h
@@ -27,6 +27,7 @@ namespace winrt::TerminalApp::implementation
 
 #define ON_ALL_ACTIONS(action) DECLARE_ACTION(action);
         ALL_SHORTCUT_ACTIONS
+        INTERNAL_SHORTCUT_ACTIONS
 #undef ON_ALL_ACTIONS
 
     private:

--- a/src/cascadia/TerminalApp/ShortcutActionDispatch.idl
+++ b/src/cascadia/TerminalApp/ShortcutActionDispatch.idl
@@ -15,6 +15,7 @@ namespace TerminalApp
         // When adding a new action, add them to AllShortcutActions.h!
         #define ON_ALL_ACTIONS(action) ACTION_EVENT(action);
         ALL_SHORTCUT_ACTIONS
+        INTERNAL_SHORTCUT_ACTIONS
         #undef ON_ALL_ACTIONS
 
     }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1684,6 +1684,7 @@ namespace winrt::TerminalApp::implementation
         // there's an actual keychord for them.
 #define ON_ALL_ACTIONS(action) HOOKUP_ACTION(action);
         ALL_SHORTCUT_ACTIONS
+        INTERNAL_SHORTCUT_ACTIONS
 #undef ON_ALL_ACTIONS
     }
 

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -560,6 +560,7 @@ namespace winrt::TerminalApp::implementation
         // These are all defined in AppActionHandlers.cpp
 #define ON_ALL_ACTIONS(action) DECLARE_ACTION_HANDLER(action);
         ALL_SHORTCUT_ACTIONS
+        INTERNAL_SHORTCUT_ACTIONS
 #undef ON_ALL_ACTIONS
 #pragma endregion
 

--- a/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
@@ -52,7 +52,6 @@ static constexpr std::string_view SwitchToTabKey{ "switchToTab" };
 static constexpr std::string_view TabSearchKey{ "tabSearch" };
 static constexpr std::string_view ToggleAlwaysOnTopKey{ "toggleAlwaysOnTop" };
 static constexpr std::string_view ToggleCommandPaletteKey{ "commandPalette" };
-static constexpr std::string_view SaveSnippetKey{ "experimental.saveSnippet" };
 static constexpr std::string_view SuggestionsKey{ "showSuggestions" };
 static constexpr std::string_view ToggleFocusModeKey{ "toggleFocusMode" };
 static constexpr std::string_view SetFocusModeKey{ "setFocusMode" };
@@ -124,12 +123,14 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     const std::map<std::string_view, ShortcutAction, std::less<>> ActionAndArgs::ActionKeyNamesMap{
 #define ON_ALL_ACTIONS(action) KEY_TO_ACTION_PAIR(action)
         ALL_SHORTCUT_ACTIONS
+    // Don't include the INTERNAL_SHORTCUT_ACTIONS here
 #undef ON_ALL_ACTIONS
     };
 
     static const std::map<ShortcutAction, std::string_view, std::less<>> ActionToStringMap{
 #define ON_ALL_ACTIONS(action) ACTION_TO_KEY_PAIR(action)
         ALL_SHORTCUT_ACTIONS
+    // Don't include the INTERNAL_SHORTCUT_ACTIONS here
 #undef ON_ALL_ACTIONS
     };
 
@@ -152,6 +153,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
 #define ON_ALL_ACTIONS_WITH_ARGS(action) ACTION_TO_SERIALIZERS_PAIR(action)
         ALL_SHORTCUT_ACTIONS_WITH_ARGS
+    // Don't include the INTERNAL_SHORTCUT_ACTIONS here
 #undef ON_ALL_ACTIONS_WITH_ARGS
     };
 

--- a/src/cascadia/TerminalSettingsModel/ActionMap.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionMap.cpp
@@ -47,6 +47,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         break;                                                         \
     }
                 ALL_SHORTCUT_ACTIONS_WITH_ARGS
+                INTERNAL_SHORTCUT_ACTIONS_WITH_ARGS
 #undef ON_ALL_ACTIONS_WITH_ARGS
             default:
                 break;
@@ -192,6 +193,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 // now add any ShortcutActions that we might have missed
 #define ON_ALL_ACTIONS(action) RegisterShortcutAction(ShortcutAction::action, availableActions, visitedActionIDs);
             ALL_SHORTCUT_ACTIONS
+            // Don't include internal actions here
 #undef ON_ALL_ACTIONS
 
             _AvailableActionsCache = single_threaded_map(std::move(availableActions));

--- a/src/cascadia/TerminalSettingsModel/AllShortcutActions.h
+++ b/src/cascadia/TerminalSettingsModel/AllShortcutActions.h
@@ -75,7 +75,6 @@
     ON_ALL_ACTIONS(CloseTabsAfter)          \
     ON_ALL_ACTIONS(TabSearch)               \
     ON_ALL_ACTIONS(MoveTab)                 \
-    ON_ALL_ACTIONS(SaveSnippet)             \
     ON_ALL_ACTIONS(BreakIntoDebugger)       \
     ON_ALL_ACTIONS(TogglePaneReadOnly)      \
     ON_ALL_ACTIONS(EnablePaneReadOnly)      \
@@ -149,7 +148,6 @@
     ON_ALL_ACTIONS_WITH_ARGS(SplitPane)            \
     ON_ALL_ACTIONS_WITH_ARGS(SwitchToTab)          \
     ON_ALL_ACTIONS_WITH_ARGS(ToggleCommandPalette) \
-    ON_ALL_ACTIONS_WITH_ARGS(SaveSnippet)          \
     ON_ALL_ACTIONS_WITH_ARGS(FocusPane)            \
     ON_ALL_ACTIONS_WITH_ARGS(ExportBuffer)         \
     ON_ALL_ACTIONS_WITH_ARGS(ClearBuffer)          \
@@ -159,3 +157,12 @@
     ON_ALL_ACTIONS_WITH_ARGS(SelectCommand)        \
     ON_ALL_ACTIONS_WITH_ARGS(SelectOutput)         \
     ON_ALL_ACTIONS_WITH_ARGS(ColorSelection)
+
+// These two macros here are for actions that we only use as internal currency.
+// They don't need to be parsed by the settings model, or saved as actions to
+// JSON.
+#define INTERNAL_SHORTCUT_ACTIONS \
+    ON_ALL_ACTIONS(SaveSnippet)
+
+#define INTERNAL_SHORTCUT_ACTIONS_WITH_ARGS \
+    ON_ALL_ACTIONS_WITH_ARGS(SaveSnippet)\

--- a/src/cascadia/TerminalSettingsModel/Command.idl
+++ b/src/cascadia/TerminalSettingsModel/Command.idl
@@ -17,6 +17,7 @@ namespace Microsoft.Terminal.Settings.Model
         // When adding a new action, add them to AllShortcutActions.h!
         #define ON_ALL_ACTIONS(action) action,
         ALL_SHORTCUT_ACTIONS
+        INTERNAL_SHORTCUT_ACTIONS
         #undef ON_ALL_ACTIONS
     };
 


### PR DESCRIPTION
In the spec review, we agreed these didn't really need to be saved to the user's own settings file. This removes parsing and saving for the `experimental.saveSnippet` action, but we still have the action _internally_. This is powered by a new x-macro for "INTERNAL_" actions.

Follow-up from #16513.
