### PR TITLE
atlas,d2d: overdraw the background bitmap by one cell on all sides

### DIFF
--- a/src/renderer/atlas/BackendD2D.cpp
+++ b/src/renderer/atlas/BackendD2D.cpp
@@ -160,7 +160,7 @@ void BackendD2D::_handleSettingsUpdate(const RenderingPayload& p)
 
          The translation in `transform` ensures that we render it off the top left of the render target.
         */
-        auto backgroundFill = std::make_unique_for_overwrite<u32[]>(static_cast<size_t>(size.width * size.height));
+        auto backgroundFill = std::make_unique_for_overwrite<u32[]>(static_cast<size_t>(size.width) * size.height);
         std::fill_n(backgroundFill.get(), size.width * size.height, u32ColorPremultiply(p.s->misc->backgroundColor));
 
         THROW_IF_FAILED(_renderTarget->CreateBitmap(size, backgroundFill.get(), size.width * sizeof(u32), &props, _backgroundBitmap.put()));

--- a/src/renderer/atlas/BackendD2D.h
+++ b/src/renderer/atlas/BackendD2D.h
@@ -67,6 +67,7 @@ namespace Microsoft::Console::Render::Atlas
         til::generation_t _generation;
         til::generation_t _fontGeneration;
         til::generation_t _cursorGeneration;
+        til::generation_t _miscGeneration;
         u16x2 _viewportCellCount{};
 
 #if ATLAS_DEBUG_SHOW_DIRTY


### PR DESCRIPTION
BackendD2D will now draw one extra cell on all sides when rendering the background, filled with the expected background color, starting at (-1, -1) to ensure that cell backgrounds do not bleed over the edges of the viewport where the is swapchain but no content.

Fixes #17672