### PR TITLE
Potential hotfix for a MSVC 14.40.33807 miscompilation

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Utils.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Utils.cpp
@@ -28,7 +28,7 @@ namespace winrt::Microsoft::Terminal::Settings
     hstring LocalizedNameForEnumName(const std::wstring_view sectionAndEnumType, const std::wstring_view enumValue, const std::wstring_view propertyType)
     {
         // Uppercase the first letter to conform to our current Resource keys
-        auto fmtKey = fmt::format(L"{}{}{}/{}", sectionAndEnumType, char(std::towupper(enumValue[0])), enumValue.substr(1), propertyType);
+        auto fmtKey = fmt::format(FMT_COMPILE(L"{}{}{}/{}"), sectionAndEnumType, std::towupper(enumValue[0]), enumValue.substr(1), propertyType);
         return GetLibraryResourceString(fmtKey);
     }
 }


### PR DESCRIPTION
We aren't sure what exactly it is, but on the latest toolchain
this code miscompiles. The fmt call throws an exception because
it supposedly has too few arguments supplied for the format string.
Debugging the issue shows that the `next_arg_id_` internal to `fmt`
is 10000, even though it's parsing the first argument. At that point
it's supposed to be 0. This code hasn't been changed in years.

My hope is that this slight shuffling of the code causes
the issue to go away.