### PR TITLE
Fix a crash when disabling the ASB

### DIFF
--- a/src/host/_stream.cpp
+++ b/src/host/_stream.cpp
@@ -336,6 +336,9 @@ void WriteCharsVT(SCREEN_INFORMATION& screenInfo, const std::wstring_view& str)
 {
     auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
     auto& stateMachine = screenInfo.GetStateMachine();
+    // If the given screenInfo is the alternate screen buffer, disabling the alternate screen buffer in this
+    // VT payload will cause the pointer to be invalidated. We thus need to get all the information we need now.
+    const auto disableNewlineTranslation = WI_IsFlagSet(screenInfo.OutputMode, DISABLE_NEWLINE_AUTO_RETURN);
     // When switch between the main and alt-buffer SCREEN_INFORMATION::GetActiveBuffer()
     // may change, so get the VtIo reference now, just in case.
     auto writer = gci.GetVtWriterForBuffer(&screenInfo);
@@ -350,7 +353,7 @@ void WriteCharsVT(SCREEN_INFORMATION& screenInfo, const std::wstring_view& str)
         // DISABLE_NEWLINE_AUTO_RETURN not being set is equivalent to a LF -> CRLF translation.
         const auto write = [&](size_t beg, size_t end) {
             const auto chunk = til::safe_slice_abs(str, beg, end);
-            if (WI_IsFlagSet(screenInfo.OutputMode, DISABLE_NEWLINE_AUTO_RETURN))
+            if (disableNewlineTranslation)
             {
                 writer.WriteUTF16(chunk);
             }


### PR DESCRIPTION
`ProcessString` may delete the ASB and cause a dangling screen info
pointer. As such, we must avoid using the pointer after the call.

Closes #17709

## Validation Steps Performed
I couldn't repro the issue.