### PR TITLE
Remove CleanupGlobalFont from tests

### DIFF
--- a/src/cascadia/UnitTests_TerminalCore/ConptyRoundtripTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ConptyRoundtripTests.cpp
@@ -64,7 +64,6 @@ class TerminalCoreUnitTests::ConptyRoundtripTests final
         m_state = std::make_unique<CommonState>();
 
         m_state->InitEvents();
-        m_state->PrepareGlobalFont();
         m_state->PrepareGlobalInputBuffer();
         m_state->PrepareGlobalRenderer();
         m_state->PrepareGlobalScreenBuffer(TerminalViewWidth, TerminalViewHeight, TerminalViewWidth, TerminalViewHeight);
@@ -76,7 +75,6 @@ class TerminalCoreUnitTests::ConptyRoundtripTests final
     {
         m_state->CleanupGlobalScreenBuffer();
         m_state->CleanupGlobalRenderer();
-        m_state->CleanupGlobalFont();
         m_state->CleanupGlobalInputBuffer();
 
         m_state.release();

--- a/src/host/ut_host/ApiRoutinesTests.cpp
+++ b/src/host/ut_host/ApiRoutinesTests.cpp
@@ -33,7 +33,6 @@ class ApiRoutinesTests
     {
         m_state = std::make_unique<CommonState>();
 
-        m_state->PrepareGlobalFont();
         m_state->PrepareGlobalInputBuffer();
         m_state->PrepareGlobalScreenBuffer();
 
@@ -54,7 +53,6 @@ class ApiRoutinesTests
         m_state->CleanupGlobalInputBuffer();
 
         m_state->CleanupGlobalScreenBuffer();
-        m_state->CleanupGlobalFont();
 
         m_state.reset(nullptr);
 

--- a/src/host/ut_host/ClipboardTests.cpp
+++ b/src/host/ut_host/ClipboardTests.cpp
@@ -38,7 +38,6 @@ class ClipboardTests
     {
         m_state = new CommonState();
 
-        m_state->PrepareGlobalFont();
         m_state->PrepareGlobalInputBuffer();
         m_state->PrepareGlobalScreenBuffer();
 
@@ -49,7 +48,6 @@ class ClipboardTests
     {
         m_state->CleanupGlobalInputBuffer();
         m_state->CleanupGlobalScreenBuffer();
-        m_state->CleanupGlobalFont();
 
         return true;
     }

--- a/src/host/ut_host/ConptyOutputTests.cpp
+++ b/src/host/ut_host/ConptyOutputTests.cpp
@@ -44,7 +44,6 @@ class ConptyOutputTests
         m_state = std::make_unique<CommonState>();
 
         m_state->InitEvents();
-        m_state->PrepareGlobalFont();
         m_state->PrepareGlobalInputBuffer();
         m_state->PrepareGlobalScreenBuffer(TerminalViewWidth, TerminalViewHeight, TerminalViewWidth, TerminalViewHeight);
 
@@ -54,7 +53,6 @@ class ConptyOutputTests
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
         m_state->CleanupGlobalScreenBuffer();
-        m_state->CleanupGlobalFont();
         m_state->CleanupGlobalInputBuffer();
 
         m_state.release();

--- a/src/host/ut_host/ObjectTests.cpp
+++ b/src/host/ut_host/ObjectTests.cpp
@@ -23,7 +23,6 @@ class ObjectTests
         m_state = new CommonState();
 
         m_state->InitEvents();
-        m_state->PrepareGlobalFont();
         m_state->PrepareGlobalInputBuffer();
         m_state->PrepareGlobalScreenBuffer();
 
@@ -33,7 +32,6 @@ class ObjectTests
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
         m_state->CleanupGlobalScreenBuffer();
-        m_state->CleanupGlobalFont();
         m_state->CleanupGlobalInputBuffer();
 
         delete m_state;

--- a/src/host/ut_host/ScreenBufferTests.cpp
+++ b/src/host/ut_host/ScreenBufferTests.cpp
@@ -55,7 +55,6 @@ class ScreenBufferTests
     {
         m_state->CleanupGlobalScreenBuffer();
         m_state->CleanupGlobalRenderer();
-        m_state->CleanupGlobalFont();
         m_state->CleanupGlobalInputBuffer();
 
         delete m_state;

--- a/src/host/ut_host/SearchTests.cpp
+++ b/src/host/ut_host/SearchTests.cpp
@@ -24,7 +24,6 @@ class SearchTests
     {
         m_state = new CommonState();
 
-        m_state->PrepareGlobalFont();
         m_state->PrepareGlobalRenderer();
         m_state->PrepareGlobalScreenBuffer();
 
@@ -35,7 +34,6 @@ class SearchTests
     {
         m_state->CleanupGlobalScreenBuffer();
         m_state->CleanupGlobalRenderer();
-        m_state->CleanupGlobalFont();
 
         delete m_state;
 

--- a/src/host/ut_host/SelectionTests.cpp
+++ b/src/host/ut_host/SelectionTests.cpp
@@ -29,7 +29,6 @@ class SelectionTests
     {
         m_state = new CommonState();
 
-        m_state->PrepareGlobalFont();
         m_state->PrepareGlobalScreenBuffer();
 
         m_pSelection = &Selection::Instance();
@@ -41,7 +40,6 @@ class SelectionTests
         m_pSelection = nullptr;
 
         m_state->CleanupGlobalScreenBuffer();
-        m_state->CleanupGlobalFont();
 
         delete m_state;
 
@@ -355,7 +353,6 @@ class SelectionInputTests
     {
         m_state = new CommonState();
 
-        m_state->PrepareGlobalFont();
         m_state->PrepareGlobalInputBuffer();
         m_state->PrepareGlobalScreenBuffer();
         m_pHistory = CommandHistory::s_Allocate(L"cmd.exe", nullptr);
@@ -373,7 +370,6 @@ class SelectionInputTests
         CommandHistory::s_Free(nullptr);
         m_pHistory = nullptr;
         m_state->CleanupGlobalScreenBuffer();
-        m_state->CleanupGlobalFont();
         m_state->CleanupGlobalInputBuffer();
 
         delete m_state;

--- a/src/host/ut_host/TextBufferIteratorTests.cpp
+++ b/src/host/ut_host/TextBufferIteratorTests.cpp
@@ -80,7 +80,6 @@ class TextBufferIteratorTests
     {
         m_state = new CommonState();
 
-        m_state->PrepareGlobalFont();
         m_state->PrepareGlobalScreenBuffer();
 
         return true;
@@ -89,7 +88,6 @@ class TextBufferIteratorTests
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
         m_state->CleanupGlobalScreenBuffer();
-        m_state->CleanupGlobalFont();
 
         delete m_state;
 

--- a/src/host/ut_host/TextBufferTests.cpp
+++ b/src/host/ut_host/TextBufferTests.cpp
@@ -37,7 +37,6 @@ class TextBufferTests
     {
         m_state = new CommonState();
 
-        m_state->PrepareGlobalFont();
         m_state->PrepareGlobalScreenBuffer();
 
         return true;
@@ -46,7 +45,6 @@ class TextBufferTests
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
         m_state->CleanupGlobalScreenBuffer();
-        m_state->CleanupGlobalFont();
 
         delete m_state;
 

--- a/src/host/ut_host/UtilsTests.cpp
+++ b/src/host/ut_host/UtilsTests.cpp
@@ -29,7 +29,6 @@ class UtilsTests
     {
         m_state = new CommonState();
 
-        m_state->PrepareGlobalFont();
         m_state->PrepareGlobalScreenBuffer();
 
         const auto seed = (UINT)time(nullptr);
@@ -42,7 +41,6 @@ class UtilsTests
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
         m_state->CleanupGlobalScreenBuffer();
-        m_state->CleanupGlobalFont();
 
         delete m_state;
 

--- a/src/inc/test/CommonState.hpp
+++ b/src/inc/test/CommonState.hpp
@@ -35,7 +35,7 @@ public:
     CommonState() :
         m_heap(GetProcessHeap()),
         m_hrTextBufferInfo(E_FAIL),
-        m_pFontInfo(nullptr),
+        m_pFontInfo{ L"Consolas", 0, 0, { 8, 12 }, 0 },
         m_backupTextBufferInfo(),
         m_readHandle(nullptr)
     {
@@ -63,15 +63,7 @@ public:
 
     void PrepareGlobalFont(const til::size coordFontSize = { 8, 12 })
     {
-        m_pFontInfo = new FontInfo(L"Consolas", 0, 0, coordFontSize, 0);
-    }
-
-    void CleanupGlobalFont()
-    {
-        if (m_pFontInfo != nullptr)
-        {
-            delete m_pFontInfo;
-        }
+        m_pFontInfo = { L"Consolas", 0, 0, coordFontSize, 0 };
     }
 
     void PrepareGlobalRenderer()
@@ -106,7 +98,7 @@ public:
         UINT uiCursorSize = 12;
 
         THROW_IF_FAILED(SCREEN_INFORMATION::CreateInstance(coordWindowSize,
-                                                           *m_pFontInfo,
+                                                           m_pFontInfo,
                                                            coordScreenBufferSize,
                                                            TextAttribute{},
                                                            TextAttribute{ FOREGROUND_BLUE | FOREGROUND_INTENSITY | BACKGROUND_RED },
@@ -252,7 +244,7 @@ public:
 private:
     HANDLE m_heap;
     HRESULT m_hrTextBufferInfo;
-    FontInfo* m_pFontInfo;
+    FontInfo m_pFontInfo;
     std::unique_ptr<TextBuffer> m_backupTextBufferInfo;
     std::unique_ptr<INPUT_READ_HANDLE_DATA> m_readHandle;
 

--- a/src/interactivity/win32/ut_interactivity_win32/UiaTextRangeTests.cpp
+++ b/src/interactivity/win32/ut_interactivity_win32/UiaTextRangeTests.cpp
@@ -340,7 +340,6 @@ class UiaTextRangeTests
         auto& gci = Microsoft::Console::Interactivity::ServiceLocator::LocateGlobals().getConsoleInformation();
         // set up common state
         _state = new CommonState();
-        _state->PrepareGlobalFont();
         _state->PrepareGlobalScreenBuffer();
         _state->PrepareNewTextBufferInfo();
 
@@ -377,7 +376,6 @@ class UiaTextRangeTests
     {
         _state->CleanupNewTextBufferInfo();
         _state->CleanupGlobalScreenBuffer();
-        _state->CleanupGlobalFont();
         delete _state;
         delete _range;
 


### PR DESCRIPTION
By always setting up the font, it simplifies the upcoming VtIo tests
for #17510 which don't need a font, but implicitly rely on it anyway.