### PR TITLE
15x faster reflow in debug builds

### DIFF
--- a/src/buffer/out/Row.cpp
+++ b/src/buffer/out/Row.cpp
@@ -985,14 +985,15 @@ uint16_t ROW::size() const noexcept
 til::CoordType ROW::GetLastNonSpaceColumn() const noexcept
 {
     const auto text = GetText();
-    const auto beg = text.begin();
-    const auto end = text.end();
+    const auto beg = text.data();
+    const auto end = beg + text.size();
+#pragma warning(suppress : 26429) // Symbol 'it' is never tested for nullness, it can be marked as not_null (f.23).
     auto it = end;
 
     for (; it != beg; --it)
     {
         // it[-1] is safe as `it` is always greater than `beg` (loop invariant).
-        if (til::at(it, -1) != L' ')
+        if (it[-1] != L' ')
         {
             break;
         }

--- a/src/buffer/out/lib/bufferout.vcxproj
+++ b/src/buffer/out/lib/bufferout.vcxproj
@@ -32,7 +32,6 @@
   <ItemGroup>
     <ClInclude Include="..\cursor.h" />
     <ClInclude Include="..\DbcsAttribute.hpp" />
-    <ClInclude Include="..\ICharRow.hpp" />
     <ClInclude Include="..\ImageSlice.hpp" />
     <ClInclude Include="..\LineRendition.hpp" />
     <ClInclude Include="..\OutputCell.hpp" />


### PR DESCRIPTION
STL iterators have a significant overhead. This improves performance
of `GetLastNonSpaceColumn` by >100x (it's too large to measure),
and reflow by ~15x in debug builds. This makes text reflow in debug
builds today ~10x faster than it used to be in release builds before
the large rewrites in #15701 and #13626.