### PR TITLE
Fix cooked read reflow under ConPTY

### DIFF
--- a/src/host/readDataCooked.hpp
+++ b/src/host/readDataCooked.hpp
@@ -164,6 +164,7 @@ private:
     bool _insertMode = false;
     bool _dirty = false;
     bool _redrawPending = false;
+    bool _clearPending = false;
 
     til::point _originInViewport;
     // This value is in the pager coordinate space. (0,0) is the first character of the


### PR DESCRIPTION
This delays the CSI J until we know the new origin of the prompt.
That way it's at the right (reflowed) position.

## Validation Steps Performed
* conhost
  * Print a ton of text
  * Write a prompt of a hundred chars
  * Resize the window very narrow / wide
  * Works ✅
* Windows Terminal
  * Write a prompt of a hundred chars
  * Resize the window very narrow / wide
  * Works ✅