### PR TITLE
Add ITerminalHandoff3 in preparation for overlapped pipes

### DIFF
--- a/src/cascadia/CascadiaPackage/Package-Can.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Can.appxmanifest
@@ -111,7 +111,6 @@
             <com:ComInterface>
                 <com:ProxyStub Id="1D1852F4-ADAD-42B6-9A43-9437AAAD7717" DisplayName="OpenConsoleHandoffProxy" Path="OpenConsoleProxy.dll"/>
                 <com:Interface Id="E686C757-9A35-4A1C-B3CE-0BCC8B5C69F4" ProxyStubClsid="1D1852F4-ADAD-42B6-9A43-9437AAAD7717"/>
-                <com:Interface Id="AA6B364F-4A50-4176-9002-0AE755E7B5EF" ProxyStubClsid="1D1852F4-ADAD-42B6-9A43-9437AAAD7717"/> <!-- ITerminalHandoff2 -->
                 <com:Interface Id="6F23DA90-15C5-4203-9DB0-64E73F1B1B00" ProxyStubClsid="1D1852F4-ADAD-42B6-9A43-9437AAAD7717"/> <!-- ITerminalHandoff3 -->
                 <com:Interface Id="746E6BC0-AB05-4E38-AB14-71E86763141F" ProxyStubClsid="1D1852F4-ADAD-42B6-9A43-9437AAAD7717"/>
             </com:ComInterface>

--- a/src/cascadia/CascadiaPackage/Package-Can.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Can.appxmanifest
@@ -111,8 +111,8 @@
             <com:ComInterface>
                 <com:ProxyStub Id="1D1852F4-ADAD-42B6-9A43-9437AAAD7717" DisplayName="OpenConsoleHandoffProxy" Path="OpenConsoleProxy.dll"/>
                 <com:Interface Id="E686C757-9A35-4A1C-B3CE-0BCC8B5C69F4" ProxyStubClsid="1D1852F4-ADAD-42B6-9A43-9437AAAD7717"/>
-                <com:Interface Id="59D55CCE-FC8A-48B4-ACE8-0A9286C6557F" ProxyStubClsid="1D1852F4-ADAD-42B6-9A43-9437AAAD7717"/> <!-- ITerminalHandoff -->
                 <com:Interface Id="AA6B364F-4A50-4176-9002-0AE755E7B5EF" ProxyStubClsid="1D1852F4-ADAD-42B6-9A43-9437AAAD7717"/> <!-- ITerminalHandoff2 -->
+                <com:Interface Id="6F23DA90-15C5-4203-9DB0-64E73F1B1B00" ProxyStubClsid="1D1852F4-ADAD-42B6-9A43-9437AAAD7717"/> <!-- ITerminalHandoff3 -->
                 <com:Interface Id="746E6BC0-AB05-4E38-AB14-71E86763141F" ProxyStubClsid="1D1852F4-ADAD-42B6-9A43-9437AAAD7717"/>
             </com:ComInterface>
         </com:Extension>

--- a/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
@@ -111,7 +111,6 @@
             <com:ComInterface>
                 <com:ProxyStub Id="DEC4804D-56D1-4F73-9FBE-6828E7C85C56" DisplayName="OpenConsoleHandoffProxy" Path="OpenConsoleProxy.dll"/>
                 <com:Interface Id="E686C757-9A35-4A1C-B3CE-0BCC8B5C69F4" ProxyStubClsid="DEC4804D-56D1-4F73-9FBE-6828E7C85C56"/>
-                <com:Interface Id="AA6B364F-4A50-4176-9002-0AE755E7B5EF" ProxyStubClsid="DEC4804D-56D1-4F73-9FBE-6828E7C85C56"/> <!-- ITerminalHandoff2 -->
                 <com:Interface Id="6F23DA90-15C5-4203-9DB0-64E73F1B1B00" ProxyStubClsid="DEC4804D-56D1-4F73-9FBE-6828E7C85C56"/> <!-- ITerminalHandoff3 -->
                 <com:Interface Id="746E6BC0-AB05-4E38-AB14-71E86763141F" ProxyStubClsid="DEC4804D-56D1-4F73-9FBE-6828E7C85C56"/>
             </com:ComInterface>

--- a/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
@@ -111,8 +111,8 @@
             <com:ComInterface>
                 <com:ProxyStub Id="DEC4804D-56D1-4F73-9FBE-6828E7C85C56" DisplayName="OpenConsoleHandoffProxy" Path="OpenConsoleProxy.dll"/>
                 <com:Interface Id="E686C757-9A35-4A1C-B3CE-0BCC8B5C69F4" ProxyStubClsid="DEC4804D-56D1-4F73-9FBE-6828E7C85C56"/>
-                <com:Interface Id="59D55CCE-FC8A-48B4-ACE8-0A9286C6557F" ProxyStubClsid="DEC4804D-56D1-4F73-9FBE-6828E7C85C56"/> <!-- ITerminalHandoff -->
                 <com:Interface Id="AA6B364F-4A50-4176-9002-0AE755E7B5EF" ProxyStubClsid="DEC4804D-56D1-4F73-9FBE-6828E7C85C56"/> <!-- ITerminalHandoff2 -->
+                <com:Interface Id="6F23DA90-15C5-4203-9DB0-64E73F1B1B00" ProxyStubClsid="DEC4804D-56D1-4F73-9FBE-6828E7C85C56"/> <!-- ITerminalHandoff3 -->
                 <com:Interface Id="746E6BC0-AB05-4E38-AB14-71E86763141F" ProxyStubClsid="DEC4804D-56D1-4F73-9FBE-6828E7C85C56"/>
             </com:ComInterface>
         </com:Extension>

--- a/src/cascadia/CascadiaPackage/Package-Pre.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Pre.appxmanifest
@@ -200,7 +200,6 @@
             <com:ComInterface>
                 <com:ProxyStub Id="1833E661-CC81-4DD0-87C6-C2F74BD39EFA" DisplayName="OpenConsoleHandoffProxy" Path="OpenConsoleProxy.dll"/>
                 <com:Interface Id="E686C757-9A35-4A1C-B3CE-0BCC8B5C69F4" ProxyStubClsid="1833E661-CC81-4DD0-87C6-C2F74BD39EFA"/>
-                <com:Interface Id="AA6B364F-4A50-4176-9002-0AE755E7B5EF" ProxyStubClsid="1833E661-CC81-4DD0-87C6-C2F74BD39EFA"/> <!-- ITerminalHandoff2 -->
                 <com:Interface Id="6F23DA90-15C5-4203-9DB0-64E73F1B1B00" ProxyStubClsid="1833E661-CC81-4DD0-87C6-C2F74BD39EFA"/> <!-- ITerminalHandoff3 -->
                 <com:Interface Id="746E6BC0-AB05-4E38-AB14-71E86763141F" ProxyStubClsid="1833E661-CC81-4DD0-87C6-C2F74BD39EFA"/>
             </com:ComInterface>

--- a/src/cascadia/CascadiaPackage/Package-Pre.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Pre.appxmanifest
@@ -200,8 +200,8 @@
             <com:ComInterface>
                 <com:ProxyStub Id="1833E661-CC81-4DD0-87C6-C2F74BD39EFA" DisplayName="OpenConsoleHandoffProxy" Path="OpenConsoleProxy.dll"/>
                 <com:Interface Id="E686C757-9A35-4A1C-B3CE-0BCC8B5C69F4" ProxyStubClsid="1833E661-CC81-4DD0-87C6-C2F74BD39EFA"/>
-                <com:Interface Id="59D55CCE-FC8A-48B4-ACE8-0A9286C6557F" ProxyStubClsid="1833E661-CC81-4DD0-87C6-C2F74BD39EFA"/> <!-- ITerminalHandoff -->
                 <com:Interface Id="AA6B364F-4A50-4176-9002-0AE755E7B5EF" ProxyStubClsid="1833E661-CC81-4DD0-87C6-C2F74BD39EFA"/> <!-- ITerminalHandoff2 -->
+                <com:Interface Id="6F23DA90-15C5-4203-9DB0-64E73F1B1B00" ProxyStubClsid="1833E661-CC81-4DD0-87C6-C2F74BD39EFA"/> <!-- ITerminalHandoff3 -->
                 <com:Interface Id="746E6BC0-AB05-4E38-AB14-71E86763141F" ProxyStubClsid="1833E661-CC81-4DD0-87C6-C2F74BD39EFA"/>
             </com:ComInterface>
         </com:Extension>

--- a/src/cascadia/CascadiaPackage/Package.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package.appxmanifest
@@ -200,8 +200,8 @@
             <com:ComInterface>
                 <com:ProxyStub Id="3171DE52-6EFA-4AEF-8A9F-D02BD67E7A4F" DisplayName="OpenConsoleHandoffProxy" Path="OpenConsoleProxy.dll"/>
                 <com:Interface Id="E686C757-9A35-4A1C-B3CE-0BCC8B5C69F4" ProxyStubClsid="3171DE52-6EFA-4AEF-8A9F-D02BD67E7A4F"/>
-                <com:Interface Id="59D55CCE-FC8A-48B4-ACE8-0A9286C6557F" ProxyStubClsid="3171DE52-6EFA-4AEF-8A9F-D02BD67E7A4F"/> <!-- ITerminalHandoff -->
                 <com:Interface Id="AA6B364F-4A50-4176-9002-0AE755E7B5EF" ProxyStubClsid="3171DE52-6EFA-4AEF-8A9F-D02BD67E7A4F"/> <!-- ITerminalHandoff2 -->
+                <com:Interface Id="6F23DA90-15C5-4203-9DB0-64E73F1B1B00" ProxyStubClsid="3171DE52-6EFA-4AEF-8A9F-D02BD67E7A4F"/> <!-- ITerminalHandoff3 -->
                 <com:Interface Id="746E6BC0-AB05-4E38-AB14-71E86763141F" ProxyStubClsid="3171DE52-6EFA-4AEF-8A9F-D02BD67E7A4F"/>
             </com:ComInterface>
         </com:Extension>

--- a/src/cascadia/CascadiaPackage/Package.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package.appxmanifest
@@ -200,7 +200,6 @@
             <com:ComInterface>
                 <com:ProxyStub Id="3171DE52-6EFA-4AEF-8A9F-D02BD67E7A4F" DisplayName="OpenConsoleHandoffProxy" Path="OpenConsoleProxy.dll"/>
                 <com:Interface Id="E686C757-9A35-4A1C-B3CE-0BCC8B5C69F4" ProxyStubClsid="3171DE52-6EFA-4AEF-8A9F-D02BD67E7A4F"/>
-                <com:Interface Id="AA6B364F-4A50-4176-9002-0AE755E7B5EF" ProxyStubClsid="3171DE52-6EFA-4AEF-8A9F-D02BD67E7A4F"/> <!-- ITerminalHandoff2 -->
                 <com:Interface Id="6F23DA90-15C5-4203-9DB0-64E73F1B1B00" ProxyStubClsid="3171DE52-6EFA-4AEF-8A9F-D02BD67E7A4F"/> <!-- ITerminalHandoff3 -->
                 <com:Interface Id="746E6BC0-AB05-4E38-AB14-71E86763141F" ProxyStubClsid="3171DE52-6EFA-4AEF-8A9F-D02BD67E7A4F"/>
             </com:ComInterface>

--- a/src/cascadia/TerminalConnection/CTerminalHandoff.h
+++ b/src/cascadia/TerminalConnection/CTerminalHandoff.h
@@ -28,19 +28,13 @@ Author(s):
 #define __CLSID_CTerminalHandoff "051F34EE-C1FD-4B19-AF75-9BA54648434C"
 #endif
 
-using NewHandoffFunction = HRESULT (*)(HANDLE, HANDLE, HANDLE, HANDLE, HANDLE, HANDLE, TERMINAL_STARTUP_INFO);
+using NewHandoffFunction = HRESULT (*)(HANDLE* in, HANDLE* out, HANDLE signal, HANDLE reference, HANDLE server, HANDLE client, const TERMINAL_STARTUP_INFO* startupInfo);
 
 struct __declspec(uuid(__CLSID_CTerminalHandoff))
-    CTerminalHandoff : public Microsoft::WRL::RuntimeClass<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::ClassicCom>, ITerminalHandoff2>
+    CTerminalHandoff : public Microsoft::WRL::RuntimeClass<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::ClassicCom>, ITerminalHandoff3>
 {
 #pragma region ITerminalHandoff
-    STDMETHODIMP EstablishPtyHandoff(HANDLE in,
-                                     HANDLE out,
-                                     HANDLE signal,
-                                     HANDLE ref,
-                                     HANDLE server,
-                                     HANDLE client,
-                                     TERMINAL_STARTUP_INFO startupInfo) override;
+    STDMETHODIMP EstablishPtyHandoff(HANDLE* in, HANDLE* out, HANDLE signal, HANDLE reference, HANDLE server, HANDLE client, const TERMINAL_STARTUP_INFO* startupInfo) override;
 
 #pragma endregion
 

--- a/src/cascadia/TerminalConnection/ConptyConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConptyConnection.cpp
@@ -482,21 +482,14 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
     void ConptyConnection::_LastConPtyClientDisconnected() noexcept
     try
     {
-        DWORD exitCode = 0;
+        DWORD exitCode{ 0 };
         GetExitCodeProcess(_piClient.hProcess, &exitCode);
 
         // Signal the closing or failure of the process.
         // exitCode might be STILL_ACTIVE if a client has called FreeConsole() and
         // thus caused the tab to close, even though the CLI app is still running.
-        const auto success = exitCode == 0 || exitCode == STILL_ACTIVE || exitCode == STATUS_CONTROL_C_EXIT;
-        const auto state = success ? ConnectionState::Closed : ConnectionState::Failed;
-
-        if (!success)
-        {
-            _indicateExitWithStatus(exitCode);
-        }
-
-        _transitionToState(state);
+        _transitionToState(exitCode == 0 || exitCode == STILL_ACTIVE ? ConnectionState::Closed : ConnectionState::Failed);
+        _indicateExitWithStatus(exitCode);
     }
     CATCH_LOG()
 

--- a/src/cascadia/TerminalConnection/ConptyConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConptyConnection.cpp
@@ -5,7 +5,6 @@
 #include "ConptyConnection.h"
 
 #include <conpty-static.h>
-#include <winternl.h>
 
 #include "CTerminalHandoff.h"
 #include "LibraryResources.h"
@@ -173,33 +172,10 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
     }
     CATCH_RETURN();
 
-    ConptyConnection::ConptyConnection(const HANDLE hSig,
-                                       const HANDLE hIn,
-                                       const HANDLE hOut,
-                                       const HANDLE hRef,
-                                       const HANDLE hServerProcess,
-                                       const HANDLE hClientProcess,
-                                       const TERMINAL_STARTUP_INFO& startupInfo) :
-        _rows{ 25 },
-        _cols{ 80 },
-        _inPipe{ hIn },
-        _outPipe{ hOut }
+    // Who decided that?
+#pragma warning(suppress : 26455) // Default constructor should not throw. Declare it 'noexcept' (f.6).
+    ConptyConnection::ConptyConnection()
     {
-        _sessionId = Utils::CreateGuid();
-
-        THROW_IF_FAILED(ConptyPackPseudoConsole(hServerProcess, hRef, hSig, &_hPC));
-        _piClient.hProcess = hClientProcess;
-
-        _startupInfo.title = winrt::hstring{ startupInfo.pszTitle, SysStringLen(startupInfo.pszTitle) };
-        _startupInfo.iconPath = winrt::hstring{ startupInfo.pszIconPath, SysStringLen(startupInfo.pszIconPath) };
-        _startupInfo.iconIndex = startupInfo.iconIndex;
-        _startupInfo.showWindow = startupInfo.wShowWindow;
-
-        try
-        {
-            _commandline = _commandlineFromProcess(hClientProcess);
-        }
-        CATCH_LOG()
     }
 
     // Function Description:
@@ -317,6 +293,53 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         {
             _sessionId = Utils::CreateGuid();
         }
+    }
+
+    static wil::unique_hfile duplicateHandle(const HANDLE in)
+    {
+        wil::unique_hfile h;
+        THROW_IF_WIN32_BOOL_FALSE(DuplicateHandle(GetCurrentProcess(), in, GetCurrentProcess(), h.addressof(), 0, FALSE, DUPLICATE_SAME_ACCESS));
+        return h;
+    }
+
+    // Misdiagnosis: out is being tested right in the first line.
+#pragma warning(suppress : 26430) // Symbol 'out' is not tested for nullness on all paths (f.23).
+    void ConptyConnection::InitializeFromHandoff(HANDLE* in, HANDLE* out, HANDLE signal, HANDLE reference, HANDLE server, HANDLE client, const TERMINAL_STARTUP_INFO* startupInfo)
+    {
+        THROW_HR_IF(E_UNEXPECTED, !in || !out || !startupInfo);
+
+        _sessionId = Utils::CreateGuid();
+
+        wil::unique_hfile inPipePseudoConsoleSide;
+        wil::unique_hfile outPipePseudoConsoleSide;
+        THROW_IF_WIN32_BOOL_FALSE(CreatePipe(&inPipePseudoConsoleSide, &_inPipe, nullptr, 0));
+        THROW_IF_WIN32_BOOL_FALSE(CreatePipe(&_outPipe, &outPipePseudoConsoleSide, nullptr, 0));
+
+        auto ownedSignal = duplicateHandle(signal);
+        auto ownedReference = duplicateHandle(reference);
+        auto ownedServer = duplicateHandle(server);
+        auto ownedClient = duplicateHandle(client);
+
+        THROW_IF_FAILED(ConptyPackPseudoConsole(ownedServer.get(), ownedReference.get(), ownedSignal.get(), &_hPC));
+        ownedServer.release();
+        ownedReference.release();
+        ownedSignal.release();
+
+        _piClient.hProcess = ownedClient.release();
+
+        _startupInfo.title = winrt::hstring{ startupInfo->pszTitle, SysStringLen(startupInfo->pszTitle) };
+        _startupInfo.iconPath = winrt::hstring{ startupInfo->pszIconPath, SysStringLen(startupInfo->pszIconPath) };
+        _startupInfo.iconIndex = startupInfo->iconIndex;
+        _startupInfo.showWindow = startupInfo->wShowWindow;
+
+        try
+        {
+            _commandline = _commandlineFromProcess(_piClient.hProcess);
+        }
+        CATCH_LOG()
+
+        *in = inPipePseudoConsoleSide.release();
+        *out = outPipePseudoConsoleSide.release();
     }
 
     winrt::hstring ConptyConnection::Commandline() const
@@ -459,14 +482,21 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
     void ConptyConnection::_LastConPtyClientDisconnected() noexcept
     try
     {
-        DWORD exitCode{ 0 };
+        DWORD exitCode = 0;
         GetExitCodeProcess(_piClient.hProcess, &exitCode);
 
         // Signal the closing or failure of the process.
         // exitCode might be STILL_ACTIVE if a client has called FreeConsole() and
         // thus caused the tab to close, even though the CLI app is still running.
-        _transitionToState(exitCode == 0 || exitCode == STILL_ACTIVE ? ConnectionState::Closed : ConnectionState::Failed);
-        _indicateExitWithStatus(exitCode);
+        const auto success = exitCode == 0 || exitCode == STILL_ACTIVE || exitCode == STATUS_CONTROL_C_EXIT;
+        const auto state = success ? ConnectionState::Closed : ConnectionState::Failed;
+
+        if (!success)
+        {
+            _indicateExitWithStatus(exitCode);
+        }
+
+        _transitionToState(state);
     }
     CATCH_LOG()
 
@@ -618,12 +648,20 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         // won't wait for us, and the known exit points _do_.
         auto strongThis{ get_strong() };
 
+        const auto cleanup = wil::scope_exit([this]() noexcept {
+            _LastConPtyClientDisconnected();
+        });
+
+        char buffer[128 * 1024];
+        DWORD read = 0;
+
+        til::u8state u8State;
+        std::wstring wstr;
+
         // process the data of the output pipe in a loop
         while (true)
         {
-            DWORD read{};
-
-            const auto readFail{ !ReadFile(_outPipe.get(), _buffer.data(), gsl::narrow_cast<DWORD>(_buffer.size()), &read, nullptr) };
+            const auto readFail{ !ReadFile(_outPipe.get(), &buffer[0], sizeof(buffer), &read, nullptr) };
 
             // When we call CancelSynchronousIo() in Close() this is the branch that's taken and gets us out of here.
             if (_isStateAtOrBeyond(ConnectionState::Closing))
@@ -648,7 +686,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
                 }
             }
 
-            const auto result{ til::u8u16(std::string_view{ _buffer.data(), read }, _u16Str, _u8State) };
+            const auto result{ til::u8u16(std::string_view{ &buffer[0], read }, wstr, u8State) };
             if (FAILED(result))
             {
                 // EXIT POINT
@@ -657,7 +695,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
                 return gsl::narrow_cast<DWORD>(result);
             }
 
-            if (_u16Str.empty())
+            if (wstr.empty())
             {
                 return 0;
             }
@@ -679,7 +717,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
             }
 
             // Pass the output to our registered event handlers
-            TerminalOutput.raise(_u16Str);
+            TerminalOutput.raise(wstr);
         }
 
         return 0;
@@ -695,11 +733,12 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         ::ConptyClosePseudoConsoleTimeout(hPC, 0);
     }
 
-    HRESULT ConptyConnection::NewHandoff(HANDLE in, HANDLE out, HANDLE signal, HANDLE ref, HANDLE server, HANDLE client, TERMINAL_STARTUP_INFO startupInfo) noexcept
+    HRESULT ConptyConnection::NewHandoff(HANDLE* in, HANDLE* out, HANDLE signal, HANDLE reference, HANDLE server, HANDLE client, const TERMINAL_STARTUP_INFO* startupInfo) noexcept
     try
     {
-        _newConnectionHandlers(winrt::make<ConptyConnection>(signal, in, out, ref, server, client, startupInfo));
-
+        auto conn = winrt::make_self<ConptyConnection>();
+        conn->InitializeFromHandoff(in, out, signal, reference, server, client, startupInfo);
+        _newConnectionHandlers(*std::move(conn));
         return S_OK;
     }
     CATCH_RETURN()

--- a/src/cascadia/TerminalConnection/ConptyConnection.h
+++ b/src/cascadia/TerminalConnection/ConptyConnection.h
@@ -13,16 +13,9 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 {
     struct ConptyConnection : ConptyConnectionT<ConptyConnection>, BaseTerminalConnection<ConptyConnection>
     {
-        ConptyConnection(const HANDLE hSig,
-                         const HANDLE hIn,
-                         const HANDLE hOut,
-                         const HANDLE hRef,
-                         const HANDLE hServerProcess,
-                         const HANDLE hClientProcess,
-                         const TERMINAL_STARTUP_INFO& startupInfo);
-
-        ConptyConnection() noexcept = default;
+        explicit ConptyConnection();
         void Initialize(const Windows::Foundation::Collections::ValueSet& settings);
+        void InitializeFromHandoff(HANDLE* in, HANDLE* out, HANDLE signal, HANDLE reference, HANDLE server, HANDLE client, const TERMINAL_STARTUP_INFO* startupInfo);
 
         static winrt::fire_and_forget final_release(std::unique_ptr<ConptyConnection> connection);
 
@@ -61,15 +54,15 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 
     private:
         static void closePseudoConsoleAsync(HPCON hPC) noexcept;
-        static HRESULT NewHandoff(HANDLE in, HANDLE out, HANDLE signal, HANDLE ref, HANDLE server, HANDLE client, TERMINAL_STARTUP_INFO startupInfo) noexcept;
+        static HRESULT NewHandoff(HANDLE* in, HANDLE* out, HANDLE signal, HANDLE reference, HANDLE server, HANDLE client, const TERMINAL_STARTUP_INFO* startupInfo) noexcept;
         static winrt::hstring _commandlineFromProcess(HANDLE process);
 
         HRESULT _LaunchAttachedClient() noexcept;
         void _indicateExitWithStatus(unsigned int status) noexcept;
         void _LastConPtyClientDisconnected() noexcept;
 
-        til::CoordType _rows{};
-        til::CoordType _cols{};
+        til::CoordType _rows = 120;
+        til::CoordType _cols = 30;
         uint64_t _initialParentHwnd{ 0 };
         hstring _commandline{};
         hstring _startingDirectory{};
@@ -87,9 +80,6 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         wil::unique_process_information _piClient;
         wil::unique_any<HPCON, decltype(closePseudoConsoleAsync), closePseudoConsoleAsync> _hPC;
 
-        til::u8state _u8State{};
-        std::wstring _u16Str{};
-        std::array<char, 4096> _buffer{};
         DWORD _flags{ 0 };
 
         til::env _initialEnv{};

--- a/src/cascadia/UnitTests_Remoting/RemotingTests.cpp
+++ b/src/cascadia/UnitTests_Remoting/RemotingTests.cpp
@@ -2586,7 +2586,6 @@ namespace RemotingUnitTests
             try
             {
                 const auto result = m1->ProposeCommandline(args);
-                VERIFY_IS_FALSE(true, L"This should have thrown");
             }
             catch (const winrt::hresult_error& e)
             {
@@ -2596,9 +2595,10 @@ namespace RemotingUnitTests
 
                 // This is the same check in WindowManager::_proposeToMonarch.
                 VERIFY_IS_TRUE(e.code() == RPC_SERVER_UNAVAILABLE_HR || e.code() == RPC_CALL_FAILED_HR);
+                return;
             }
-            // just don't catch other types of exceptions. They'll take out
-            // TAEF, which will count as a failure.
+
+            VERIFY_FAIL(L"This should have thrown");
         }
     }
 

--- a/src/host/proxy/IConsoleHandoff.idl
+++ b/src/host/proxy/IConsoleHandoff.idl
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import "oaidl.idl";
-import "ocidl.idl";
+import "unknwn.idl";
 
 typedef struct _CONSOLE_PORTABLE_ATTACH_MSG
 {

--- a/src/host/proxy/ITerminalHandoff.idl
+++ b/src/host/proxy/ITerminalHandoff.idl
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import "oaidl.idl";
-import "ocidl.idl";
-
+import "unknwn.idl";
 
 typedef struct _TERMINAL_STARTUP_INFO
 {
@@ -33,6 +31,7 @@ typedef struct _TERMINAL_STARTUP_INFO
 // versions of interfaces in the file here, even if the old version is no longer
 // in use.
 
+// This was the original prototype. The reasons for changes to it are explained below.
 [
     object,
     uuid(59D55CCE-FC8A-48B4-ACE8-0A9286C6557F)
@@ -47,6 +46,9 @@ typedef struct _TERMINAL_STARTUP_INFO
                                 [in, system_handle(sh_process)] HANDLE client);
 };
 
+// We didn't consider the need for TERMINAL_STARTUP_INFO, because Windows Terminal never had support for launching
+// .lnk files in the first place. They aren't executables after all, but rather a shell thing.
+// Its need quickly became apparent right after releasing ITerminalHandoff, which is why it was very short-lived.
 [
     object,
     uuid(AA6B364F-4A50-4176-9002-0AE755E7B5EF)
@@ -59,4 +61,22 @@ typedef struct _TERMINAL_STARTUP_INFO
                                 [in, system_handle(sh_process)] HANDLE server,
                                 [in, system_handle(sh_process)] HANDLE client,
                                 [in] TERMINAL_STARTUP_INFO startupInfo);
+};
+
+// Quite a while later, we realized that passing the in/out handles as [in] instead of [out] has always been flawed.
+// It prevents the terminal from making choices over the pipe buffer size and whether to use overlapped IO or not.
+// The other handles remain [in] parameters because they have always been created internally by ConPTY.
+// Additionally, passing TERMINAL_STARTUP_INFO by-value was unusual under COM as structs are usually given by-ref.
+[
+    object,
+    uuid(6F23DA90-15C5-4203-9DB0-64E73F1B1B00)
+] interface ITerminalHandoff3 : IUnknown
+{
+    HRESULT EstablishPtyHandoff([out, system_handle(sh_pipe)] HANDLE* in,
+                                [out, system_handle(sh_pipe)] HANDLE* out,
+                                [in, system_handle(sh_pipe)] HANDLE signal,
+                                [in, system_handle(sh_file)] HANDLE reference,
+                                [in, system_handle(sh_process)] HANDLE server,
+                                [in, system_handle(sh_process)] HANDLE client,
+                                [in] const TERMINAL_STARTUP_INFO* startupInfo);
 };

--- a/src/host/srvinit.cpp
+++ b/src/host/srvinit.cpp
@@ -574,7 +574,7 @@ try
 
     // GH#13211 - Make sure the terminal obeys the resizing quirk. Otherwise,
     // defterm connections to the Terminal are going to have weird resizing.
-    const auto commandLine = fmt::format(FMT_COMPILE(L" --headless --signal {:#x}"),
+    const auto commandLine = fmt::format(FMT_COMPILE(L" --headless --resizeQuirk --signal {:#x}"),
                                          (int64_t)signalPipeOurSide.release());
 
     ConsoleArguments consoleArgs(commandLine, inPipeOurSide.release(), outPipeOurSide.release());

--- a/src/host/srvinit.cpp
+++ b/src/host/srvinit.cpp
@@ -457,18 +457,7 @@ try
 
     wil::unique_handle signalPipeTheirSide;
     wil::unique_handle signalPipeOurSide;
-
-    wil::unique_handle inPipeTheirSide;
-    wil::unique_handle inPipeOurSide;
-
-    wil::unique_handle outPipeTheirSide;
-    wil::unique_handle outPipeOurSide;
-
     RETURN_IF_WIN32_BOOL_FALSE(CreatePipe(signalPipeOurSide.addressof(), signalPipeTheirSide.addressof(), nullptr, 0));
-
-    RETURN_IF_WIN32_BOOL_FALSE(CreatePipe(inPipeOurSide.addressof(), inPipeTheirSide.addressof(), nullptr, 0));
-
-    RETURN_IF_WIN32_BOOL_FALSE(CreatePipe(outPipeTheirSide.addressof(), outPipeOurSide.addressof(), nullptr, 0));
 
     TraceLoggingWrite(g_hConhostV2EventTraceProvider,
                       "SrvInit_ReceiveHandoff_OpenedPipes",
@@ -491,7 +480,7 @@ try
 
     const auto serverProcess = GetCurrentProcess();
 
-    ::Microsoft::WRL::ComPtr<ITerminalHandoff2> handoff;
+    ::Microsoft::WRL::ComPtr<ITerminalHandoff3> handoff;
 
     TraceLoggingWrite(g_hConhostV2EventTraceProvider,
                       "SrvInit_PrepareToCreateDelegationTerminal",
@@ -566,26 +555,26 @@ try
 
     myStartupInfo.wShowWindow = settings.GetShowWindow();
 
-    RETURN_IF_FAILED(handoff->EstablishPtyHandoff(inPipeTheirSide.get(),
-                                                  outPipeTheirSide.get(),
+    wil::unique_handle inPipeOurSide;
+    wil::unique_handle outPipeOurSide;
+    RETURN_IF_FAILED(handoff->EstablishPtyHandoff(inPipeOurSide.addressof(),
+                                                  outPipeOurSide.addressof(),
                                                   signalPipeTheirSide.get(),
                                                   refHandle.get(),
                                                   serverProcess,
                                                   clientProcess.get(),
-                                                  myStartupInfo));
+                                                  &myStartupInfo));
 
     TraceLoggingWrite(g_hConhostV2EventTraceProvider,
                       "SrvInit_DelegateToTerminalSucceeded",
                       TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
                       TraceLoggingKeyword(TIL_KEYWORD_TRACE));
 
-    inPipeTheirSide.reset();
-    outPipeTheirSide.reset();
     signalPipeTheirSide.reset();
 
     // GH#13211 - Make sure the terminal obeys the resizing quirk. Otherwise,
     // defterm connections to the Terminal are going to have weird resizing.
-    const auto commandLine = fmt::format(FMT_COMPILE(L" --headless --resizeQuirk --signal {:#x}"),
+    const auto commandLine = fmt::format(FMT_COMPILE(L" --headless --signal {:#x}"),
                                          (int64_t)signalPipeOurSide.release());
 
     ConsoleArguments consoleArgs(commandLine, inPipeOurSide.release(), outPipeOurSide.release());

--- a/src/inc/til/u8u16convert.h
+++ b/src/inc/til/u8u16convert.h
@@ -26,7 +26,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
     // state structure for maintenance of UTF-8 partials
     struct u8state
     {
-        char partials[4];
+        char partials[4]{};
         uint8_t have{};
         uint8_t want{};
 


### PR DESCRIPTION
Without a renderer in #17510 we cannot skip "frames" anymore.
As such, using overlapped IO becomes crucial to avoid a regression
in performance. ITerminalHandoff3 fixes this by allowing the terminal
to pick the pipes it wants, which mirrors CreatePseudoConsole
where the caller can also pick its own pipes.

## Validation Steps Performed
* Do a handoff with the dev build
* Input/Output works ✅