### PR TITLE
Fix session persistence when the session ends

### DIFF
--- a/src/cascadia/Remoting/Monarch.cpp
+++ b/src/cascadia/Remoting/Monarch.cpp
@@ -165,12 +165,6 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
             {
                 peasantSearch->second.Quit();
             }
-            else
-            {
-                // Somehow we don't have our own peasant, this should never happen.
-                // We are trying to quit anyways so just fail here.
-                assert(peasantSearch != _peasants.end());
-            }
         }
     }
 

--- a/src/cascadia/Remoting/Monarch.cpp
+++ b/src/cascadia/Remoting/Monarch.cpp
@@ -96,7 +96,6 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
 
             peasant.ShowNotificationIconRequested([this](auto&&, auto&&) { ShowNotificationIconRequested.raise(*this, nullptr); });
             peasant.HideNotificationIconRequested([this](auto&&, auto&&) { HideNotificationIconRequested.raise(*this, nullptr); });
-            peasant.QuitAllRequested({ this, &Monarch::_handleQuitAll });
 
             {
                 std::unique_lock lock{ _peasantsMutex };
@@ -134,7 +133,7 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
     // - <none> used
     // Return Value:
     // - <none>
-    void Monarch::_handleQuitAll(const winrt::Windows::Foundation::IInspectable& /*sender*/, const winrt::Windows::Foundation::IInspectable& /*args*/)
+    void Monarch::QuitAll()
     {
         if (_quitting.exchange(true, std::memory_order_relaxed))
         {

--- a/src/cascadia/Remoting/Monarch.h
+++ b/src/cascadia/Remoting/Monarch.h
@@ -86,6 +86,7 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
 
         uint64_t AddPeasant(winrt::Microsoft::Terminal::Remoting::IPeasant peasant);
         void SignalClose(const uint64_t peasantId);
+        void QuitAll();
 
         uint64_t GetNumberOfPeasants();
 

--- a/src/cascadia/Remoting/Monarch.idl
+++ b/src/cascadia/Remoting/Monarch.idl
@@ -63,6 +63,7 @@ namespace Microsoft.Terminal.Remoting
         void HandleActivatePeasant(WindowActivatedArgs args);
         void SummonWindow(SummonWindowSelectionArgs args);
         void SignalClose(UInt64 peasantId);
+        void QuitAll();
 
         void SummonAllWindows();
         Boolean DoesQuakeWindowExist();

--- a/src/cascadia/Remoting/Peasant.cpp
+++ b/src/cascadia/Remoting/Peasant.cpp
@@ -260,22 +260,6 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                           TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 
-    void Peasant::RequestQuitAll()
-    {
-        try
-        {
-            QuitAllRequested.raise(*this, nullptr);
-        }
-        catch (...)
-        {
-            LOG_CAUGHT_EXCEPTION();
-        }
-        TraceLoggingWrite(g_hRemotingProvider,
-                          "Peasant_RequestQuit",
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
-    }
-
     void Peasant::AttachContentToWindow(Remoting::AttachRequest request)
     {
         try

--- a/src/cascadia/Remoting/Peasant.h
+++ b/src/cascadia/Remoting/Peasant.h
@@ -56,7 +56,6 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
         void RequestRename(const winrt::Microsoft::Terminal::Remoting::RenameRequestArgs& args);
         void RequestShowNotificationIcon();
         void RequestHideNotificationIcon();
-        void RequestQuitAll();
         void Quit();
 
         void AttachContentToWindow(Remoting::AttachRequest request);
@@ -76,7 +75,6 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
 
         til::typed_event<> ShowNotificationIconRequested;
         til::typed_event<> HideNotificationIconRequested;
-        til::typed_event<> QuitAllRequested;
         til::typed_event<> QuitRequested;
 
         til::typed_event<winrt::Windows::Foundation::IInspectable, winrt::Microsoft::Terminal::Remoting::AttachRequest> AttachRequested;

--- a/src/cascadia/Remoting/Peasant.idl
+++ b/src/cascadia/Remoting/Peasant.idl
@@ -80,7 +80,6 @@ namespace Microsoft.Terminal.Remoting
 
         void RequestShowNotificationIcon();
         void RequestHideNotificationIcon();
-        void RequestQuitAll();
         void Quit();
 
         void AttachContentToWindow(AttachRequest request);
@@ -95,7 +94,6 @@ namespace Microsoft.Terminal.Remoting
 
         event Windows.Foundation.TypedEventHandler<Object, Object> ShowNotificationIconRequested;
         event Windows.Foundation.TypedEventHandler<Object, Object> HideNotificationIconRequested;
-        event Windows.Foundation.TypedEventHandler<Object, Object> QuitAllRequested;
         event Windows.Foundation.TypedEventHandler<Object, Object> QuitRequested;
 
         event Windows.Foundation.TypedEventHandler<Object, AttachRequest> AttachRequested;

--- a/src/cascadia/Remoting/WindowManager.cpp
+++ b/src/cascadia/Remoting/WindowManager.cpp
@@ -375,6 +375,18 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
         WindowClosed.raise(s, e);
     }
 
+    void WindowManager::QuitAll()
+    {
+        if (_monarch)
+        {
+            try
+            {
+                _monarch.QuitAll();
+            }
+            CATCH_LOG()
+        }
+    }
+
     void WindowManager::SignalClose(const Remoting::Peasant& peasant)
     {
         if (_monarch)

--- a/src/cascadia/Remoting/WindowManager.h
+++ b/src/cascadia/Remoting/WindowManager.h
@@ -32,6 +32,7 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
         Remoting::Peasant CreatePeasant(const Remoting::WindowRequestedArgs& args);
 
         void SignalClose(const Remoting::Peasant& peasant);
+        void QuitAll();
         void SummonWindow(const Remoting::SummonWindowSelectionArgs& args);
         void SummonAllWindows();
         Windows::Foundation::Collections::IVectorView<winrt::Microsoft::Terminal::Remoting::PeasantInfo> GetPeasantInfos();

--- a/src/cascadia/Remoting/WindowManager.idl
+++ b/src/cascadia/Remoting/WindowManager.idl
@@ -12,6 +12,7 @@ namespace Microsoft.Terminal.Remoting
         Peasant CreatePeasant(WindowRequestedArgs args);
 
         void SignalClose(Peasant p);
+        void QuitAll();
 
         void UpdateActiveTabTitle(String title, Peasant p);
 

--- a/src/cascadia/UnitTests_Remoting/RemotingTests.cpp
+++ b/src/cascadia/UnitTests_Remoting/RemotingTests.cpp
@@ -82,7 +82,6 @@ namespace RemotingUnitTests
         void Summon(const Remoting::SummonWindowBehavior& /*args*/) DIE;
         void RequestShowNotificationIcon() DIE;
         void RequestHideNotificationIcon() DIE;
-        void RequestQuitAll() DIE;
         void Quit() DIE;
         void AttachContentToWindow(Remoting::AttachRequest) DIE;
         void SendContent(winrt::Microsoft::Terminal::Remoting::RequestReceiveContentArgs) DIE;
@@ -94,7 +93,6 @@ namespace RemotingUnitTests
         til::typed_event<winrt::Windows::Foundation::IInspectable, Remoting::SummonWindowBehavior> SummonRequested;
         til::typed_event<> ShowNotificationIconRequested;
         til::typed_event<> HideNotificationIconRequested;
-        til::typed_event<> QuitAllRequested;
         til::typed_event<> QuitRequested;
         til::typed_event<winrt::Windows::Foundation::IInspectable, winrt::Microsoft::Terminal::Remoting::AttachRequest> AttachRequested;
         til::typed_event<winrt::Windows::Foundation::IInspectable, winrt::Microsoft::Terminal::Remoting::RequestReceiveContentArgs> SendContentRequested;

--- a/src/cascadia/UnitTests_Remoting/RemotingTests.cpp
+++ b/src/cascadia/UnitTests_Remoting/RemotingTests.cpp
@@ -109,6 +109,7 @@ namespace RemotingUnitTests
         void HandleActivatePeasant(Remoting::WindowActivatedArgs /*args*/) DIE;
         void SummonWindow(Remoting::SummonWindowSelectionArgs /*args*/) DIE;
         void SignalClose(uint64_t /*peasantId*/) DIE;
+        void QuitAll() DIE;
 
         void SummonAllWindows() DIE;
         bool DoesQuakeWindowExist() DIE;

--- a/src/cascadia/WindowsTerminal/AppHost.h
+++ b/src/cascadia/WindowsTerminal/AppHost.h
@@ -123,8 +123,8 @@ private:
     void _SystemMenuChangeRequested(const winrt::Windows::Foundation::IInspectable& sender,
                                     const winrt::TerminalApp::SystemMenuChangeArgs& args);
 
-    winrt::fire_and_forget _QuitRequested(const winrt::Windows::Foundation::IInspectable& sender,
-                                          const winrt::Windows::Foundation::IInspectable& args);
+    void _QuitRequested(const winrt::Windows::Foundation::IInspectable& sender,
+                        const winrt::Windows::Foundation::IInspectable& args);
 
     void _RequestQuitAll(const winrt::Windows::Foundation::IInspectable& sender,
                          const winrt::Windows::Foundation::IInspectable& args);


### PR DESCRIPTION
Once all applications that have received a `WM_ENDSESSION` message
have returned from processing said message, windows will terminate
all processes. This forces us to process the message synchronously.
This meant that this issue was timing dependent. If Windows Terminal
was quick at persisting buffers and you had some other application that
was slow to shut down (e.g. Steam), you would never see this issue.

Closes #17179
Closes #17250

## Validation Steps Performed
* Set up a lean Hyper-V VM for fast reboots
* `Set-VMComPort <vm> 1 \\.pipe\\<pipe>`
* Hook up WIL to write to COM1
* Add a ton of debug prints all over the place
* Read COM output with Putty for hours
* RTFM, and notice that the `WM_ENDSESSION` documentation states
  "the session can end any time after all applications
  have returned from processing this message"
* Be very very sad ✅
* Fix it
* Rebooting now shows on COM1 that persistence runs ✅
* Windows get restored after reboot ✅