### PR TITLE
Address feedback from #17510

### DIFF
--- a/src/host/VtIo.cpp
+++ b/src/host/VtIo.cpp
@@ -161,7 +161,7 @@ bool VtIo::IsUsingVt() const
     }
 
     {
-        auto writer = GetWriter();
+        Writer writer{ this };
 
         // GH#4999 - Send a sequence to the connected terminal to request
         // win32-input-mode from them. This will enable the connected terminal to
@@ -359,15 +359,13 @@ void VtIo::FormatAttributes(std::wstring& target, const TextAttribute& attribute
     target.append(bufW, len);
 }
 
-VtIo::Writer VtIo::GetWriter() noexcept
-{
-    _corked += 1;
-    return Writer{ this };
-}
-
 VtIo::Writer::Writer(VtIo* io) noexcept :
     _io{ io }
 {
+    if (_io)
+    {
+        _io->_corked += 1;
+    }
 }
 
 VtIo::Writer::~Writer() noexcept
@@ -379,21 +377,6 @@ VtIo::Writer::~Writer() noexcept
         _io->_writerTainted = true;
         _io->_uncork();
     }
-}
-
-VtIo::Writer::Writer(Writer&& other) noexcept :
-    _io{ std::exchange(other._io, nullptr) }
-{
-}
-
-VtIo::Writer& VtIo::Writer::operator=(Writer&& other) noexcept
-{
-    if (this != &other)
-    {
-        this->~Writer();
-        _io = std::exchange(other._io, nullptr);
-    }
-    return *this;
 }
 
 VtIo::Writer::operator bool() const noexcept
@@ -538,11 +521,19 @@ void VtIo::Writer::WriteUTF16(std::wstring_view str) const
         THROW_HR_MSG(E_INVALIDARG, "string too large");
     }
 
+    // C++23's resize_and_overwrite is too valuable to not use.
+    // It reduce the CPU overhead by roughly half.
+#if !defined(_HAS_CXX23) || !_HAS_CXX23
+#define resize_and_overwrite _Resize_and_overwrite
+#endif
+
     // NOTE: Throwing inside resize_and_overwrite invokes undefined behavior.
-    _io->_back._Resize_and_overwrite(totalUTF8Cap, [&](char* buf, const size_t) noexcept {
+    _io->_back.resize_and_overwrite(totalUTF8Cap, [&](char* buf, const size_t) noexcept {
         const auto len = WideCharToMultiByte(CP_UTF8, 0, str.data(), gsl::narrow_cast<int>(incomingUTF16Len), buf + existingUTF8Len, gsl::narrow_cast<int>(incomingUTF8Cap), nullptr, nullptr);
         return existingUTF8Len + std::max(0, len);
     });
+
+#undef resize_and_overwrite
 }
 
 // When DISABLE_NEWLINE_AUTO_RETURN is not set (Bad! Don't do it!) we'll do newline translation for you.
@@ -637,6 +628,12 @@ void VtIo::Writer::WriteUCS2(wchar_t ch) const
 
 void VtIo::Writer::WriteUCS2StripControlChars(wchar_t ch) const
 {
+    // If any of the values in the buffer are C0 or C1 controls, we need to
+    // convert them to printable codepoints, otherwise they'll end up being
+    // evaluated as control characters by the receiving terminal. We use the
+    // DOS 437 code page for the C0 controls and DEL, and just a `?` for the
+    // C1 controls, since that's what you would most likely have seen in the
+    // legacy v1 console with raster fonts.
     if (ch < 0x20)
     {
         static constexpr wchar_t lut[] = {

--- a/src/host/VtIo.cpp
+++ b/src/host/VtIo.cpp
@@ -169,8 +169,8 @@ bool VtIo::IsUsingVt() const
         // this sequence, it'll just ignore it.
 
         writer.WriteUTF8(
-            "\033[?1004h" // Focus Event Mode
-            "\033[?9001h" // Win32 Input Mode
+            "\x1b[?1004h" // Focus Event Mode
+            "\x1b[?9001h" // Win32 Input Mode
         );
 
         // MSFT: 15813316
@@ -692,6 +692,20 @@ void VtIo::Writer::WriteASB(bool enabled) const
     char buf[] = "\x1b[?1049h";
     buf[std::size(buf) - 2] = enabled ? 'h' : 'l';
     _io->_back.append(&buf[0], std::size(buf) - 1);
+}
+
+void VtIo::Writer::WriteWindowVisibility(bool visible) const
+{
+    char buf[] = "\x1b[1t";
+    buf[2] = visible ? '1' : '2';
+    _io->_back.append(&buf[0], std::size(buf) - 1);
+}
+
+void VtIo::Writer::WriteWindowTitle(std::wstring_view title) const
+{
+    WriteUTF8("\x1b]0;");
+    WriteUTF16StripControlChars(title);
+    WriteUTF8("\x1b\\");
 }
 
 void VtIo::Writer::WriteAttributes(const TextAttribute& attributes) const

--- a/src/host/VtIo.hpp
+++ b/src/host/VtIo.hpp
@@ -22,8 +22,8 @@ namespace Microsoft::Console::VirtualTerminal
 
             Writer(const Writer&) = delete;
             Writer& operator=(const Writer&) = delete;
-            Writer(Writer&& other) noexcept;
-            Writer& operator=(Writer&& other) noexcept;
+            Writer(Writer&& other) = delete;
+            Writer& operator=(Writer&& other) = delete;
 
             explicit operator bool() const noexcept;
 
@@ -60,12 +60,8 @@ namespace Microsoft::Console::VirtualTerminal
         bool IsUsingVt() const;
         [[nodiscard]] HRESULT StartIfNeeded();
 
-        [[nodiscard]] HRESULT SuppressResizeRepaint();
-        [[nodiscard]] HRESULT SetCursorPosition(const til::point coordCursor);
-        [[nodiscard]] HRESULT SwitchScreenBuffer(const bool useAltBuffer);
         void SendCloseEvent();
         void CreatePseudoWindow();
-        Writer GetWriter() noexcept;
 
     private:
         [[nodiscard]] HRESULT _Initialize(const HANDLE InHandle, const HANDLE OutHandle, _In_opt_ const HANDLE SignalHandle);

--- a/src/host/VtIo.hpp
+++ b/src/host/VtIo.hpp
@@ -41,6 +41,8 @@ namespace Microsoft::Console::VirtualTerminal
             void WriteSGR1006(bool enabled) const;
             void WriteDECAWM(bool enabled) const;
             void WriteASB(bool enabled) const;
+            void WriteWindowVisibility(bool visible) const;
+            void WriteWindowTitle(std::wstring_view title) const;
             void WriteAttributes(const TextAttribute& attributes) const;
             void WriteInfos(til::point target, std::span<const CHAR_INFO> infos) const;
 

--- a/src/host/_output.cpp
+++ b/src/host/_output.cpp
@@ -383,13 +383,7 @@ static FillConsoleResult FillConsoleImpl(SCREEN_INFORMATION& screenInfo, FillCon
         LockConsole();
         const auto unlock = wil::scope_exit([&] { UnlockConsole(); });
 
-        // GH#3126 - This is a shim for powershell's `Clear-Host` function. In
-        // the vintage console, `Clear-Host` is supposed to clear the entire
-        // buffer. In conpty however, there's no difference between the viewport
-        // and the entirety of the buffer. We're going to see if this API call
-        // exactly matched the way we expect powershell to call it. If it does,
-        // then let's manually emit a ^[[3J to the connected terminal, so that
-        // their entire buffer will be cleared as well.
+        // See FillConsoleOutputCharacterWImpl and its identical code.
         if (enablePowershellShim)
         {
             auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();

--- a/src/host/_stream.cpp
+++ b/src/host/_stream.cpp
@@ -370,7 +370,7 @@ void WriteCharsVT(SCREEN_INFORMATION& screenInfo, const std::wstring_view& str)
 
             static constexpr std::array<std::string_view, 2> mapping{ {
                 { "\x1b[?1004h\x1b[?9001h" }, // RIS: Focus Event Mode + Win32 Input Mode
-                { "\033[?1004h" } // DECSET_FOCUS: Focus Event Mode
+                { "\x1b[?1004h" } // DECSET_FOCUS: Focus Event Mode
             } };
             static_assert(static_cast<size_t>(InjectionType::Count) == mapping.size(), "you need to update the mapping array");
 

--- a/src/host/consoleInformation.cpp
+++ b/src/host/consoleInformation.cpp
@@ -125,12 +125,18 @@ VtIo* CONSOLE_INFORMATION::GetVtIo() noexcept
 
 VtIo::Writer CONSOLE_INFORMATION::GetVtWriter() noexcept
 {
-    return _vtIo.IsUsingVt() ? _vtIo.GetWriter() : VtIo::Writer{};
+    // If we're not ConPTY, we return an empty writer, which indicates to the caller to do nothing.
+    const auto ok = _vtIo.IsUsingVt();
+    return VtIo::Writer{ ok ? &_vtIo : nullptr };
 }
 
 VtIo::Writer CONSOLE_INFORMATION::GetVtWriterForBuffer(const SCREEN_INFORMATION* context) noexcept
 {
-    return _vtIo.IsUsingVt() && (pCurrentScreenBuffer == context || pCurrentScreenBuffer == context->GetAltBuffer()) ? _vtIo.GetWriter() : VtIo::Writer{};
+    // If the given context is not the current screen buffer, we also return an empty writer.
+    // We check both for equality and the alt buffer, because we may switch between the main/alt
+    // buffer while processing the input and this method should return a valid writer in both cases.
+    const auto ok = _vtIo.IsUsingVt() && (pCurrentScreenBuffer == context || pCurrentScreenBuffer == context->GetAltBuffer());
+    return VtIo::Writer{ ok ? &_vtIo : nullptr };
 }
 
 bool CONSOLE_INFORMATION::IsInVtIoMode() const noexcept

--- a/src/host/getset.cpp
+++ b/src/host/getset.cpp
@@ -1631,9 +1631,7 @@ void ApiRoutines::GetConsoleDisplayModeImpl(ULONG& flags) noexcept
 
     if (auto writer = gci.GetVtWriter())
     {
-        writer.WriteUTF8("\x1b]0;");
-        writer.WriteUTF16StripControlChars(title);
-        writer.WriteUTF8("\x7");
+        writer.WriteWindowTitle(title);
         writer.Submit();
     }
 

--- a/src/host/ut_host/VtIoTests.cpp
+++ b/src/host/ut_host/VtIoTests.cpp
@@ -85,7 +85,6 @@ class ::Microsoft::Console::VirtualTerminal::VtIoTests
     TEST_CLASS_SETUP(ClassSetup)
     {
         wil::unique_hfile tx;
-        //std::tie(tx, rx) = createOverlappedPipe(16 * 1024);
         THROW_IF_WIN32_BOOL_FALSE(CreatePipe(rx.addressof(), tx.addressof(), nullptr, 16 * 1024));
 
         DWORD mode = PIPE_READMODE_BYTE | PIPE_NOWAIT;

--- a/src/interactivity/base/InteractivityFactory.cpp
+++ b/src/interactivity/base/InteractivityFactory.cpp
@@ -499,9 +499,7 @@ void InteractivityFactory::_WritePseudoWindowCallback(bool showOrHide)
     auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
     if (auto writer = gci.GetVtWriter())
     {
-        char buf[] = "\x1b[1t";
-        buf[2] = showOrHide ? '1' : '2';
-        writer.WriteUTF8(buf);
+        writer.WriteWindowVisibility(showOrHide);
         writer.Submit();
     }
 }

--- a/src/terminal/parser/stateMachine.hpp
+++ b/src/terminal/parser/stateMachine.hpp
@@ -37,10 +37,15 @@ namespace Microsoft::Console::VirtualTerminal
     // the their indexes.
     static_assert(MAX_PARAMETER_COUNT * MAX_SUBPARAMETER_COUNT <= 256);
 
+    // When we encounter something like a RIS (hard reset), ConPTY must re-enable
+    // modes that it relies on (like the Win32 Input Mode). To do this, the VT
+    // parser tells it the positions of any such relevant VT sequences.
     enum class InjectionType : size_t
     {
         RIS,
         DECSET_FOCUS,
+
+        Count,
     };
 
     struct Injection


### PR DESCRIPTION
* Added/changed comments as mentioned.
* Improved the ugly `resize_and_overwrite` hack into the STL.
* Add `Write` functions for xterm's window API.
* The only reason we needed a move operator for `VtIo::Writer`
  is because we used it in a ternary in `CONSOLE_INFORMATION`.
  Ternaries are like if branches with hidden move assignments.
  Instead, we simply construct each `Writer` in place.
  No ternary = No move = No problems in life.
  The best benefit of this is that this makes calling `GetVtWriter`
  a hundred times cheaper.

Otherwise, I still need to extend a few tests in `VtIoTests`,
but I'm planning to do that later.