### PR TITLE
Fix double paste when CF_UNICODETEXT & CF_HDROP are present

### DIFF
--- a/src/interactivity/win32/Clipboard.cpp
+++ b/src/interactivity/win32/Clipboard.cpp
@@ -75,6 +75,7 @@ void Clipboard::Paste()
         // NOTE: Some applications don't add a trailing null character. This includes past conhost versions.
         const auto maxLen = GlobalSize(handle) / sizeof(wchar_t);
         StringPaste(str, wcsnlen(str, maxLen));
+        return;
     }
 
     // We get CF_HDROP when a user copied a file with Ctrl+C in Explorer and pastes that into the terminal (among others).


### PR DESCRIPTION
Well, this one is rather simple. :)
tl;dr: We shouldn't call `StringPaste` twice for the same paste.

Closes MSFT:51822029