### PR TITLE
Move FindActionableControlCharacter to Types

### DIFF
--- a/src/types/inc/utils.hpp
+++ b/src/types/inc/utils.hpp
@@ -114,6 +114,8 @@ namespace Microsoft::Console::Utils
     // testing easier.
     std::wstring_view TrimPaste(std::wstring_view textView) noexcept;
 
+    const wchar_t* FindActionableControlCharacter(const wchar_t* beg, const size_t len) noexcept;
+
     // Same deal, but in TerminalPage::_evaluatePathForCwd
     std::wstring EvaluateStartingDirectory(std::wstring_view cwd, std::wstring_view startingDirectory);
 

--- a/src/types/utils.cpp
+++ b/src/types/utils.cpp
@@ -847,6 +847,114 @@ std::wstring_view Utils::TrimPaste(std::wstring_view textView) noexcept
     return textView.substr(0, lastNonSpace + 1);
 }
 
+// Disable vectorization-unfriendly warnings.
+#pragma warning(push)
+#pragma warning(disable : 26429) // Symbol '...' is never tested for nullness, it can be marked as not_null (f.23).
+#pragma warning(disable : 26472) // Don't use a static_cast for arithmetic conversions. Use brace initialization, gsl::narrow_cast or gsl::narrow (type.1).
+#pragma warning(disable : 26481) // Don't use pointer arithmetic. Use span instead (bounds.1).
+#pragma warning(disable : 26490) // Don't use reinterpret_cast (type.1).
+
+// Returns true for C0 characters and C1 [single-character] CSI.
+constexpr bool isActionableFromGround(const wchar_t wch) noexcept
+{
+    // This is equivalent to:
+    //   return (wch <= 0x1f) || (wch >= 0x7f && wch <= 0x9f);
+    // It's written like this to get MSVC to emit optimal assembly for findActionableFromGround.
+    // It lacks the ability to turn boolean operators into binary operations and also happens
+    // to fail to optimize the printable-ASCII range check into a subtraction & comparison.
+    return (wch <= 0x1f) | (static_cast<wchar_t>(wch - 0x7f) <= 0x20);
+}
+
+const wchar_t* Utils::FindActionableControlCharacter(const wchar_t* beg, const size_t len) noexcept
+{
+    auto it = beg;
+
+    // The following vectorized code replicates isActionableFromGround which is equivalent to:
+    //   (wch <= 0x1f) || (wch >= 0x7f && wch <= 0x9f)
+    // or rather its more machine friendly equivalent:
+    //   (wch <= 0x1f) | ((wch - 0x7f) <= 0x20)
+#if defined(TIL_SSE_INTRINSICS)
+
+    for (const auto end = beg + (len & ~size_t{ 7 }); it < end; it += 8)
+    {
+        const auto wch = _mm_loadu_si128(reinterpret_cast<const __m128i*>(it));
+        const auto z = _mm_setzero_si128();
+
+        // Dealing with unsigned numbers in SSE2 is annoying because it has poor support for that.
+        // We'll use subtractions with saturation ("SubS") to work around that. A check like
+        // a < b can be implemented as "max(0, a - b) == 0" and "max(0, a - b)" is what "SubS" is.
+
+        // Check for (wch < 0x20)
+        auto a = _mm_subs_epu16(wch, _mm_set1_epi16(0x1f));
+        // Check for "((wch - 0x7f) <= 0x20)" by adding 0x10000-0x7f, which overflows to a
+        // negative number if "wch >= 0x7f" and then subtracting 0x9f-0x7f with saturation to an
+        // unsigned number (= can't go lower than 0), which results in all numbers up to 0x9f to be 0.
+        auto b = _mm_subs_epu16(_mm_add_epi16(wch, _mm_set1_epi16(static_cast<short>(0xff81))), _mm_set1_epi16(0x20));
+        a = _mm_cmpeq_epi16(a, z);
+        b = _mm_cmpeq_epi16(b, z);
+
+        const auto c = _mm_or_si128(a, b);
+        const auto mask = _mm_movemask_epi8(c);
+
+        if (mask)
+        {
+            unsigned long offset;
+            _BitScanForward(&offset, mask);
+            it += offset / 2;
+            return it;
+        }
+    }
+
+#elif defined(TIL_ARM_NEON_INTRINSICS)
+
+    uint64_t mask;
+
+    for (const auto end = beg + (len & ~size_t{ 7 });;)
+    {
+        if (it >= end)
+        {
+            goto plainSearch;
+        }
+
+        const auto wch = vld1q_u16(it);
+        const auto a = vcleq_u16(wch, vdupq_n_u16(0x1f));
+        const auto b = vcleq_u16(vsubq_u16(wch, vdupq_n_u16(0x7f)), vdupq_n_u16(0x20));
+        const auto c = vorrq_u16(a, b);
+
+        mask = vgetq_lane_u64(c, 0);
+        if (mask)
+        {
+            break;
+        }
+        it += 4;
+
+        mask = vgetq_lane_u64(c, 1);
+        if (mask)
+        {
+            break;
+        }
+        it += 4;
+    }
+
+    unsigned long offset;
+    _BitScanForward64(&offset, mask);
+    it += offset / 16;
+    return it;
+
+plainSearch:
+
+#endif
+
+#pragma loop(no_vector)
+    for (const auto end = beg + len; it < end && !isActionableFromGround(*it); ++it)
+    {
+    }
+
+    return it;
+}
+
+#pragma warning(pop)
+
 std::wstring Utils::EvaluateStartingDirectory(
     std::wstring_view currentDirectory,
     std::wstring_view startingDirectory)


### PR DESCRIPTION
This will allow us to use `FindActionableControlCharacter` in code
outside of our VT parser. #17510 uses it to sanitize inputs.