### PR TITLE
wint_t is not wchar_t

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Utils.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Utils.cpp
@@ -28,7 +28,7 @@ namespace winrt::Microsoft::Terminal::Settings
     hstring LocalizedNameForEnumName(const std::wstring_view sectionAndEnumType, const std::wstring_view enumValue, const std::wstring_view propertyType)
     {
         // Uppercase the first letter to conform to our current Resource keys
-        auto fmtKey = fmt::format(FMT_COMPILE(L"{}{}{}/{}"), sectionAndEnumType, std::towupper(enumValue[0]), enumValue.substr(1), propertyType);
+        auto fmtKey = fmt::format(FMT_COMPILE(L"{}{}{}/{}"), sectionAndEnumType, static_cast<wchar_t>(std::towupper(enumValue[0])), enumValue.substr(1), propertyType);
         return GetLibraryResourceString(fmtKey);
     }
 }


### PR DESCRIPTION
`towupper` return `wint_t` which is `int`. 🤦

## Validation Steps Performed
Open the settings menu. 🤦✅