### PR TITLE
Create a base class for all pane content events

### DIFF
--- a/src/cascadia/TerminalApp/BasicPaneEvents.h
+++ b/src/cascadia/TerminalApp/BasicPaneEvents.h
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+
+namespace winrt::TerminalApp::implementation
+{
+    struct BasicPaneEvents
+    {
+        til::typed_event<> ConnectionStateChanged;
+        til::typed_event<IPaneContent> CloseRequested;
+        til::typed_event<IPaneContent, winrt::TerminalApp::BellEventArgs> BellRequested;
+        til::typed_event<IPaneContent> TitleChanged;
+        til::typed_event<IPaneContent> TabColorChanged;
+        til::typed_event<IPaneContent> TaskbarProgressChanged;
+        til::typed_event<IPaneContent> ReadOnlyChanged;
+        til::typed_event<IPaneContent> FocusRequested;
+
+        til::typed_event<winrt::Windows::Foundation::IInspectable, Microsoft::Terminal::Settings::Model::Command> DispatchCommandRequested;
+    };
+}

--- a/src/cascadia/TerminalApp/ScratchpadContent.h
+++ b/src/cascadia/TerminalApp/ScratchpadContent.h
@@ -29,7 +29,7 @@ namespace winrt::TerminalApp::implementation
         winrt::hstring Icon() const;
         Windows::Foundation::IReference<winrt::Windows::UI::Color> TabColor() const noexcept { return nullptr; }
         winrt::Windows::UI::Xaml::Media::Brush BackgroundBrush();
-        
+
         // See BasicPaneEvents for most generic event definitions
 
     private:

--- a/src/cascadia/TerminalApp/ScratchpadContent.h
+++ b/src/cascadia/TerminalApp/ScratchpadContent.h
@@ -3,10 +3,11 @@
 
 #pragma once
 #include "winrt/TerminalApp.h"
+#include "BasicPaneEvents.h"
 
 namespace winrt::TerminalApp::implementation
 {
-    class ScratchpadContent : public winrt::implements<ScratchpadContent, IPaneContent>
+    class ScratchpadContent : public winrt::implements<ScratchpadContent, IPaneContent>, public BasicPaneEvents
     {
     public:
         ScratchpadContent();
@@ -28,15 +29,8 @@ namespace winrt::TerminalApp::implementation
         winrt::hstring Icon() const;
         Windows::Foundation::IReference<winrt::Windows::UI::Color> TabColor() const noexcept { return nullptr; }
         winrt::Windows::UI::Xaml::Media::Brush BackgroundBrush();
-
-        til::typed_event<> ConnectionStateChanged;
-        til::typed_event<IPaneContent> CloseRequested;
-        til::typed_event<IPaneContent, winrt::TerminalApp::BellEventArgs> BellRequested;
-        til::typed_event<IPaneContent> TitleChanged;
-        til::typed_event<IPaneContent> TabColorChanged;
-        til::typed_event<IPaneContent> TaskbarProgressChanged;
-        til::typed_event<IPaneContent> ReadOnlyChanged;
-        til::typed_event<IPaneContent> FocusRequested;
+        
+        // See BasicPaneEvents for most generic event definitions
 
     private:
         winrt::Windows::UI::Xaml::Controls::Grid _root{ nullptr };

--- a/src/cascadia/TerminalApp/SettingsPaneContent.h
+++ b/src/cascadia/TerminalApp/SettingsPaneContent.h
@@ -4,10 +4,11 @@
 #pragma once
 #include "winrt/TerminalApp.h"
 #include <LibraryResources.h>
+#include "BasicPaneEvents.h"
 
 namespace winrt::TerminalApp::implementation
 {
-    class SettingsPaneContent : public winrt::implements<SettingsPaneContent, IPaneContent>
+    class SettingsPaneContent : public winrt::implements<SettingsPaneContent, IPaneContent>, public BasicPaneEvents
     {
     public:
         SettingsPaneContent(winrt::Microsoft::Terminal::Settings::Model::CascadiaSettings settings);
@@ -30,14 +31,7 @@ namespace winrt::TerminalApp::implementation
         Windows::Foundation::IReference<winrt::Windows::UI::Color> TabColor() const noexcept;
         winrt::Windows::UI::Xaml::Media::Brush BackgroundBrush();
 
-        til::typed_event<> ConnectionStateChanged;
-        til::typed_event<IPaneContent> CloseRequested;
-        til::typed_event<IPaneContent, winrt::TerminalApp::BellEventArgs> BellRequested;
-        til::typed_event<IPaneContent> TitleChanged;
-        til::typed_event<IPaneContent> TabColorChanged;
-        til::typed_event<IPaneContent> TaskbarProgressChanged;
-        til::typed_event<IPaneContent> ReadOnlyChanged;
-        til::typed_event<IPaneContent> FocusRequested;
+        // See BasicPaneEvents for most generic event definitions
 
     private:
         winrt::Microsoft::Terminal::Settings::Editor::MainPage _sui{ nullptr };

--- a/src/cascadia/TerminalApp/SnippetsPaneContent.h
+++ b/src/cascadia/TerminalApp/SnippetsPaneContent.h
@@ -11,11 +11,7 @@
 
 namespace winrt::TerminalApp::implementation
 {
-<<<<<<< HEAD:src/cascadia/TerminalApp/SnippetsPaneContent.h
-    struct SnippetsPaneContent : SnippetsPaneContentT<SnippetsPaneContent>
-=======
-    struct TasksPaneContent : TasksPaneContentT<TasksPaneContent>, BasicPaneEvents
->>>>>>> f8e5bfa09 (hey this works great):src/cascadia/TerminalApp/TasksPaneContent.h
+    struct SnippetsPaneContent : SnippetsPaneContentT<SnippetsPaneContent>, BasicPaneEvents
     {
         SnippetsPaneContent();
 

--- a/src/cascadia/TerminalApp/SnippetsPaneContent.h
+++ b/src/cascadia/TerminalApp/SnippetsPaneContent.h
@@ -4,13 +4,18 @@
 #pragma once
 #include "SnippetsPaneContent.g.h"
 #include "FilteredTask.g.h"
+#include "BasicPaneEvents.h"
 #include "FilteredCommand.h"
 #include "ActionPaletteItem.h"
 #include <LibraryResources.h>
 
 namespace winrt::TerminalApp::implementation
 {
+<<<<<<< HEAD:src/cascadia/TerminalApp/SnippetsPaneContent.h
     struct SnippetsPaneContent : SnippetsPaneContentT<SnippetsPaneContent>
+=======
+    struct TasksPaneContent : TasksPaneContentT<TasksPaneContent>, BasicPaneEvents
+>>>>>>> f8e5bfa09 (hey this works great):src/cascadia/TerminalApp/TasksPaneContent.h
     {
         SnippetsPaneContent();
 
@@ -34,16 +39,7 @@ namespace winrt::TerminalApp::implementation
         void SetLastActiveControl(const Microsoft::Terminal::Control::TermControl& control);
         bool HasSnippets() const;
 
-        til::typed_event<> ConnectionStateChanged;
-        til::typed_event<IPaneContent> CloseRequested;
-        til::typed_event<IPaneContent, winrt::TerminalApp::BellEventArgs> BellRequested;
-        til::typed_event<IPaneContent> TitleChanged;
-        til::typed_event<IPaneContent> TabColorChanged;
-        til::typed_event<IPaneContent> TaskbarProgressChanged;
-        til::typed_event<IPaneContent> ReadOnlyChanged;
-        til::typed_event<IPaneContent> FocusRequested;
-
-        til::typed_event<winrt::Windows::Foundation::IInspectable, Microsoft::Terminal::Settings::Model::Command> DispatchCommandRequested;
+        // See BasicPaneEvents for most generic event definitions
 
         til::property_changed_event PropertyChanged;
 

--- a/src/cascadia/TerminalApp/TerminalPaneContent.h
+++ b/src/cascadia/TerminalApp/TerminalPaneContent.h
@@ -4,6 +4,7 @@
 #pragma once
 #include "TerminalPaneContent.g.h"
 #include "BellEventArgs.g.h"
+#include "BasicPaneEvents.h"
 
 namespace winrt::TerminalApp::implementation
 {
@@ -16,7 +17,7 @@ namespace winrt::TerminalApp::implementation
         til::property<bool> FlashTaskbar;
     };
 
-    struct TerminalPaneContent : TerminalPaneContentT<TerminalPaneContent>
+    struct TerminalPaneContent : TerminalPaneContentT<TerminalPaneContent>, BasicPaneEvents
     {
         TerminalPaneContent(const winrt::Microsoft::Terminal::Settings::Model::Profile& profile,
                             const TerminalApp::TerminalSettingsCache& cache,
@@ -51,14 +52,8 @@ namespace winrt::TerminalApp::implementation
         Windows::Foundation::Size GridUnitSize();
 
         til::typed_event<TerminalApp::TerminalPaneContent, winrt::Windows::Foundation::IInspectable> RestartTerminalRequested;
-        til::typed_event<> ConnectionStateChanged;
-        til::typed_event<IPaneContent> CloseRequested;
-        til::typed_event<IPaneContent, winrt::TerminalApp::BellEventArgs> BellRequested;
-        til::typed_event<IPaneContent> TitleChanged;
-        til::typed_event<IPaneContent> TabColorChanged;
-        til::typed_event<IPaneContent> TaskbarProgressChanged;
-        til::typed_event<IPaneContent> ReadOnlyChanged;
-        til::typed_event<IPaneContent> FocusRequested;
+
+        // See BasicPaneEvents for most generic event definitions
 
     private:
         winrt::Microsoft::Terminal::Control::TermControl _control{ nullptr };


### PR DESCRIPTION
These events are kinda just boilerplate that now keeps getting copy-pasta'd every time I make new pane types. 

This instead moves them all to a singular base class, so the definitions stay in sync. 