### PR TITLE
build: switch back to the "latest" OneBranch build image

### DIFF
--- a/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
@@ -106,11 +106,6 @@ extends:
       - stage: Build
         displayName: Build
         dependsOn: []
-        variables:
-          # This was set by the parent build, but we need to override it to select a specific compiler version
-          - template: ./build/pipelines/templates-v2/variables-onebranch-config.yml@self
-            parameters:
-              containerVersion: 1.0.02566.28
         jobs:
           - template: ./build/pipelines/templates-v2/job-build-project.yml@self
             parameters:


### PR DESCRIPTION
Thanks to a string of compiler bugs, we had to use an older container image that shipped with VS 17.9.

Unfortunately, that container image is falling further and further out of date. The build agents don't cache it any longer, so they spend 30-45 minutes of every build pulling it from the registry.

With the changes to ConPTY in #17510 removing the need for til::bitmap, we no longer need to work around the compiler bugs it exposed.

Furthermore, 17.10.6+ has a much more robust and presumably "working" compiler.