### PR TITLE
Return strings directly from read_file_as_utf8_string_if_exists

### DIFF
--- a/src/cascadia/TerminalSettingsModel/ActionMap.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionMap.cpp
@@ -923,13 +923,12 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     {
         // This returns an empty string if we fail to load the file.
         std::filesystem::path localSnippetsPath{ std::wstring_view{ currentWorkingDirectory + L"\\.wt.json" } };
-        const auto localTasksFileContents = til::io::read_file_as_utf8_string_if_exists(localSnippetsPath);
-        if (!localTasksFileContents.has_value() || localTasksFileContents->empty())
+        const auto data = til::io::read_file_as_utf8_string_if_exists(localSnippetsPath);
+        if (data.empty())
         {
             return {};
         }
 
-        const auto& data = *localTasksFileContents;
         Json::Value root;
         std::string errs;
         const std::unique_ptr<Json::CharReader> reader{ Json::CharReaderBuilder{}.newCharReader() };

--- a/src/cascadia/TerminalSettingsModel/ApplicationState.cpp
+++ b/src/cascadia/TerminalSettingsModel/ApplicationState.cpp
@@ -146,7 +146,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         std::unique_ptr<Json::CharReader> reader{ Json::CharReaderBuilder{}.newCharReader() };
 
         // First get shared state out of `state.json`.
-        const auto sharedData = _readSharedContents().value_or(std::string{});
+        const auto sharedData = _readSharedContents();
         if (!sharedData.empty())
         {
             Json::Value root;
@@ -165,7 +165,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                 FromJson(root, FileSource::Shared);
 
                 // Then, try and get anything in elevated-state
-                if (const auto localData{ _readLocalContents().value_or(std::string{}) }; !localData.empty())
+                if (const auto localData{ _readLocalContents() }; !localData.empty())
                 {
                     Json::Value root;
                     if (!reader->parse(localData.data(), localData.data() + localData.size(), &root, &errs))
@@ -216,7 +216,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             // First load the contents of state.json into a json blob. This will
             // contain the Shared properties and the unelevated instance's Local
             // properties.
-            const auto sharedData = _readSharedContents().value_or(std::string{});
+            const auto sharedData = _readSharedContents();
             if (!sharedData.empty())
             {
                 if (!reader->parse(sharedData.data(), sharedData.data() + sharedData.size(), &root, &errs))
@@ -334,7 +334,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     // - Read the contents of our "shared" state - state that should be shared
     //   for elevated and unelevated instances. This is things like the list of
     //   generated profiles, the command palette commandlines.
-    std::optional<std::string> ApplicationState::_readSharedContents() const
+    std::string ApplicationState::_readSharedContents() const
     {
         return til::io::read_file_as_utf8_string_if_exists(_sharedPath);
     }
@@ -346,7 +346,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     //   those don't matter when unelevated).
     // - When elevated, this will DELETE `elevated-state.json` if it has bad
     //   permissions, so we don't potentially read malicious data.
-    std::optional<std::string> ApplicationState::_readLocalContents() const
+    std::string ApplicationState::_readLocalContents() const
     {
         return ::Microsoft::Console::Utils::IsRunningElevated() ?
                    til::io::read_file_as_utf8_string_if_exists(_elevatedPath, true) :

--- a/src/cascadia/TerminalSettingsModel/ApplicationState.h
+++ b/src/cascadia/TerminalSettingsModel/ApplicationState.h
@@ -95,9 +95,9 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         Json::Value _toJsonWithBlob(Json::Value& root, FileSource parseSource) const noexcept;
 
-        std::optional<std::string> _readSharedContents() const;
+        std::string _readSharedContents() const;
         void _writeSharedContents(const std::string_view content) const;
-        std::optional<std::string> _readLocalContents() const;
+        std::string _readLocalContents() const;
         void _writeLocalContents(const std::string_view content) const;
     };
 }

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -237,8 +237,11 @@ void SettingsLoader::FindFragmentsAndMergeIntoUserSettings()
             {
                 try
                 {
-                    const auto content = til::io::read_file_as_utf8_string(fragmentExt.path());
-                    _parseFragment(source, content, fragmentSettings);
+                    const auto content = til::io::read_file_as_utf8_string_if_exists(fragmentExt.path());
+                    if (!content.empty())
+                    {
+                        _parseFragment(source, content, fragmentSettings);
+                    }
                 }
                 CATCH_LOG();
             }
@@ -934,7 +937,7 @@ Model::CascadiaSettings CascadiaSettings::LoadAll()
 try
 {
     FILETIME lastWriteTime{};
-    auto settingsString = til::io::read_file_as_utf8_string_if_exists(_settingsPath(), false, &lastWriteTime).value_or(std::string{});
+    auto settingsString = til::io::read_file_as_utf8_string_if_exists(_settingsPath(), false, &lastWriteTime);
     auto firstTimeSetup = settingsString.empty();
 
     // If it's the firstTimeSetup and a preview build, then try to
@@ -947,7 +950,7 @@ try
         {
             try
             {
-                settingsString = til::io::read_file_as_utf8_string_if_exists(_releaseSettingsPath()).value_or(std::string{});
+                settingsString = til::io::read_file_as_utf8_string_if_exists(_releaseSettingsPath());
                 releaseSettingExists = settingsString.empty() ? false : true;
             }
             catch (...)


### PR DESCRIPTION
* Every single place that called `read_file_as_utf8_string_if_exists`
  would immediately do a `.value_or(std::string{})`.
  As such, the function now returns a string directly.
* There was just one caller to `read_file_as_utf8_string`
  and it only cared about files that are non-empty.
  As such, the specialization got removed.

Both of these make sense to me, as in practice there's seldom
a difference between an empty file and a non-existent one.

## Validation Steps Performed
* Compiles ✅
* Starts ✅
* Deleting the `settings.json` contents triggers a reload ✅