### PR TITLE
Fix various cooked read issues

### DIFF
--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -445,7 +445,6 @@ size_t TextBuffer::FitTextIntoColumns(const std::wstring_view& chars, til::Coord
     while (dist < len)
     {
         cwd.GraphemeNext(state, chars);
-        dist += state.len;
         col += state.width;
 
         // If we ran out of columns, we need to always return `columnLimit` and not `cols`,
@@ -457,6 +456,8 @@ size_t TextBuffer::FitTextIntoColumns(const std::wstring_view& chars, til::Coord
             columns = columnLimit;
             return dist;
         }
+
+        dist += state.len;
     }
 
     // But if we simply ran out of text we just need to return the actual number of columns.

--- a/src/host/readDataCooked.hpp
+++ b/src/host/readDataCooked.hpp
@@ -168,6 +168,7 @@ private:
     til::point _originInViewport;
     // This value is in the pager coordinate space. (0,0) is the first character of the
     // first line, independent on where the prompt actually appears on the screen.
+    // The coordinate is "end exclusive", so the last character is 1 in front of it.
     til::point _pagerPromptEnd;
     // The scroll position of the pager.
     til::CoordType _pagerContentTop = 0;


### PR DESCRIPTION
* Wide glyphs that don't fit into the last column got treated
  as narrow glyphs which broke line layout.
* Wide glyphs that don't fit into the last column got manually
  padded with whitespace which broke Ctrl+A + Ctrl+C in conhost.
* Sudden increases/decreases in the pager height would leave
  parts of the viewport with leftover text and not clear it away.
* Deleting an entire word at the start of a line would only delete
  its first two characters.

Closes #17554