### PR TITLE
Fix cursor inheritance

### DIFF
--- a/src/inc/til/atomic.h
+++ b/src/inc/til/atomic.h
@@ -5,23 +5,29 @@
 
 namespace til
 {
+    // Similar to std::atomic<T>::wait, but slightly faster and with the ability to specify a timeout.
+    // Returns false on failure, which is pretty much always a timeout. (We prevent invalid arguments by taking references.)
     template<typename T>
-    inline void atomic_wait(const std::atomic<T>& atomic, const T& current, DWORD waitMilliseconds = INFINITE) noexcept
+    bool atomic_wait(const std::atomic<T>& atomic, const T& current, DWORD waitMilliseconds = INFINITE) noexcept
     {
         static_assert(sizeof(atomic) == sizeof(current));
 #pragma warning(suppress : 26492) // Don't use const_cast to cast away const or volatile
-        WaitOnAddress(const_cast<std::atomic<T>*>(&atomic), const_cast<T*>(&current), sizeof(current), waitMilliseconds);
+        return WaitOnAddress(const_cast<std::atomic<T>*>(&atomic), const_cast<T*>(&current), sizeof(current), waitMilliseconds);
     }
 
+    // Wakes at most one of the threads waiting on the atomic via atomic_wait().
+    // Don't use this with std::atomic<T>::wait, because it's not guaranteed to work in the future.
     template<typename T>
-    inline void atomic_notify_one(const std::atomic<T>& atomic) noexcept
+    void atomic_notify_one(const std::atomic<T>& atomic) noexcept
     {
 #pragma warning(suppress : 26492) // Don't use const_cast to cast away const or volatile
         WakeByAddressSingle(const_cast<std::atomic<T>*>(&atomic));
     }
 
+    // Wakes all threads waiting on the atomic via atomic_wait().
+    // Don't use this with std::atomic<T>::wait, because it's not guaranteed to work in the future.
     template<typename T>
-    inline void atomic_notify_all(const std::atomic<T>& atomic) noexcept
+    void atomic_notify_all(const std::atomic<T>& atomic) noexcept
     {
 #pragma warning(suppress : 26492) // Don't use const_cast to cast away const or volatile
         WakeByAddressAll(const_cast<std::atomic<T>*>(&atomic));

--- a/src/terminal/parser/InputStateMachineEngine.cpp
+++ b/src/terminal/parser/InputStateMachineEngine.cpp
@@ -105,11 +105,11 @@ InputStateMachineEngine::InputStateMachineEngine(std::unique_ptr<IInteractDispat
 
 void InputStateMachineEngine::WaitUntilDSR(DWORD timeout) const noexcept
 {
+    // atomic_wait() returns false when the timeout expires.
     // Technically we should decrement the timeout with each iteration,
     // but I suspect infinite spurious wake-ups are a theoretical problem.
-    while (_lookingForDSR.load(std::memory_order::relaxed))
+    while (_lookingForDSR.load(std::memory_order::relaxed) && til::atomic_wait(_lookingForDSR, true, timeout))
     {
-        til::atomic_wait(_lookingForDSR, true, timeout);
     }
 }
 


### PR DESCRIPTION
#17574 had 2 bugs, which I failed to notice because I didn't test
the code again after fixing the `WaitUntilDSR` boolean expression:
* The `VtInputThread` needs to be running in order
  for us to see any VT input get parsed.
  * Consequentially, the console lock must be suspended while we wait.
* Since `WaitUntilDSR` didn't detect timeouts it would loop forever.
  This wasn't obvious before, because it wouldn't loop at all. (lol)