### PR TITLE
pdp: add quick release notes to the store pages

### DIFF
--- a/build/StoreSubmission/Preview/PDPs/en-US/PDP.xml
+++ b/build/StoreSubmission/Preview/PDPs/en-US/PDP.xml
@@ -56,6 +56,13 @@ This is an open source project and we welcome community participation. To partic
   <ReleaseNotes _locID="App_ReleaseNotes">
     <!-- _locComment_text="{MaxLength=1500} {Locked=__VERSION_NUMBER__} App Release Note" -->Version __VERSION_NUMBER__
 
+- We've rewritten how console applications are hosted inside Terminal! Please report any bugs you encounter.
+- Terminal now supports Sixels!
+- You can now open a docked panel containing snippets of commands you have saved to use later
+- Command Prompt users on the latest Windows 11 release may see a "quick tip" icon that suggests installable software from WinGet
+- Selected text will now be much more visible (and customizable!)
+- A number of reliabilty bugs, convenience issues and annoyances have been fixed.
+
 Please see our GitHub releases page for additional details.
   </ReleaseNotes>
   <ScreenshotCaptions>

--- a/build/StoreSubmission/Stable/PDPs/en-US/PDP.xml
+++ b/build/StoreSubmission/Stable/PDPs/en-US/PDP.xml
@@ -56,6 +56,13 @@ This is an open source project and we welcome community participation. To partic
   <ReleaseNotes _locID="App_ReleaseNotes">
     <!-- _locComment_text="{MaxLength=1500} {Locked=__VERSION_NUMBER__} App Release Note" -->Version __VERSION_NUMBER__
 
+- Terminal will now remember the contents of the window when you use session restoration.
+- You can now use multiple fonts at the same time.
+- Box-drawing characters are now rendered with pixel perfection.
+- The experience of using an IME inside Terminal has been significantly improved.
+- The color schemes inside your JSON file will now be much simpler.
+- A number of bugs around URL handling, double-width rows, line wrapping, and more have been fixed.
+
 Please see our GitHub releases page for additional details.
   </ReleaseNotes>
   <ScreenshotCaptions>


### PR DESCRIPTION
Now that the store displays changelogs, it seems unfair for us to not put something in here.

These are intended to give a rough idea, not to be perfect, as they are not the product of my hours of changelog writing (since I am lazy and put that off until the day of release 🫣)