### PR TITLE
Add helper functions for pipes

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -1205,6 +1205,7 @@ nouicompat
 nounihan
 NOYIELD
 NOZORDER
+NPFS
 nrcs
 NSTATUS
 ntapi

--- a/src/types/inc/utils.hpp
+++ b/src/types/inc/utils.hpp
@@ -15,6 +15,12 @@ Author(s):
 
 namespace Microsoft::Console::Utils
 {
+    struct Pipe
+    {
+        wil::unique_hfile server;
+        wil::unique_hfile client;
+    };
+
     // Function Description:
     // - Returns -1, 0 or +1 to indicate the sign of the passed-in value.
     template<typename T>
@@ -24,6 +30,10 @@ namespace Microsoft::Console::Utils
     }
 
     bool IsValidHandle(const HANDLE handle) noexcept;
+    bool HandleWantsOverlappedIo(HANDLE handle) noexcept;
+    Pipe CreatePipe(DWORD bufferSize);
+    Pipe CreateOverlappedPipe(DWORD openMode, DWORD bufferSize);
+    HRESULT GetOverlappedResultSameThread(const OVERLAPPED* overlapped, DWORD* bytesTransferred) noexcept;
 
     // Function Description:
     // - Clamps a long in between `min` and `SHRT_MAX`

--- a/src/types/utils.cpp
+++ b/src/types/utils.cpp
@@ -700,6 +700,43 @@ Utils::Pipe Utils::CreatePipe(DWORD bufferSize)
 // The code below contains comments to create unidirectional pipes.
 Utils::Pipe Utils::CreateOverlappedPipe(DWORD openMode, DWORD bufferSize)
 {
+    LARGE_INTEGER timeout = { .QuadPart = -10'0000'0000 }; // 1 second
+    UNICODE_STRING emptyPath{};
+    IO_STATUS_BLOCK statusBlock;
+    OBJECT_ATTRIBUTES objectAttributes{
+        .Length = sizeof(OBJECT_ATTRIBUTES),
+        .ObjectName = &emptyPath,
+        .Attributes = OBJ_CASE_INSENSITIVE,
+    };
+    DWORD serverDesiredAccess = 0;
+    DWORD clientDesiredAccess = 0;
+    DWORD serverShareAccess = 0;
+    DWORD clientShareAccess = 0;
+
+    switch (openMode)
+    {
+    case PIPE_ACCESS_INBOUND:
+        serverDesiredAccess = SYNCHRONIZE | GENERIC_READ | FILE_WRITE_ATTRIBUTES;
+        clientDesiredAccess = SYNCHRONIZE | GENERIC_WRITE | FILE_READ_ATTRIBUTES;
+        serverShareAccess = FILE_SHARE_WRITE;
+        clientShareAccess = FILE_SHARE_READ;
+        break;
+    case PIPE_ACCESS_OUTBOUND:
+        serverDesiredAccess = SYNCHRONIZE | GENERIC_WRITE | FILE_READ_ATTRIBUTES;
+        clientDesiredAccess = SYNCHRONIZE | GENERIC_READ | FILE_WRITE_ATTRIBUTES;
+        serverShareAccess = FILE_SHARE_READ;
+        clientShareAccess = FILE_SHARE_WRITE;
+        break;
+    case PIPE_ACCESS_DUPLEX:
+        serverDesiredAccess = SYNCHRONIZE | GENERIC_READ | GENERIC_WRITE;
+        clientDesiredAccess = SYNCHRONIZE | GENERIC_READ | GENERIC_WRITE;
+        serverShareAccess = FILE_SHARE_READ | FILE_SHARE_WRITE;
+        clientShareAccess = FILE_SHARE_READ | FILE_SHARE_WRITE;
+        break;
+    default:
+        THROW_HR(E_UNEXPECTED);
+    }
+
     // Cache a handle to the pipe driver.
     static const auto pipeDirectory = []() {
         UNICODE_STRING path = RTL_CONSTANT_STRING(L"\\Device\\NamedPipe\\");
@@ -727,41 +764,14 @@ Utils::Pipe Utils::CreateOverlappedPipe(DWORD openMode, DWORD bufferSize)
         return dir;
     }();
 
-    LARGE_INTEGER timeout = { .QuadPart = -10'0000'0000 }; // 1 second
-    UNICODE_STRING emptyPath{};
-    IO_STATUS_BLOCK statusBlock;
-    OBJECT_ATTRIBUTES objectAttributes{
-        .Length = sizeof(OBJECT_ATTRIBUTES),
-        .ObjectName = &emptyPath,
-        .Attributes = OBJ_CASE_INSENSITIVE,
-    };
-    DWORD desiredAccess = 0;
-    DWORD shareAccess = 0;
-
-    switch (openMode)
-    {
-    case PIPE_ACCESS_INBOUND:
-        desiredAccess = SYNCHRONIZE | GENERIC_READ | FILE_WRITE_ATTRIBUTES;
-        shareAccess = FILE_SHARE_WRITE;
-        break;
-    case PIPE_ACCESS_OUTBOUND:
-        desiredAccess = SYNCHRONIZE | GENERIC_WRITE | FILE_READ_ATTRIBUTES;
-        shareAccess = FILE_SHARE_READ;
-        break;
-    default:
-        desiredAccess = SYNCHRONIZE | GENERIC_READ | GENERIC_WRITE;
-        shareAccess = FILE_SHARE_READ | FILE_SHARE_WRITE;
-        break;
-    }
-
     wil::unique_hfile server;
     objectAttributes.RootDirectory = pipeDirectory.get();
     THROW_IF_NTSTATUS_FAILED(NtCreateNamedPipeFile(
         /* FileHandle        */ server.addressof(),
-        /* DesiredAccess     */ desiredAccess,
+        /* DesiredAccess     */ serverDesiredAccess,
         /* ObjectAttributes  */ &objectAttributes,
         /* IoStatusBlock     */ &statusBlock,
-        /* ShareAccess       */ FILE_SHARE_READ | FILE_SHARE_WRITE,
+        /* ShareAccess       */ serverShareAccess,
         /* CreateDisposition */ FILE_CREATE,
         /* CreateOptions     */ 0, // would be FILE_SYNCHRONOUS_IO_NONALERT for a synchronous pipe
         /* NamedPipeType     */ FILE_PIPE_BYTE_STREAM_TYPE,
@@ -772,32 +782,16 @@ Utils::Pipe Utils::CreateOverlappedPipe(DWORD openMode, DWORD bufferSize)
         /* OutboundQuota     */ bufferSize,
         /* DefaultTimeout    */ &timeout));
 
-    switch (openMode)
-    {
-    case PIPE_ACCESS_INBOUND:
-        desiredAccess = SYNCHRONIZE | GENERIC_WRITE | FILE_READ_ATTRIBUTES;
-        shareAccess = FILE_SHARE_READ;
-        break;
-    case PIPE_ACCESS_OUTBOUND:
-        desiredAccess = SYNCHRONIZE | GENERIC_READ | FILE_WRITE_ATTRIBUTES;
-        shareAccess = FILE_SHARE_WRITE;
-        break;
-    default:
-        desiredAccess = SYNCHRONIZE | GENERIC_READ | GENERIC_WRITE;
-        shareAccess = FILE_SHARE_READ | FILE_SHARE_WRITE;
-        break;
-    }
-
     wil::unique_hfile client;
     objectAttributes.RootDirectory = server.get();
     THROW_IF_NTSTATUS_FAILED(NtCreateFile(
         /* FileHandle        */ client.addressof(),
-        /* DesiredAccess     */ desiredAccess,
+        /* DesiredAccess     */ clientDesiredAccess,
         /* ObjectAttributes  */ &objectAttributes,
         /* IoStatusBlock     */ &statusBlock,
         /* AllocationSize    */ nullptr,
         /* FileAttributes    */ 0,
-        /* ShareAccess       */ shareAccess,
+        /* ShareAccess       */ clientShareAccess,
         /* CreateDisposition */ FILE_OPEN,
         /* CreateOptions     */ FILE_NON_DIRECTORY_FILE, // would include FILE_SYNCHRONOUS_IO_NONALERT for a synchronous pipe
         /* EaBuffer          */ nullptr,


### PR DESCRIPTION
Split off from #17510:
* `HandleWantsOverlappedIo` can be used to check if a handle requires
  overlapped IO. This is important, as `ReadFile` and `WriteFile` are
  documented to not work correctly if an overlapped handle is used
  without overlapped IO and vice versa.
  In my tests with pipes, this appears to be true.
* `CreatePipe` creates a synchronous, unidirectional pipe.
* `CreateOverlappedPipe` does what it says on the tin, while allowing
  you to specify the direction of the pipe (in, out, duplex).
* `GetOverlappedResultSameThread` is largely the same as
  `GetOverlappedResult`, but adds back a neat optimization from
  the time before Windows 7. I thought it was neat.