### PR TITLE
Fix cursor invalidation with horizontal scrolling

### DIFF
--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -1191,8 +1191,9 @@ void Renderer::_invalidateCurrentCursor() const
 
     const auto lineRendition = _currentCursorOptions.lineRendition;
     const auto cursorWidth = _currentCursorOptions.fIsDoubleWidth ? 2 : 1;
+    const auto x = coord.x - _viewport.Left();
 
-    til::rect rect{ coord.x, coord.y, coord.x + cursorWidth, coord.y + 1 };
+    til::rect rect{ x, coord.y, x + cursorWidth, coord.y + 1 };
     rect = BufferToScreenLine(rect, lineRendition);
 
     if (view.TrimToViewport(&rect))


### PR DESCRIPTION
`InvalidateCursor` wants a viewport-relative coordinate.
Thankfully, this bug hasn't shipped anywhere yet.

## Validation Steps Performed
* Enable horizontal scrolling in conhost
* Horizontally scroll
* Cursor blinks ✅