### PR TITLE
Add elipses back in to some command names

### DIFF
--- a/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
@@ -118,13 +118,13 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="SetColorSchemeParentCommandName" xml:space="preserve">
-    <value>Select color scheme</value>
+    <value>Select color scheme...</value>
   </data>
   <data name="NewTabParentCommandName" xml:space="preserve">
-    <value>New tab</value>
+    <value>New tab...</value>
   </data>
   <data name="SplitPaneParentCommandName" xml:space="preserve">
-    <value>Split pane</value>
+    <value>Split pane...</value>
   </data>
   <data name="SnippetsPaneCommandName" xml:space="preserve">
     <value>Open snippets pane</value>
@@ -329,7 +329,7 @@
     <comment>{Locked="JSON"}. "JSON" is the extension of the file that will be opened.</comment>
   </data>
   <data name="OpenTabColorPickerCommandKey" xml:space="preserve">
-    <value>Set the tab color</value>
+    <value>Set the tab color...</value>
   </data>
   <data name="PasteTextCommandKey" xml:space="preserve">
     <value>Paste</value>
@@ -351,7 +351,7 @@
     <value>Reset tab title</value>
   </data>
   <data name="OpenTabRenamerCommandKey" xml:space="preserve">
-    <value>Rename tab title</value>
+    <value>Rename tab title...</value>
   </data>
   <data name="ResizePaneCommandKey" xml:space="preserve">
     <value>Resize pane</value>
@@ -445,7 +445,7 @@
     <value>Switch to the last tab</value>
   </data>
   <data name="TabSearchCommandKey" xml:space="preserve">
-    <value>Search for tab</value>
+    <value>Search for tab...</value>
   </data>
   <data name="ToggleAlwaysOnTopCommandKey" xml:space="preserve">
     <value>Toggle always on top mode</value>
@@ -454,10 +454,10 @@
     <value>Toggle command palette</value>
   </data>
   <data name="SuggestionsCommandHistoryCommandKey" xml:space="preserve">
-    <value>Recent commands</value>
+    <value>Recent commands...</value>
   </data>
   <data name="SuggestionsCommandKey" xml:space="preserve">
-    <value>Open suggestions</value>
+    <value>Open suggestions...</value>
   </data>
   <data name="ToggleCommandPaletteCommandLineModeCommandKey" xml:space="preserve">
     <value>Toggle command palette in command line mode</value>
@@ -509,7 +509,7 @@
     <value>Break into the debugger</value>
   </data>
   <data name="OpenSettingsUICommandKey" xml:space="preserve">
-    <value>Open settings</value>
+    <value>Open settings...</value>
   </data>
   <data name="RenameWindowCommandKey" xml:space="preserve">
     <value>Rename window to "{0}"</value>
@@ -519,7 +519,7 @@
     <value>Reset window name</value>
   </data>
   <data name="OpenWindowRenamerCommandKey" xml:space="preserve">
-    <value>Rename window</value>
+    <value>Rename window...</value>
   </data>
   <data name="DisplayWorkingDirectoryCommandKey" xml:space="preserve">
     <value>Display Terminal's current working directory</value>
@@ -570,7 +570,7 @@
     <value>Quit the Terminal</value>
   </data>
   <data name="SetOpacityParentCommandName" xml:space="preserve">
-    <value>Set background opacity</value>
+    <value>Set background opacity...</value>
   </data>
   <data name="IncreaseOpacityCommandKey" xml:space="preserve">
     <value>Increase background opacity by {0}%</value>


### PR DESCRIPTION
In #16886, the key for the nested action got renamed from `Split Pane...` to `Split pane`. This accidentally caused a collision because now there's two actions with the same name! The settings model then prefers the user's action over the one defined in defaults.json, thus completely hiding the nested version.

To fix this, we're just adding the `...` back in. There's two cases here:
- Nested commands
   - impacted keys: `SetColorSchemeParentCommandName`, `NewTabParentCommandName`, `SplitPaneParentCommandName`, `SetOpacityParentCommandName`
   - The problematic ones are `NewTabParentCommandName` and `SplitPaneParentCommandName` because they now have the same name as the default `newTab` and `splitPane` actions. Really, we just need to add `...` back into those. According to #16846, we should remove `...` from all of them because it's redundant with the `>` in the command palette. However, I added the `...` to all of these for consistency with nested items.
- Actions that move us to another control
   - impacted keys: `OpenTabColorPickerCommandKey`, `OpenTabRenamerCommandKey`, `TabSearchCommandKey`, `SuggestionsCommandHistoryCommandKey`, `SuggestionsCommandKey`, `OpenSettingsUICommandKey`, `OpenWindowRenamerCommandKey`, `SetOpacityParentCommandName`
   - These aren't a problem (in the same way as the above, at least). However, they all result in the focus moving into a completely different control. I'm adding them back in because that seems to be the right move. #16846 mentions the `...` in menu items

🚨(HOLD ON, as I'm reading through the original issue, I found more detailed descriptions, so I'm gonna update this appropriately then take it out of draft)

Side effect of #16886 which closed #16846
Closes #17294, #17684