### PR TITLE
AtlasEngine: Fix dirty rects during scrolling

### DIFF
--- a/src/renderer/atlas/AtlasEngine.api.cpp
+++ b/src/renderer/atlas/AtlasEngine.api.cpp
@@ -98,7 +98,7 @@ constexpr HRESULT vec2_narrow(U x, U y, vec2<T>& out) noexcept
 
 [[nodiscard]] HRESULT AtlasEngine::InvalidateHighlight(std::span<const til::point_span> highlights, const TextBuffer& buffer) noexcept
 {
-    const auto viewportOrigin = til::point{ _api.s->viewportOffset.x, _api.s->viewportOffset.y };
+    const auto viewportOrigin = til::point{ _api.viewportOffset.x, _api.viewportOffset.y };
     const auto viewport = til::rect{ 0, 0, _api.s->viewportCellCount.x, _api.s->viewportCellCount.y };
     const auto cellCountX = static_cast<til::CoordType>(_api.s->viewportCellCount.x);
     for (const auto& hi : highlights)
@@ -221,10 +221,7 @@ try
     {
         _api.s.write()->viewportCellCount = viewportCellCount;
     }
-    if (_api.s->viewportOffset != viewportOffset)
-    {
-        _api.s.write()->viewportOffset = viewportOffset;
-    }
+    _api.viewportOffset = viewportOffset;
 
     return S_OK;
 }

--- a/src/renderer/atlas/AtlasEngine.h
+++ b/src/renderer/atlas/AtlasEngine.h
@@ -179,6 +179,9 @@ namespace Microsoft::Console::Render::Atlas
             u16r invalidatedCursorArea = invalidatedAreaNone;
             range<u16> invalidatedRows = invalidatedRowsNone; // x is treated as "top" and y as "bottom"
             i16 scrollOffset = 0;
+
+            // The position of the viewport inside the text buffer (in cells).
+            u16x2 viewportOffset{ 0, 0 };
         } _api;
     };
 }

--- a/src/renderer/atlas/common.h
+++ b/src/renderer/atlas/common.h
@@ -409,8 +409,6 @@ namespace Microsoft::Console::Render::Atlas
         u16x2 targetSize{ 0, 0 };
         // Size of the portion of the text buffer that we're drawing on the screen.
         u16x2 viewportCellCount{ 0, 0 };
-        // The position of the viewport inside the text buffer (in cells).
-        u16x2 viewportOffset{ 0, 0 };
     };
 
     using GenerationalSettings = til::generational<Settings>;


### PR DESCRIPTION
This regressed in #15707. By having the `viewportOffset` on the
`Settings` object we accidentally invalidate the entire viewport
every time it scrolls. That doesn't break anything of course,
but it's better to prevent this.

This PR additionally contains a fix for clamping the y coordinates
coming from `Renderer`: Since `viewportCellCount.y` is a count and
thus exclusive, but clamp's max is inclusive, we must subtract 1.