### PR TITLE
Set the default for `autoMarkPrompts` to `true`

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2855,7 +2855,7 @@
           }
         },
         "autoMarkPrompts": {
-          "default": false,
+          "default": true,
           "description": "When set to true, prompts will automatically be marked.",
           "type": "boolean"
         },

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -95,7 +95,7 @@ Author(s):
     X(bool, RightClickContextMenu, "experimental.rightClickContextMenu", false)                                                                                \
     X(Windows::Foundation::Collections::IVector<winrt::hstring>, BellSound, "bellSound", nullptr)                                                              \
     X(bool, Elevate, "elevate", false)                                                                                                                         \
-    X(bool, AutoMarkPrompts, "autoMarkPrompts", false)                                                                                                         \
+    X(bool, AutoMarkPrompts, "autoMarkPrompts", true)                                                                                                          \
     X(bool, ShowMarks, "showMarksOnScrollbar", false)                                                                                                          \
     X(bool, RepositionCursorWithMouse, "experimental.repositionCursorWithMouse", false)                                                                        \
     X(bool, ReloadEnvironmentVariables, "compatibility.reloadEnvironmentVariables", true)                                                                      \


### PR DESCRIPTION
As we discussed in bug bash.

There's really no downside to us enabling it by default (and leaving showMarksOnScrollbar: false). It'll mark lines as "prompts" when the user hits enter. This will have a couple good side effects:
* When folks have right-aligned prompts (like, from oh-my-posh), the `enter` will terminate where shell integration thinks the command is, so that the right-prompt doesn't end up in the commandline history
* the scrollToMark actions will Just Work without any other shell integration

Closes #17632
