### PR TITLE
`x-save` the commandline in the current window

### DIFF
--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -1020,10 +1020,21 @@ void AppCommandlineArgs::ValidateStartupCommands()
     // handoff connection from the operating system.
     if (!_isHandoffListener)
     {
+        // If we only have a single x-save command, then set our target to the
+        // current terminal window. This will prevent us from spawning a new
+        // window just to save the commandline.
+        if (_startupActions.size() == 1 &&
+            _startupActions.front().Action() == ShortcutAction::SaveSnippet &&
+            _windowTarget.empty())
+        {
+            _windowTarget = "0";
+        }
         // If we parsed no commands, or the first command we've parsed is not a new
         // tab action, prepend a new-tab command to the front of the list.
-        if (_startupActions.empty() ||
-            _startupActions.front().Action() != ShortcutAction::NewTab)
+        // (also, we don't need to do this if the only action is a x-save)
+        else if (_startupActions.empty() ||
+                 (_startupActions.front().Action() != ShortcutAction::NewTab &&
+                  _startupActions.front().Action() != ShortcutAction::SaveSnippet))
         {
             // Build the NewTab action from the values we've parsed on the commandline.
             NewTerminalArgs newTerminalArgs{};

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -550,6 +550,10 @@ namespace winrt::TerminalApp::implementation
                 return winrt::make<FindTargetWindowResult>(WindowingBehaviorUseNone);
             }
 
+            // Validate the args now. This will make sure that in the case of a
+            // single x-save command, we toss that commandline to the current
+            // terminal window
+            appArgs.ValidateStartupCommands();
             const std::string parsedTarget{ appArgs.GetTargetWindow() };
 
             // If the user did not provide any value on the commandline,


### PR DESCRIPTION
By manually setting the `_windowTarget` to `0`, we can make sure to toss `x-save` commandlines at the current terminal window (so long as there is one).

Edge cases:
* You passed other subcommands with `x-save`: Well, we'll do whatever we would have normally done for multiple subcommands. We won't `x-save` in the current window, we'll obey your settings. That seems to make sense
* You ran `wt x-save` without an open Terminal window: We'll open a terminal window during the process of handling it. That seems sensible.

Closes #17366
