### PR TITLE
Fix misalignment of Sixel image slices

### DIFF
--- a/src/buffer/out/ImageSlice.cpp
+++ b/src/buffer/out/ImageSlice.cpp
@@ -65,7 +65,6 @@ RGBQUAD* ImageSlice::MutablePixels(const til::CoordType columnBegin, const til::
         _columnBegin = existingData ? std::min(_columnBegin, columnBegin) : columnBegin;
         _columnEnd = existingData ? std::max(_columnEnd, columnEnd) : columnEnd;
         _pixelWidth = (_columnEnd - _columnBegin) * _cellSize.width;
-        _pixelWidth = (_pixelWidth + 3) & ~3; // Renderer needs this as a multiple of 4
         const auto bufferSize = _pixelWidth * _cellSize.height;
         if (existingData)
         {

--- a/src/renderer/gdi/paint.cpp
+++ b/src/renderer/gdi/paint.cpp
@@ -685,7 +685,7 @@ try
     const auto srcWidth = imageSlice.PixelWidth();
     const auto srcHeight = srcCellSize.height;
     const auto dstWidth = srcWidth * dstCellSize.width / srcCellSize.width;
-    const auto dstHeight = srcHeight * dstCellSize.height / srcCellSize.height;
+    const auto dstHeight = dstCellSize.height;
     const auto x = (imageSlice.ColumnOffset() - viewportLeft) * dstCellSize.width;
     const auto y = targetRow * dstCellSize.height;
 


### PR DESCRIPTION
## Summary of the Pull Request

When we have a series of image slices of differing widths, which also
don't align with the cell boundaries, we can get rounding errors in the
scaling which makes the different slices appear misaligned.

This PR fixes the issue by removing the 4 pixel width alignment that was
enforced in the `ImageSlice` class, since that's not actually necessary
when the pixels themselves are already 4 bytes in size. And without
that, the widths should be correctly aligned with the cell boundaries.

## References and Relevant Issues

The initial Sixel implementation was added in PR #17421.

## Validation Steps Performed

I've confirmed that this fixes the rendering glitches reported in
#17711, and all my existing Sixel tests still work as expected.

## PR Checklist
- [x] Closes #17711
