### PR TITLE
Port selection in conhost and Terminal to use til::generational

### DIFF
--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -15,6 +15,7 @@
 #include "../../types/inc/GlyphWidth.hpp"
 #include "../../cascadia/terminalcore/ITerminalInput.hpp"
 
+#include <til/generational.h>
 #include <til/ticket_lock.h>
 #include <til/winrt.h>
 
@@ -381,14 +382,15 @@ private:
     // the pivot is the til::point that remains selected when you extend a selection in any direction
     //   this is particularly useful when a word selection is extended over its starting point
     //   see TerminalSelection.cpp for more information
-    struct SelectionAnchors
+    struct SelectionInfo
     {
         til::point start;
         til::point end;
         til::point pivot;
+        bool blockSelection = false;
+        bool active = false;
     };
-    std::optional<SelectionAnchors> _selection;
-    bool _blockSelection = false;
+    til::generational<SelectionInfo> _selection{};
     std::wstring _wordDelimiters;
     SelectionExpansion _multiClickSelectionMode = SelectionExpansion::Char;
     SelectionInteractionMode _selectionMode = SelectionInteractionMode::None;
@@ -473,6 +475,7 @@ private:
     void _MoveByWord(SelectionDirection direction, til::point& pos);
     void _MoveByViewport(SelectionDirection direction, til::point& pos) noexcept;
     void _MoveByBuffer(SelectionDirection direction, til::point& pos) noexcept;
+    void _SetSelectionEnd(SelectionInfo* selection, const til::point position, std::optional<SelectionExpansion> newExpansionMode = std::nullopt);
 #pragma endregion
 
 #ifdef UNIT_TESTING

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -339,23 +339,25 @@ void Terminal::SearchMissingCommand(const std::wstring_view command)
 void Terminal::NotifyBufferRotation(const int delta)
 {
     // Update our selection, so it doesn't move as the buffer is cycled
-    if (_selection)
+    if (_selection->active)
     {
+        auto selection{ _selection.write() };
+        wil::hide_name _selection;
         // If the end of the selection will be out of range after the move, we just
         // clear the selection. Otherwise we move both the start and end points up
         // by the given delta and clamp to the first row.
-        if (_selection->end.y < delta)
+        if (selection->end.y < delta)
         {
-            _selection.reset();
+            selection->active = false;
         }
         else
         {
             // Stash this, so we can make sure to update the pivot to match later.
-            const auto pivotWasStart = _selection->start == _selection->pivot;
-            _selection->start.y = std::max(_selection->start.y - delta, 0);
-            _selection->end.y = std::max(_selection->end.y - delta, 0);
+            const auto pivotWasStart = selection->start == selection->pivot;
+            selection->start.y = std::max(selection->start.y - delta, 0);
+            selection->end.y = std::max(selection->end.y - delta, 0);
             // Make sure to sync the pivot with whichever value is the right one.
-            _selection->pivot = pivotWasStart ? _selection->start : _selection->end;
+            selection->pivot = pivotWasStart ? selection->start : selection->end;
         }
     }
 

--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -57,7 +57,7 @@ std::vector<til::inclusive_rect> Terminal::_GetSelectionRects() const noexcept
 
     try
     {
-        return _activeBuffer().GetTextRects(_selection->start, _selection->end, _blockSelection, false);
+        return _activeBuffer().GetTextRects(_selection->start, _selection->end, _selection->blockSelection, false);
     }
     CATCH_LOG();
     return result;
@@ -78,7 +78,7 @@ std::vector<til::point_span> Terminal::_GetSelectionSpans() const noexcept
 
     try
     {
-        return _activeBuffer().GetTextSpans(_selection->start, _selection->end, _blockSelection, false);
+        return _activeBuffer().GetTextSpans(_selection->start, _selection->end, _selection->blockSelection, false);
     }
     CATCH_LOG();
     return result;
@@ -158,13 +158,13 @@ const Terminal::SelectionEndpoint Terminal::SelectionEndpointTarget() const noex
 const bool Terminal::IsSelectionActive() const noexcept
 {
     _assertLocked();
-    return _selection.has_value();
+    return _selection->active;
 }
 
 const bool Terminal::IsBlockSelection() const noexcept
 {
     _assertLocked();
-    return _blockSelection;
+    return _selection->blockSelection;
 }
 
 // Method Description:
@@ -175,15 +175,18 @@ const bool Terminal::IsBlockSelection() const noexcept
 void Terminal::MultiClickSelection(const til::point viewportPos, SelectionExpansion expansionMode)
 {
     // set the selection pivot to expand the selection using SetSelectionEnd()
-    _selection = SelectionAnchors{};
-    _selection->pivot = _ConvertToBufferCell(viewportPos);
+    auto selection{ _selection.write() };
+    wil::hide_name _selection;
+
+    selection->pivot = _ConvertToBufferCell(viewportPos);
+    selection->active = true;
 
     _multiClickSelectionMode = expansionMode;
     SetSelectionEnd(viewportPos);
 
     // we need to set the _selectionPivot again
     // for future shift+clicks
-    _selection->pivot = _selection->start;
+    selection->pivot = selection->start;
 }
 
 // Method Description:
@@ -194,13 +197,21 @@ void Terminal::SetSelectionAnchor(const til::point viewportPos)
 {
     _assertLocked();
 
-    _selection = SelectionAnchors{};
-    _selection->pivot = _ConvertToBufferCell(viewportPos);
+    auto selection{ _selection.write() };
+    wil::hide_name _selection;
+
+    selection->pivot = _ConvertToBufferCell(viewportPos);
+    selection->active = true;
 
     _multiClickSelectionMode = SelectionExpansion::Char;
     SetSelectionEnd(viewportPos);
 
-    _selection->start = _selection->pivot;
+    selection->start = selection->pivot;
+}
+
+void Terminal::SetSelectionEnd(const til::point viewportPos, std::optional<SelectionExpansion> newExpansionMode)
+{
+    _SetSelectionEnd(_selection.write(), viewportPos, newExpansionMode);
 }
 
 // Method Description:
@@ -209,9 +220,10 @@ void Terminal::SetSelectionAnchor(const til::point viewportPos)
 // Arguments:
 // - viewportPos: the (x,y) coordinate on the visible viewport
 // - newExpansionMode: overwrites the _multiClickSelectionMode for this function call. Used for ShiftClick
-void Terminal::SetSelectionEnd(const til::point viewportPos, std::optional<SelectionExpansion> newExpansionMode)
+void Terminal::_SetSelectionEnd(SelectionInfo* selection, const til::point viewportPos, std::optional<SelectionExpansion> newExpansionMode)
 {
-    if (!IsSelectionActive())
+    wil::hide_name _selection;
+    if (!selection->active)
     {
         // capture a log for spurious endpoint sets without an active selection
         LOG_HR(E_ILLEGAL_STATE_CHANGE);
@@ -231,17 +243,17 @@ void Terminal::SetSelectionEnd(const til::point viewportPos, std::optional<Selec
     if (newExpansionMode.has_value())
     {
         // shift-click operations only expand the target side
-        auto& anchorToExpand = targetStart ? _selection->start : _selection->end;
+        auto& anchorToExpand = targetStart ? selection->start : selection->end;
         anchorToExpand = targetStart ? expandedAnchors.first : expandedAnchors.second;
 
         // the other anchor should then become the pivot (we don't expand it)
-        auto& anchorToPivot = targetStart ? _selection->end : _selection->start;
-        anchorToPivot = _selection->pivot;
+        auto& anchorToPivot = targetStart ? selection->end : selection->start;
+        anchorToPivot = selection->pivot;
     }
     else
     {
         // expand both anchors
-        std::tie(_selection->start, _selection->end) = expandedAnchors;
+        std::tie(selection->start, selection->end) = expandedAnchors;
     }
     _selectionMode = SelectionInteractionMode::Mouse;
     _selectionIsTargetingUrl = false;
@@ -307,7 +319,7 @@ std::pair<til::point, til::point> Terminal::_ExpandSelectionAnchors(std::pair<ti
 // - isEnabled: new value for _blockSelection
 void Terminal::SetBlockSelection(const bool isEnabled) noexcept
 {
-    _blockSelection = isEnabled;
+    _selection.write()->blockSelection = isEnabled;
 }
 
 Terminal::SelectionInteractionMode Terminal::SelectionMode() const noexcept
@@ -331,11 +343,13 @@ void Terminal::ToggleMarkMode()
         {
             // No selection --> start one at the cursor
             const auto cursorPos{ _activeBuffer().GetCursor().GetPosition() };
-            _selection = SelectionAnchors{};
-            _selection->start = cursorPos;
-            _selection->end = cursorPos;
-            _selection->pivot = cursorPos;
-            _blockSelection = false;
+            *_selection.write() = SelectionInfo{
+                .start = cursorPos,
+                .end = cursorPos,
+                .pivot = cursorPos,
+                .blockSelection = false,
+                .active = true,
+            };
             WI_SetAllFlags(_selectionEndpoint, SelectionEndpoint::Start | SelectionEndpoint::End);
         }
         else if (WI_AreAllFlagsClear(_selectionEndpoint, SelectionEndpoint::Start | SelectionEndpoint::End))
@@ -365,13 +379,13 @@ void Terminal::SwitchSelectionEndpoint() noexcept
         {
             // moving end --> now we're moving start
             _selectionEndpoint = SelectionEndpoint::Start;
-            _selection->pivot = _selection->end;
+            _selection.write()->pivot = _selection->end;
         }
         else if (WI_IsFlagSet(_selectionEndpoint, SelectionEndpoint::Start))
         {
             // moving start --> now we're moving end
             _selectionEndpoint = SelectionEndpoint::End;
-            _selection->pivot = _selection->start;
+            _selection.write()->pivot = _selection->start;
         }
     }
 }
@@ -381,9 +395,11 @@ void Terminal::ExpandSelectionToWord()
     if (IsSelectionActive())
     {
         const auto& buffer = _activeBuffer();
-        _selection->start = buffer.GetWordStart(_selection->start, _wordDelimiters);
-        _selection->pivot = _selection->start;
-        _selection->end = buffer.GetWordEnd(_selection->end, _wordDelimiters);
+        auto selection{ _selection.write() };
+        wil::hide_name _selection;
+        selection->start = buffer.GetWordStart(selection->start, _wordDelimiters);
+        selection->pivot = selection->start;
+        selection->end = buffer.GetWordEnd(selection->end, _wordDelimiters);
 
         // if we're targeting both endpoints, instead just target "end"
         if (WI_IsFlagSet(_selectionEndpoint, SelectionEndpoint::Start) && WI_IsFlagSet(_selectionEndpoint, SelectionEndpoint::End))
@@ -528,12 +544,16 @@ void Terminal::SelectHyperlink(const SearchDirection dir)
     }
 
     // 2. Select the hyperlink
-    _selection->start = result->first;
-    _selection->pivot = result->first;
-    _selection->end = result->second;
-    bufferSize.DecrementInBounds(_selection->end);
-    _selectionIsTargetingUrl = true;
-    _selectionEndpoint = SelectionEndpoint::End;
+    {
+        auto selection{ _selection.write() };
+        wil::hide_name _selection;
+        selection->start = result->first;
+        selection->pivot = result->first;
+        selection->end = result->second;
+        bufferSize.DecrementInBounds(selection->end);
+        _selectionIsTargetingUrl = true;
+        _selectionEndpoint = SelectionEndpoint::End;
+    }
 
     // 3. Scroll to the selected area (if necessary)
     _ScrollToPoint(_selection->end);
@@ -646,19 +666,23 @@ void Terminal::UpdateSelection(SelectionDirection direction, SelectionExpansion 
     // 3. Actually modify the selection state
     _selectionIsTargetingUrl = false;
     _selectionMode = std::max(_selectionMode, SelectionInteractionMode::Keyboard);
+
+    auto selection{ _selection.write() };
+    wil::hide_name _selection;
+
     if (shouldMoveBothEndpoints)
     {
         // [Mark Mode] + shift unpressed --> move all three (i.e. just use arrow keys)
-        _selection->start = targetPos;
-        _selection->end = targetPos;
-        _selection->pivot = targetPos;
+        selection->start = targetPos;
+        selection->end = targetPos;
+        selection->pivot = targetPos;
     }
     else
     {
         // [Mark Mode] + shift --> updating a standard selection
         // This is also standard quick-edit modification
         bool targetStart = false;
-        std::tie(_selection->start, _selection->end) = _PivotSelection(targetPos, targetStart);
+        std::tie(selection->start, selection->end) = _PivotSelection(targetPos, targetStart);
 
         // IMPORTANT! Pivoting the selection here might have changed which endpoint we're targeting.
         // So let's set the targeted endpoint again.
@@ -673,10 +697,15 @@ void Terminal::UpdateSelection(SelectionDirection direction, SelectionExpansion 
 void Terminal::SelectAll()
 {
     const auto bufferSize{ _activeBuffer().GetSize() };
-    _selection = SelectionAnchors{};
-    _selection->start = bufferSize.Origin();
-    _selection->end = { bufferSize.RightInclusive(), _GetMutableViewport().BottomInclusive() };
-    _selection->pivot = _selection->end;
+    const til::point end{ bufferSize.RightInclusive(), _GetMutableViewport().BottomInclusive() };
+    *_selection.write() = SelectionInfo{
+        .start = bufferSize.Origin(),
+        .end = end,
+        .pivot = end,
+        .blockSelection = false,
+        .active = true,
+    };
+
     _selectionMode = SelectionInteractionMode::Keyboard;
     _selectionIsTargetingUrl = false;
     _ScrollToPoint(_selection->start);
@@ -824,7 +853,7 @@ void Terminal::_MoveByBuffer(SelectionDirection direction, til::point& pos) noex
 void Terminal::ClearSelection()
 {
     _assertLocked();
-    _selection = std::nullopt;
+    _selection.write()->active = false;
     _selectionMode = SelectionInteractionMode::None;
     _selectionIsTargetingUrl = false;
     _selectionEndpoint = static_cast<SelectionEndpoint>(0);
@@ -858,7 +887,7 @@ Terminal::TextCopyData Terminal::RetrieveSelectedTextFromBuffer(const bool singl
 
     const auto& textBuffer = _activeBuffer();
 
-    const auto req = TextBuffer::CopyRequest::FromConfig(textBuffer, _selection->start, _selection->end, singleLine, _blockSelection, _trimBlockSelection);
+    const auto req = TextBuffer::CopyRequest::FromConfig(textBuffer, _selection->start, _selection->end, singleLine, _selection->blockSelection, _trimBlockSelection);
     data.plainText = textBuffer.GetPlainText(req);
 
     if (html || rtf)

--- a/src/host/selection.cpp
+++ b/src/host/selection.cpp
@@ -12,25 +12,41 @@
 using namespace Microsoft::Console::Interactivity;
 using namespace Microsoft::Console::Types;
 
-Selection::Selection() :
-    _fSelectionVisible(false),
-    _ulSavedCursorSize(0),
-    _fSavedCursorVisible(false),
-    _savedCursorType(CursorType::Legacy),
-    _dwSelectionFlags(0),
-    _fLineSelection(true),
-    _fUseAlternateSelection(false),
-    _allowMouseDragSelection{ true }
-{
-    ZeroMemory((void*)&_srSelectionRect, sizeof(_srSelectionRect));
-    ZeroMemory((void*)&_coordSelectionAnchor, sizeof(_coordSelectionAnchor));
-    ZeroMemory((void*)&_coordSavedCursorPosition, sizeof(_coordSavedCursorPosition));
-}
+Selection::Selection() {}
 
 Selection& Selection::Instance()
 {
     static std::unique_ptr<Selection> _instance{ new Selection() };
     return *_instance;
+}
+
+void Selection::_RegenerateSelectionRects() const
+{
+    if (_lastSelectionGeneration == _d.generation())
+    {
+        return;
+    }
+
+    _lastSelectionRects.clear();
+
+    if (!_d->fSelectionVisible)
+    {
+        return;
+    }
+
+    const auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
+    const auto& screenInfo = gci.GetActiveOutputBuffer();
+
+    // _coordSelectionAnchor is at one of the corners of _srSelectionRects
+    // endSelectionAnchor is at the exact opposite corner
+    til::point endSelectionAnchor;
+    endSelectionAnchor.x = (_d->coordSelectionAnchor.x == _d->srSelectionRect.left) ? _d->srSelectionRect.right : _d->srSelectionRect.left;
+    endSelectionAnchor.y = (_d->coordSelectionAnchor.y == _d->srSelectionRect.top) ? _d->srSelectionRect.bottom : _d->srSelectionRect.top;
+
+    const auto blockSelection = !IsLineSelection();
+    auto rects = screenInfo.GetTextBuffer().GetTextRects(_d->coordSelectionAnchor, endSelectionAnchor, blockSelection, false);
+    _lastSelectionRects = std::move(rects);
+    _lastSelectionGeneration = _d.generation();
 }
 
 // Routine Description:
@@ -43,22 +59,8 @@ Selection& Selection::Instance()
 // - Throws exceptions for out of memory issues
 std::vector<til::inclusive_rect> Selection::GetSelectionRects() const
 {
-    if (!_fSelectionVisible)
-    {
-        return std::vector<til::inclusive_rect>();
-    }
-
-    const auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
-    const auto& screenInfo = gci.GetActiveOutputBuffer();
-
-    // _coordSelectionAnchor is at one of the corners of _srSelectionRects
-    // endSelectionAnchor is at the exact opposite corner
-    til::point endSelectionAnchor;
-    endSelectionAnchor.x = (_coordSelectionAnchor.x == _srSelectionRect.left) ? _srSelectionRect.right : _srSelectionRect.left;
-    endSelectionAnchor.y = (_coordSelectionAnchor.y == _srSelectionRect.top) ? _srSelectionRect.bottom : _srSelectionRect.top;
-
-    const auto blockSelection = !IsLineSelection();
-    return screenInfo.GetTextBuffer().GetTextRects(_coordSelectionAnchor, endSelectionAnchor, blockSelection, false);
+    _RegenerateSelectionRects();
+    return _lastSelectionRects;
 }
 
 // Routine Description:
@@ -95,12 +97,12 @@ void Selection::_SetSelectionVisibility(const bool fMakeVisible)
 {
     if (IsInSelectingState() && IsAreaSelected())
     {
-        if (fMakeVisible == _fSelectionVisible)
+        if (fMakeVisible == _d->fSelectionVisible)
         {
             return;
         }
 
-        _fSelectionVisible = fMakeVisible;
+        _d.write()->fSelectionVisible = fMakeVisible;
 
         _PaintSelection();
     }
@@ -138,16 +140,20 @@ void Selection::InitializeMouseSelection(const til::point coordBufferPos)
 
     // set flags
     _SetSelectingState(true);
-    _dwSelectionFlags = CONSOLE_MOUSE_SELECTION | CONSOLE_SELECTION_NOT_EMPTY;
+    auto d{ _d.write() };
+
+    wil::hide_name _d;
+
+    d->dwSelectionFlags = CONSOLE_MOUSE_SELECTION | CONSOLE_SELECTION_NOT_EMPTY;
 
     // store anchor and rectangle of selection
-    _coordSelectionAnchor = coordBufferPos;
+    d->coordSelectionAnchor = coordBufferPos;
 
     // since we've started with just a point, the rectangle is 1x1 on the point given
-    _srSelectionRect.left = coordBufferPos.x;
-    _srSelectionRect.right = coordBufferPos.x;
-    _srSelectionRect.top = coordBufferPos.y;
-    _srSelectionRect.bottom = coordBufferPos.y;
+    d->srSelectionRect.left = coordBufferPos.x;
+    d->srSelectionRect.right = coordBufferPos.x;
+    d->srSelectionRect.top = coordBufferPos.y;
+    d->srSelectionRect.bottom = coordBufferPos.y;
 
     // Check for ALT-Mouse Down "use alternate selection"
     // If in box mode, use line mode. If in line mode, use box mode.
@@ -180,9 +186,17 @@ void Selection::InitializeMouseSelection(const til::point coordBufferPos)
 void Selection::AdjustSelection(const til::point coordSelectionStart, const til::point coordSelectionEnd)
 {
     // modify the anchor and then just use extend to adjust the other portion of the selection rectangle
-    _coordSelectionAnchor = coordSelectionStart;
-    ExtendSelection(coordSelectionEnd);
-    _allowMouseDragSelection = false;
+    auto d{ _d.write() };
+    wil::hide_name _d;
+
+    d->coordSelectionAnchor = coordSelectionStart;
+    _ExtendSelection(d, coordSelectionEnd);
+    d->allowMouseDragSelection = false;
+}
+
+void Selection::ExtendSelection(_In_ til::point coordBufferPos)
+{
+    _ExtendSelection(_d.write(), coordBufferPos);
 }
 
 // Routine Description:
@@ -192,12 +206,14 @@ void Selection::AdjustSelection(const til::point coordSelectionStart, const til:
 // - coordBufferPos - Position to extend/contract the current selection up to.
 // Return Value:
 // - <none>
-void Selection::ExtendSelection(_In_ til::point coordBufferPos)
+void Selection::_ExtendSelection(Selection::SelectionData* d, _In_ til::point coordBufferPos)
 {
+    wil::hide_name _d;
+
     auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
     auto& screenInfo = gci.GetActiveOutputBuffer();
 
-    _allowMouseDragSelection = true;
+    d->allowMouseDragSelection = true;
 
     // ensure position is within buffer bounds. Not less than 0 and not greater than the screen buffer size.
     try
@@ -218,9 +234,9 @@ void Selection::ExtendSelection(_In_ til::point coordBufferPos)
         // scroll if necessary to make cursor visible.
         screenInfo.MakeCursorVisible(coordBufferPos);
 
-        _dwSelectionFlags |= CONSOLE_SELECTION_NOT_EMPTY;
-        _srSelectionRect.left = _srSelectionRect.right = _coordSelectionAnchor.x;
-        _srSelectionRect.top = _srSelectionRect.bottom = _coordSelectionAnchor.y;
+        d->dwSelectionFlags |= CONSOLE_SELECTION_NOT_EMPTY;
+        d->srSelectionRect.left = d->srSelectionRect.right = d->coordSelectionAnchor.x;
+        d->srSelectionRect.top = d->srSelectionRect.bottom = d->coordSelectionAnchor.y;
 
         ShowSelection();
     }
@@ -231,36 +247,36 @@ void Selection::ExtendSelection(_In_ til::point coordBufferPos)
     }
 
     // remember previous selection rect
-    auto srNewSelection = _srSelectionRect;
+    auto srNewSelection = d->srSelectionRect;
 
     // update selection rect
     // this adjusts the rectangle dimensions based on which way the move was requested
     // in respect to the original selection position (the anchor)
-    if (coordBufferPos.x <= _coordSelectionAnchor.x)
+    if (coordBufferPos.x <= d->coordSelectionAnchor.x)
     {
         srNewSelection.left = coordBufferPos.x;
-        srNewSelection.right = _coordSelectionAnchor.x;
+        srNewSelection.right = d->coordSelectionAnchor.x;
     }
-    else if (coordBufferPos.x > _coordSelectionAnchor.x)
+    else if (coordBufferPos.x > d->coordSelectionAnchor.x)
     {
         srNewSelection.right = coordBufferPos.x;
-        srNewSelection.left = _coordSelectionAnchor.x;
+        srNewSelection.left = d->coordSelectionAnchor.x;
     }
-    if (coordBufferPos.y <= _coordSelectionAnchor.y)
+    if (coordBufferPos.y <= d->coordSelectionAnchor.y)
     {
         srNewSelection.top = coordBufferPos.y;
-        srNewSelection.bottom = _coordSelectionAnchor.y;
+        srNewSelection.bottom = d->coordSelectionAnchor.y;
     }
-    else if (coordBufferPos.y > _coordSelectionAnchor.y)
+    else if (coordBufferPos.y > d->coordSelectionAnchor.y)
     {
         srNewSelection.bottom = coordBufferPos.y;
-        srNewSelection.top = _coordSelectionAnchor.y;
+        srNewSelection.top = d->coordSelectionAnchor.y;
     }
 
     // This function is called on WM_MOUSEMOVE.
     // Prevent triggering an invalidation just because the mouse moved
     // in the same cell without changing the actual (visible) selection.
-    if (_srSelectionRect == srNewSelection)
+    if (d->srSelectionRect == srNewSelection)
     {
         return;
     }
@@ -268,7 +284,7 @@ void Selection::ExtendSelection(_In_ til::point coordBufferPos)
     // call special update method to modify the displayed selection in-place
     // NOTE: Using HideSelection, editing the rectangle, then ShowSelection will cause flicker.
     //_PaintUpdateSelection(&srNewSelection);
-    _srSelectionRect = srNewSelection;
+    d->srSelectionRect = srNewSelection;
     _PaintSelection();
 
     // Fire off an event to let accessibility apps know the selection has changed.
@@ -376,10 +392,13 @@ void Selection::ClearSelection(const bool fStartingNewSelection)
             LOG_IF_FAILED(window->SignalUia(UIA_Text_TextSelectionChangedEventId));
         }
 
-        _dwSelectionFlags = 0;
+        auto d{ _d.write() };
+        wil::hide_name _d;
+
+        d->dwSelectionFlags = 0;
 
         // If we were using alternate selection, cancel it here before starting a new area.
-        _fUseAlternateSelection = false;
+        d->fUseAlternateSelection = false;
 
         // Only unblock if we're not immediately starting a new selection. Otherwise stay blocked.
         if (!fStartingNewSelection)
@@ -463,9 +482,12 @@ void Selection::InitializeMarkSelection()
 
     Scrolling::s_ClearScroll();
 
+    auto d{ _d.write() };
+    wil::hide_name _d;
+
     // set flags
     _SetSelectingState(true);
-    _dwSelectionFlags = 0;
+    d->dwSelectionFlags = 0;
 
     // save old cursor position and make console cursor into selection cursor.
     auto& screenInfo = gci.GetActiveOutputBuffer();
@@ -479,7 +501,7 @@ void Selection::InitializeMarkSelection()
     // set the cursor position as the anchor position
     // it will get updated as the cursor moves for mark mode,
     // but it serves to prepare us for the inevitable start of the selection with Shift+Arrow Key
-    _coordSelectionAnchor = coordPosition;
+    d->coordSelectionAnchor = coordPosition;
 
     // set frame title text
     const auto pWindow = ServiceLocator::LocateConsoleWindow();
@@ -529,8 +551,8 @@ void Selection::SelectAll()
 
     // Get existing selection rectangle parameters
     const auto fOldSelectionExisted = IsAreaSelected();
-    const auto srOldSelection = _srSelectionRect;
-    const auto coordOldAnchor = _coordSelectionAnchor;
+    const auto srOldSelection = _d->srSelectionRect;
+    const auto coordOldAnchor = _d->coordSelectionAnchor;
 
     // Attempt to get the boundaries of the current input line.
     til::point coordInputStart;

--- a/src/host/selection.hpp
+++ b/src/host/selection.hpp
@@ -22,6 +22,7 @@ Revision History:
 
 #include "../interactivity/inc/IAccessibilityNotifier.hpp"
 #include "../interactivity/inc/IConsoleWindow.hpp"
+#include "til/generational.h"
 
 class Selection
 {
@@ -153,29 +154,39 @@ private:
     // TODO: console selection mode should be in here
     // TODO: consider putting word delims in here
 
-    // -- State/Flags --
-    // This replaces/deprecates CONSOLE_SELECTION_INVERTED on gci->SelectionFlags
-    bool _fSelectionVisible;
+    struct SelectionData
+    {
+        // -- State/Flags --
+        // This replaces/deprecates CONSOLE_SELECTION_INVERTED on gci->SelectionFlags
+        bool fSelectionVisible{ false };
 
-    bool _fLineSelection; // whether to use line selection or block selection
-    bool _fUseAlternateSelection; // whether the user has triggered the alternate selection method
-    bool _allowMouseDragSelection; // true if the dragging the mouse should change the selection
+        bool fLineSelection{ true }; // whether to use line selection or block selection
+        bool fUseAlternateSelection{ false }; // whether the user has triggered the alternate selection method
+        bool allowMouseDragSelection{ true }; // true if the dragging the mouse should change the selection
 
-    // Flags for this DWORD are defined in wincon.h. Search for def:CONSOLE_SELECTION_IN_PROGRESS, etc.
-    DWORD _dwSelectionFlags;
+        // Flags for this DWORD are defined in wincon.h. Search for def:CONSOLE_SELECTION_IN_PROGRESS, etc.
+        DWORD dwSelectionFlags{ 0 };
 
-    // -- Current Selection Data --
-    // Anchor is the point the selection was started from (and will be one of the corners of the rectangle).
-    til::point _coordSelectionAnchor;
-    // Rectangle is the area inscribing the selection. It is extended to screen edges in a particular way for line selection.
-    til::inclusive_rect _srSelectionRect;
+        // -- Current Selection Data --
+        // Anchor is the point the selection was started from (and will be one of the corners of the rectangle).
+        til::point coordSelectionAnchor{};
+        // Rectangle is the area inscribing the selection. It is extended to screen edges in a particular way for line selection.
+        til::inclusive_rect srSelectionRect{};
 
-    // -- Saved Cursor Data --
-    // Saved when a selection is started for restoration later. Position is in character coordinates, not pixels.
-    til::point _coordSavedCursorPosition;
-    ULONG _ulSavedCursorSize;
-    bool _fSavedCursorVisible;
-    CursorType _savedCursorType;
+        // -- Saved Cursor Data --
+        // Saved when a selection is started for restoration later. Position is in character coordinates, not pixels.
+        til::point coordSavedCursorPosition{};
+        ULONG ulSavedCursorSize{ 0 };
+        bool fSavedCursorVisible{ false };
+        CursorType savedCursorType{ CursorType::Legacy };
+    };
+    til::generational<SelectionData> _d{};
+
+    mutable std::vector<til::inclusive_rect> _lastSelectionRects;
+    mutable til::generation_t _lastSelectionGeneration;
+
+    void _ExtendSelection(SelectionData* d, _In_ til::point coordBufferPos);
+    void _RegenerateSelectionRects() const;
 
 #ifdef UNIT_TESTING
     friend class SelectionTests;

--- a/src/host/selectionState.cpp
+++ b/src/host/selectionState.cpp
@@ -58,7 +58,7 @@ bool Selection::IsLineSelection() const
     // if line selection is on and alternate is off -OR-
     // if line selection is off and alternate is on...
 
-    return (_fLineSelection != _fUseAlternateSelection);
+    return (_d->fLineSelection != _d->fUseAlternateSelection);
 }
 
 // Routine Description:
@@ -75,14 +75,14 @@ void Selection::_AlignAlternateSelection(const bool fAlignToLineSelect)
         // states are opposite when in line selection.
         // e.g. Line = true, Alternate = false.
         // and  Line = false, Alternate = true.
-        _fUseAlternateSelection = !_fLineSelection;
+        _d.write()->fUseAlternateSelection = !_d->fLineSelection;
     }
     else
     {
         // states are the same when in box selection.
         // e.g. Line = true, Alternate = true.
         // and  Line = false, Alternate = false.
-        _fUseAlternateSelection = _fLineSelection;
+        _d.write()->fUseAlternateSelection = _d->fLineSelection;
     }
 }
 
@@ -94,7 +94,7 @@ void Selection::_AlignAlternateSelection(const bool fAlignToLineSelect)
 // - True if the selection variables contain valid selection data. False otherwise.
 bool Selection::IsAreaSelected() const
 {
-    return WI_IsFlagSet(_dwSelectionFlags, CONSOLE_SELECTION_NOT_EMPTY);
+    return WI_IsFlagSet(_d->dwSelectionFlags, CONSOLE_SELECTION_NOT_EMPTY);
 }
 
 // Routine Description:
@@ -105,7 +105,7 @@ bool Selection::IsAreaSelected() const
 // - True if the selection was started as mark mode. False otherwise.
 bool Selection::IsKeyboardMarkSelection() const
 {
-    return WI_IsFlagClear(_dwSelectionFlags, CONSOLE_MOUSE_SELECTION);
+    return WI_IsFlagClear(_d->dwSelectionFlags, CONSOLE_MOUSE_SELECTION);
 }
 
 // Routine Description:
@@ -118,7 +118,7 @@ bool Selection::IsKeyboardMarkSelection() const
 // - True if the selection is mouse-initiated. False otherwise.
 bool Selection::IsMouseInitiatedSelection() const
 {
-    return WI_IsFlagSet(_dwSelectionFlags, CONSOLE_MOUSE_SELECTION);
+    return WI_IsFlagSet(_d->dwSelectionFlags, CONSOLE_MOUSE_SELECTION);
 }
 
 // Routine Description:
@@ -130,12 +130,12 @@ bool Selection::IsMouseInitiatedSelection() const
 // - True if the mouse button is currently down. False otherwise.
 bool Selection::IsMouseButtonDown() const
 {
-    return WI_IsFlagSet(_dwSelectionFlags, CONSOLE_MOUSE_DOWN);
+    return WI_IsFlagSet(_d->dwSelectionFlags, CONSOLE_MOUSE_DOWN);
 }
 
 void Selection::MouseDown()
 {
-    WI_SetFlag(_dwSelectionFlags, CONSOLE_MOUSE_DOWN);
+    WI_SetFlag(_d.write()->dwSelectionFlags, CONSOLE_MOUSE_DOWN);
 
     // We must capture the mouse on button down to ensure we receive messages if
     //      it comes back up outside the window.
@@ -148,7 +148,7 @@ void Selection::MouseDown()
 
 void Selection::MouseUp()
 {
-    WI_ClearFlag(_dwSelectionFlags, CONSOLE_MOUSE_DOWN);
+    WI_ClearFlag(_d.write()->dwSelectionFlags, CONSOLE_MOUSE_DOWN);
 
     const auto pWindow = ServiceLocator::LocateConsoleWindow();
     if (pWindow != nullptr)
@@ -165,10 +165,11 @@ void Selection::MouseUp()
 // - <none>
 void Selection::_SaveCursorData(const Cursor& cursor) noexcept
 {
-    _coordSavedCursorPosition = cursor.GetPosition();
-    _ulSavedCursorSize = cursor.GetSize();
-    _fSavedCursorVisible = cursor.IsVisible();
-    _savedCursorType = cursor.GetType();
+    auto d{ _d.write() };
+    d->coordSavedCursorPosition = cursor.GetPosition();
+    d->ulSavedCursorSize = cursor.GetSize();
+    d->fSavedCursorVisible = cursor.IsVisible();
+    d->savedCursorType = cursor.GetType();
 }
 
 // Routine Description:
@@ -179,11 +180,11 @@ void Selection::_SaveCursorData(const Cursor& cursor) noexcept
 // - <none>
 void Selection::_RestoreDataToCursor(Cursor& cursor) noexcept
 {
-    cursor.SetSize(_ulSavedCursorSize);
-    cursor.SetIsVisible(_fSavedCursorVisible);
-    cursor.SetType(_savedCursorType);
+    cursor.SetSize(_d->ulSavedCursorSize);
+    cursor.SetIsVisible(_d->fSavedCursorVisible);
+    cursor.SetType(_d->savedCursorType);
     cursor.SetIsOn(true);
-    cursor.SetPosition(_coordSavedCursorPosition);
+    cursor.SetPosition(_d->coordSavedCursorPosition);
 }
 
 // Routine Description:
@@ -194,7 +195,7 @@ void Selection::_RestoreDataToCursor(Cursor& cursor) noexcept
 // - current selection anchor
 til::point Selection::GetSelectionAnchor() const noexcept
 {
-    return _coordSelectionAnchor;
+    return _d->coordSelectionAnchor;
 }
 
 // Routine Description:
@@ -205,19 +206,19 @@ til::point Selection::GetSelectionAnchor() const noexcept
 // - The current selection anchors
 std::pair<til::point, til::point> Selection::GetSelectionAnchors() const noexcept
 {
-    if (!_fSelectionVisible)
+    if (!_d->fSelectionVisible)
     {
         // return anchors that represent an empty selection
         return { { 0, 0 }, { -1, -1 } };
     }
 
-    auto startSelectionAnchor = _coordSelectionAnchor;
+    auto startSelectionAnchor = _d->coordSelectionAnchor;
 
     // _coordSelectionAnchor is at one of the corners of _srSelectionRects
     // endSelectionAnchor is at the exact opposite corner
     til::point endSelectionAnchor;
-    endSelectionAnchor.x = (_coordSelectionAnchor.x == _srSelectionRect.left) ? _srSelectionRect.right : _srSelectionRect.left;
-    endSelectionAnchor.y = (_coordSelectionAnchor.y == _srSelectionRect.top) ? _srSelectionRect.bottom : _srSelectionRect.top;
+    endSelectionAnchor.x = (_d->coordSelectionAnchor.x == _d->srSelectionRect.left) ? _d->srSelectionRect.right : _d->srSelectionRect.left;
+    endSelectionAnchor.y = (_d->coordSelectionAnchor.y == _d->srSelectionRect.top) ? _d->srSelectionRect.bottom : _d->srSelectionRect.top;
 
     if (startSelectionAnchor > endSelectionAnchor)
     {
@@ -237,7 +238,7 @@ std::pair<til::point, til::point> Selection::GetSelectionAnchors() const noexcep
 // - The rectangle to fill with selection data.
 til::inclusive_rect Selection::GetSelectionRectangle() const noexcept
 {
-    return _srSelectionRect;
+    return _d->srSelectionRect;
 }
 
 // Routine Description:
@@ -250,7 +251,7 @@ til::inclusive_rect Selection::GetSelectionRectangle() const noexcept
 DWORD Selection::GetPublicSelectionFlags() const noexcept
 {
     // CONSOLE_SELECTION_VALID is the union (binary OR) of all externally valid flags in wincon.h
-    return (_dwSelectionFlags & CONSOLE_SELECTION_VALID);
+    return (_d->dwSelectionFlags & CONSOLE_SELECTION_VALID);
 }
 
 // Routine Description:
@@ -262,12 +263,12 @@ DWORD Selection::GetPublicSelectionFlags() const noexcept
 // - <none>
 void Selection::SetLineSelection(const bool fLineSelectionOn)
 {
-    if (_fLineSelection != fLineSelectionOn)
+    if (_d->fLineSelection != fLineSelectionOn)
     {
         // Ensure any existing selections are cleared so the draw state is updated appropriately.
         ClearSelection();
 
-        _fLineSelection = fLineSelectionOn;
+        _d.write()->fLineSelection = fLineSelectionOn;
     }
 }
 
@@ -282,7 +283,7 @@ void Selection::SetLineSelection(const bool fLineSelectionOn)
 // - true if the selection can be changed by a mouse drag
 bool Selection::ShouldAllowMouseDragSelection(const til::point mousePosition) const noexcept
 {
-    const auto viewport = Viewport::FromInclusive(_srSelectionRect);
+    const auto viewport = Viewport::FromInclusive(_d->srSelectionRect);
     const auto selectionContainsMouse = viewport.IsInBounds(mousePosition);
-    return _allowMouseDragSelection || !selectionContainsMouse;
+    return _d->allowMouseDragSelection || !selectionContainsMouse;
 }

--- a/src/host/ut_host/SelectionTests.cpp
+++ b/src/host/ut_host/SelectionTests.cpp
@@ -59,7 +59,7 @@ class SelectionTests
     void VerifyGetSelectionRects_BoxMode()
     {
         const auto selectionRects = m_pSelection->GetSelectionRects();
-        const UINT cRectanglesExpected = m_pSelection->_srSelectionRect.bottom - m_pSelection->_srSelectionRect.top + 1;
+        const UINT cRectanglesExpected = m_pSelection->_d->srSelectionRect.bottom - m_pSelection->_d->srSelectionRect.top + 1;
 
         if (VERIFY_ARE_EQUAL(cRectanglesExpected, selectionRects.size()))
         {
@@ -68,61 +68,76 @@ class SelectionTests
                 // ensure each rectangle is exactly the width requested (block selection)
                 const auto psrRect = &selectionRects[iRect];
 
-                const auto sRectangleLineNumber = (til::CoordType)iRect + m_pSelection->_srSelectionRect.top;
+                const auto sRectangleLineNumber = (til::CoordType)iRect + m_pSelection->_d->srSelectionRect.top;
 
                 VERIFY_ARE_EQUAL(psrRect->top, sRectangleLineNumber);
                 VERIFY_ARE_EQUAL(psrRect->bottom, sRectangleLineNumber);
 
-                VERIFY_ARE_EQUAL(psrRect->left, m_pSelection->_srSelectionRect.left);
-                VERIFY_ARE_EQUAL(psrRect->right, m_pSelection->_srSelectionRect.right);
+                VERIFY_ARE_EQUAL(psrRect->left, m_pSelection->_d->srSelectionRect.left);
+                VERIFY_ARE_EQUAL(psrRect->right, m_pSelection->_d->srSelectionRect.right);
             }
         }
     }
 
     TEST_METHOD(TestGetSelectionRects_BoxMode)
     {
-        m_pSelection->_fSelectionVisible = true;
+        {
+            auto selection{ m_pSelection->_d.write() };
+            selection->fSelectionVisible = true;
 
-        // set selection region
-        m_pSelection->_srSelectionRect.top = 0;
-        m_pSelection->_srSelectionRect.bottom = 3;
-        m_pSelection->_srSelectionRect.left = 1;
-        m_pSelection->_srSelectionRect.right = 10;
+            // set selection region
+            selection->srSelectionRect.top = 0;
+            selection->srSelectionRect.bottom = 3;
+            selection->srSelectionRect.left = 1;
+            selection->srSelectionRect.right = 10;
 
-        // #1 top-left to bottom right selection first
-        m_pSelection->_coordSelectionAnchor.x = m_pSelection->_srSelectionRect.left;
-        m_pSelection->_coordSelectionAnchor.y = m_pSelection->_srSelectionRect.top;
+            // #1 top-left to bottom right selection first
+            selection->coordSelectionAnchor.x = selection->srSelectionRect.left;
+            selection->coordSelectionAnchor.y = selection->srSelectionRect.top;
 
-        // A. false/false for the selection modes should mean box selection
-        m_pSelection->_fLineSelection = false;
-        m_pSelection->_fUseAlternateSelection = false;
+            // A. false/false for the selection modes should mean box selection
+            selection->fLineSelection = false;
+            selection->fUseAlternateSelection = false;
 
-        VerifyGetSelectionRects_BoxMode();
+            VerifyGetSelectionRects_BoxMode();
+        }
 
-        // B. true/true for the selection modes should also mean box selection
-        m_pSelection->_fLineSelection = true;
-        m_pSelection->_fUseAlternateSelection = true;
+        {
+            auto selection{ m_pSelection->_d.write() };
+            // B. true/true for the selection modes should also mean box selection
+            selection->fLineSelection = true;
+            selection->fUseAlternateSelection = true;
 
-        VerifyGetSelectionRects_BoxMode();
+            VerifyGetSelectionRects_BoxMode();
+        }
 
-        // now try the other 3 configurations of box region.
-        // #2 top-right to bottom-left selection
-        m_pSelection->_coordSelectionAnchor.x = m_pSelection->_srSelectionRect.right;
-        m_pSelection->_coordSelectionAnchor.y = m_pSelection->_srSelectionRect.top;
+        {
+            auto selection{ m_pSelection->_d.write() };
+            // now try the other 3 configurations of box region.
+            // #2 top-right to bottom-left selection
+            selection->coordSelectionAnchor.x = selection->srSelectionRect.right;
+            selection->coordSelectionAnchor.y = selection->srSelectionRect.top;
 
-        VerifyGetSelectionRects_BoxMode();
+            VerifyGetSelectionRects_BoxMode();
+        }
 
-        // #3 bottom-left to top-right selection
-        m_pSelection->_coordSelectionAnchor.x = m_pSelection->_srSelectionRect.left;
-        m_pSelection->_coordSelectionAnchor.y = m_pSelection->_srSelectionRect.bottom;
+        {
+            auto selection{ m_pSelection->_d.write() };
+            // #3 bottom-left to top-right selection
+            selection->coordSelectionAnchor.x = selection->srSelectionRect.left;
+            selection->coordSelectionAnchor.y = selection->srSelectionRect.bottom;
 
-        VerifyGetSelectionRects_BoxMode();
+            VerifyGetSelectionRects_BoxMode();
+        }
 
-        // #4 bottom-right to top-left selection
-        m_pSelection->_coordSelectionAnchor.x = m_pSelection->_srSelectionRect.right;
-        m_pSelection->_coordSelectionAnchor.y = m_pSelection->_srSelectionRect.bottom;
+        {
+            auto selection{ m_pSelection->_d.write() };
+            // #4 bottom-right to top-left selection
+            selection->coordSelectionAnchor.x = selection->srSelectionRect.right;
+            selection->coordSelectionAnchor.y = selection->srSelectionRect.bottom;
 
-        VerifyGetSelectionRects_BoxMode();
+            VerifyGetSelectionRects_BoxMode();
+        }
     }
 
     void VerifyGetSelectionRects_LineMode()
@@ -130,7 +145,7 @@ class SelectionTests
         const auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
 
         const auto selectionRects = m_pSelection->GetSelectionRects();
-        const UINT cRectanglesExpected = m_pSelection->_srSelectionRect.bottom - m_pSelection->_srSelectionRect.top + 1;
+        const UINT cRectanglesExpected = m_pSelection->_d->srSelectionRect.bottom - m_pSelection->_d->srSelectionRect.top + 1;
 
         if (VERIFY_ARE_EQUAL(cRectanglesExpected, selectionRects.size()))
         {
@@ -148,7 +163,7 @@ class SelectionTests
 
             if (fHaveOneLine)
             {
-                auto srSelectionRect = m_pSelection->_srSelectionRect;
+                auto srSelectionRect = m_pSelection->_d->srSelectionRect;
                 VERIFY_ARE_EQUAL(srSelectionRect.top, srSelectionRect.bottom);
 
                 const auto psrRect = &selectionRects[0];
@@ -167,7 +182,7 @@ class SelectionTests
                     // ensure each rectangle is exactly the width requested (block selection)
                     const auto psrRect = &selectionRects[iRect];
 
-                    const auto sRectangleLineNumber = (til::CoordType)iRect + m_pSelection->_srSelectionRect.top;
+                    const auto sRectangleLineNumber = (til::CoordType)iRect + m_pSelection->_d->srSelectionRect.top;
 
                     VERIFY_ARE_EQUAL(psrRect->top, sRectangleLineNumber);
                     VERIFY_ARE_EQUAL(psrRect->bottom, sRectangleLineNumber);
@@ -198,8 +213,8 @@ class SelectionTests
 
                 auto fRemoveRegion = false;
 
-                auto srSelectionRect = m_pSelection->_srSelectionRect;
-                auto coordAnchor = m_pSelection->_coordSelectionAnchor;
+                auto srSelectionRect = m_pSelection->_d->srSelectionRect;
+                auto coordAnchor = m_pSelection->_d->coordSelectionAnchor;
 
                 // if the anchor is in the top right or bottom left corner, we must have removed a region. otherwise, it stays as is.
                 if (coordAnchor.y == srSelectionRect.top && coordAnchor.x == srSelectionRect.right)
@@ -236,69 +251,90 @@ class SelectionTests
 
     TEST_METHOD(TestGetSelectionRects_LineMode)
     {
-        m_pSelection->_fSelectionVisible = true;
+        {
+            auto selection{ m_pSelection->_d.write() };
+            selection->fSelectionVisible = true;
 
-        // Part I: Multiple line selection
-        // set selection region
-        m_pSelection->_srSelectionRect.top = 0;
-        m_pSelection->_srSelectionRect.bottom = 3;
-        m_pSelection->_srSelectionRect.left = 1;
-        m_pSelection->_srSelectionRect.right = 10;
+            // Part I: Multiple line selection
+            // set selection region
+            selection->srSelectionRect.top = 0;
+            selection->srSelectionRect.bottom = 3;
+            selection->srSelectionRect.left = 1;
+            selection->srSelectionRect.right = 10;
 
-        // #1 top-left to bottom right selection first
-        m_pSelection->_coordSelectionAnchor.x = m_pSelection->_srSelectionRect.left;
-        m_pSelection->_coordSelectionAnchor.y = m_pSelection->_srSelectionRect.top;
+            // #1 top-left to bottom right selection first
+            selection->coordSelectionAnchor.x = selection->srSelectionRect.left;
+            selection->coordSelectionAnchor.y = selection->srSelectionRect.top;
 
-        // A. true/false for the selection modes should mean line selection
-        m_pSelection->_fLineSelection = true;
-        m_pSelection->_fUseAlternateSelection = false;
+            // A. true/false for the selection modes should mean line selection
+            selection->fLineSelection = true;
+            selection->fUseAlternateSelection = false;
 
-        VerifyGetSelectionRects_LineMode();
+            VerifyGetSelectionRects_LineMode();
+        }
 
-        // B. false/true for the selection modes should also mean line selection
-        m_pSelection->_fLineSelection = false;
-        m_pSelection->_fUseAlternateSelection = true;
+        {
+            auto selection{ m_pSelection->_d.write() };
+            // B. false/true for the selection modes should also mean line selection
+            selection->fLineSelection = false;
+            selection->fUseAlternateSelection = true;
 
-        VerifyGetSelectionRects_LineMode();
+            VerifyGetSelectionRects_LineMode();
+        }
 
-        // now try the other 3 configurations of box region.
-        // #2 top-right to bottom-left selection
-        m_pSelection->_coordSelectionAnchor.x = m_pSelection->_srSelectionRect.right;
-        m_pSelection->_coordSelectionAnchor.y = m_pSelection->_srSelectionRect.top;
+        {
+            auto selection{ m_pSelection->_d.write() };
+            // now try the other 3 configurations of box region.
+            // #2 top-right to bottom-left selection
+            selection->coordSelectionAnchor.x = selection->srSelectionRect.right;
+            selection->coordSelectionAnchor.y = selection->srSelectionRect.top;
 
-        VerifyGetSelectionRects_LineMode();
+            VerifyGetSelectionRects_LineMode();
+        }
 
-        // #3 bottom-left to top-right selection
-        m_pSelection->_coordSelectionAnchor.x = m_pSelection->_srSelectionRect.left;
-        m_pSelection->_coordSelectionAnchor.y = m_pSelection->_srSelectionRect.bottom;
+        {
+            auto selection{ m_pSelection->_d.write() };
+            // #3 bottom-left to top-right selection
+            selection->coordSelectionAnchor.x = selection->srSelectionRect.left;
+            selection->coordSelectionAnchor.y = selection->srSelectionRect.bottom;
 
-        VerifyGetSelectionRects_LineMode();
+            VerifyGetSelectionRects_LineMode();
+        }
 
-        // #4 bottom-right to top-left selection
-        m_pSelection->_coordSelectionAnchor.x = m_pSelection->_srSelectionRect.right;
-        m_pSelection->_coordSelectionAnchor.y = m_pSelection->_srSelectionRect.bottom;
+        {
+            auto selection{ m_pSelection->_d.write() };
+            // #4 bottom-right to top-left selection
+            selection->coordSelectionAnchor.x = selection->srSelectionRect.right;
+            selection->coordSelectionAnchor.y = selection->srSelectionRect.bottom;
 
-        VerifyGetSelectionRects_LineMode();
+            VerifyGetSelectionRects_LineMode();
+        }
 
-        // Part II: Single line selection
-        m_pSelection->_srSelectionRect.top = 2;
-        m_pSelection->_srSelectionRect.bottom = 2;
-        m_pSelection->_srSelectionRect.left = 1;
-        m_pSelection->_srSelectionRect.right = 10;
+        {
+            auto selection{ m_pSelection->_d.write() };
+            // Part II: Single line selection
+            selection->srSelectionRect.top = 2;
+            selection->srSelectionRect.bottom = 2;
+            selection->srSelectionRect.left = 1;
+            selection->srSelectionRect.right = 10;
 
-        // #1: left to right selection
-        m_pSelection->_coordSelectionAnchor.x = m_pSelection->_srSelectionRect.left;
-        VERIFY_IS_TRUE(m_pSelection->_srSelectionRect.bottom == m_pSelection->_srSelectionRect.top);
-        m_pSelection->_coordSelectionAnchor.y = m_pSelection->_srSelectionRect.bottom;
+            // #1: left to right selection
+            selection->coordSelectionAnchor.x = selection->srSelectionRect.left;
+            VERIFY_IS_TRUE(selection->srSelectionRect.bottom == selection->srSelectionRect.top);
+            selection->coordSelectionAnchor.y = selection->srSelectionRect.bottom;
 
-        VerifyGetSelectionRects_LineMode();
+            VerifyGetSelectionRects_LineMode();
+        }
 
-        // #2: right to left selection
-        m_pSelection->_coordSelectionAnchor.x = m_pSelection->_srSelectionRect.right;
-        VERIFY_IS_TRUE(m_pSelection->_srSelectionRect.bottom == m_pSelection->_srSelectionRect.top);
-        m_pSelection->_coordSelectionAnchor.y = m_pSelection->_srSelectionRect.top;
+        {
+            auto selection{ m_pSelection->_d.write() };
+            // #2: right to left selection
+            selection->coordSelectionAnchor.x = selection->srSelectionRect.right;
+            VERIFY_IS_TRUE(selection->srSelectionRect.bottom == selection->srSelectionRect.top);
+            selection->coordSelectionAnchor.y = selection->srSelectionRect.top;
 
-        VerifyGetSelectionRects_LineMode();
+            VerifyGetSelectionRects_LineMode();
+        }
     }
 
     void TestBisectSelectionDelta(til::CoordType sTargetX, til::CoordType sTargetY, til::CoordType sLength, til::CoordType sDeltaLeft, til::CoordType sDeltaRight)


### PR DESCRIPTION
In #17638, I am moving selection to an earlier phase of rendering (so
that further phases can take it into account). Since I am drafting off
the design of search highlights, one of the required changes is moving
to passing `span`s of `point_span`s around to make selection effectively
zero-copy.

We can't easily have zero-copy selection propagation without caching,
and we can't have caching without mandatory cache invalidation.

This pull request moves both conhost and Terminal to use
`til::generational` for all selection members that impact the ranges
that would be produced from `GetSelectionRects`.

This required a move from `std::optional<>` to a boolean to determine
whether a selection was active in Terminal.

We will no longer regenerate the selection rects from the selection
anchors plus the text buffer *every single frame*.

Apart from being annoying to read, there is one downside.

If you begin a selection on a narrow character, _and that narrow
character later turns into a wide character_, we will show it as
half-selected.

This should be a rare-enough case that we can accept it as a regression.