### PR TITLE
til: add til::point_span_subspan_within_rect

### DIFF
--- a/src/inc/til/rect.h
+++ b/src/inc/til/rect.h
@@ -765,6 +765,13 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
         }
         RETURN_WIN32(ERROR_UNHANDLED_EXCEPTION);
     }
+
+    constexpr std::span<const til::point_span> point_span_subspan_within_rect(const std::span<const til::point_span>& pointSpan, const til::rect rect)
+    {
+        const auto beg = std::lower_bound(pointSpan.begin(), pointSpan.end(), rect.top, [](const auto& ps, const auto& drTop) { return ps.end.y < drTop; });
+        const auto end = std::upper_bound(beg, pointSpan.end(), rect.bottom, [](const auto& drBottom, const auto& ps) { return drBottom < ps.start.y; });
+        return { beg, end };
+    }
 }
 
 #ifdef __WEX_COMMON_H__

--- a/src/inc/til/rect.h
+++ b/src/inc/til/rect.h
@@ -766,6 +766,10 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
         RETURN_WIN32(ERROR_UNHANDLED_EXCEPTION);
     }
 
+    // Given a span of til::point_span, returns the sub-span of all point spans that
+    // cover the given rectangle. This function **DOES NOT** change any of the point_spans.
+    // It is therefore possible that you will get a point_span whose start and/or end
+    // are outside the rectangle.
     constexpr std::span<const til::point_span> point_span_subspan_within_rect(const std::span<const til::point_span>& pointSpan, const til::rect rect)
     {
         const auto beg = std::lower_bound(pointSpan.begin(), pointSpan.end(), rect.top, [](const auto& ps, const auto& drTop) { return ps.end.y < drTop; });

--- a/src/inc/til/rect.h
+++ b/src/inc/til/rect.h
@@ -766,10 +766,10 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
         RETURN_WIN32(ERROR_UNHANDLED_EXCEPTION);
     }
 
-    // Given a span of til::point_span, returns the sub-span of all point spans that
+    // Given an ordered span of til::point_span, returns the sub-span of all point spans that
     // cover the given rectangle. This function **DOES NOT** change any of the point_spans.
-    // It is therefore possible that you will get a point_span whose start and/or end
-    // are outside the rectangle.
+    // It is therefore possible that you will get a point_span whose start and/or end are
+    // outside the rectangle.
     constexpr std::span<const til::point_span> point_span_subspan_within_rect(const std::span<const til::point_span>& pointSpan, const til::rect rect)
     {
         const auto beg = std::lower_bound(pointSpan.begin(), pointSpan.end(), rect.top, [](const auto& ps, const auto& drTop) { return ps.end.y < drTop; });

--- a/src/renderer/atlas/AtlasEngine.cpp
+++ b/src/renderer/atlas/AtlasEngine.cpp
@@ -291,8 +291,6 @@ CATCH_RETURN()
 {
     // remove the highlighted regions that falls outside of the dirty region
     {
-        const auto& highlights = info.searchHighlights;
-
         // get the buffer origin relative to the viewport, and use it to calculate
         // the dirty region to be relative to the buffer origin
         const til::CoordType offsetX = _api.viewportOffset.x;
@@ -300,9 +298,7 @@ CATCH_RETURN()
         const til::point bufferOrigin{ -offsetX, -offsetY };
         const auto dr = _api.dirtyRect.to_origin(bufferOrigin);
 
-        const auto hiBeg = std::lower_bound(highlights.begin(), highlights.end(), dr.top, [](const auto& ps, const auto& drTop) { return ps.end.y < drTop; });
-        const auto hiEnd = std::upper_bound(hiBeg, highlights.end(), dr.bottom, [](const auto& drBottom, const auto& ps) { return drBottom < ps.start.y; });
-        _api.searchHighlights = { hiBeg, hiEnd };
+        _api.searchHighlights = til::point_span_subspan_within_rect(info.searchHighlights, dr);
 
         // do the same for the focused search highlight
         if (info.searchHighlightFocused)


### PR DESCRIPTION
This pulls one of the inlines in AtlasEngine out as a helper so we can use it elsewhere.