### PR TITLE
Log action dispatch occurrence

### DIFF
--- a/src/cascadia/TerminalApp/ShortcutActionDispatch.cpp
+++ b/src/cascadia/TerminalApp/ShortcutActionDispatch.cpp
@@ -19,20 +19,6 @@ using namespace winrt::TerminalApp;
 
 namespace winrt::TerminalApp::implementation
 {
-    std::wstring ExtractAction(const ActionAndArgs& actionAndArgs)
-    {
-        // Formatted as "User.{action}" or "User.{action}.{hash}"
-        const auto id = actionAndArgs.GenerateID();
-        std::wstring_view remaining{ id };
-
-        // Throw away "User."
-        std::ignore = til::prefix_split(remaining, L'.');
-
-        // Get the "{action}" part
-        const auto actionName = til::prefix_split(remaining, L'.');
-        return std::wstring{ actionName };
-    }
-
     // Method Description:
     // - Dispatch the appropriate event for the given ActionAndArgs. Constructs
     //   an ActionEventArgs to hold the IActionArgs payload for the event, and
@@ -71,7 +57,7 @@ namespace winrt::TerminalApp::implementation
                 g_hTerminalAppProvider,
                 "ActionDispatched",
                 TraceLoggingDescription("Event emitted when an action was successfully performed"),
-                TraceLoggingValue(ExtractAction(actionAndArgs).data(), "Action"),
+                TraceLoggingValue(static_cast<int>(actionAndArgs.Action()), "Action"),
                 TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
                 TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
         }

--- a/src/cascadia/TerminalApp/ShortcutActionDispatch.cpp
+++ b/src/cascadia/TerminalApp/ShortcutActionDispatch.cpp
@@ -21,23 +21,15 @@ namespace winrt::TerminalApp::implementation
 {
     std::wstring ExtractAction(const ActionAndArgs& actionAndArgs)
     {
-        std::wstring id{ actionAndArgs.GenerateID() };
-        const auto segment1 = id.find(L'.');
-        const auto segment2 = id.find(L'.', segment1 + 1);
-        if (segment1 != std::wstring::npos)
-        {
-            if (segment2 != std::wstring::npos)
-            {
-                return id.substr(segment1 + 1, segment2 - segment1 - 1);
-            }
-            else
-            {
-                return id.substr(segment1 + 1);
-            }
-        }
-        // This shouldn't be possible.
-        // GenerateID() returns L"User.{}" unless it's invalid
-        return nullptr;
+        // Formatted as "User.{action}" or "User.{action}.{hash}"
+        std::wstring_view remaining{ actionAndArgs.GenerateID() };
+
+        // Throw away "User."
+        std::ignore = til::prefix_split(remaining, L'.');
+
+        // Get the "{action}" part
+        const auto actionName = til::prefix_split(remaining, L'.');
+        return std::wstring{ actionName };
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/ShortcutActionDispatch.cpp
+++ b/src/cascadia/TerminalApp/ShortcutActionDispatch.cpp
@@ -22,7 +22,8 @@ namespace winrt::TerminalApp::implementation
     std::wstring ExtractAction(const ActionAndArgs& actionAndArgs)
     {
         // Formatted as "User.{action}" or "User.{action}.{hash}"
-        std::wstring_view remaining{ actionAndArgs.GenerateID() };
+        const auto id = actionAndArgs.GenerateID();
+        std::wstring_view remaining{ id };
 
         // Throw away "User."
         std::ignore = til::prefix_split(remaining, L'.');

--- a/src/cascadia/TerminalSettingsModel/Command.idl
+++ b/src/cascadia/TerminalSettingsModel/Command.idl
@@ -30,8 +30,6 @@ namespace Microsoft.Terminal.Settings.Model
 
         IActionArgs Args;
         ShortcutAction Action;
-
-        String GenerateID();
     };
 
     [default_interface] runtimeclass Command : ISettingsModelObject

--- a/src/cascadia/TerminalSettingsModel/Command.idl
+++ b/src/cascadia/TerminalSettingsModel/Command.idl
@@ -30,6 +30,8 @@ namespace Microsoft.Terminal.Settings.Model
 
         IActionArgs Args;
         ShortcutAction Action;
+
+        String GenerateID();
     };
 
     [default_interface] runtimeclass Command : ISettingsModelObject


### PR DESCRIPTION
Some simple logic to report whenever an action has successfully occurred (and what ShortcutAction was used).

Note, there will be some false positives here from startup. I noticed we get a `newTab` on launch. This is probably a result of restoring the window layout of the previous session since we're using ActionAndArgs for that.