### PR TITLE
Track and log changes to settings

### DIFF
--- a/.github/actions/spelling/allow/allow.txt
+++ b/.github/actions/spelling/allow/allow.txt
@@ -27,7 +27,7 @@ gje
 godbolt
 hyperlinking
 hyperlinks
-kbd
+Kbds
 kje
 libfuzzer
 liga

--- a/.github/actions/spelling/allow/allow.txt
+++ b/.github/actions/spelling/allow/allow.txt
@@ -44,6 +44,7 @@ mkmk
 mnt
 mru
 nje
+NTMTo
 notwrapped
 ogonek
 overlined

--- a/.github/actions/spelling/allow/allow.txt
+++ b/.github/actions/spelling/allow/allow.txt
@@ -27,6 +27,7 @@ gje
 godbolt
 hyperlinking
 hyperlinks
+kbd
 kje
 libfuzzer
 liga

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -432,6 +432,10 @@ namespace winrt::TerminalApp::implementation
                 return;
             }
         }
+        else
+        {
+            _settings.LogSettingChanges(true);
+        }
 
         if (initialLoad)
         {

--- a/src/cascadia/TerminalSettingsEditor/LaunchViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/LaunchViewModel.cpp
@@ -92,8 +92,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         const LaunchPosition newPos{ xCoordRef, _Settings.GlobalSettings().InitialPosition().Y };
         _Settings.GlobalSettings().InitialPosition(newPos);
         _NotifyChanges(L"LaunchParametersCurrentValue");
-
-        // TODO CARLOS: telemetry for InitialPos
     }
 
     void LaunchViewModel::InitialPosY(double yCoord)
@@ -107,8 +105,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         const LaunchPosition newPos{ _Settings.GlobalSettings().InitialPosition().X, yCoordRef };
         _Settings.GlobalSettings().InitialPosition(newPos);
         _NotifyChanges(L"LaunchParametersCurrentValue");
-
-        // TODO CARLOS: telemetry for InitialPos
     }
 
     void LaunchViewModel::UseDefaultLaunchPosition(bool useDefaultPosition)
@@ -120,7 +116,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             InitialPosY(NAN);
         }
         _NotifyChanges(L"UseDefaultLaunchPosition", L"LaunchParametersCurrentValue", L"InitialPosX", L"InitialPosY");
-        // TODO CARLOS: telemetry for InitialPos
     }
 
     bool LaunchViewModel::UseDefaultLaunchPosition()

--- a/src/cascadia/TerminalSettingsEditor/LaunchViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/LaunchViewModel.cpp
@@ -92,6 +92,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         const LaunchPosition newPos{ xCoordRef, _Settings.GlobalSettings().InitialPosition().Y };
         _Settings.GlobalSettings().InitialPosition(newPos);
         _NotifyChanges(L"LaunchParametersCurrentValue");
+
+        // TODO CARLOS: telemetry for InitialPos
     }
 
     void LaunchViewModel::InitialPosY(double yCoord)
@@ -105,6 +107,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         const LaunchPosition newPos{ _Settings.GlobalSettings().InitialPosition().X, yCoordRef };
         _Settings.GlobalSettings().InitialPosition(newPos);
         _NotifyChanges(L"LaunchParametersCurrentValue");
+
+        // TODO CARLOS: telemetry for InitialPos
     }
 
     void LaunchViewModel::UseDefaultLaunchPosition(bool useDefaultPosition)
@@ -116,6 +120,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             InitialPosY(NAN);
         }
         _NotifyChanges(L"UseDefaultLaunchPosition", L"LaunchParametersCurrentValue", L"InitialPosX", L"InitialPosY");
+        // TODO CARLOS: telemetry for InitialPos
     }
 
     bool LaunchViewModel::UseDefaultLaunchPosition()

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -481,6 +481,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     void MainPage::SaveButton_Click(const IInspectable& /*sender*/, const RoutedEventArgs& /*args*/)
     {
+        _settingsClone.LogSettingChanges(false);
         _settingsClone.WriteSettingsToDisk();
     }
 

--- a/src/cascadia/TerminalSettingsEditor/pch.h
+++ b/src/cascadia/TerminalSettingsEditor/pch.h
@@ -51,6 +51,13 @@
 #include <winrt/Microsoft.Terminal.Settings.Model.h>
 #include <winrt/Microsoft.Terminal.UI.h>
 
+// Including TraceLogging essentials for the binary
+#include <TraceLoggingProvider.h>
+#include <winmeta.h>
+TRACELOGGING_DECLARE_PROVIDER(g_hSettingsEditorProvider);
+#include <telemetry/ProjectTelemetry.h>
+#include <TraceLoggingActivity.h>
+
 #include <shlobj.h>
 #include <shobjidl_core.h>
 #include <dwrite_3.h>

--- a/src/cascadia/TerminalSettingsEditor/pch.h
+++ b/src/cascadia/TerminalSettingsEditor/pch.h
@@ -51,13 +51,6 @@
 #include <winrt/Microsoft.Terminal.Settings.Model.h>
 #include <winrt/Microsoft.Terminal.UI.h>
 
-// Including TraceLogging essentials for the binary
-#include <TraceLoggingProvider.h>
-#include <winmeta.h>
-TRACELOGGING_DECLARE_PROVIDER(g_hSettingsEditorProvider);
-#include <telemetry/ProjectTelemetry.h>
-#include <TraceLoggingActivity.h>
-
 #include <shlobj.h>
 #include <shobjidl_core.h>
 #include <dwrite_3.h>

--- a/src/cascadia/TerminalSettingsModel/ActionMap.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionMap.cpp
@@ -570,6 +570,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         const auto action = cmd.ActionAndArgs().Action();
         const auto id = action == ShortcutAction::Invalid ? hstring{} : cmd.ID();
         _KeyMap.insert_or_assign(keys, id);
+        _changeLog.emplace(KeysKey);
     }
 
     // Method Description:

--- a/src/cascadia/TerminalSettingsModel/ActionMap.h
+++ b/src/cascadia/TerminalSettingsModel/ActionMap.h
@@ -73,7 +73,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         Json::Value ToJson() const;
         Json::Value KeyBindingsToJson() const;
         bool FixupsAppliedDuringLoad() const;
-        void LogSettingChanges(std::set<std::string_view>& changes, std::string_view& context) const;
+        void LogSettingChanges(std::set<std::string>& changes, const std::string& context) const;
 
         // modification
         bool RebindKeys(const Control::KeyChord& oldKeys, const Control::KeyChord& newKeys);
@@ -104,8 +104,6 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         void _TryUpdateKeyChord(const Model::Command& cmd, const Control::KeyChord& keys);
 
         std::vector<Model::Command> _updateLocalSnippetCache(winrt::hstring currentWorkingDirectory);
-
-        void _logCommand(const Model::Command& cmd);
 
         Windows::Foundation::Collections::IMap<hstring, Model::ActionAndArgs> _AvailableActionsCache{ nullptr };
         Windows::Foundation::Collections::IMap<hstring, Model::Command> _NameMapCache{ nullptr };
@@ -141,7 +139,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         til::shared_mutex<std::unordered_map<hstring, std::vector<Model::Command>>> _cwdLocalSnippetsCache{};
 
-        std::set<std::string_view> _changeLog;
+        std::set<std::string> _changeLog;
 
         friend class SettingsModelUnitTests::KeyBindingsTests;
         friend class SettingsModelUnitTests::DeserializationTests;

--- a/src/cascadia/TerminalSettingsModel/ActionMap.h
+++ b/src/cascadia/TerminalSettingsModel/ActionMap.h
@@ -73,6 +73,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         Json::Value ToJson() const;
         Json::Value KeyBindingsToJson() const;
         bool FixupsAppliedDuringLoad() const;
+        void LogSettingChanges(std::set<std::string_view>& changes, std::string_view& context) const;
 
         // modification
         bool RebindKeys(const Control::KeyChord& oldKeys, const Control::KeyChord& newKeys);
@@ -103,6 +104,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         void _TryUpdateKeyChord(const Model::Command& cmd, const Control::KeyChord& keys);
 
         std::vector<Model::Command> _updateLocalSnippetCache(winrt::hstring currentWorkingDirectory);
+
+        void _logCommand(const Model::Command& cmd);
 
         Windows::Foundation::Collections::IMap<hstring, Model::ActionAndArgs> _AvailableActionsCache{ nullptr };
         Windows::Foundation::Collections::IMap<hstring, Model::Command> _NameMapCache{ nullptr };
@@ -137,6 +140,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         Windows::Foundation::Collections::IMap<Control::KeyChord, Model::Command> _ResolvedKeyToActionMapCache{ nullptr };
 
         til::shared_mutex<std::unordered_map<hstring, std::vector<Model::Command>>> _cwdLocalSnippetsCache{};
+
+        std::set<std::string_view> _changeLog;
 
         friend class SettingsModelUnitTests::KeyBindingsTests;
         friend class SettingsModelUnitTests::DeserializationTests;

--- a/src/cascadia/TerminalSettingsModel/ActionMap.h
+++ b/src/cascadia/TerminalSettingsModel/ActionMap.h
@@ -73,7 +73,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         Json::Value ToJson() const;
         Json::Value KeyBindingsToJson() const;
         bool FixupsAppliedDuringLoad() const;
-        void LogSettingChanges(std::set<std::string>& changes, const std::string& context) const;
+        void LogSettingChanges(std::set<std::string>& changes, const std::string_view& context) const;
 
         // modification
         bool RebindKeys(const Control::KeyChord& oldKeys, const Control::KeyChord& newKeys);

--- a/src/cascadia/TerminalSettingsModel/ActionMapSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionMapSerialization.cpp
@@ -159,7 +159,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         return keybindingsList;
     }
 
-    void ActionMap::LogSettingChanges(std::set<std::string>& changes, const std::string& context) const
+    void ActionMap::LogSettingChanges(std::set<std::string>& changes, const std::string_view& context) const
     {
         for (const auto& setting : _changeLog)
         {

--- a/src/cascadia/TerminalSettingsModel/ActionMapSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionMapSerialization.cpp
@@ -78,7 +78,9 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             // Now check if this is a command block
             if (jsonBlock.isMember(JsonKey(CommandsKey)) || jsonBlock.isMember(JsonKey(ActionKey)))
             {
-                AddAction(*Command::FromJson(jsonBlock, warnings, origin), keys);
+                auto command = Command::FromJson(jsonBlock, warnings, origin);
+                command->LogSettingChanges(_changeLog);
+                AddAction(*command, keys);
 
                 if (jsonBlock.isMember(JsonKey(KeysKey)))
                 {
@@ -155,5 +157,13 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         }
 
         return keybindingsList;
+    }
+
+    void ActionMap::LogSettingChanges(std::set<std::string_view>& changes, std::string_view& context) const
+    {
+        for (const auto& setting : _changeLog)
+        {
+            changes.emplace(fmt::format(FMT_COMPILE("{}.{}"), context, setting));
+        }
     }
 }

--- a/src/cascadia/TerminalSettingsModel/ActionMapSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionMapSerialization.cpp
@@ -118,8 +118,6 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                     for (const auto& [id, kbd] : userDefaultKbds)
                     {
                         const auto keyJson{ jsonBlock.find(&*KeysKey.cbegin(), (&*KeysKey.cbegin()) + KeysKey.size()) };
-                        OutputDebugString(idJson.data());
-                        OutputDebugStringA(keyJson->asString().data());
                         if (idJson == id && keyJson->asString() == kbd)
                         {
                             isUserDefaultKbd = true;

--- a/src/cascadia/TerminalSettingsModel/ActionMapSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionMapSerialization.cpp
@@ -159,7 +159,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         return keybindingsList;
     }
 
-    void ActionMap::LogSettingChanges(std::set<std::string_view>& changes, std::string_view& context) const
+    void ActionMap::LogSettingChanges(std::set<std::string>& changes, const std::string& context) const
     {
         for (const auto& setting : _changeLog)
         {

--- a/src/cascadia/TerminalSettingsModel/ActionMapSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionMapSerialization.cpp
@@ -107,6 +107,30 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
                 // any existing keybinding with the same keychord in this layer will get overwritten
                 _KeyMap.insert_or_assign(keys, idJson);
+
+                if (!_changeLog.contains(KeysKey.data()))
+                {
+                    // Log "keys" field, but only if it's one that isn't in userDefaults.json
+                    static constexpr std::array<std::pair<std::wstring_view, std::string_view>, 3> userDefaultKbds{ { { L"Terminal.CopyToClipboard", "ctrl+c" },
+                                                                                                                      { L"Terminal.PasteFromClipboard", "ctrl+v" },
+                                                                                                                      { L"Terminal.DuplicatePaneAuto", "alt+shift+d" } } };
+                    bool isUserDefaultKbd = false;
+                    for (const auto& [id, kbd] : userDefaultKbds)
+                    {
+                        const auto keyJson{ jsonBlock.find(&*KeysKey.cbegin(), (&*KeysKey.cbegin()) + KeysKey.size()) };
+                        OutputDebugString(idJson.data());
+                        OutputDebugStringA(keyJson->asString().data());
+                        if (idJson == id && keyJson->asString() == kbd)
+                        {
+                            isUserDefaultKbd = true;
+                            break;
+                        }
+                    }
+                    if (!isUserDefaultKbd)
+                    {
+                        _changeLog.emplace(KeysKey);
+                    }
+                }
             }
         }
 

--- a/src/cascadia/TerminalSettingsModel/AppearanceConfig.cpp
+++ b/src/cascadia/TerminalSettingsModel/AppearanceConfig.cpp
@@ -110,7 +110,7 @@ void AppearanceConfig::LayerJson(const Json::Value& json)
         // to make the UI happy, set ColorSchemeName.
         JsonUtils::GetValueForKey(json, ColorSchemeKey, _DarkColorSchemeName);
         _LightColorSchemeName = _DarkColorSchemeName;
-        _logSettingSet(ColorSchemeKey);
+        _logSettingSet(std::string{ ColorSchemeKey });
     }
     else if (json["colorScheme"].isObject())
     {
@@ -172,20 +172,20 @@ winrt::hstring AppearanceConfig::ExpandedBackgroundImagePath()
     }
 }
 
-void AppearanceConfig::_logSettingSet(std::string_view setting)
+void AppearanceConfig::_logSettingSet(const std::string& setting)
 {
     _changeLog.emplace(setting);
 }
 
-void AppearanceConfig::_logSettingIfSet(std::string_view setting, const bool isSet)
+void AppearanceConfig::_logSettingIfSet(const std::string_view& setting, const bool isSet)
 {
     if (isSet)
     {
-        _logSettingSet(setting);
+        _logSettingSet(std::string{ setting });
     }
 }
 
-void AppearanceConfig::LogSettingChanges(std::set<std::string_view>& changes, std::string_view& context) const
+void AppearanceConfig::LogSettingChanges(std::set<std::string>& changes, const std::string& context) const
 {
     for (const auto& setting : _changeLog)
     {

--- a/src/cascadia/TerminalSettingsModel/AppearanceConfig.cpp
+++ b/src/cascadia/TerminalSettingsModel/AppearanceConfig.cpp
@@ -110,7 +110,7 @@ void AppearanceConfig::LayerJson(const Json::Value& json)
         // to make the UI happy, set ColorSchemeName.
         JsonUtils::GetValueForKey(json, ColorSchemeKey, _DarkColorSchemeName);
         _LightColorSchemeName = _DarkColorSchemeName;
-        _logSettingSet(std::string{ ColorSchemeKey });
+        _logSettingSet(ColorSchemeKey);
     }
     else if (json["colorScheme"].isObject())
     {
@@ -172,7 +172,7 @@ winrt::hstring AppearanceConfig::ExpandedBackgroundImagePath()
     }
 }
 
-void AppearanceConfig::_logSettingSet(const std::string& setting)
+void AppearanceConfig::_logSettingSet(const std::string_view& setting)
 {
     _changeLog.emplace(setting);
 }
@@ -185,7 +185,7 @@ void AppearanceConfig::_logSettingIfSet(const std::string_view& setting, const b
     }
 }
 
-void AppearanceConfig::LogSettingChanges(std::set<std::string>& changes, const std::string& context) const
+void AppearanceConfig::LogSettingChanges(std::set<std::string>& changes, const std::string_view& context) const
 {
     for (const auto& setting : _changeLog)
     {

--- a/src/cascadia/TerminalSettingsModel/AppearanceConfig.cpp
+++ b/src/cascadia/TerminalSettingsModel/AppearanceConfig.cpp
@@ -181,7 +181,7 @@ void AppearanceConfig::_logSettingIfSet(const std::string_view& setting, const b
 {
     if (isSet)
     {
-        _logSettingSet(std::string{ setting });
+        _logSettingSet(setting);
     }
 }
 

--- a/src/cascadia/TerminalSettingsModel/AppearanceConfig.cpp
+++ b/src/cascadia/TerminalSettingsModel/AppearanceConfig.cpp
@@ -90,12 +90,34 @@ Json::Value AppearanceConfig::ToJson() const
 void AppearanceConfig::LayerJson(const Json::Value& json)
 {
     JsonUtils::GetValueForKey(json, ForegroundKey, _Foreground);
+    if (_Foreground.has_value())
+    {
+        _logSettingSet(ForegroundKey, _Foreground.value());
+    }
     JsonUtils::GetValueForKey(json, BackgroundKey, _Background);
+    if (_Background.has_value())
+    {
+        _logSettingSet(BackgroundKey, _Background.value());
+    }
     JsonUtils::GetValueForKey(json, SelectionBackgroundKey, _SelectionBackground);
+    if (_SelectionBackground.has_value())
+    {
+        _logSettingSet(SelectionBackgroundKey, _SelectionBackground.value());
+    }
     JsonUtils::GetValueForKey(json, CursorColorKey, _CursorColor);
+    if (_CursorColor.has_value())
+    {
+        _logSettingSet(CursorColorKey, _CursorColor.value());
+    }
 
     JsonUtils::GetValueForKey(json, LegacyAcrylicTransparencyKey, _Opacity);
     JsonUtils::GetValueForKey(json, OpacityKey, _Opacity, JsonUtils::OptionalConverter<float, IntAsFloatPercentConversionTrait>{});
+    if (_Opacity.has_value())
+    {
+        _logSettingSet(OpacityKey, _Opacity.value());
+    }
+
+    // TODO CARLOS: how do we want to track this? Do we want to track the color scheme name?
     if (json["colorScheme"].isString())
     {
         // to make the UI happy, set ColorSchemeName.
@@ -110,7 +132,13 @@ void AppearanceConfig::LayerJson(const Json::Value& json)
     }
 
 #define APPEARANCE_SETTINGS_LAYER_JSON(type, name, jsonKey, ...) \
-    JsonUtils::GetValueForKey(json, jsonKey, _##name);
+    {                                                            \
+        JsonUtils::GetValueForKey(json, jsonKey, _##name);       \
+        if (_##name.has_value())                                 \
+        {                                                        \
+            _logSettingSet(jsonKey, _##name.value());            \
+        }                                                        \
+    }                                                            \
     MTSM_APPEARANCE_SETTINGS(APPEARANCE_SETTINGS_LAYER_JSON)
 #undef APPEARANCE_SETTINGS_LAYER_JSON
 }
@@ -154,5 +182,72 @@ winrt::hstring AppearanceConfig::ExpandedBackgroundImagePath()
     else
     {
         return winrt::hstring{ wil::ExpandEnvironmentStringsW<std::wstring>(path.c_str()) };
+    }
+}
+
+winrt::hstring _convertVal(const winrt::Microsoft::Terminal::Core::CursorStyle val)
+{
+    OutputDebugString(L"CursorStyle\n");
+    JsonUtils::ConversionTrait<decltype(val)> converter{};
+    return winrt::to_hstring(converter.ToJson(val).asString());
+}
+
+winrt::hstring _convertVal(const winrt::Windows::UI::Xaml::Media::Stretch val)
+{
+    OutputDebugString(L"BackgroundImageStretchMode\n");
+    JsonUtils::ConversionTrait<decltype(val)> converter{};
+    return winrt::to_hstring(converter.ToJson(val).asString());
+}
+
+winrt::hstring _convertVal(const winrt::Microsoft::Terminal::Settings::Model::ConvergedAlignment val)
+{
+    OutputDebugString(L"BackgroundImageAlignment\n");
+    JsonUtils::ConversionTrait<decltype(val)> converter{};
+    return winrt::to_hstring(converter.ToJson(val).asString());
+}
+
+winrt::hstring _convertVal(const winrt::Microsoft::Terminal::Settings::Model::IntenseStyle val)
+{
+    OutputDebugString(L"IntenseTextStyle\n");
+    JsonUtils::ConversionTrait<decltype(val)> converter{};
+    return winrt::to_hstring(converter.ToJson(val).asString());
+}
+
+winrt::hstring _convertVal(const winrt::Microsoft::Terminal::Core::AdjustTextMode val)
+{
+    OutputDebugString(L"AdjustIndistinguishableColors\n");
+    JsonUtils::ConversionTrait<decltype(val)> converter{};
+    return winrt::to_hstring(converter.ToJson(val).asString());
+}
+
+winrt::hstring _convertVal(const std::optional<winrt::Microsoft::Terminal::Core::Color> val)
+{
+    // TODO CARLOS: test this one specifically
+    //  - std::nullopt -> "null"
+    //  - color -> something
+    OutputDebugString(L"optional<Color>\n");
+    JsonUtils::ConversionTrait<decltype(val)> converter{};
+    return winrt::to_hstring(converter.ToJson(val).asString());
+}
+
+winrt::hstring _convertVal(auto& val)
+{
+    OutputDebugString(L"auto\n");
+    return winrt::to_hstring(val);
+}
+
+void AppearanceConfig::_logSettingSet(std::string_view setting, auto& value)
+{
+    OutputDebugStringA(setting.data());
+    OutputDebugStringA(" - ");
+    std::wstring val{ _convertVal(value).c_str() };
+    _changeLog.insert_or_assign(setting, std::wstring_view{ val });
+}
+
+void AppearanceConfig::_logSettingValIfSet(const Json::Value& json, std::string_view setting)
+{
+    if (auto found{ json.find(&*setting.cbegin(), (&*setting.cbegin()) + setting.size()) })
+    {
+        _changeLog.insert_or_assign(setting, std::wstring_view{ til::u8u16(found->asString()) });
     }
 }

--- a/src/cascadia/TerminalSettingsModel/AppearanceConfig.h
+++ b/src/cascadia/TerminalSettingsModel/AppearanceConfig.h
@@ -31,7 +31,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         static winrt::com_ptr<AppearanceConfig> CopyAppearance(const AppearanceConfig* source, winrt::weak_ref<Profile> sourceProfile);
         Json::Value ToJson() const;
         void LayerJson(const Json::Value& json);
-        void LogSettingChanges(std::set<std::string_view>& changes, std::string_view& context) const;
+        void LogSettingChanges(std::set<std::string>& changes, const std::string& context) const;
 
         Model::Profile SourceProfile();
 
@@ -53,9 +53,9 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
     private:
         winrt::weak_ref<Profile> _sourceProfile;
-        std::set<std::string_view> _changeLog;
+        std::set<std::string> _changeLog;
 
-        void _logSettingSet(std::string_view setting);
-        void _logSettingIfSet(std::string_view setting, const bool isSet);
+        void _logSettingSet(const std::string& setting);
+        void _logSettingIfSet(const std::string_view& setting, const bool isSet);
     };
 }

--- a/src/cascadia/TerminalSettingsModel/AppearanceConfig.h
+++ b/src/cascadia/TerminalSettingsModel/AppearanceConfig.h
@@ -52,5 +52,9 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
     private:
         winrt::weak_ref<Profile> _sourceProfile;
+        std::map<std::string_view, std::wstring_view> _changeLog;
+
+        void _logSettingSet(std::string_view setting, auto& value);
+        void _logSettingValIfSet(const Json::Value& json, std::string_view setting);
     };
 }

--- a/src/cascadia/TerminalSettingsModel/AppearanceConfig.h
+++ b/src/cascadia/TerminalSettingsModel/AppearanceConfig.h
@@ -31,7 +31,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         static winrt::com_ptr<AppearanceConfig> CopyAppearance(const AppearanceConfig* source, winrt::weak_ref<Profile> sourceProfile);
         Json::Value ToJson() const;
         void LayerJson(const Json::Value& json);
-        void LogSettingChanges(std::set<std::string>& changes, const std::string& context) const;
+        void LogSettingChanges(std::set<std::string>& changes, const std::string_view& context) const;
 
         Model::Profile SourceProfile();
 
@@ -55,7 +55,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         winrt::weak_ref<Profile> _sourceProfile;
         std::set<std::string> _changeLog;
 
-        void _logSettingSet(const std::string& setting);
+        void _logSettingSet(const std::string_view& setting);
         void _logSettingIfSet(const std::string_view& setting, const bool isSet);
     };
 }

--- a/src/cascadia/TerminalSettingsModel/AppearanceConfig.h
+++ b/src/cascadia/TerminalSettingsModel/AppearanceConfig.h
@@ -31,6 +31,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         static winrt::com_ptr<AppearanceConfig> CopyAppearance(const AppearanceConfig* source, winrt::weak_ref<Profile> sourceProfile);
         Json::Value ToJson() const;
         void LayerJson(const Json::Value& json);
+        void LogSettingChanges(std::set<std::string_view>& changes, std::string_view& context) const;
 
         Model::Profile SourceProfile();
 
@@ -52,9 +53,9 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
     private:
         winrt::weak_ref<Profile> _sourceProfile;
-        std::map<std::string_view, std::wstring_view> _changeLog;
+        std::set<std::string_view> _changeLog;
 
-        void _logSettingSet(std::string_view setting, auto& value);
-        void _logSettingValIfSet(const Json::Value& json, std::string_view setting);
+        void _logSettingSet(std::string_view setting);
+        void _logSettingIfSet(std::string_view setting, const bool isSet);
     };
 }

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
@@ -48,7 +48,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         std::unordered_map<winrt::hstring, winrt::com_ptr<implementation::ColorScheme>> colorSchemes;
         std::unordered_map<winrt::hstring, winrt::hstring> colorSchemeRemappings;
         bool fixupsAppliedDuringLoad{ false };
-        std::set<std::string_view> themesChangeLog;
+        std::set<std::string> themesChangeLog;
 
         void clear();
     };
@@ -97,7 +97,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         void _executeGenerator(const IDynamicProfileGenerator& generator);
 
         std::unordered_set<std::wstring_view> _ignoredNamespaces;
-        std::set<std::string_view> themesChangeLog;
+        std::set<std::string> themesChangeLog;
         // See _getNonUserOriginProfiles().
         size_t _userProfileCount = 0;
     };
@@ -177,7 +177,6 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         void _validateThemeExists();
 
         void _researchOnLoad();
-        std::set<std::string_view> _logSettingChanges() const;
 
         // user settings
         winrt::hstring _hash;
@@ -185,7 +184,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         winrt::com_ptr<implementation::Profile> _baseLayerProfile = winrt::make_self<implementation::Profile>();
         winrt::Windows::Foundation::Collections::IObservableVector<Model::Profile> _allProfiles = winrt::single_threaded_observable_vector<Model::Profile>();
         winrt::Windows::Foundation::Collections::IObservableVector<Model::Profile> _activeProfiles = winrt::single_threaded_observable_vector<Model::Profile>();
-        std::set<std::string_view> _themesChangeLog{};
+        std::set<std::string> _themesChangeLog{};
 
         // load errors
         winrt::Windows::Foundation::Collections::IVector<Model::SettingsLoadWarnings> _warnings = winrt::single_threaded_vector<Model::SettingsLoadWarnings>();

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
@@ -48,6 +48,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         std::unordered_map<winrt::hstring, winrt::com_ptr<implementation::ColorScheme>> colorSchemes;
         std::unordered_map<winrt::hstring, winrt::hstring> colorSchemeRemappings;
         bool fixupsAppliedDuringLoad{ false };
+        std::set<std::string_view> themesChangeLog;
 
         void clear();
     };
@@ -96,6 +97,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         void _executeGenerator(const IDynamicProfileGenerator& generator);
 
         std::unordered_set<std::wstring_view> _ignoredNamespaces;
+        std::set<std::string_view> themesChangeLog;
         // See _getNonUserOriginProfiles().
         size_t _userProfileCount = 0;
     };
@@ -150,6 +152,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         void ExpandCommands();
 
+        void LogSettingChanges(bool isJsonLoad) const;
+
     private:
         static const std::filesystem::path& _settingsPath();
         static const std::filesystem::path& _releaseSettingsPath();
@@ -173,6 +177,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         void _validateThemeExists();
 
         void _researchOnLoad();
+        std::set<std::string_view> _logSettingChanges() const;
 
         // user settings
         winrt::hstring _hash;
@@ -180,6 +185,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         winrt::com_ptr<implementation::Profile> _baseLayerProfile = winrt::make_self<implementation::Profile>();
         winrt::Windows::Foundation::Collections::IObservableVector<Model::Profile> _allProfiles = winrt::single_threaded_observable_vector<Model::Profile>();
         winrt::Windows::Foundation::Collections::IObservableVector<Model::Profile> _activeProfiles = winrt::single_threaded_observable_vector<Model::Profile>();
+        std::set<std::string_view> _themesChangeLog{};
 
         // load errors
         winrt::Windows::Foundation::Collections::IVector<Model::SettingsLoadWarnings> _warnings = winrt::single_threaded_vector<Model::SettingsLoadWarnings>();

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.idl
@@ -24,6 +24,7 @@ namespace Microsoft.Terminal.Settings.Model
 
         CascadiaSettings Copy();
         void WriteSettingsToDisk();
+        void LogSettingChanges(Boolean isJsonLoad);
 
         String Hash { get; };
 

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -643,7 +643,8 @@ void SettingsLoader::_parse(const OriginTag origin, const winrt::hstring& source
                     // versions of these themes overriding the built-in ones.
                     continue;
                 }
-                else
+
+                if (origin != OriginTag::InBox)
                 {
                     static std::string_view themesContext{ "themes" };
                     theme->LogSettingChanges(settings.themesChangeLog, themesContext);
@@ -1630,9 +1631,6 @@ void CascadiaSettings::LogSettingChanges(bool isJsonLoad) const
     // report changes
     for (const auto& change : changes)
     {
-        OutputDebugStringA(change.data());
-        OutputDebugStringA("\n");
-
         // A `isJsonLoad ? "JsonSettingsChanged" : "UISettingsChanged"`
         //   would be nice, but that apparently isn't allowed in the macro below.
         // Also, there's guidance to not send too much data all in one event,

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -1601,20 +1601,20 @@ void CascadiaSettings::LogSettingChanges(bool isJsonLoad) const
 
     // aggregate setting changes
     std::set<std::string> changes;
-    static std::string globalContext{ "global" };
+    static constexpr std::string_view globalContext{ "global" };
     _globals->LogSettingChanges(changes, globalContext);
 
     // Actions are not expected to change when loaded from the settings UI
-    static std::string actionContext{ "action" };
+    static constexpr std::string_view actionContext{ "action" };
     winrt::get_self<implementation::ActionMap>(_globals->ActionMap())->LogSettingChanges(changes, actionContext);
 
-    static std::string profileContext{ "profile" };
+    static constexpr std::string_view profileContext{ "profile" };
     for (const auto& profile : _allProfiles)
     {
         winrt::get_self<Profile>(profile)->LogSettingChanges(changes, profileContext);
     }
 
-    static std::string profileDefaultsContext{ "profileDefaults" };
+    static constexpr std::string_view profileDefaultsContext{ "profileDefaults" };
     _baseLayerProfile->LogSettingChanges(changes, profileDefaultsContext);
 
     // Themes are not expected to change when loaded from the settings UI

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -1652,7 +1652,7 @@ void CascadiaSettings::LogSettingChanges(bool isJsonLoad) const
                               TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
         }
 #else
-        OutputDebugStringA(isJsonLoad ? "JsonSettingsChanged\n" : "UISettingsChanged\n");
+        OutputDebugStringA(isJsonLoad ? "JsonSettingsChanged - " : "UISettingsChanged - ");
         OutputDebugStringA(change.data());
         OutputDebugStringA("\n");
 #endif // !_DEBUG

--- a/src/cascadia/TerminalSettingsModel/Command.cpp
+++ b/src/cascadia/TerminalSettingsModel/Command.cpp
@@ -749,22 +749,22 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             switch (_IterateOn)
             {
             case ExpandCommandType::Profiles:
-                changes.insert(fmt::format(FMT_COMPILE("{}.{}"), std::string{ IterateOnKey }, "profiles"));
+                changes.emplace(fmt::format(FMT_COMPILE("{}.{}"), IterateOnKey, "profiles"));
                 break;
             case ExpandCommandType::ColorSchemes:
-                changes.insert(fmt::format(FMT_COMPILE("{}.{}"), std::string{ IterateOnKey }, "schemes"));
+                changes.emplace(fmt::format(FMT_COMPILE("{}.{}"), IterateOnKey, "schemes"));
                 break;
             }
         }
 
         if (!_Description.empty())
         {
-            changes.insert(fmt::format(FMT_COMPILE("{}"), std::string{ DescriptionKey }));
+            changes.emplace(fmt::format(FMT_COMPILE("{}"), DescriptionKey));
         }
 
         if (IsNestedCommand())
         {
-            changes.insert(fmt::format(FMT_COMPILE("{}"), std::string{ CommandsKey }));
+            changes.emplace(fmt::format(FMT_COMPILE("{}"), CommandsKey));
         }
         else
         {
@@ -774,7 +774,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                 // covers actions w/out args
                 // - "command": "unbound" --> "unbound"
                 // - "command": "copy"    --> "copy"
-                changes.insert(fmt::format(FMT_COMPILE("{}"), json.asString()));
+                changes.emplace(fmt::format(FMT_COMPILE("{}"), json.asString()));
             }
             else
             {
@@ -789,7 +789,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
                 for (const auto& actionArg : members)
                 {
-                    changes.insert(fmt::format(FMT_COMPILE("{}.{}"), shortcutActionName, actionArg));
+                    changes.emplace(fmt::format(FMT_COMPILE("{}.{}"), shortcutActionName, actionArg));
                 }
             }
         }

--- a/src/cascadia/TerminalSettingsModel/Command.cpp
+++ b/src/cascadia/TerminalSettingsModel/Command.cpp
@@ -742,29 +742,29 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         return winrt::single_threaded_vector<Model::Command>(std::move(result));
     }
 
-    void Command::LogSettingChanges(std::set<std::string_view>& changes)
+    void Command::LogSettingChanges(std::set<std::string>& changes)
     {
         if (_IterateOn != ExpandCommandType::None)
         {
             switch (_IterateOn)
             {
             case ExpandCommandType::Profiles:
-                changes.insert(fmt::format(FMT_COMPILE("{}.{}"), IterateOnKey, "profiles"));
+                changes.insert(fmt::format(FMT_COMPILE("{}.{}"), std::string{ IterateOnKey }, "profiles"));
                 break;
             case ExpandCommandType::ColorSchemes:
-                changes.insert(fmt::format(FMT_COMPILE("{}.{}"), IterateOnKey, "schemes"));
+                changes.insert(fmt::format(FMT_COMPILE("{}.{}"), std::string{ IterateOnKey }, "schemes"));
                 break;
             }
         }
 
         if (!_Description.empty())
         {
-            changes.insert(fmt::format(FMT_COMPILE("{}"), DescriptionKey));
+            changes.insert(fmt::format(FMT_COMPILE("{}"), std::string{ DescriptionKey }));
         }
 
         if (IsNestedCommand())
         {
-            changes.insert(fmt::format(FMT_COMPILE("{}"), CommandsKey));
+            changes.insert(fmt::format(FMT_COMPILE("{}"), std::string{ CommandsKey }));
         }
         else
         {
@@ -782,7 +782,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                 // - "command": { "action": "copy", "singleLine": true }                           --> "copy.singleLine"
                 // - "command": { "action": "copy", "singleLine": true, "dismissSelection": true } --> "copy.singleLine", "copy.dismissSelection"
 
-                std::string_view shortcutActionName{ json[JsonKey("action")].asString() };
+                const std::string shortcutActionName{ json[JsonKey("action")].asString() };
 
                 auto members = json.getMemberNames();
                 members.erase(std::remove_if(members.begin(), members.end(), [](const auto& member) { return member == "action"; }), members.end());

--- a/src/cascadia/TerminalSettingsModel/Command.cpp
+++ b/src/cascadia/TerminalSettingsModel/Command.cpp
@@ -741,4 +741,57 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         return winrt::single_threaded_vector<Model::Command>(std::move(result));
     }
+
+    void Command::LogSettingChanges(std::set<std::string_view>& changes)
+    {
+        if (_IterateOn != ExpandCommandType::None)
+        {
+            switch (_IterateOn)
+            {
+            case ExpandCommandType::Profiles:
+                changes.insert(fmt::format(FMT_COMPILE("{}.{}"), IterateOnKey, "profiles"));
+                break;
+            case ExpandCommandType::ColorSchemes:
+                changes.insert(fmt::format(FMT_COMPILE("{}.{}"), IterateOnKey, "schemes"));
+                break;
+            }
+        }
+
+        if (!_Description.empty())
+        {
+            changes.insert(fmt::format(FMT_COMPILE("{}"), DescriptionKey));
+        }
+
+        if (IsNestedCommand())
+        {
+            changes.insert(fmt::format(FMT_COMPILE("{}"), CommandsKey));
+        }
+        else
+        {
+            const auto json{ ActionAndArgs::ToJson(ActionAndArgs()) };
+            if (json.isString())
+            {
+                // covers actions w/out args
+                // - "command": "unbound" --> "unbound"
+                // - "command": "copy"    --> "copy"
+                changes.insert(fmt::format(FMT_COMPILE("{}"), json.asString()));
+            }
+            else
+            {
+                // covers actions w/ args
+                // - "command": { "action": "copy", "singleLine": true }                           --> "copy.singleLine"
+                // - "command": { "action": "copy", "singleLine": true, "dismissSelection": true } --> "copy.singleLine", "copy.dismissSelection"
+
+                std::string_view shortcutActionName{ json[JsonKey("action")].asString() };
+
+                auto members = json.getMemberNames();
+                members.erase(std::remove_if(members.begin(), members.end(), [](const auto& member) { return member == "action"; }), members.end());
+
+                for (const auto& actionArg : members)
+                {
+                    changes.insert(fmt::format(FMT_COMPILE("{}.{}"), shortcutActionName, actionArg));
+                }
+            }
+        }
+    }
 }

--- a/src/cascadia/TerminalSettingsModel/Command.cpp
+++ b/src/cascadia/TerminalSettingsModel/Command.cpp
@@ -759,12 +759,12 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         if (!_Description.empty())
         {
-            changes.emplace(fmt::format(FMT_COMPILE("{}"), DescriptionKey));
+            changes.emplace(DescriptionKey);
         }
 
         if (IsNestedCommand())
         {
-            changes.emplace(fmt::format(FMT_COMPILE("{}"), CommandsKey));
+            changes.emplace(CommandsKey);
         }
         else
         {

--- a/src/cascadia/TerminalSettingsModel/Command.h
+++ b/src/cascadia/TerminalSettingsModel/Command.h
@@ -61,6 +61,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                                                            const Json::Value& json,
                                                            const OriginTag origin);
         Json::Value ToJson() const;
+        void LogSettingChanges(std::set<std::string_view>& changes);
 
         bool HasNestedCommands() const;
         bool IsNestedCommand() const noexcept;

--- a/src/cascadia/TerminalSettingsModel/Command.h
+++ b/src/cascadia/TerminalSettingsModel/Command.h
@@ -61,7 +61,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                                                            const Json::Value& json,
                                                            const OriginTag origin);
         Json::Value ToJson() const;
-        void LogSettingChanges(std::set<std::string_view>& changes);
+        void LogSettingChanges(std::set<std::string>& changes);
 
         bool HasNestedCommands() const;
         bool IsNestedCommand() const noexcept;

--- a/src/cascadia/TerminalSettingsModel/FontConfig.cpp
+++ b/src/cascadia/TerminalSettingsModel/FontConfig.cpp
@@ -110,7 +110,7 @@ winrt::Microsoft::Terminal::Settings::Model::Profile FontConfig::SourceProfile()
     return _sourceProfile.get();
 }
 
-void FontConfig::_logSettingSet(std::string_view setting)
+void FontConfig::_logSettingSet(const std::string& setting)
 {
     if (setting == "axes" && _FontAxes.has_value())
     {
@@ -132,7 +132,7 @@ void FontConfig::_logSettingSet(std::string_view setting)
     }
 }
 
-void FontConfig::_logSettingIfSet(std::string_view setting, const bool isSet)
+void FontConfig::_logSettingIfSet(const std::string& setting, const bool isSet)
 {
     if (isSet)
     {
@@ -140,7 +140,7 @@ void FontConfig::_logSettingIfSet(std::string_view setting, const bool isSet)
     }
 }
 
-void FontConfig::LogSettingChanges(std::set<std::string_view>& changes, std::string_view& context) const
+void FontConfig::LogSettingChanges(std::set<std::string>& changes, const std::string& context) const
 {
     for (const auto& setting : _changeLog)
     {

--- a/src/cascadia/TerminalSettingsModel/FontConfig.cpp
+++ b/src/cascadia/TerminalSettingsModel/FontConfig.cpp
@@ -110,7 +110,7 @@ winrt::Microsoft::Terminal::Settings::Model::Profile FontConfig::SourceProfile()
     return _sourceProfile.get();
 }
 
-void FontConfig::_logSettingSet(const std::string& setting)
+void FontConfig::_logSettingSet(const std::string_view& setting)
 {
     if (setting == "axes" && _FontAxes.has_value())
     {
@@ -132,7 +132,7 @@ void FontConfig::_logSettingSet(const std::string& setting)
     }
 }
 
-void FontConfig::_logSettingIfSet(const std::string& setting, const bool isSet)
+void FontConfig::_logSettingIfSet(const std::string_view& setting, const bool isSet)
 {
     if (isSet)
     {
@@ -140,7 +140,7 @@ void FontConfig::_logSettingIfSet(const std::string& setting, const bool isSet)
     }
 }
 
-void FontConfig::LogSettingChanges(std::set<std::string>& changes, const std::string& context) const
+void FontConfig::LogSettingChanges(std::set<std::string>& changes, const std::string_view& context) const
 {
     for (const auto& setting : _changeLog)
     {

--- a/src/cascadia/TerminalSettingsModel/FontConfig.h
+++ b/src/cascadia/TerminalSettingsModel/FontConfig.h
@@ -35,7 +35,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         static winrt::com_ptr<FontConfig> CopyFontInfo(const FontConfig* source, winrt::weak_ref<Profile> sourceProfile);
         Json::Value ToJson() const;
         void LayerJson(const Json::Value& json);
-        void LogSettingChanges(std::set<std::string>& changes, const std::string& context) const;
+        void LogSettingChanges(std::set<std::string>& changes, const std::string_view& context) const;
 
         Model::Profile SourceProfile();
 
@@ -48,7 +48,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         winrt::weak_ref<Profile> _sourceProfile;
         std::set<std::string> _changeLog;
 
-        void _logSettingSet(const std::string& setting);
-        void _logSettingIfSet(const std::string& setting, const bool isSet);
+        void _logSettingSet(const std::string_view& setting);
+        void _logSettingIfSet(const std::string_view& setting, const bool isSet);
     };
 }

--- a/src/cascadia/TerminalSettingsModel/FontConfig.h
+++ b/src/cascadia/TerminalSettingsModel/FontConfig.h
@@ -35,6 +35,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         static winrt::com_ptr<FontConfig> CopyFontInfo(const FontConfig* source, winrt::weak_ref<Profile> sourceProfile);
         Json::Value ToJson() const;
         void LayerJson(const Json::Value& json);
+        void LogSettingChanges(std::set<std::string_view>& changes, std::string_view& context) const;
 
         Model::Profile SourceProfile();
 
@@ -45,11 +46,9 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
     private:
         winrt::weak_ref<Profile> _sourceProfile;
-        std::map<std::string_view, std::wstring_view> _changeLog;
-        std::map<std::wstring_view, std::wstring_view> _changeLogAxes;
-        std::map<std::wstring_view, std::wstring_view> _changeLogFeatures;
+        std::set<std::string_view> _changeLog;
 
-        void _logSettingSet(std::string_view setting, winrt::Windows::Foundation::Collections::IMap<winrt::hstring, float>& value);
-        void _logSettingSet(std::string_view setting, auto& value);
+        void _logSettingSet(std::string_view setting);
+        void _logSettingIfSet(std::string_view setting, const bool isSet);
     };
 }

--- a/src/cascadia/TerminalSettingsModel/FontConfig.h
+++ b/src/cascadia/TerminalSettingsModel/FontConfig.h
@@ -45,5 +45,11 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
     private:
         winrt::weak_ref<Profile> _sourceProfile;
+        std::map<std::string_view, std::wstring_view> _changeLog;
+        std::map<std::wstring_view, std::wstring_view> _changeLogAxes;
+        std::map<std::wstring_view, std::wstring_view> _changeLogFeatures;
+
+        void _logSettingSet(std::string_view setting, winrt::Windows::Foundation::Collections::IMap<winrt::hstring, float>& value);
+        void _logSettingSet(std::string_view setting, auto& value);
     };
 }

--- a/src/cascadia/TerminalSettingsModel/FontConfig.h
+++ b/src/cascadia/TerminalSettingsModel/FontConfig.h
@@ -35,7 +35,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         static winrt::com_ptr<FontConfig> CopyFontInfo(const FontConfig* source, winrt::weak_ref<Profile> sourceProfile);
         Json::Value ToJson() const;
         void LayerJson(const Json::Value& json);
-        void LogSettingChanges(std::set<std::string_view>& changes, std::string_view& context) const;
+        void LogSettingChanges(std::set<std::string>& changes, const std::string& context) const;
 
         Model::Profile SourceProfile();
 
@@ -46,9 +46,9 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
     private:
         winrt::weak_ref<Profile> _sourceProfile;
-        std::set<std::string_view> _changeLog;
+        std::set<std::string> _changeLog;
 
-        void _logSettingSet(std::string_view setting);
-        void _logSettingIfSet(std::string_view setting, const bool isSet);
+        void _logSettingSet(const std::string& setting);
+        void _logSettingIfSet(const std::string& setting, const bool isSet);
     };
 }

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
@@ -154,7 +154,6 @@ void GlobalAppSettings::LayerJson(const Json::Value& json, const OriginTag origi
     }
     LayerActionsFrom(json, origin, true);
 
-    // TODO CARLOS: validate this works
     JsonUtils::GetValueForKey(json, LegacyReloadEnvironmentVariablesKey, _legacyReloadEnvironmentVariables);
     if (json[LegacyReloadEnvironmentVariablesKey.data()])
     {

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
@@ -406,8 +406,8 @@ void GlobalAppSettings::_logSettingIfSet(const std::string_view& setting, const 
     {
         // Exclude some false positives from userDefaults.json
         const bool settingCopyFormattingToDefault = til::equals_insensitive_ascii(setting, "copyFormatting") && _CopyFormatting.has_value() && _CopyFormatting.value() == static_cast<Control::CopyFormat>(0);
-        const bool settingNTMtoDefault = til::equals_insensitive_ascii(setting, "newTabMenu") && _NewTabMenu.has_value() && _NewTabMenu->Size() == 1 && _NewTabMenu->GetAt(0).Type() == NewTabMenuEntryType::RemainingProfiles;
-        if (!settingCopyFormattingToDefault && !settingNTMtoDefault)
+        const bool settingNTMToDefault = til::equals_insensitive_ascii(setting, "newTabMenu") && _NewTabMenu.has_value() && _NewTabMenu->Size() == 1 && _NewTabMenu->GetAt(0).Type() == NewTabMenuEntryType::RemainingProfiles;
+        if (!settingCopyFormattingToDefault && !settingNTMToDefault)
         {
             _logSettingSet(setting);
         }

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
@@ -404,7 +404,13 @@ void GlobalAppSettings::_logSettingIfSet(const std::string_view& setting, const 
 {
     if (isSet)
     {
-        _logSettingSet(setting);
+        // Exclude some false positives from userDefaults.json
+        const bool settingCopyFormattingToDefault = til::equals_insensitive_ascii(setting, "copyFormatting") && _CopyFormatting.has_value() && _CopyFormatting.value() == static_cast<Control::CopyFormat>(0);
+        const bool settingNTMtoDefault = til::equals_insensitive_ascii(setting, "newTabMenu") && _NewTabMenu.has_value() && _NewTabMenu->Size() == 1 && _NewTabMenu->GetAt(0).Type() == NewTabMenuEntryType::RemainingProfiles;
+        if (!settingCopyFormattingToDefault && !settingNTMtoDefault)
+        {
+            _logSettingSet(setting);
+        }
     }
 }
 

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
@@ -157,7 +157,7 @@ void GlobalAppSettings::LayerJson(const Json::Value& json, const OriginTag origi
     JsonUtils::GetValueForKey(json, LegacyReloadEnvironmentVariablesKey, _legacyReloadEnvironmentVariables);
     if (json[LegacyReloadEnvironmentVariablesKey.data()])
     {
-        _logSettingSet(LegacyReloadEnvironmentVariablesKey);
+        _logSettingSet(std::string{ LegacyReloadEnvironmentVariablesKey });
     }
 }
 
@@ -325,7 +325,7 @@ bool GlobalAppSettings::ShouldUsePersistedLayout() const
     return FirstWindowPreference() == FirstWindowPreference::PersistedWindowLayout && !IsolatedMode();
 }
 
-void GlobalAppSettings::_logSettingSet(std::string_view setting)
+void GlobalAppSettings::_logSettingSet(const std::string& setting)
 {
     if (setting == "theme")
     {
@@ -339,8 +339,8 @@ void GlobalAppSettings::_logSettingSet(std::string_view setting)
             }
             else
             {
-                _changeLog.insert(std::string_view{ fmt::format(FMT_COMPILE("{}.{}"), setting, "dark") });
-                _changeLog.insert(std::string_view{ fmt::format(FMT_COMPILE("{}.{}"), setting, "light") });
+                _changeLog.emplace(fmt::format(FMT_COMPILE("{}.{}"), setting, "dark"));
+                _changeLog.emplace(fmt::format(FMT_COMPILE("{}.{}"), setting, "light"));
             }
         }
     }
@@ -375,25 +375,25 @@ void GlobalAppSettings::_logSettingSet(std::string_view setting)
                     // ignore invalid
                     continue;
                 }
-                _changeLog.insert(std::string_view{ fmt::format(FMT_COMPILE("{}.{}"), setting, entryType) });
+                _changeLog.emplace(fmt::format(FMT_COMPILE("{}.{}"), setting, entryType));
             }
         }
     }
     else
     {
-        _changeLog.insert(setting);
+        _changeLog.emplace(setting);
     }
 }
 
-void GlobalAppSettings::_logSettingIfSet(std::string_view setting, const bool isSet)
+void GlobalAppSettings::_logSettingIfSet(const std::string& setting, const bool isSet)
 {
     if (isSet)
     {
-        _logSettingSet(setting);
+        _logSettingSet(std::string{ setting });
     }
 }
 
-void GlobalAppSettings::LogSettingChanges(std::set<std::string_view>& changes, std::string_view& context) const
+void GlobalAppSettings::LogSettingChanges(std::set<std::string>& changes, const std::string& context) const
 {
     for (const auto& setting : _changeLog)
     {

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
@@ -159,6 +159,21 @@ void GlobalAppSettings::LayerJson(const Json::Value& json, const OriginTag origi
     {
         _logSettingSet(LegacyReloadEnvironmentVariablesKey);
     }
+
+    // Remove settings included in userDefaults
+    static constexpr std::array<std::pair<std::string_view, std::string_view>, 2> userDefaultSettings{ { { "copyOnSelect", "false" },
+                                                                                                         { "copyFormatting", "false" } } };
+    for (const auto& [setting, val] : userDefaultSettings)
+    {
+        if (const auto settingJson{ json.find(&*setting.cbegin(), (&*setting.cbegin()) + setting.size()) })
+        {
+            if (settingJson->asString() == val)
+            {
+                // false positive!
+                _changeLog.erase(std::string{ setting });
+            }
+        }
+    }
 }
 
 void GlobalAppSettings::LayerActionsFrom(const Json::Value& json, const OriginTag origin, const bool withKeybindings)

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
@@ -373,7 +373,7 @@ void GlobalAppSettings::_logSettingSet(std::string_view setting)
                     entryType = "action";
                     break;
                 case NewTabMenuEntryType::Invalid:
-                    // ignore invalid 
+                    // ignore invalid
                     continue;
                 }
                 _changeLog.insert(std::string_view{ fmt::format(FMT_COMPILE("{}.{}"), setting, entryType) });

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
@@ -157,7 +157,7 @@ void GlobalAppSettings::LayerJson(const Json::Value& json, const OriginTag origi
     JsonUtils::GetValueForKey(json, LegacyReloadEnvironmentVariablesKey, _legacyReloadEnvironmentVariables);
     if (json[LegacyReloadEnvironmentVariablesKey.data()])
     {
-        _logSettingSet(std::string{ LegacyReloadEnvironmentVariablesKey });
+        _logSettingSet(LegacyReloadEnvironmentVariablesKey);
     }
 }
 
@@ -325,7 +325,7 @@ bool GlobalAppSettings::ShouldUsePersistedLayout() const
     return FirstWindowPreference() == FirstWindowPreference::PersistedWindowLayout && !IsolatedMode();
 }
 
-void GlobalAppSettings::_logSettingSet(const std::string& setting)
+void GlobalAppSettings::_logSettingSet(const std::string_view& setting)
 {
     if (setting == "theme")
     {
@@ -335,7 +335,7 @@ void GlobalAppSettings::_logSettingSet(const std::string& setting)
             // so we need to check if they were explicitly set
             if (_Theme->DarkName() == _Theme->LightName())
             {
-                _changeLog.insert(setting);
+                _changeLog.emplace(setting);
             }
             else
             {
@@ -385,15 +385,15 @@ void GlobalAppSettings::_logSettingSet(const std::string& setting)
     }
 }
 
-void GlobalAppSettings::_logSettingIfSet(const std::string& setting, const bool isSet)
+void GlobalAppSettings::_logSettingIfSet(const std::string_view& setting, const bool isSet)
 {
     if (isSet)
     {
-        _logSettingSet(std::string{ setting });
+        _logSettingSet(setting);
     }
 }
 
-void GlobalAppSettings::LogSettingChanges(std::set<std::string>& changes, const std::string& context) const
+void GlobalAppSettings::LogSettingChanges(std::set<std::string>& changes, const std::string_view& context) const
 {
     for (const auto& setting : _changeLog)
     {

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.h
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.h
@@ -72,6 +72,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         bool LegacyReloadEnvironmentVariables() const noexcept { return _legacyReloadEnvironmentVariables; }
 
+        void LogSettingChanges(std::set<std::string_view>& changes, std::string_view& context) const;
+
         INHERITABLE_SETTING(Model::GlobalAppSettings, hstring, UnparsedDefaultProfile, L"");
 
 #define GLOBAL_SETTINGS_INITIALIZE(type, name, jsonKey, ...) \
@@ -89,12 +91,13 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         winrt::guid _defaultProfile{};
         bool _legacyReloadEnvironmentVariables{ true };
         winrt::com_ptr<implementation::ActionMap> _actionMap{ winrt::make_self<implementation::ActionMap>() };
-        std::map<std::string_view, std::wstring_view> _changeLog;
+        std::set<std::string_view> _changeLog;
 
         std::vector<SettingsLoadWarnings> _keybindingsWarnings;
         Windows::Foundation::Collections::IMap<winrt::hstring, Model::ColorScheme> _colorSchemes{ winrt::single_threaded_map<winrt::hstring, Model::ColorScheme>() };
         Windows::Foundation::Collections::IMap<winrt::hstring, Model::Theme> _themes{ winrt::single_threaded_map<winrt::hstring, Model::Theme>() };
 
-        void _logSettingSet(std::string_view setting, auto& value);
+        void _logSettingSet(std::string_view setting);
+        void _logSettingIfSet(std::string_view setting, const bool isSet);
     };
 }

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.h
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.h
@@ -72,7 +72,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         bool LegacyReloadEnvironmentVariables() const noexcept { return _legacyReloadEnvironmentVariables; }
 
-        void LogSettingChanges(std::set<std::string_view>& changes, std::string_view& context) const;
+        void LogSettingChanges(std::set<std::string>& changes, const std::string& context) const;
 
         INHERITABLE_SETTING(Model::GlobalAppSettings, hstring, UnparsedDefaultProfile, L"");
 
@@ -91,13 +91,13 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         winrt::guid _defaultProfile{};
         bool _legacyReloadEnvironmentVariables{ true };
         winrt::com_ptr<implementation::ActionMap> _actionMap{ winrt::make_self<implementation::ActionMap>() };
-        std::set<std::string_view> _changeLog;
+        std::set<std::string> _changeLog;
 
         std::vector<SettingsLoadWarnings> _keybindingsWarnings;
         Windows::Foundation::Collections::IMap<winrt::hstring, Model::ColorScheme> _colorSchemes{ winrt::single_threaded_map<winrt::hstring, Model::ColorScheme>() };
         Windows::Foundation::Collections::IMap<winrt::hstring, Model::Theme> _themes{ winrt::single_threaded_map<winrt::hstring, Model::Theme>() };
 
-        void _logSettingSet(std::string_view setting);
-        void _logSettingIfSet(std::string_view setting, const bool isSet);
+        void _logSettingSet(const std::string& setting);
+        void _logSettingIfSet(const std::string& setting, const bool isSet);
     };
 }

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.h
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.h
@@ -75,7 +75,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         INHERITABLE_SETTING(Model::GlobalAppSettings, hstring, UnparsedDefaultProfile, L"");
 
 #define GLOBAL_SETTINGS_INITIALIZE(type, name, jsonKey, ...) \
-    INHERITABLE_SETTING(Model::GlobalAppSettings, type, name, ##__VA_ARGS__)
+    INHERITABLE_SETTING_WITH_LOGGING(Model::GlobalAppSettings, type, name, jsonKey, ##__VA_ARGS__)
         MTSM_GLOBAL_SETTINGS(GLOBAL_SETTINGS_INITIALIZE)
 #undef GLOBAL_SETTINGS_INITIALIZE
 
@@ -89,9 +89,12 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         winrt::guid _defaultProfile{};
         bool _legacyReloadEnvironmentVariables{ true };
         winrt::com_ptr<implementation::ActionMap> _actionMap{ winrt::make_self<implementation::ActionMap>() };
+        std::map<std::string_view, std::wstring_view> _changeLog;
 
         std::vector<SettingsLoadWarnings> _keybindingsWarnings;
         Windows::Foundation::Collections::IMap<winrt::hstring, Model::ColorScheme> _colorSchemes{ winrt::single_threaded_map<winrt::hstring, Model::ColorScheme>() };
         Windows::Foundation::Collections::IMap<winrt::hstring, Model::Theme> _themes{ winrt::single_threaded_map<winrt::hstring, Model::Theme>() };
+
+        void _logSettingSet(std::string_view setting, auto& value);
     };
 }

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.h
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.h
@@ -72,7 +72,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         bool LegacyReloadEnvironmentVariables() const noexcept { return _legacyReloadEnvironmentVariables; }
 
-        void LogSettingChanges(std::set<std::string>& changes, const std::string& context) const;
+        void LogSettingChanges(std::set<std::string>& changes, const std::string_view& context) const;
 
         INHERITABLE_SETTING(Model::GlobalAppSettings, hstring, UnparsedDefaultProfile, L"");
 
@@ -97,7 +97,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         Windows::Foundation::Collections::IMap<winrt::hstring, Model::ColorScheme> _colorSchemes{ winrt::single_threaded_map<winrt::hstring, Model::ColorScheme>() };
         Windows::Foundation::Collections::IMap<winrt::hstring, Model::Theme> _themes{ winrt::single_threaded_map<winrt::hstring, Model::Theme>() };
 
-        void _logSettingSet(const std::string& setting);
-        void _logSettingIfSet(const std::string& setting, const bool isSet);
+        void _logSettingSet(const std::string_view& setting);
+        void _logSettingIfSet(const std::string_view& setting, const bool isSet);
     };
 }

--- a/src/cascadia/TerminalSettingsModel/IInheritable.h
+++ b/src/cascadia/TerminalSettingsModel/IInheritable.h
@@ -185,6 +185,27 @@ public:                                                                      \
         _##name = value;                                                     \
     }
 
+#define INHERITABLE_SETTING_WITH_LOGGING(projectedType, type, name, jsonKey, ...) \
+    _BASE_INHERITABLE_SETTING(projectedType, std::optional<type>, name, ...)      \
+public:                                                                           \
+    /* Returns the resolved value for this setting */                             \
+    /* fallback: user set value --> inherited value --> system set value */       \
+    type name() const                                                             \
+    {                                                                             \
+        const auto val{ _get##name##Impl() };                                     \
+        return val ? *val : type{ __VA_ARGS__ };                                  \
+    }                                                                             \
+                                                                                  \
+    /* Overwrite the user set value */                                            \
+    void name(const type& value)                                                  \
+    {                                                                             \
+        if (name() != value)                                                      \
+        {                                                                         \
+            _logSettingSet(jsonKey, value);                                       \
+        }                                                                         \
+        _##name = value;                                                          \
+    }
+
 // This macro is similar to the one above, but is reserved for optional settings
 // like Profile.Foreground (where null is interpreted
 // as an acceptable value, rather than "inherit")

--- a/src/cascadia/TerminalSettingsModel/IInheritable.h
+++ b/src/cascadia/TerminalSettingsModel/IInheritable.h
@@ -199,9 +199,9 @@ public:                                                                         
     /* Overwrite the user set value */                                            \
     void name(const type& value)                                                  \
     {                                                                             \
-        if (name() != value)                                                      \
+        if (!_##name.has_value() || _##name.value() != value)                     \
         {                                                                         \
-            _logSettingSet(jsonKey, value);                                       \
+            _logSettingSet(jsonKey);                                              \
         }                                                                         \
         _##name = value;                                                          \
     }

--- a/src/cascadia/TerminalSettingsModel/Profile.cpp
+++ b/src/cascadia/TerminalSettingsModel/Profile.cpp
@@ -215,7 +215,7 @@ void Profile::LayerJson(const Json::Value& json)
         unfocusedAppearance->LayerJson(json[JsonKey(UnfocusedAppearanceKey)]);
         _UnfocusedAppearance = *unfocusedAppearance;
 
-        _logSettingSet(UnfocusedAppearanceKey);
+        _logSettingSet(std::string{ UnfocusedAppearanceKey });
     }
 }
 
@@ -527,33 +527,33 @@ std::wstring Profile::NormalizeCommandLine(LPCWSTR commandLine)
     return normalized;
 }
 
-void Profile::_logSettingSet(std::string_view setting)
+void Profile::_logSettingSet(const std::string& setting)
 {
-    _changeLog.insert(setting);
+    _changeLog.emplace(setting);
 }
 
-void Profile::_logSettingIfSet(std::string_view setting, const bool isSet)
+void Profile::_logSettingIfSet(const std::string_view& setting, const bool isSet)
 {
     if (isSet)
     {
-        _logSettingSet(setting);
+        _logSettingSet(std::string{ setting });
     }
 }
 
-void Profile::LogSettingChanges(std::set<std::string_view>& changes, std::string_view& context) const
+void Profile::LogSettingChanges(std::set<std::string>& changes, const std::string& context) const
 {
     for (const auto& setting : _changeLog)
     {
         changes.emplace(fmt::format(FMT_COMPILE("{}.{}"), context, setting));
     }
 
-    std::string_view fontContext{ fmt::format(FMT_COMPILE("{}.{}"), context, FontInfoKey) };
+    std::string fontContext{ fmt::format(FMT_COMPILE("{}.{}"), context, FontInfoKey) };
     winrt::get_self<implementation::FontConfig>(_FontInfo)->LogSettingChanges(changes, fontContext);
 
     // We don't want to distinguish between "profile.defaultAppearance.*" and "profile.unfocusedAppearance.*" settings,
     //   but we still want to aggregate all of the appearance settings from both appearances.
     // Log them as "profile.appearance.*"
-    std::string_view appContext{ fmt::format(FMT_COMPILE("{}.{}"), context, "appearance") };
+    std::string appContext{ fmt::format(FMT_COMPILE("{}.{}"), context, "appearance") };
     winrt::get_self<implementation::AppearanceConfig>(_DefaultAppearance)->LogSettingChanges(changes, appContext);
     if (_UnfocusedAppearance)
     {

--- a/src/cascadia/TerminalSettingsModel/Profile.cpp
+++ b/src/cascadia/TerminalSettingsModel/Profile.cpp
@@ -215,7 +215,7 @@ void Profile::LayerJson(const Json::Value& json)
         unfocusedAppearance->LayerJson(json[JsonKey(UnfocusedAppearanceKey)]);
         _UnfocusedAppearance = *unfocusedAppearance;
 
-        _logSettingSet(std::string{ UnfocusedAppearanceKey });
+        _logSettingSet(UnfocusedAppearanceKey);
     }
 }
 
@@ -527,7 +527,7 @@ std::wstring Profile::NormalizeCommandLine(LPCWSTR commandLine)
     return normalized;
 }
 
-void Profile::_logSettingSet(const std::string& setting)
+void Profile::_logSettingSet(const std::string_view& setting)
 {
     _changeLog.emplace(setting);
 }
@@ -536,11 +536,11 @@ void Profile::_logSettingIfSet(const std::string_view& setting, const bool isSet
 {
     if (isSet)
     {
-        _logSettingSet(std::string{ setting });
+        _logSettingSet(setting);
     }
 }
 
-void Profile::LogSettingChanges(std::set<std::string>& changes, const std::string& context) const
+void Profile::LogSettingChanges(std::set<std::string>& changes, const std::string_view& context) const
 {
     for (const auto& setting : _changeLog)
     {

--- a/src/cascadia/TerminalSettingsModel/Profile.cpp
+++ b/src/cascadia/TerminalSettingsModel/Profile.cpp
@@ -552,16 +552,12 @@ void Profile::_logSettingIfSet(const std::string_view& setting, const bool isSet
         const bool settingCommandlineToWinPow = til::equals_insensitive_ascii(setting, "commandline") && _Commandline.has_value() && til::equals_insensitive_ascii(*_Commandline, L"%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe");
         const bool settingCommandlineToCmd = til::equals_insensitive_ascii(setting, "commandline") && _Commandline.has_value() && til::equals_insensitive_ascii(*_Commandline, L"%SystemRoot%\\System32\\cmd.exe");
         // clang-format off
-        if ((isWinPow && (settingHiddenToFalse || settingCommandlineToWinPow))
-            || (isCmd && (settingHiddenToFalse || settingCommandlineToCmd))
-            || (isACS && settingHiddenToFalse)
-            || (isWTDynamicProfile && settingHiddenToFalse))
+        if (!(isWinPow && (settingHiddenToFalse || settingCommandlineToWinPow))
+            && !(isCmd && (settingHiddenToFalse || settingCommandlineToCmd))
+            && !(isACS && settingHiddenToFalse)
+            && !(isWTDynamicProfile && settingHiddenToFalse))
         {
             // clang-format on
-            // skip
-        }
-        else
-        {
             _logSettingSet(setting);
         }
     }

--- a/src/cascadia/TerminalSettingsModel/Profile.h
+++ b/src/cascadia/TerminalSettingsModel/Profile.h
@@ -131,7 +131,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
     public:
 #define PROFILE_SETTINGS_INITIALIZE(type, name, jsonKey, ...) \
-    INHERITABLE_SETTING(Model::Profile, type, name, ##__VA_ARGS__)
+    INHERITABLE_SETTING_WITH_LOGGING(Model::Profile, type, name, jsonKey, ##__VA_ARGS__)
         MTSM_PROFILE_SETTINGS(PROFILE_SETTINGS_INITIALIZE)
 #undef PROFILE_SETTINGS_INITIALIZE
 
@@ -140,12 +140,14 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         Model::FontConfig _FontInfo{ winrt::make<FontConfig>(weak_ref<Model::Profile>(*this)) };
 
         std::optional<winrt::hstring> _evaluatedIcon{ std::nullopt };
+        std::map<std::string_view, std::wstring_view> _changeLog;
 
         static std::wstring EvaluateStartingDirectory(const std::wstring& directory);
 
         static guid _GenerateGuidForProfile(const std::wstring_view& name, const std::wstring_view& source) noexcept;
 
         winrt::hstring _evaluateIcon() const;
+        void _logSettingSet(std::string_view setting, auto& value);
 
         friend class SettingsModelUnitTests::DeserializationTests;
         friend class SettingsModelUnitTests::ProfileTests;

--- a/src/cascadia/TerminalSettingsModel/Profile.h
+++ b/src/cascadia/TerminalSettingsModel/Profile.h
@@ -108,7 +108,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         void _FinalizeInheritance() override;
 
-        void LogSettingChanges(std::set<std::string_view>& changes, std::string_view& context) const;
+        void LogSettingChanges(std::set<std::string>& changes, const std::string& context) const;
 
         // Special fields
         hstring Icon() const;
@@ -142,15 +142,15 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         Model::FontConfig _FontInfo{ winrt::make<FontConfig>(weak_ref<Model::Profile>(*this)) };
 
         std::optional<winrt::hstring> _evaluatedIcon{ std::nullopt };
-        std::set<std::string_view> _changeLog;
+        std::set<std::string> _changeLog;
 
         static std::wstring EvaluateStartingDirectory(const std::wstring& directory);
 
         static guid _GenerateGuidForProfile(const std::wstring_view& name, const std::wstring_view& source) noexcept;
 
         winrt::hstring _evaluateIcon() const;
-        void _logSettingSet(std::string_view setting);
-        void _logSettingIfSet(std::string_view setting, const bool isSet);
+        void _logSettingSet(const std::string& setting);
+        void _logSettingIfSet(const std::string_view& setting, const bool isSet);
 
         friend class SettingsModelUnitTests::DeserializationTests;
         friend class SettingsModelUnitTests::ProfileTests;

--- a/src/cascadia/TerminalSettingsModel/Profile.h
+++ b/src/cascadia/TerminalSettingsModel/Profile.h
@@ -108,7 +108,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         void _FinalizeInheritance() override;
 
-        void LogSettingChanges(std::set<std::string>& changes, const std::string& context) const;
+        void LogSettingChanges(std::set<std::string>& changes, const std::string_view& context) const;
 
         // Special fields
         hstring Icon() const;
@@ -149,7 +149,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         static guid _GenerateGuidForProfile(const std::wstring_view& name, const std::wstring_view& source) noexcept;
 
         winrt::hstring _evaluateIcon() const;
-        void _logSettingSet(const std::string& setting);
+        void _logSettingSet(const std::string_view& setting);
         void _logSettingIfSet(const std::string_view& setting, const bool isSet);
 
         friend class SettingsModelUnitTests::DeserializationTests;

--- a/src/cascadia/TerminalSettingsModel/Profile.h
+++ b/src/cascadia/TerminalSettingsModel/Profile.h
@@ -108,6 +108,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         void _FinalizeInheritance() override;
 
+        void LogSettingChanges(std::set<std::string_view>& changes, std::string_view& context) const;
+
         // Special fields
         hstring Icon() const;
         void Icon(const hstring& value);
@@ -140,14 +142,15 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         Model::FontConfig _FontInfo{ winrt::make<FontConfig>(weak_ref<Model::Profile>(*this)) };
 
         std::optional<winrt::hstring> _evaluatedIcon{ std::nullopt };
-        std::map<std::string_view, std::wstring_view> _changeLog;
+        std::set<std::string_view> _changeLog;
 
         static std::wstring EvaluateStartingDirectory(const std::wstring& directory);
 
         static guid _GenerateGuidForProfile(const std::wstring_view& name, const std::wstring_view& source) noexcept;
 
         winrt::hstring _evaluateIcon() const;
-        void _logSettingSet(std::string_view setting, auto& value);
+        void _logSettingSet(std::string_view setting);
+        void _logSettingIfSet(std::string_view setting, const bool isSet);
 
         friend class SettingsModelUnitTests::DeserializationTests;
         friend class SettingsModelUnitTests::ProfileTests;

--- a/src/cascadia/TerminalSettingsModel/Theme.cpp
+++ b/src/cascadia/TerminalSettingsModel/Theme.cpp
@@ -292,6 +292,37 @@ winrt::com_ptr<Theme> Theme::FromJson(const Json::Value& json)
     return result;
 }
 
+void Theme::LogSettingChanges(std::set<std::string_view>& changes, std::string_view& context)
+{
+#define GET_INNER_THEME_SETTING(type, name, jsonKey, ...) \
+    if (isSet)                                            \
+        changes.insert(fmt::format(FMT_COMPILE("{}.{}.{}"), context, outerJsonKey, jsonKey));
+
+#define GET_OUTER_THEME_SETTING(type, name, jsonKey, ...) \
+    const bool is##name##Set = _##name != nullptr;        \
+    std::string_view outer##name##JsonKey = jsonKey;
+
+    MTSM_THEME_SETTINGS(GET_OUTER_THEME_SETTING)
+
+    bool isSet = isWindowSet;
+    std::string_view outerJsonKey = outerWindowJsonKey;
+    MTSM_THEME_WINDOW_SETTINGS(GET_INNER_THEME_SETTING)
+
+    isSet = isSettingsSet;
+    outerJsonKey = outerSettingsJsonKey;
+    MTSM_THEME_SETTINGS_SETTINGS(GET_INNER_THEME_SETTING)
+
+    isSet = isTabRowSet;
+    outerJsonKey = outerTabRowJsonKey;
+    MTSM_THEME_TABROW_SETTINGS(GET_INNER_THEME_SETTING)
+
+    isSet = isTabSet;
+    outerJsonKey = outerTabJsonKey;
+    MTSM_THEME_TAB_SETTINGS(GET_INNER_THEME_SETTING)
+#undef GET_INNER_THEME_SETTING
+#undef GET_OUTER_THEME_SETTING
+}
+
 // Method Description:
 // - Create a new serialized JsonObject from an instance of this class
 // Arguments:

--- a/src/cascadia/TerminalSettingsModel/Theme.cpp
+++ b/src/cascadia/TerminalSettingsModel/Theme.cpp
@@ -292,7 +292,7 @@ winrt::com_ptr<Theme> Theme::FromJson(const Json::Value& json)
     return result;
 }
 
-void Theme::LogSettingChanges(std::set<std::string>& changes, std::string& context)
+void Theme::LogSettingChanges(std::set<std::string>& changes, const std::string_view& context)
 {
 #pragma warning(push)
 #pragma warning(disable : 5103) // pasting '{' and 'winrt' does not result in a valid preprocessing token
@@ -305,7 +305,7 @@ void Theme::LogSettingChanges(std::set<std::string>& changes, std::string& conte
 
 #define LOG_IF_SET(type, name, jsonKey, ...) \
     if (obj.name() != type{##__VA_ARGS__ })  \
-        changes.insert(fmt::format(FMT_COMPILE("{}.{}.{}"), context, outerJsonKey, jsonKey));
+        changes.emplace(fmt::format(FMT_COMPILE("{}.{}.{}"), context, outerJsonKey, jsonKey));
 
     if (isWindowSet)
     {

--- a/src/cascadia/TerminalSettingsModel/Theme.cpp
+++ b/src/cascadia/TerminalSettingsModel/Theme.cpp
@@ -294,33 +294,49 @@ winrt::com_ptr<Theme> Theme::FromJson(const Json::Value& json)
 
 void Theme::LogSettingChanges(std::set<std::string_view>& changes, std::string_view& context)
 {
-#define GET_INNER_THEME_SETTING(type, name, jsonKey, ...) \
-    if (isSet)                                            \
-        changes.insert(fmt::format(FMT_COMPILE("{}.{}.{}"), context, outerJsonKey, jsonKey));
+#pragma warning(push)
+#pragma warning(disable : 5103) // pasting '{' and 'winrt' does not result in a valid preprocessing token
 
-#define GET_OUTER_THEME_SETTING(type, name, jsonKey, ...) \
-    const bool is##name##Set = _##name != nullptr;        \
+#define GENERATE_SET_CHECK_AND_JSON_KEYS(type, name, jsonKey, ...) \
+    const bool is##name##Set = _##name != nullptr;                 \
     std::string_view outer##name##JsonKey = jsonKey;
 
-    MTSM_THEME_SETTINGS(GET_OUTER_THEME_SETTING)
+    MTSM_THEME_SETTINGS(GENERATE_SET_CHECK_AND_JSON_KEYS)
 
-    bool isSet = isWindowSet;
-    std::string_view outerJsonKey = outerWindowJsonKey;
-    MTSM_THEME_WINDOW_SETTINGS(GET_INNER_THEME_SETTING)
+#define LOG_IF_SET(type, name, jsonKey, ...) \
+    if (obj.name() != type{##__VA_ARGS__ })  \
+        changes.insert(fmt::format(FMT_COMPILE("{}.{}.{}"), context, outerJsonKey, jsonKey));
 
-    isSet = isSettingsSet;
-    outerJsonKey = outerSettingsJsonKey;
-    MTSM_THEME_SETTINGS_SETTINGS(GET_INNER_THEME_SETTING)
+    if (isWindowSet)
+    {
+        const auto obj = _Window;
+        const auto outerJsonKey = outerWindowJsonKey;
+        MTSM_THEME_WINDOW_SETTINGS(LOG_IF_SET)
+    }
 
-    isSet = isTabRowSet;
-    outerJsonKey = outerTabRowJsonKey;
-    MTSM_THEME_TABROW_SETTINGS(GET_INNER_THEME_SETTING)
+    if (isSettingsSet)
+    {
+        const auto obj = _Settings;
+        const auto outerJsonKey = outerSettingsJsonKey;
+        MTSM_THEME_SETTINGS_SETTINGS(LOG_IF_SET)
+    }
 
-    isSet = isTabSet;
-    outerJsonKey = outerTabJsonKey;
-    MTSM_THEME_TAB_SETTINGS(GET_INNER_THEME_SETTING)
-#undef GET_INNER_THEME_SETTING
-#undef GET_OUTER_THEME_SETTING
+    if (isTabRowSet)
+    {
+        const auto obj = _TabRow;
+        const auto outerJsonKey = outerTabRowJsonKey;
+        MTSM_THEME_TABROW_SETTINGS(LOG_IF_SET)
+    }
+
+    if (isTabSet)
+    {
+        const auto obj = _Tab;
+        const auto outerJsonKey = outerTabJsonKey;
+        MTSM_THEME_TAB_SETTINGS(LOG_IF_SET)
+    }
+#undef LOG_IF_SET
+#undef GENERATE_SET_CHECK_AND_JSON_KEYS
+#pragma warning(pop)
 }
 
 // Method Description:

--- a/src/cascadia/TerminalSettingsModel/Theme.cpp
+++ b/src/cascadia/TerminalSettingsModel/Theme.cpp
@@ -292,7 +292,7 @@ winrt::com_ptr<Theme> Theme::FromJson(const Json::Value& json)
     return result;
 }
 
-void Theme::LogSettingChanges(std::set<std::string_view>& changes, std::string_view& context)
+void Theme::LogSettingChanges(std::set<std::string>& changes, std::string& context)
 {
 #pragma warning(push)
 #pragma warning(disable : 5103) // pasting '{' and 'winrt' does not result in a valid preprocessing token

--- a/src/cascadia/TerminalSettingsModel/Theme.h
+++ b/src/cascadia/TerminalSettingsModel/Theme.h
@@ -79,6 +79,9 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         Json::Value ToJson();                  \
                                                \
         macro(THEME_SETTINGS_INITIALIZE);      \
+                                               \
+    private:                                   \
+        std::set<std::string_view> _changeLog; \
     };
 
     THEME_OBJECT(WindowTheme, MTSM_THEME_WINDOW_SETTINGS);
@@ -97,8 +100,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         hstring ToString();
 
         static com_ptr<Theme> FromJson(const Json::Value& json);
-        void LayerJson(const Json::Value& json);
         Json::Value ToJson() const;
+        void LogSettingChanges(std::set<std::string_view>& changes, std::string_view& context);
 
         winrt::Windows::UI::Xaml::ElementTheme RequestedTheme() const noexcept;
 

--- a/src/cascadia/TerminalSettingsModel/Theme.h
+++ b/src/cascadia/TerminalSettingsModel/Theme.h
@@ -79,9 +79,6 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         Json::Value ToJson();                  \
                                                \
         macro(THEME_SETTINGS_INITIALIZE);      \
-                                               \
-    private:                                   \
-        std::set<std::string_view> _changeLog; \
     };
 
     THEME_OBJECT(WindowTheme, MTSM_THEME_WINDOW_SETTINGS);
@@ -101,7 +98,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         static com_ptr<Theme> FromJson(const Json::Value& json);
         Json::Value ToJson() const;
-        void LogSettingChanges(std::set<std::string_view>& changes, std::string_view& context);
+        void LogSettingChanges(std::set<std::string>& changes, std::string& context);
 
         winrt::Windows::UI::Xaml::ElementTheme RequestedTheme() const noexcept;
 

--- a/src/cascadia/TerminalSettingsModel/Theme.h
+++ b/src/cascadia/TerminalSettingsModel/Theme.h
@@ -98,7 +98,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         static com_ptr<Theme> FromJson(const Json::Value& json);
         Json::Value ToJson() const;
-        void LogSettingChanges(std::set<std::string>& changes, std::string& context);
+        void LogSettingChanges(std::set<std::string>& changes, const std::string_view& context);
 
         winrt::Windows::UI::Xaml::ElementTheme RequestedTheme() const noexcept;
 


### PR DESCRIPTION
Adds functionality throughout the settings model to keep track of which settings have been set.

There are two entry points:
- AppLogic.cpp: this is where we perform a settings reload by loading the JSON
- MainPage.cpp: this is where the Save button is clicked in the settings UI

Both of these entry points call into `CascadiaSettings::LogSettingChanges()` where we aggregate the list of changes (specifically, _which_ settings changed, not _what_ their value is).

Just about all of the settings model objects now have a `LogSettingChanges(std::set& changes, std::string_view context)` on them.
- `changes` is where we aggregate all of the changes to. In it being a set, we don't need to worry about duplicates and can do things like iterate across all of the profiles.
- `context` prepends a string to the setting. This'll allow us to better identify where a setting was changes (i.e. "global.X" are global settings). We also use this to distinguish between settings set in the ~base layer~ profile defaults vs individual profiles.

The change log in each object is modified via two ways:
- `LayerJson()` changes: this is useful for detecting JSON changes! All we're doing is checking if the setting has a value (due to inheritance, just about everything is an optional here!). If the value is set, we add the json key to the change log
- `INHERITABLE_SETTING_WITH_LOGGING` in IInheritable.h: we already use this macro to define getters and setters. This new macro updates the setter to check if the value was set to something different. If so, log it!

 Other notes:
- We're not distinguishing between `defaultAppearance` and `unfocusedAppearance`
- We are distinguishing between `profileDefaults` and `profile` (any other profile)
- New Tab Menu Customization:
   - we really just care about the entry types. Handled in `GlobalAppSettings`
- Font:
   - We still have support for legacy values here. We still want to track them, but just use the modern keys.
- `Theme`:
   - We don't do inheritance here, so we have to approach it differently. During the JSON load, we log each setting. However, we don't have `LayerJson`! So instead, do the work in `CascadiaSettings` and store the changes there. Note that we don't track any changes made via setters. This is fine for now since themes aren't even in the settings UI, so we wouldn't get much use out of it anyways.
- Actions:
   - Actions are weird because we can have nested and iterable actions too, but `ActionsAndArgs` as a whole add a ton of functionality. I handled it over in `Command::LogSettingChanges` and we generally just serialize it to JSON to get the keys. It's a lot easier than dealing with the object model.

Epic: #10000
Auto-Save (ish): #12424 