### PR TITLE
Fix a crash during settings update

### DIFF
--- a/src/cascadia/TerminalApp/TerminalWindow.cpp
+++ b/src/cascadia/TerminalApp/TerminalWindow.cpp
@@ -767,13 +767,22 @@ namespace winrt::TerminalApp::implementation
     // definitely not on OUR UI thread.
     winrt::fire_and_forget TerminalWindow::UpdateSettings(winrt::TerminalApp::SettingsLoadEventArgs args)
     {
-        _settings = args.NewSettings();
+        // GH#17620: We have a bug somewhere where a window doesn't get unregistered from the window list.
+        // This causes UpdateSettings calls where the thread dispatcher is already null.
+        const auto dispatcher = _root->Dispatcher();
+        if (!dispatcher)
+        {
+            co_return;
+        }
 
         const auto weakThis{ get_weak() };
-        co_await wil::resume_foreground(_root->Dispatcher());
+        co_await wil::resume_foreground(dispatcher);
+
         // Back on our UI thread...
         if (auto logic{ weakThis.get() })
         {
+            _settings = args.NewSettings();
+
             // Update the settings in TerminalPage
             // We're on our UI thread right now, so this is safe
             _root->SetSettings(_settings, true);


### PR DESCRIPTION
* Adds a check whether the thread dispatcher is already null.
  (See code comments.)
* Moves the `_settings` to only happen on the UI thread.
  Anything else wouldn't be thread safe.

Closes #17620

## Validation Steps Performed
Not reproducible. 🚫