### PR TITLE
AtlasEngine: Fix a buffer overrun

### DIFF
--- a/src/renderer/atlas/BackendD3D.cpp
+++ b/src/renderer/atlas/BackendD3D.cpp
@@ -1069,12 +1069,13 @@ void BackendD3D::_uploadBackgroundBitmap(const RenderingPayload& p)
 
     auto src = std::bit_cast<const char*>(p.backgroundBitmap.data());
     const auto srcEnd = std::bit_cast<const char*>(p.backgroundBitmap.data() + p.backgroundBitmap.size());
+    const auto srcWidth = p.s->viewportCellCount.x * sizeof(u32);
     const auto srcStride = p.colorBitmapRowStride * sizeof(u32);
     auto dst = static_cast<char*>(mapped.pData);
 
     while (src < srcEnd)
     {
-        memcpy(dst, src, srcStride);
+        memcpy(dst, src, srcWidth);
         src += srcStride;
         dst += mapped.RowPitch;
     }


### PR DESCRIPTION
The strided `memcpy` between buffers failed to account for situations
where the destination stride is smaller than the source stride.
The solution is to only copy as many bytes as are in each row.

## Validation Steps Performed
Even with AppVerifier the issue could not be reproduced.
Adding an `assert(srcStride <= mapped.RowPitch)`, however, did trap
the bug when WARP is used while BackendD3D is force-enabled.