### PR TITLE
Log number of interactive sessions

### DIFF
--- a/src/cascadia/WindowsTerminal/WindowThread.cpp
+++ b/src/cascadia/WindowsTerminal/WindowThread.cpp
@@ -6,6 +6,8 @@
 
 using namespace winrt::Microsoft::Terminal::Remoting;
 
+bool WindowThread::_loggedInteraction = false;
+
 WindowThread::WindowThread(winrt::TerminalApp::AppLogic logic,
                            winrt::Microsoft::Terminal::Remoting::WindowRequestedArgs args,
                            winrt::Microsoft::Terminal::Remoting::WindowManager manager,
@@ -189,6 +191,18 @@ int WindowThread::_messagePump()
         if (message.message == AppHost::WM_REFRIGERATE)
         {
             break;
+        }
+
+        if (!_loggedInteraction && (message.message == WM_KEYDOWN || message.message == WM_SYSKEYDOWN))
+        {
+            TraceLoggingWrite(
+                g_hWindowsTerminalProvider,
+                "InteractiveSession",
+                TraceLoggingDescription("Emmitted the first time a key is pressed"),
+                TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
+            _loggedInteraction = true;
         }
 
         // GH#638 (Pressing F7 brings up both the history AND a caret browsing message)

--- a/src/cascadia/WindowsTerminal/WindowThread.cpp
+++ b/src/cascadia/WindowsTerminal/WindowThread.cpp
@@ -198,7 +198,7 @@ int WindowThread::_messagePump()
             TraceLoggingWrite(
                 g_hWindowsTerminalProvider,
                 "InteractiveSession",
-                TraceLoggingDescription("Emmitted the first time a key is pressed"),
+                TraceLoggingDescription("Emitted the first time a key is pressed"),
                 TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
                 TraceLoggingKeyword(TIL_KEYWORD_TRACE),
                 TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));

--- a/src/cascadia/WindowsTerminal/WindowThread.cpp
+++ b/src/cascadia/WindowsTerminal/WindowThread.cpp
@@ -197,7 +197,7 @@ int WindowThread::_messagePump()
         {
             TraceLoggingWrite(
                 g_hWindowsTerminalProvider,
-                "InteractiveSession",
+                "SessionBecameInteractive",
                 TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
                 TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
             _loggedInteraction = true;

--- a/src/cascadia/WindowsTerminal/WindowThread.cpp
+++ b/src/cascadia/WindowsTerminal/WindowThread.cpp
@@ -198,9 +198,7 @@ int WindowThread::_messagePump()
             TraceLoggingWrite(
                 g_hWindowsTerminalProvider,
                 "InteractiveSession",
-                TraceLoggingDescription("Emitted the first time a key is pressed"),
                 TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                TraceLoggingKeyword(TIL_KEYWORD_TRACE),
                 TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
             _loggedInteraction = true;
         }

--- a/src/cascadia/WindowsTerminal/WindowThread.h
+++ b/src/cascadia/WindowsTerminal/WindowThread.h
@@ -42,6 +42,7 @@ private:
     winrt::event_token _UpdateSettingsRequestedToken;
 
     std::unique_ptr<::IslandWindow> _warmWindow{ nullptr };
+    static bool _loggedInteraction;
 
     int _messagePump();
     void _pumpRemainingXamlMessages();


### PR DESCRIPTION
This sends a telemetry event if a session is interacted with. Specifically, key events are essential to have an interactive session in Windows Terminal, so we're tracking sessions that have had a key down event.