### PR TITLE
schema: add reloadEnvironmentVariables to newTerminalArgs

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -621,7 +621,7 @@
         },
         "reloadEnvironmentVariables": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "When set to true, a new environment block will be generated when creating a new session. Otherwise, the session will inherit the variables the Terminal was started with."
         }
       },

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -622,7 +622,7 @@
         "reloadEnvironmentVariables": {
           "type": "boolean",
           "default": false,
-          "description": "When set to true, a new environment block will be generated when creating a new session. Otherwise, the session will instead inherit the variables the Terminal was started with."
+          "description": "When set to true, a new environment block will be generated when creating a new session. Otherwise, the session will inherit the variables the Terminal was started with."
         }
       },
       "type": "object"

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -618,6 +618,11 @@
           "type": "boolean",
           "default": false,
           "description": "This will override the profile's `elevate` setting."
+        },
+        "reloadEnvironmentVariables": {
+          "type": "boolean",
+          "default": false,
+          "description": "When set to true, a new environment block will be generated when creating a new session. Otherwise, the session will instead inherit the variables the Terminal was started with."
         }
       },
       "type": "object"


### PR DESCRIPTION
Updates the schema to include `reloadEnvironmentVariables` for New Terminal Args.

Other properties that aren't included:
- `__content`: we're explicitly not including this in the schema since it's only used internally. In fact, we even throw an error if it is defined (sample code)!
- `sessionId`: there isn't really a legit use for this one, so we'll leave it undocumented and as an implementation detail.

Closes #17469 

[sample code]: https://github.com/microsoft/terminal/blame/0199ca33ddb4a02ca3549627d772ce6b330ed1ce/src/cascadia/TerminalSettingsModel/ActionArgs.h