### PR TITLE
Align the OSS ConPTY API with Windows 11 24H2

### DIFF
--- a/src/cascadia/TerminalConnection/ConptyConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConptyConnection.cpp
@@ -755,7 +755,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 
     void ConptyConnection::closePseudoConsoleAsync(HPCON hPC) noexcept
     {
-        ::ConptyClosePseudoConsoleTimeout(hPC, 0);
+        ::ConptyClosePseudoConsole(hPC);
     }
 
     HRESULT ConptyConnection::NewHandoff(HANDLE* in, HANDLE* out, HANDLE signal, HANDLE reference, HANDLE server, HANDLE client, const TERMINAL_STARTUP_INFO* startupInfo) noexcept

--- a/src/inc/conpty-static.h
+++ b/src/inc/conpty-static.h
@@ -44,6 +44,5 @@ CONPTY_EXPORT HRESULT WINAPI ConptyReparentPseudoConsole(HPCON hPC, HWND newPare
 CONPTY_EXPORT HRESULT WINAPI ConptyReleasePseudoConsole(HPCON hPC);
 
 CONPTY_EXPORT VOID WINAPI ConptyClosePseudoConsole(HPCON hPC);
-CONPTY_EXPORT VOID WINAPI ConptyClosePseudoConsoleTimeout(HPCON hPC, DWORD dwMilliseconds);
 
 CONPTY_EXPORT HRESULT WINAPI ConptyPackPseudoConsole(HANDLE hServerProcess, HANDLE hRef, HANDLE hSignal, HPCON* phPC);

--- a/src/winconpty/dll/winconpty.def
+++ b/src/winconpty/dll/winconpty.def
@@ -4,7 +4,6 @@ EXPORTS
     ConptyCreatePseudoConsoleAsUser
     ConptyResizePseudoConsole
     ConptyClosePseudoConsole
-    ConptyClosePseudoConsoleTimeout
     ConptyClearPseudoConsole
     ConptyShowHidePseudoConsole
     ConptyReparentPseudoConsole
@@ -18,3 +17,4 @@ EXPORTS
     ResizePseudoConsole = ConptyResizePseudoConsole
     ClosePseudoConsole = ConptyClosePseudoConsole
     ClearPseudoConsole = ConptyClearPseudoConsole
+    ReleasePseudoConsole = ConptyReleasePseudoConsole

--- a/src/winconpty/ft_pty/ConPtyTests.cpp
+++ b/src/winconpty/ft_pty/ConPtyTests.cpp
@@ -165,10 +165,10 @@ void ConPtyTests::CreateConPtyNoPipes()
     VERIFY_FAILED(_CreatePseudoConsole(defaultSize, nullptr, nullptr, 0, &pcon));
 
     VERIFY_SUCCEEDED(_CreatePseudoConsole(defaultSize, nullptr, goodOut, 0, &pcon));
-    _ClosePseudoConsoleMembers(&pcon, INFINITE);
+    _ClosePseudoConsoleMembers(&pcon);
 
     VERIFY_SUCCEEDED(_CreatePseudoConsole(defaultSize, goodIn, nullptr, 0, &pcon));
-    _ClosePseudoConsoleMembers(&pcon, INFINITE);
+    _ClosePseudoConsoleMembers(&pcon);
 }
 
 void ConPtyTests::CreateConPtyBadSize()
@@ -212,7 +212,7 @@ void ConPtyTests::GoodCreate()
                              &pcon));
 
     auto closePty = wil::scope_exit([&] {
-        _ClosePseudoConsoleMembers(&pcon, INFINITE);
+        _ClosePseudoConsoleMembers(&pcon);
     });
 }
 
@@ -241,7 +241,7 @@ void ConPtyTests::GoodCreateMultiple()
                              0,
                              &pcon1));
     auto closePty1 = wil::scope_exit([&] {
-        _ClosePseudoConsoleMembers(&pcon1, INFINITE);
+        _ClosePseudoConsoleMembers(&pcon1);
     });
 
     VERIFY_SUCCEEDED(
@@ -251,7 +251,7 @@ void ConPtyTests::GoodCreateMultiple()
                              0,
                              &pcon2));
     auto closePty2 = wil::scope_exit([&] {
-        _ClosePseudoConsoleMembers(&pcon2, INFINITE);
+        _ClosePseudoConsoleMembers(&pcon2);
     });
 }
 
@@ -278,7 +278,7 @@ void ConPtyTests::SurvivesOnBreakOutput()
                              0,
                              &pty));
     auto closePty1 = wil::scope_exit([&] {
-        _ClosePseudoConsoleMembers(&pty, INFINITE);
+        _ClosePseudoConsoleMembers(&pty);
     });
 
     DWORD dwExit;
@@ -337,7 +337,7 @@ void ConPtyTests::DiesOnClose()
                              0,
                              &pty));
     auto closePty1 = wil::scope_exit([&] {
-        _ClosePseudoConsoleMembers(&pty, INFINITE);
+        _ClosePseudoConsoleMembers(&pty);
     });
 
     DWORD dwExit;
@@ -361,7 +361,7 @@ void ConPtyTests::DiesOnClose()
     Log::Comment(NoThrowString().Format(L"Sleep a bit to let the process attach"));
     Sleep(100);
 
-    _ClosePseudoConsoleMembers(&pty, INFINITE);
+    _ClosePseudoConsoleMembers(&pty);
 
     GetExitCodeProcess(hConPtyProcess.get(), &dwExit);
     VERIFY_ARE_NOT_EQUAL(dwExit, (DWORD)STILL_ACTIVE);

--- a/src/winconpty/ft_pty/ConPtyTests.cpp
+++ b/src/winconpty/ft_pty/ConPtyTests.cpp
@@ -363,6 +363,7 @@ void ConPtyTests::DiesOnClose()
 
     _ClosePseudoConsoleMembers(&pty);
 
+    WaitForSingleObject(hConPtyProcess.get(), 3000);
     GetExitCodeProcess(hConPtyProcess.get(), &dwExit);
     VERIFY_ARE_NOT_EQUAL(dwExit, (DWORD)STILL_ACTIVE);
 }

--- a/src/winconpty/winconpty.h
+++ b/src/winconpty/winconpty.h
@@ -71,7 +71,7 @@ HRESULT _ResizePseudoConsole(_In_ const PseudoConsole* const pPty, _In_ const CO
 HRESULT _ClearPseudoConsole(_In_ const PseudoConsole* const pPty);
 HRESULT _ShowHidePseudoConsole(_In_ const PseudoConsole* const pPty, const bool show);
 HRESULT _ReparentPseudoConsole(_In_ const PseudoConsole* const pPty, _In_ const HWND newParent);
-void _ClosePseudoConsoleMembers(_In_ PseudoConsole* pPty, _In_ DWORD dwMilliseconds);
+void _ClosePseudoConsoleMembers(_In_ PseudoConsole* pPty);
 
 HRESULT WINAPI ConptyCreatePseudoConsoleAsUser(_In_ HANDLE hToken,
                                                _In_ COORD size,


### PR DESCRIPTION
This removes `ClosePseudoConsoleTimeout` as waiting for conhost
to exit is prone to deadlocks due to incorrect API usage.
Additionally, this publicly exposes `ReleasePseudoConsole`.