### PR TITLE
Introduce the concept of "selection spans" instead of "rects"

### DIFF
--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -208,7 +208,7 @@ public:
     const std::vector<size_t> GetPatternId(const til::point location) const override;
 
     std::pair<COLORREF, COLORREF> GetAttributeColors(const TextAttribute& attr) const noexcept override;
-    std::vector<Microsoft::Console::Types::Viewport> GetSelectionRects() noexcept override;
+    std::span<const til::point_span> GetSelectionSpans() const noexcept override;
     std::span<const til::point_span> GetSearchHighlights() const noexcept override;
     const til::point_span* GetSearchHighlightFocused() const noexcept override;
     const bool IsSelectionActive() const noexcept override;
@@ -356,6 +356,9 @@ private:
     std::vector<til::point_span> _searchHighlights;
     size_t _searchHighlightFocused = 0;
 
+    mutable std::vector<til::point_span> _lastSelectionSpans;
+    mutable til::generation_t _lastSelectionGeneration{};
+
     CursorType _defaultCursorShape = CursorType::Legacy;
 
     til::enumset<Mode> _systemMode{ Mode::AutoWrap };
@@ -466,7 +469,6 @@ private:
 
 #pragma region TextSelection
     // These methods are defined in TerminalSelection.cpp
-    std::vector<til::inclusive_rect> _GetSelectionRects() const noexcept;
     std::vector<til::point_span> _GetSelectionSpans() const noexcept;
     std::pair<til::point, til::point> _PivotSelection(const til::point targetPos, bool& targetStart) const noexcept;
     std::pair<til::point, til::point> _ExpandSelectionAnchors(std::pair<til::point, til::point> anchors) const;

--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -43,27 +43,6 @@ DEFINE_ENUM_FLAG_OPERATORS(Terminal::SelectionEndpoint);
  */
 
 // Method Description:
-// - Helper to determine the selected region of the buffer. Used for rendering.
-// Return Value:
-// - A vector of rectangles representing the regions to select, line by line. They are absolute coordinates relative to the buffer origin.
-std::vector<til::inclusive_rect> Terminal::_GetSelectionRects() const noexcept
-{
-    std::vector<til::inclusive_rect> result;
-
-    if (!IsSelectionActive())
-    {
-        return result;
-    }
-
-    try
-    {
-        return _activeBuffer().GetTextRects(_selection->start, _selection->end, _selection->blockSelection, false);
-    }
-    CATCH_LOG();
-    return result;
-}
-
-// Method Description:
 // - Identical to GetTextRects if it's a block selection, else returns a single span for the whole selection.
 // Return Value:
 // - A vector of one or more spans representing the selection. They are absolute coordinates relative to the buffer origin.

--- a/src/cascadia/TerminalCore/terminalrenderdata.cpp
+++ b/src/cascadia/TerminalCore/terminalrenderdata.cpp
@@ -127,17 +127,16 @@ std::pair<COLORREF, COLORREF> Terminal::GetAttributeColors(const TextAttribute& 
     return GetRenderSettings().GetAttributeColors(attr);
 }
 
-std::vector<Microsoft::Console::Types::Viewport> Terminal::GetSelectionRects() noexcept
+std::span<const til::point_span> Terminal::GetSelectionSpans() const noexcept
 try
 {
-    std::vector<Viewport> result;
-
-    for (const auto& lineRect : _GetSelectionRects())
+    if (_selection.generation() != _lastSelectionGeneration)
     {
-        result.emplace_back(Viewport::FromInclusive(lineRect));
+        _lastSelectionSpans = _GetSelectionSpans();
+        _lastSelectionGeneration = _selection.generation();
     }
 
-    return result;
+    return _lastSelectionSpans;
 }
 catch (...)
 {

--- a/src/cascadia/UnitTests_Control/ControlInteractivityTests.cpp
+++ b/src/cascadia/UnitTests_Control/ControlInteractivityTests.cpp
@@ -336,7 +336,6 @@ namespace ControlUnitTests
                                     true);
         Log::Comment(L"Verify that there's one selection");
         VERIFY_IS_TRUE(core->HasSelection());
-        VERIFY_ARE_EQUAL(1u, core->_terminal->GetSelectionRects().size());
 
         Log::Comment(L"Drag the mouse down a whole row");
         const til::point terminalPosition2{ 1, 1 };
@@ -349,7 +348,6 @@ namespace ControlUnitTests
                                     true);
         Log::Comment(L"Verify that there's now two selections (one on each row)");
         VERIFY_IS_TRUE(core->HasSelection());
-        VERIFY_ARE_EQUAL(2u, core->_terminal->GetSelectionRects().size());
 
         Log::Comment(L"Release the mouse");
         interactivity->PointerReleased(noMouseDown,
@@ -358,7 +356,6 @@ namespace ControlUnitTests
                                        cursorPosition2.to_core_point());
         Log::Comment(L"Verify that there's still two selections");
         VERIFY_IS_TRUE(core->HasSelection());
-        VERIFY_ARE_EQUAL(2u, core->_terminal->GetSelectionRects().size());
 
         Log::Comment(L"click outside the current selection");
         const til::point terminalPosition3{ 2, 2 };
@@ -370,7 +367,6 @@ namespace ControlUnitTests
                                       cursorPosition3.to_core_point());
         Log::Comment(L"Verify that there's now no selection");
         VERIFY_IS_FALSE(core->HasSelection());
-        VERIFY_ARE_EQUAL(0u, core->_terminal->GetSelectionRects().size());
 
         Log::Comment(L"Drag the mouse");
         const til::point terminalPosition4{ 3, 2 };
@@ -383,7 +379,6 @@ namespace ControlUnitTests
                                     true);
         Log::Comment(L"Verify that there's now one selection");
         VERIFY_IS_TRUE(core->HasSelection());
-        VERIFY_ARE_EQUAL(1u, core->_terminal->GetSelectionRects().size());
     }
 
     void ControlInteractivityTests::ScrollWithSelection()
@@ -438,7 +433,6 @@ namespace ControlUnitTests
                                     true);
         Log::Comment(L"Verify that there's one selection");
         VERIFY_IS_TRUE(core->HasSelection());
-        VERIFY_ARE_EQUAL(1u, core->_terminal->GetSelectionRects().size());
 
         Log::Comment(L"Verify the location of the selection");
         // The viewport is on row 21, so the selection will be on:
@@ -586,7 +580,6 @@ namespace ControlUnitTests
                                     true);
         Log::Comment(L"Verify that there's one selection");
         VERIFY_IS_TRUE(core->HasSelection());
-        VERIFY_ARE_EQUAL(1u, core->_terminal->GetSelectionRects().size());
 
         Log::Comment(L"Verify that it started on the first cell we clicked on, not the one we dragged to");
         til::point expectedAnchor{ 0, 0 };
@@ -631,7 +624,6 @@ namespace ControlUnitTests
                                     true);
         Log::Comment(L"Verify that there's one selection");
         VERIFY_IS_TRUE(core->HasSelection());
-        VERIFY_ARE_EQUAL(1u, core->_terminal->GetSelectionRects().size());
 
         Log::Comment(L"Verify that it started on the first cell we clicked on, not the one we dragged to");
         til::point expectedAnchor{ 0, 0 };
@@ -801,7 +793,6 @@ namespace ControlUnitTests
                                     true);
         Log::Comment(L"Verify that there's one selection");
         VERIFY_IS_TRUE(core->HasSelection());
-        VERIFY_ARE_EQUAL(1u, core->_terminal->GetSelectionRects().size());
 
         Log::Comment(L"Verify the location of the selection");
         // The viewport is on row (historySize + 5), so the selection will be on:
@@ -860,7 +851,6 @@ namespace ControlUnitTests
                                     cursorPosition0.to_core_point(),
                                     true);
         VERIFY_IS_TRUE(core->HasSelection());
-        VERIFY_ARE_EQUAL(1u, core->_terminal->GetSelectionRects().size());
         {
             const auto anchor{ core->_terminal->GetSelectionAnchor() };
             const auto end{ core->_terminal->GetSelectionEnd() };
@@ -885,7 +875,6 @@ namespace ControlUnitTests
                                     cursorPosition1.to_core_point(),
                                     true);
         VERIFY_IS_TRUE(core->HasSelection());
-        VERIFY_ARE_EQUAL(1u, core->_terminal->GetSelectionRects().size());
         {
             const auto anchor{ core->_terminal->GetSelectionAnchor() };
             const auto end{ core->_terminal->GetSelectionEnd() };

--- a/src/cascadia/UnitTests_TerminalCore/ScrollTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ScrollTest.cpp
@@ -38,7 +38,6 @@ namespace
         HRESULT Invalidate(const til::rect* /*psrRegion*/) noexcept { return S_OK; }
         HRESULT InvalidateCursor(const til::rect* /*psrRegion*/) noexcept { return S_OK; }
         HRESULT InvalidateSystem(const til::rect* /*prcDirtyClient*/) noexcept { return S_OK; }
-        HRESULT InvalidateSelection(const std::vector<til::rect>& /*rectangles*/) noexcept { return S_OK; }
         HRESULT InvalidateScroll(const til::point* pcoordDelta) noexcept
         {
             _triggerScrollDelta = *pcoordDelta;

--- a/src/host/renderData.cpp
+++ b/src/host/renderData.cpp
@@ -59,24 +59,11 @@ const FontInfo& RenderData::GetFontInfo() const noexcept
 }
 
 // Method Description:
-// - Retrieves one rectangle per line describing the area of the viewport
+// - Retrieves one span per line describing the area of the viewport
 //   that should be highlighted in some way to represent a user-interactive selection
-// Return Value:
-// - Vector of Viewports describing the area selected
-std::vector<Viewport> RenderData::GetSelectionRects() noexcept
+std::span<const til::point_span> RenderData::GetSelectionSpans() const noexcept
 {
-    std::vector<Viewport> result;
-
-    try
-    {
-        for (const auto& select : Selection::Instance().GetSelectionRects())
-        {
-            result.emplace_back(Viewport::FromInclusive(select));
-        }
-    }
-    CATCH_LOG();
-
-    return result;
+    return Selection::Instance().GetSelectionSpans();
 }
 
 // Method Description:
@@ -368,7 +355,7 @@ const til::point RenderData::GetSelectionEnd() const noexcept
     //  - SelectionAnchor: the initial position where the selection was started
     //  - SelectionRect: the rectangular region denoting a portion of the buffer that is selected
 
-    // The following is an excerpt from Selection::s_GetSelectionRects
+    // The following is an excerpt from Selection::GetSelectionSpans
     // if the anchor (start of select) was in the top right or bottom left of the box,
     // we need to remove rectangular overlap in the middle.
     // e.g.

--- a/src/host/renderData.hpp
+++ b/src/host/renderData.hpp
@@ -25,7 +25,7 @@ public:
     TextBuffer& GetTextBuffer() const noexcept override;
     const FontInfo& GetFontInfo() const noexcept override;
 
-    std::vector<Microsoft::Console::Types::Viewport> GetSelectionRects() noexcept override;
+    std::span<const til::point_span> GetSelectionSpans() const noexcept override;
 
     void LockConsole() noexcept override;
     void UnlockConsole() noexcept override;

--- a/src/host/selection.cpp
+++ b/src/host/selection.cpp
@@ -20,14 +20,14 @@ Selection& Selection::Instance()
     return *_instance;
 }
 
-void Selection::_RegenerateSelectionRects() const
+void Selection::_RegenerateSelectionSpans() const
 {
     if (_lastSelectionGeneration == _d.generation())
     {
         return;
     }
 
-    _lastSelectionRects.clear();
+    _lastSelectionSpans.clear();
 
     if (!_d->fSelectionVisible)
     {
@@ -44,23 +44,17 @@ void Selection::_RegenerateSelectionRects() const
     endSelectionAnchor.y = (_d->coordSelectionAnchor.y == _d->srSelectionRect.top) ? _d->srSelectionRect.bottom : _d->srSelectionRect.top;
 
     const auto blockSelection = !IsLineSelection();
-    auto rects = screenInfo.GetTextBuffer().GetTextRects(_d->coordSelectionAnchor, endSelectionAnchor, blockSelection, false);
-    _lastSelectionRects = std::move(rects);
+    _lastSelectionSpans = screenInfo.GetTextBuffer().GetTextSpans(_d->coordSelectionAnchor,
+                                                                  endSelectionAnchor,
+                                                                  blockSelection,
+                                                                  false);
     _lastSelectionGeneration = _d.generation();
 }
 
-// Routine Description:
-// - Determines the line-by-line selection rectangles based on global selection state.
-// Arguments:
-// - <none> - Uses internal state to know what area is selected already.
-// Return Value:
-// - Returns a vector where each til::inclusive_rect is one Row worth of the area to be selected.
-// - Returns empty vector if no rows are selected.
-// - Throws exceptions for out of memory issues
-std::vector<til::inclusive_rect> Selection::GetSelectionRects() const
+std::span<const til::point_span> Selection::GetSelectionSpans() const
 {
-    _RegenerateSelectionRects();
-    return _lastSelectionRects;
+    _RegenerateSelectionSpans();
+    return { _lastSelectionSpans.cbegin(), _lastSelectionSpans.cend() };
 }
 
 // Routine Description:

--- a/src/host/selection.hpp
+++ b/src/host/selection.hpp
@@ -29,7 +29,7 @@ class Selection
 public:
     ~Selection() = default;
 
-    std::vector<til::inclusive_rect> GetSelectionRects() const;
+    std::span<const til::point_span> GetSelectionSpans() const;
 
     void ShowSelection();
     void HideSelection();
@@ -182,11 +182,11 @@ private:
     };
     til::generational<SelectionData> _d{};
 
-    mutable std::vector<til::inclusive_rect> _lastSelectionRects;
+    mutable std::vector<til::point_span> _lastSelectionSpans;
     mutable til::generation_t _lastSelectionGeneration;
 
     void _ExtendSelection(SelectionData* d, _In_ til::point coordBufferPos);
-    void _RegenerateSelectionRects() const;
+    void _RegenerateSelectionSpans() const;
 
 #ifdef UNIT_TESTING
     friend class SelectionTests;

--- a/src/interactivity/onecore/BgfxEngine.cpp
+++ b/src/interactivity/onecore/BgfxEngine.cpp
@@ -48,11 +48,6 @@ BgfxEngine::BgfxEngine(PVOID SharedViewBase, LONG DisplayHeight, LONG DisplayWid
     return S_OK;
 }
 
-[[nodiscard]] HRESULT BgfxEngine::InvalidateSelection(const std::vector<til::rect>& /*rectangles*/) noexcept
-{
-    return S_OK;
-}
-
 [[nodiscard]] HRESULT BgfxEngine::InvalidateScroll(const til::point* /*pcoordDelta*/) noexcept
 {
     return S_OK;

--- a/src/interactivity/onecore/BgfxEngine.hpp
+++ b/src/interactivity/onecore/BgfxEngine.hpp
@@ -35,7 +35,6 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT Invalidate(const til::rect* psrRegion) noexcept override;
         [[nodiscard]] HRESULT InvalidateCursor(const til::rect* psrRegion) noexcept override;
         [[nodiscard]] HRESULT InvalidateSystem(const til::rect* prcDirtyClient) noexcept override;
-        [[nodiscard]] HRESULT InvalidateSelection(const std::vector<til::rect>& rectangles) noexcept override;
         [[nodiscard]] HRESULT InvalidateScroll(const til::point* pcoordDelta) noexcept override;
         [[nodiscard]] HRESULT InvalidateAll() noexcept override;
 

--- a/src/interactivity/win32/Clipboard.cpp
+++ b/src/interactivity/win32/Clipboard.cpp
@@ -321,9 +321,6 @@ void Clipboard::StoreSelectionToClipboard(const bool copyFormatting)
         return;
     }
 
-    // read selection area.
-    const auto selectionRects = selection.GetSelectionRects();
-
     const auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
     const auto& buffer = gci.GetActiveOutputBuffer().GetTextBuffer();
     const auto& renderSettings = gci.GetRenderSettings();

--- a/src/renderer/atlas/AtlasEngine.api.cpp
+++ b/src/renderer/atlas/AtlasEngine.api.cpp
@@ -83,27 +83,13 @@ constexpr HRESULT vec2_narrow(U x, U y, vec2<T>& out) noexcept
     return Invalidate(&rect);
 }
 
-[[nodiscard]] HRESULT AtlasEngine::InvalidateSelection(const std::vector<til::rect>& rectangles) noexcept
-{
-    for (const auto& rect : rectangles)
-    {
-        // BeginPaint() protects against invalid out of bounds numbers.
-        // TODO: rect can contain invalid out of bounds coordinates when the selection is being
-        // dragged outside of the viewport (and the window begins scrolling automatically).
-        _api.invalidatedRows.start = gsl::narrow_cast<u16>(std::min<int>(_api.invalidatedRows.start, std::max<int>(0, rect.top)));
-        _api.invalidatedRows.end = gsl::narrow_cast<u16>(std::max<int>(_api.invalidatedRows.end, std::max<int>(0, rect.bottom)));
-    }
-    return S_OK;
-}
-
-[[nodiscard]] HRESULT AtlasEngine::InvalidateHighlight(std::span<const til::point_span> highlights, const TextBuffer& buffer) noexcept
+void AtlasEngine::_invalidateSpans(std::span<const til::point_span> spans, const TextBuffer& buffer) noexcept
 {
     const auto viewportOrigin = til::point{ _api.viewportOffset.x, _api.viewportOffset.y };
     const auto viewport = til::rect{ 0, 0, _api.s->viewportCellCount.x, _api.s->viewportCellCount.y };
-    const auto cellCountX = static_cast<til::CoordType>(_api.s->viewportCellCount.x);
-    for (const auto& hi : highlights)
+    for (auto&& sp : spans)
     {
-        hi.iterate_rows(cellCountX, [&](til::CoordType row, til::CoordType beg, til::CoordType end) {
+        sp.iterate_rows(til::CoordTypeMax, [&](til::CoordType row, til::CoordType beg, til::CoordType end) {
             const auto shift = buffer.GetLineRendition(row) != LineRendition::SingleWidth ? 1 : 0;
             beg <<= shift;
             end <<= shift;
@@ -114,7 +100,22 @@ constexpr HRESULT vec2_narrow(U x, U y, vec2<T>& out) noexcept
             _api.invalidatedRows.end = gsl::narrow_cast<u16>(std::max<int>(_api.invalidatedRows.end, std::max<int>(0, rect.bottom)));
         });
     }
+}
 
+[[nodiscard]] HRESULT AtlasEngine::InvalidateSelection(std::span<const til::rect> selections) noexcept
+{
+    if (!selections.empty())
+    {
+        // INVARIANT: This assumes that `selections` is sorted by increasing Y
+        _api.invalidatedRows.start = gsl::narrow_cast<u16>(std::min<int>(_api.invalidatedRows.start, std::max<int>(0, selections.front().top)));
+        _api.invalidatedRows.end = gsl::narrow_cast<u16>(std::max<int>(_api.invalidatedRows.end, std::max<int>(0, selections.back().bottom)));
+    }
+    return S_OK;
+}
+
+[[nodiscard]] HRESULT AtlasEngine::InvalidateHighlight(std::span<const til::point_span> highlights, const TextBuffer& buffer) noexcept
+{
+    _invalidateSpans(highlights, buffer);
     return S_OK;
 }
 

--- a/src/renderer/atlas/AtlasEngine.h
+++ b/src/renderer/atlas/AtlasEngine.h
@@ -31,7 +31,7 @@ namespace Microsoft::Console::Render::Atlas
         [[nodiscard]] HRESULT Invalidate(const til::rect* psrRegion) noexcept override;
         [[nodiscard]] HRESULT InvalidateCursor(const til::rect* psrRegion) noexcept override;
         [[nodiscard]] HRESULT InvalidateSystem(const til::rect* prcDirtyClient) noexcept override;
-        [[nodiscard]] HRESULT InvalidateSelection(const std::vector<til::rect>& rectangles) noexcept override;
+        [[nodiscard]] HRESULT InvalidateSelection(std::span<const til::rect> selections) noexcept override;
         [[nodiscard]] HRESULT InvalidateHighlight(std::span<const til::point_span> highlights, const TextBuffer& buffer) noexcept override;
         [[nodiscard]] HRESULT InvalidateScroll(const til::point* pcoordDelta) noexcept override;
         [[nodiscard]] HRESULT InvalidateAll() noexcept override;
@@ -98,6 +98,7 @@ namespace Microsoft::Console::Render::Atlas
         [[nodiscard]] HRESULT _updateFont(const FontInfoDesired& fontInfoDesired, FontInfo& fontInfo, const std::unordered_map<std::wstring_view, float>& features, const std::unordered_map<std::wstring_view, float>& axes) noexcept;
         void _resolveFontMetrics(const FontInfoDesired& fontInfoDesired, FontInfo& fontInfo, FontSettings* fontMetrics = nullptr);
         [[nodiscard]] bool _updateWithNearbyFontCollection() noexcept;
+        void _invalidateSpans(std::span<const til::point_span> spans, const TextBuffer& buffer) noexcept;
 
         // AtlasEngine.r.cpp
         ATLAS_ATTR_COLD void _recreateAdapter();

--- a/src/renderer/base/RenderEngineBase.cpp
+++ b/src/renderer/base/RenderEngineBase.cpp
@@ -7,7 +7,7 @@
 using namespace Microsoft::Console;
 using namespace Microsoft::Console::Render;
 
-[[nodiscard]] HRESULT RenderEngineBase::InvalidateSelection(const std::vector<til::rect>& /*rectangles*/) noexcept
+[[nodiscard]] HRESULT RenderEngineBase::InvalidateSelection(std::span<const til::rect> /*selections*/) noexcept
 {
     return S_OK;
 }

--- a/src/renderer/base/RenderEngineBase.cpp
+++ b/src/renderer/base/RenderEngineBase.cpp
@@ -7,6 +7,11 @@
 using namespace Microsoft::Console;
 using namespace Microsoft::Console::Render;
 
+[[nodiscard]] HRESULT RenderEngineBase::InvalidateSelection(const std::vector<til::rect>& /*rectangles*/) noexcept
+{
+    return S_OK;
+}
+
 [[nodiscard]] HRESULT RenderEngineBase::InvalidateHighlight(std::span<const til::point_span> /*highlights*/, const TextBuffer& /*renditions*/) noexcept
 {
     return S_OK;

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -1261,6 +1261,7 @@ void Renderer::_PaintCursor(_In_ IRenderEngine* const pEngine)
     RenderFrameInfo info;
     info.searchHighlights = _pData->GetSearchHighlights();
     info.searchHighlightFocused = _pData->GetSearchHighlightFocused();
+    info.selectionSpans = _pData->GetSelectionSpans();
     return pEngine->PrepareRenderInfo(std::move(info));
 }
 

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -325,32 +325,46 @@ void Renderer::TriggerTeardown() noexcept
 // Return Value:
 // - <none>
 void Renderer::TriggerSelection()
+try
 {
-    try
+    const auto spans = _pData->GetSelectionSpans();
+    if (spans.size() != _lastSelectionPaintSize || (!spans.empty() && _lastSelectionPaintSpan != til::point_span{ spans.front().start, spans.back().end }))
     {
-        // Get selection rectangles
-        auto rects = _GetSelectionRects();
+        std::vector<til::rect> newSelectionViewportRects;
 
-        // Make a viewport representing the coordinates that are currently presentable.
-        const til::rect viewport{ _pData->GetViewport().Dimensions() };
-
-        // Restrict all previous selection rectangles to inside the current viewport bounds
-        for (auto& sr : _previousSelection)
+        _lastSelectionPaintSize = spans.size();
+        if (_lastSelectionPaintSize)
         {
-            sr &= viewport;
+            _lastSelectionPaintSpan = til::point_span{ spans.front().start, spans.back().end };
+
+            const auto& buffer = _pData->GetTextBuffer();
+            const auto bufferWidth = buffer.GetSize().Width();
+            const til::rect vp{ _viewport.ToExclusive() };
+            for (auto&& sp : spans)
+            {
+                sp.iterate_rows(bufferWidth, [&](til::CoordType row, til::CoordType min, til::CoordType max) {
+                    const auto shift = buffer.GetLineRendition(row) != LineRendition::SingleWidth ? 1 : 0;
+                    max += 1; // Selection spans are inclusive (still)
+                    min <<= shift;
+                    max <<= shift;
+                    til::rect r{ min, row, max, row + 1 };
+                    newSelectionViewportRects.emplace_back(r.to_origin(vp));
+                });
+            }
         }
 
         FOREACH_ENGINE(pEngine)
         {
-            LOG_IF_FAILED(pEngine->InvalidateSelection(_previousSelection));
-            LOG_IF_FAILED(pEngine->InvalidateSelection(rects));
+            LOG_IF_FAILED(pEngine->InvalidateSelection(_lastSelectionRectsByViewport));
+            LOG_IF_FAILED(pEngine->InvalidateSelection(newSelectionViewportRects));
         }
 
-        _previousSelection = std::move(rects);
+        std::exchange(_lastSelectionRectsByViewport, newSelectionViewportRects);
+
         NotifyPaintFrame();
     }
-    CATCH_LOG();
 }
+CATCH_LOG()
 
 // Routine Description:
 // - Called when the search highlight areas in the console have changed.
@@ -1278,15 +1292,11 @@ void Renderer::_PaintSelection(_In_ IRenderEngine* const pEngine)
         std::span<const til::rect> dirtyAreas;
         LOG_IF_FAILED(pEngine->GetDirtyArea(dirtyAreas));
 
-        // Get selection rectangles
-        const auto rectangles = _GetSelectionRects();
-
-        std::vector<til::rect> dirtySearchRectangles;
-        for (auto& dirtyRect : dirtyAreas)
+        for (auto&& dirtyRect : dirtyAreas)
         {
-            for (const auto& rect : rectangles)
+            for (const auto& rect : _lastSelectionRectsByViewport)
             {
-                if (const auto rectCopy = rect & dirtyRect)
+                if (const auto rectCopy{ rect & dirtyRect })
                 {
                     LOG_IF_FAILED(pEngine->PaintSelection(rectCopy));
                 }
@@ -1331,32 +1341,6 @@ void Renderer::_PaintSelection(_In_ IRenderEngine* const pEngine)
     return pEngine->ScrollFrame();
 }
 
-// Routine Description:
-// - Helper to determine the selected region of the buffer.
-// Return Value:
-// - A vector of rectangles representing the regions to select, line by line.
-std::vector<til::rect> Renderer::_GetSelectionRects() const
-{
-    const auto& buffer = _pData->GetTextBuffer();
-    auto rects = _pData->GetSelectionRects();
-    // Adjust rectangles to viewport
-    auto view = _pData->GetViewport();
-
-    std::vector<til::rect> result;
-    result.reserve(rects.size());
-
-    for (auto rect : rects)
-    {
-        // Convert buffer offsets to the equivalent range of screen cells
-        // expected by callers, taking line rendition into account.
-        const auto lineRendition = buffer.GetLineRendition(rect.Top());
-        rect = Viewport::FromInclusive(BufferToScreenLine(rect.ToInclusive(), lineRendition));
-        result.emplace_back(view.ConvertToOrigin(rect).ToExclusive());
-    }
-
-    return result;
-}
-
 // Method Description:
 // - Offsets all of the selection rectangles we might be holding onto
 //   as the previously selected area. If the whole viewport scrolls,
@@ -1370,7 +1354,7 @@ void Renderer::_ScrollPreviousSelection(const til::point delta)
 {
     if (delta != til::point{ 0, 0 })
     {
-        for (auto& rc : _previousSelection)
+        for (auto& rc : _lastSelectionRectsByViewport)
         {
             rc += delta;
         }

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -109,7 +109,6 @@ namespace Microsoft::Console::Render
         void _PaintCursor(_In_ IRenderEngine* const pEngine);
         [[nodiscard]] HRESULT _UpdateDrawingBrushes(_In_ IRenderEngine* const pEngine, const TextAttribute attr, const bool usingSoftFont, const bool isSettingDefaultBrushes);
         [[nodiscard]] HRESULT _PerformScrolling(_In_ IRenderEngine* const pEngine);
-        std::vector<til::rect> _GetSelectionRects() const;
         void _ScrollPreviousSelection(const til::point delta);
         [[nodiscard]] HRESULT _PaintTitle(IRenderEngine* const pEngine);
         bool _isInHoveredInterval(til::point coordTarget) const noexcept;
@@ -131,11 +130,14 @@ namespace Microsoft::Console::Render
         CursorOptions _currentCursorOptions;
         std::optional<CompositionCache> _compositionCache;
         std::vector<Cluster> _clusterBuffer;
-        std::vector<til::rect> _previousSelection;
         std::function<void()> _pfnBackgroundColorChanged;
         std::function<void()> _pfnFrameColorChanged;
         std::function<void()> _pfnRendererEnteredErrorState;
         bool _destructing = false;
         bool _forceUpdateViewport = false;
+
+        til::point_span _lastSelectionPaintSpan{};
+        size_t _lastSelectionPaintSize{};
+        std::vector<til::rect> _lastSelectionRectsByViewport{};
     };
 }

--- a/src/renderer/gdi/gdirenderer.hpp
+++ b/src/renderer/gdi/gdirenderer.hpp
@@ -27,7 +27,7 @@ namespace Microsoft::Console::Render
 
         [[nodiscard]] HRESULT SetHwnd(const HWND hwnd) noexcept;
 
-        [[nodiscard]] HRESULT InvalidateSelection(const std::vector<til::rect>& rectangles) noexcept override;
+        [[nodiscard]] HRESULT InvalidateSelection(std::span<const til::rect> selections) noexcept override;
         [[nodiscard]] HRESULT InvalidateScroll(const til::point* const pcoordDelta) noexcept override;
         [[nodiscard]] HRESULT InvalidateSystem(const til::rect* const prcDirtyClient) noexcept override;
         [[nodiscard]] HRESULT Invalidate(const til::rect* const psrRegion) noexcept override;

--- a/src/renderer/gdi/invalidate.cpp
+++ b/src/renderer/gdi/invalidate.cpp
@@ -5,6 +5,7 @@
 
 #include "gdirenderer.hpp"
 #include "../../types/inc/Viewport.hpp"
+#include "../buffer/out/textBuffer.hpp"
 
 #pragma hdrstop
 
@@ -46,13 +47,12 @@ HRESULT GdiEngine::InvalidateScroll(const til::point* const pcoordDelta) noexcep
 // - rectangles - Vector of rectangles to draw, line by line
 // Return Value:
 // - HRESULT S_OK or GDI-based error code
-HRESULT GdiEngine::InvalidateSelection(const std::vector<til::rect>& rectangles) noexcept
+HRESULT GdiEngine::InvalidateSelection(std::span<const til::rect> selections) noexcept
 {
-    for (const auto& rect : rectangles)
+    for (auto&& rect : selections)
     {
         RETURN_IF_FAILED(Invalidate(&rect));
     }
-
     return S_OK;
 }
 

--- a/src/renderer/inc/IRenderData.hpp
+++ b/src/renderer/inc/IRenderData.hpp
@@ -46,9 +46,9 @@ namespace Microsoft::Console::Render
         virtual til::point GetTextBufferEndPosition() const noexcept = 0;
         virtual TextBuffer& GetTextBuffer() const noexcept = 0;
         virtual const FontInfo& GetFontInfo() const noexcept = 0;
-        virtual std::vector<Microsoft::Console::Types::Viewport> GetSelectionRects() noexcept = 0;
         virtual std::span<const til::point_span> GetSearchHighlights() const noexcept = 0;
         virtual const til::point_span* GetSearchHighlightFocused() const noexcept = 0;
+        virtual std::span<const til::point_span> GetSelectionSpans() const noexcept = 0;
         virtual void LockConsole() noexcept = 0;
         virtual void UnlockConsole() noexcept = 0;
 

--- a/src/renderer/inc/IRenderEngine.hpp
+++ b/src/renderer/inc/IRenderEngine.hpp
@@ -32,6 +32,7 @@ namespace Microsoft::Console::Render
     {
         std::span<const til::point_span> searchHighlights;
         const til::point_span* searchHighlightFocused;
+        std::span<const til::point_span> selectionSpans;
     };
 
     enum class GridLines

--- a/src/renderer/inc/IRenderEngine.hpp
+++ b/src/renderer/inc/IRenderEngine.hpp
@@ -67,7 +67,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] virtual HRESULT Invalidate(const til::rect* psrRegion) noexcept = 0;
         [[nodiscard]] virtual HRESULT InvalidateCursor(const til::rect* psrRegion) noexcept = 0;
         [[nodiscard]] virtual HRESULT InvalidateSystem(const til::rect* prcDirtyClient) noexcept = 0;
-        [[nodiscard]] virtual HRESULT InvalidateSelection(const std::vector<til::rect>& rectangles) noexcept = 0;
+        [[nodiscard]] virtual HRESULT InvalidateSelection(std::span<const til::rect> selections) noexcept = 0;
         [[nodiscard]] virtual HRESULT InvalidateHighlight(std::span<const til::point_span> highlights, const TextBuffer& buffer) noexcept = 0;
         [[nodiscard]] virtual HRESULT InvalidateScroll(const til::point* pcoordDelta) noexcept = 0;
         [[nodiscard]] virtual HRESULT InvalidateAll() noexcept = 0;

--- a/src/renderer/inc/RenderEngineBase.hpp
+++ b/src/renderer/inc/RenderEngineBase.hpp
@@ -24,6 +24,7 @@ namespace Microsoft::Console::Render
     class RenderEngineBase : public IRenderEngine
     {
     public:
+        [[nodiscard]] HRESULT InvalidateSelection(const std::vector<til::rect>& rectangles) noexcept override;
         [[nodiscard]] HRESULT InvalidateHighlight(std::span<const til::point_span> highlights, const TextBuffer& buffer) noexcept override;
         [[nodiscard]] HRESULT InvalidateTitle(const std::wstring_view proposedTitle) noexcept override;
 

--- a/src/renderer/inc/RenderEngineBase.hpp
+++ b/src/renderer/inc/RenderEngineBase.hpp
@@ -24,7 +24,7 @@ namespace Microsoft::Console::Render
     class RenderEngineBase : public IRenderEngine
     {
     public:
-        [[nodiscard]] HRESULT InvalidateSelection(const std::vector<til::rect>& rectangles) noexcept override;
+        [[nodiscard]] HRESULT InvalidateSelection(std::span<const til::rect> selections) noexcept override;
         [[nodiscard]] HRESULT InvalidateHighlight(std::span<const til::point_span> highlights, const TextBuffer& buffer) noexcept override;
         [[nodiscard]] HRESULT InvalidateTitle(const std::wstring_view proposedTitle) noexcept override;
 

--- a/src/renderer/uia/UiaRenderer.cpp
+++ b/src/renderer/uia/UiaRenderer.cpp
@@ -20,7 +20,6 @@ UiaEngine::UiaEngine(IUiaEventDispatcher* dispatcher) :
     _textBufferChanged{ false },
     _cursorChanged{ false },
     _isEnabled{ true },
-    _prevSelection{},
     _prevCursorRegion{},
     RenderEngineBase()
 {
@@ -110,40 +109,11 @@ CATCH_RETURN();
 // - rectangles - One or more rectangles describing character positions on the grid
 // Return Value:
 // - S_OK
-[[nodiscard]] HRESULT UiaEngine::InvalidateSelection(const std::vector<til::rect>& rectangles) noexcept
+[[nodiscard]] HRESULT UiaEngine::InvalidateSelection(std::span<const til::rect> /*rectangles*/) noexcept
 {
-    // early exit: different number of rows
-    if (_prevSelection.size() != rectangles.size())
-    {
-        try
-        {
-            _selectionChanged = true;
-            _prevSelection = rectangles;
-        }
-        CATCH_LOG_RETURN_HR(E_FAIL);
-        return S_OK;
-    }
-
-    for (size_t i = 0; i < rectangles.size(); i++)
-    {
-        try
-        {
-            const auto prevRect = _prevSelection.at(i);
-            const auto newRect = rectangles.at(i);
-
-            // if any value is different, selection has changed
-            if (prevRect.top != newRect.top || prevRect.right != newRect.right || prevRect.left != newRect.left || prevRect.bottom != newRect.bottom)
-            {
-                _selectionChanged = true;
-                _prevSelection = rectangles;
-                return S_OK;
-            }
-        }
-        CATCH_LOG_RETURN_HR(E_FAIL);
-    }
-
-    // assume selection has not changed
-    _selectionChanged = false;
+    // INVARIANT: Renderer checks the incoming selection spans and only calls InvalidateSelection
+    // if they have actually changed.
+    _selectionChanged = true;
     return S_OK;
 }
 

--- a/src/renderer/uia/UiaRenderer.hpp
+++ b/src/renderer/uia/UiaRenderer.hpp
@@ -42,7 +42,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT Invalidate(const til::rect* const psrRegion) noexcept override;
         [[nodiscard]] HRESULT InvalidateCursor(const til::rect* const psrRegion) noexcept override;
         [[nodiscard]] HRESULT InvalidateSystem(const til::rect* const prcDirtyClient) noexcept override;
-        [[nodiscard]] HRESULT InvalidateSelection(const std::vector<til::rect>& rectangles) noexcept override;
+        [[nodiscard]] HRESULT InvalidateSelection(std::span<const til::rect> rectangles) noexcept override;
         [[nodiscard]] HRESULT InvalidateScroll(const til::point* const pcoordDelta) noexcept override;
         [[nodiscard]] HRESULT InvalidateAll() noexcept override;
         [[nodiscard]] HRESULT NotifyNewText(const std::wstring_view newText) noexcept override;
@@ -74,7 +74,6 @@ namespace Microsoft::Console::Render
 
         Microsoft::Console::Types::IUiaEventDispatcher* _dispatcher;
 
-        std::vector<til::rect> _prevSelection;
         til::rect _prevCursorRegion;
     };
 }

--- a/src/renderer/wddmcon/WddmConRenderer.cpp
+++ b/src/renderer/wddmcon/WddmConRenderer.cpp
@@ -181,11 +181,6 @@ CATCH_RETURN()
     return S_OK;
 }
 
-[[nodiscard]] HRESULT WddmConEngine::InvalidateSelection(const std::vector<til::rect>& /*rectangles*/) noexcept
-{
-    return S_OK;
-}
-
 [[nodiscard]] HRESULT WddmConEngine::InvalidateScroll(const til::point* const /*pcoordDelta*/) noexcept
 {
     return S_OK;

--- a/src/renderer/wddmcon/WddmConRenderer.hpp
+++ b/src/renderer/wddmcon/WddmConRenderer.hpp
@@ -28,7 +28,6 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT Invalidate(const til::rect* const psrRegion) noexcept override;
         [[nodiscard]] HRESULT InvalidateCursor(const til::rect* const psrRegion) noexcept override;
         [[nodiscard]] HRESULT InvalidateSystem(const til::rect* const prcDirtyClient) noexcept override;
-        [[nodiscard]] HRESULT InvalidateSelection(const std::vector<til::rect>& rectangles) noexcept override;
         [[nodiscard]] HRESULT InvalidateScroll(const til::point* const pcoordDelta) noexcept override;
         [[nodiscard]] HRESULT InvalidateAll() noexcept override;
 


### PR DESCRIPTION
Right now, selections are stored as a set of points (start, end, pivot)
and converted into rectangles based on the contents of the screen buffer
**every single render pass**.

They are also painted fairly late in the rendering cycle.

This pull request makes a few changes to how selections happen.

Selections are now requested earlier in the rendering pass, during the
creation of the `RenderInfo`, and stored as a `span<point_span>`. To
make that `span` work, the selection data must be durably stored
somewhere.

Therefore, Terminal and conhost now take advantage of their new
generational selection data (#17676) to create and cache arrays of
`point_span`s covering their selections.

Unlike selection rects, linear (non-box) selections take only a single
entry in the span set. Also unlike selection rects, but _like_ search
highlights, selection spans use buffer coordinates.

In the future, AtlasEngine can use the information sent in during
`PrepareRenderInfo` to influence text rendering decisions such as the
foreground and background color for a grapheme cluster or the gridlines.

Unfortunately, GDI is stuck with the old selection rendering
implementation _and therefore, we still need to produce selection rects
with viewport coordinates_ and filter them down to the render engine's
dirty region. This is because GDI wants to **invert** all on-screen
pixels in the selection range after the final render to make sure
sixels, pixels, and lines are all displayed in the appropriate vintage
style.

As part of this change, I've migrated conhost's search highlight to not
read text directly out of the buffer but instead use the new
`CopyRequest` added by @tusharsnx in #16377.

Many of the tests for conhost behavior had a copy of conhost's code in
them, which sorta begs the question. I migrated them to use hardcoded
expected values to better catch regressions.

In Terminal, the "SelectAfterScroll" ControlCore tests weren't testing
*anything* they said they were, so I made them do so.