### PR TITLE
Use a PasswordBox instead of a TextBox for the AzureOpenAI key

### DIFF
--- a/.github/actions/spelling/allow/allow.txt
+++ b/.github/actions/spelling/allow/allow.txt
@@ -25,6 +25,7 @@ gantt
 ghe
 gje
 godbolt
+gpt
 hyperlinking
 hyperlinks
 kje
@@ -55,6 +56,7 @@ pwn
 pwshw
 qof
 qps
+Quarternary
 quickfix
 rclt
 reimplementation

--- a/src/cascadia/TerminalSettingsEditor/AISettings.cpp
+++ b/src/cascadia/TerminalSettingsEditor/AISettings.cpp
@@ -76,12 +76,12 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     void AISettings::StoreKeyAndEndpoint_Click(const IInspectable& /*sender*/, const RoutedEventArgs& /*e*/)
     {
         // only store anything if both fields are filled
-        if (!EndpointInputBox().Text().empty() && !KeyInputBox().Text().empty())
+        if (!EndpointInputBox().Text().empty() && !KeyInputBox().Password().empty())
         {
             _ViewModel.AIEndpoint(EndpointInputBox().Text());
-            _ViewModel.AIKey(KeyInputBox().Text());
+            _ViewModel.AIKey(KeyInputBox().Password());
             EndpointInputBox().Text(L"");
-            KeyInputBox().Text(L"");
+            KeyInputBox().Password(L"");
 
             TraceLoggingWrite(
                 g_hSettingsEditorProvider,

--- a/src/cascadia/TerminalSettingsEditor/AISettings.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AISettings.xaml
@@ -133,10 +133,10 @@
                             <TextBlock x:Uid="AISettings_KeyTextBox"
                                        Grid.Row="3"
                                        VerticalAlignment="Center" />
-                            <TextBox x:Name="KeyInputBox"
-                                     Grid.Row="4"
-                                     HorizontalAlignment="Stretch"
-                                     VerticalAlignment="Center" />
+                            <PasswordBox x:Name="KeyInputBox"
+                                         Grid.Row="4"
+                                         HorizontalAlignment="Stretch"
+                                         VerticalAlignment="Center" />
                             <Button Grid.Row="5"
                                     HorizontalAlignment="Right"
                                     VerticalAlignment="Center"


### PR DESCRIPTION
Instead of a TextBox for the input of the AzureOpenAI key, we use a PasswordBox now which hides the input.
