### PR TITLE
MSBuildCache: Allow duplicate outputs under "obj\*\vcpkg\**"

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,7 +42,7 @@
     <MSBuildCacheIdenticalDuplicateOutputPatterns>$(MSBuildCacheIdenticalDuplicateOutputPatterns);bin\**</MSBuildCacheIdenticalDuplicateOutputPatterns>
 
     <!-- 
-      vpkg is invoked for each and every vcxproj and each invocation uses the same base dir for logging, so allow these duplicate "outputs".
+      vcpkg is invoked for each and every vcxproj and each invocation uses the same base dir for logging, so allow these duplicate "outputs".
     -->
     <MSBuildCacheIdenticalDuplicateOutputPatterns>$(MSBuildCacheIdenticalDuplicateOutputPatterns);obj\*\vcpkg\**</MSBuildCacheIdenticalDuplicateOutputPatterns>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -41,6 +41,11 @@
     -->
     <MSBuildCacheIdenticalDuplicateOutputPatterns>$(MSBuildCacheIdenticalDuplicateOutputPatterns);bin\**</MSBuildCacheIdenticalDuplicateOutputPatterns>
 
+    <!-- 
+      vpkg is invoked for each and every vcxproj and each invocation uses the same base dir for logging, so allow these duplicate "outputs".
+    -->
+    <MSBuildCacheIdenticalDuplicateOutputPatterns>$(MSBuildCacheIdenticalDuplicateOutputPatterns);obj\*\vcpkg\**</MSBuildCacheIdenticalDuplicateOutputPatterns>
+
     <!-- version of MSBuildCache is not part of the cache key -->
     <PackagesConfigFile>$(MSBuildThisFileDirectory)\dep\nuget\packages.config</PackagesConfigFile>
     <MSBuildCacheIgnoredInputPatterns>$(MSBuildCacheIgnoredInputPatterns);$(PackagesConfigFile)</MSBuildCacheIgnoredInputPatterns>


### PR DESCRIPTION
MSBuildCache: Allow duplicate outputs under `obj\*\vcpkg\**`