### PR TITLE
Remove SetTextAttributes from the ITerminalApi interface

### DIFF
--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -132,7 +132,6 @@ public:
     Microsoft::Console::VirtualTerminal::StateMachine& GetStateMachine() noexcept override;
     BufferState GetBufferAndViewport() noexcept override;
     void SetViewportPosition(const til::point position) noexcept override;
-    void SetTextAttributes(const TextAttribute& attrs) noexcept override;
     void SetSystemMode(const Mode mode, const bool enabled) noexcept override;
     bool GetSystemMode(const Mode mode) const noexcept override;
     void ReturnAnswerback() override;

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -54,11 +54,6 @@ try
 }
 CATCH_LOG()
 
-void Terminal::SetTextAttributes(const TextAttribute& attrs) noexcept
-{
-    _activeBuffer().SetCurrentAttributes(attrs);
-}
-
 void Terminal::SetSystemMode(const Mode mode, const bool enabled) noexcept
 {
     _assertLocked();

--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -88,18 +88,6 @@ void ConhostInternalGetSet::SetViewportPosition(const til::point position)
     info.UpdateBottom();
 }
 
-// Method Description:
-// - Sets the current TextAttribute of the active screen buffer. Text
-//   written to this buffer will be written with these attributes.
-// Arguments:
-// - attrs: The new TextAttribute to use
-// Return Value:
-// - <none>
-void ConhostInternalGetSet::SetTextAttributes(const TextAttribute& attrs)
-{
-    _io.GetActiveOutputBuffer().SetAttributes(attrs);
-}
-
 // Routine Description:
 // - Sets the state of one of the system modes.
 // Arguments:

--- a/src/host/outputStream.hpp
+++ b/src/host/outputStream.hpp
@@ -35,8 +35,6 @@ public:
     BufferState GetBufferAndViewport() override;
     void SetViewportPosition(const til::point position) override;
 
-    void SetTextAttributes(const TextAttribute& attrs) override;
-
     void SetSystemMode(const Mode mode, const bool enabled) override;
     bool GetSystemMode(const Mode mode) const override;
 

--- a/src/terminal/adapter/ITerminalApi.hpp
+++ b/src/terminal/adapter/ITerminalApi.hpp
@@ -52,8 +52,6 @@ namespace Microsoft::Console::VirtualTerminal
 
         virtual bool IsVtInputEnabled() const = 0;
 
-        virtual void SetTextAttributes(const TextAttribute& attrs) = 0;
-
         enum class Mode : size_t
         {
             AutoWrap,

--- a/src/terminal/adapter/PageManager.cpp
+++ b/src/terminal/adapter/PageManager.cpp
@@ -40,16 +40,9 @@ const TextAttribute& Page::Attributes() const noexcept
     return _buffer.GetCurrentAttributes();
 }
 
-void Page::SetAttributes(const TextAttribute& attr, ITerminalApi* api) const
+void Page::SetAttributes(const TextAttribute& attr) const
 {
     _buffer.SetCurrentAttributes(attr);
-    // If the api parameter was specified, we need to pass the new attributes
-    // through to the api. This occurs when there's a potential for the colors
-    // to be changed, which may require some legacy remapping in conhost.
-    if (api)
-    {
-        api->SetTextAttributes(attr);
-    }
 }
 
 til::size Page::Size() const noexcept

--- a/src/terminal/adapter/PageManager.cpp
+++ b/src/terminal/adapter/PageManager.cpp
@@ -40,7 +40,7 @@ const TextAttribute& Page::Attributes() const noexcept
     return _buffer.GetCurrentAttributes();
 }
 
-void Page::SetAttributes(const TextAttribute& attr) const
+void Page::SetAttributes(const TextAttribute& attr) const noexcept
 {
     _buffer.SetCurrentAttributes(attr);
 }

--- a/src/terminal/adapter/PageManager.hpp
+++ b/src/terminal/adapter/PageManager.hpp
@@ -25,7 +25,7 @@ namespace Microsoft::Console::VirtualTerminal
         til::CoordType Number() const noexcept;
         Cursor& Cursor() const noexcept;
         const TextAttribute& Attributes() const noexcept;
-        void SetAttributes(const TextAttribute& attr, ITerminalApi* api = nullptr) const;
+        void SetAttributes(const TextAttribute& attr) const;
         til::size Size() const noexcept;
         til::CoordType Top() const noexcept;
         til::CoordType Bottom() const noexcept;

--- a/src/terminal/adapter/PageManager.hpp
+++ b/src/terminal/adapter/PageManager.hpp
@@ -25,7 +25,7 @@ namespace Microsoft::Console::VirtualTerminal
         til::CoordType Number() const noexcept;
         Cursor& Cursor() const noexcept;
         const TextAttribute& Attributes() const noexcept;
-        void SetAttributes(const TextAttribute& attr) const;
+        void SetAttributes(const TextAttribute& attr) const noexcept;
         til::size Size() const noexcept;
         til::CoordType Top() const noexcept;
         til::CoordType Bottom() const noexcept;

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -555,7 +555,7 @@ bool AdaptDispatch::CursorRestoreState()
     }
 
     // Restore text attributes.
-    page.SetAttributes(savedCursorState.Attributes, &_api);
+    page.SetAttributes(savedCursorState.Attributes);
 
     // Restore designated character sets.
     _termOutput.RestoreFrom(savedCursorState.TermOutput);

--- a/src/terminal/adapter/adaptDispatchGraphics.cpp
+++ b/src/terminal/adapter/adaptDispatchGraphics.cpp
@@ -425,7 +425,7 @@ bool AdaptDispatch::SetGraphicsRendition(const VTParameters options)
     const auto page = _pages.ActivePage();
     auto attr = page.Attributes();
     _ApplyGraphicsOptions(options, attr);
-    page.SetAttributes(attr, &_api);
+    page.SetAttributes(attr);
     return true;
 }
 
@@ -487,6 +487,6 @@ bool AdaptDispatch::PopGraphicsRendition()
 {
     const auto page = _pages.ActivePage();
     const auto& currentAttributes = page.Attributes();
-    page.SetAttributes(_sgrStack.Pop(currentAttributes), &_api);
+    page.SetAttributes(_sgrStack.Pop(currentAttributes));
     return true;
 }


### PR DESCRIPTION
## Summary of the Pull Request

The only reason we had the `SetTextAttributes` method in `ITerminalApi`
was to allow for conhost to remap the default color attributes when the
VT PowerShell quirk was active. Since that quirk has now been removed,
there's no need for this API anymore.

## References and Relevant Issues

The PowerShell quirk was removed in PR #17666.

## Validation Steps Performed

I've had to update all the attribute tests in adapterTest to manually
check the expected attributes, since those checks were previously being
handled in a `SetTextAttributes` mock which no longer exists.

I've also performed some manual tests of the VT attribute operations to
double check that they're still working as expected.
