### PR TITLE
Revert lazy loading Quick Fix UI

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1760,15 +1760,12 @@ namespace winrt::TerminalApp::implementation
                 page->_PopulateContextMenu(weakTerm.get(), sender.try_as<MUX::Controls::CommandBarFlyout>(), true);
             }
         });
-        if constexpr (Feature_QuickFix::IsEnabled())
-        {
-            term.QuickFixMenu().Opening([weak = get_weak(), weakTerm](auto&& sender, auto&& /*args*/) {
-                if (const auto& page{ weak.get() })
-                {
-                    page->_PopulateQuickFixMenu(weakTerm.get(), sender.try_as<Controls::MenuFlyout>());
-                }
-            });
-        }
+        term.QuickFixMenu().Opening([weak = get_weak(), weakTerm](auto&& sender, auto&& /*args*/) {
+            if (const auto& page{ weak.get() })
+            {
+                page->_PopulateQuickFixMenu(weakTerm.get(), sender.try_as<Controls::MenuFlyout>());
+            }
+        });
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1760,12 +1760,15 @@ namespace winrt::TerminalApp::implementation
                 page->_PopulateContextMenu(weakTerm.get(), sender.try_as<MUX::Controls::CommandBarFlyout>(), true);
             }
         });
-        term.QuickFixMenu().Opening([weak = get_weak(), weakTerm](auto&& sender, auto&& /*args*/) {
-            if (const auto& page{ weak.get() })
-            {
-                page->_PopulateQuickFixMenu(weakTerm.get(), sender.try_as<Controls::MenuFlyout>());
-            }
-        });
+        if constexpr (Feature_QuickFix::IsEnabled())
+        {
+            term.QuickFixMenu().Opening([weak = get_weak(), weakTerm](auto&& sender, auto&& /*args*/) {
+                if (const auto& page{ weak.get() })
+                {
+                    page->_PopulateQuickFixMenu(weakTerm.get(), sender.try_as<Controls::MenuFlyout>());
+                }
+            });
+        }
     }
 
     // Method Description:

--- a/src/cascadia/TerminalControl/TermControl.xaml
+++ b/src/cascadia/TerminalControl/TermControl.xaml
@@ -1282,11 +1282,11 @@
 
                         <Button x:Name="QuickFixButton"
                                 x:Uid="QuickFixButton"
-                                x:Load="False"
                                 Width="{x:Bind QuickFixButtonWidth, Mode=OneWay}"
                                 Padding="0"
                                 HorizontalContentAlignment="Center"
                                 VerticalContentAlignment="Center"
+                                x:Load="False"
                                 AllowFocusOnInteraction="False"
                                 CornerRadius="0,5,5,0"
                                 PointerEntered="_QuickFixButton_PointerEntered"

--- a/src/cascadia/TerminalControl/TermControl.xaml
+++ b/src/cascadia/TerminalControl/TermControl.xaml
@@ -1286,7 +1286,6 @@
                                 Padding="0"
                                 HorizontalContentAlignment="Center"
                                 VerticalContentAlignment="Center"
-                                x:Load="False"
                                 AllowFocusOnInteraction="False"
                                 CornerRadius="0,5,5,0"
                                 PointerEntered="_QuickFixButton_PointerEntered"

--- a/src/cascadia/TerminalControl/TermControl.xaml
+++ b/src/cascadia/TerminalControl/TermControl.xaml
@@ -1282,6 +1282,7 @@
 
                         <Button x:Name="QuickFixButton"
                                 x:Uid="QuickFixButton"
+                                x:Load="False"
                                 Width="{x:Bind QuickFixButtonWidth, Mode=OneWay}"
                                 Padding="0"
                                 HorizontalContentAlignment="Center"


### PR DESCRIPTION
Turns out, when the branding disables the feature, we try to get `QuickFixMenu` when it's not loaded, causing a crash [here](https://github.com/microsoft/terminal/blob/dabc70ee21247fa8fa0bde976b456b124fb4b82a/src/cascadia/TerminalApp/TerminalPage.cpp#L1763-L1769). 

Since we end up loading the quick fix menu when we scroll or apply UI settings, we're actually loading the quick fix menu pretty early on. So might as well remove the `x:Load="False"`. If we feel strongly about keeping the lazy loading functionality, we can do that later (and probably apply the same heuristic to the other XAML we're registering in TerminalApp).

This also adds a feature flag check when registering the menu in TerminalApp.

Closes #17548