### PR TITLE
Fix overwrite key binding warning in the SUI

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/ActionsViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ActionsViewModel.cpp
@@ -278,9 +278,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // Check for this special case:
         //  we're changing the key chord,
         //  but the new key chord is already in use
+        const auto& conflictingCmd{ _Settings.ActionMap().GetActionByKeyChord(args.NewKeys()) };
         if (isNewAction || args.OldKeys().Modifiers() != args.NewKeys().Modifiers() || args.OldKeys().Vkey() != args.NewKeys().Vkey())
         {
-            const auto& conflictingCmd{ _Settings.ActionMap().GetActionByKeyChord(args.NewKeys()) };
             if (conflictingCmd)
             {
                 // We're about to overwrite another key chord.
@@ -324,13 +324,18 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             }
         }
 
-        // update settings model and view model
-        applyChangesToSettingsModel();
+        // if there was a conflictingCmd, the flyout we created will handle whether changes need to be propagated
+        // otherwise, go ahead and apply the changes
+        if (!conflictingCmd)
+        {
+            // update settings model and view model
+            applyChangesToSettingsModel();
 
-        // We NEED to toggle the edit mode here,
-        // so that if nothing changed, we still exit
-        // edit mode.
-        senderVM.ToggleEditMode();
+            // We NEED to toggle the edit mode here,
+            // so that if nothing changed, we still exit
+            // edit mode.
+            senderVM.ToggleEditMode();
+        }
     }
 
     void ActionsViewModel::_KeyBindingViewModelDeleteNewlyAddedKeyBindingHandler(const Editor::KeyBindingViewModel& senderVM, const IInspectable& /*args*/)

--- a/src/cascadia/TerminalSettingsEditor/ActionsViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ActionsViewModel.cpp
@@ -278,11 +278,13 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // Check for this special case:
         //  we're changing the key chord,
         //  but the new key chord is already in use
-        const auto& conflictingCmd{ _Settings.ActionMap().GetActionByKeyChord(args.NewKeys()) };
+        bool conflictFound{ false };
         if (isNewAction || args.OldKeys().Modifiers() != args.NewKeys().Modifiers() || args.OldKeys().Vkey() != args.NewKeys().Vkey())
         {
+            const auto& conflictingCmd{ _Settings.ActionMap().GetActionByKeyChord(args.NewKeys()) };
             if (conflictingCmd)
             {
+                conflictFound = true;
                 // We're about to overwrite another key chord.
                 // Display a confirmation dialog.
                 TextBlock errorMessageTB{};
@@ -324,9 +326,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             }
         }
 
-        // if there was a conflictingCmd, the flyout we created will handle whether changes need to be propagated
+        // if there was a conflict, the flyout we created will handle whether changes need to be propagated
         // otherwise, go ahead and apply the changes
-        if (!conflictingCmd)
+        if (!conflictFound)
         {
             // update settings model and view model
             applyChangesToSettingsModel();


### PR DESCRIPTION
## Summary of the Pull Request
Fixes a regression from the actions MVVM change in #14292 - attempting to overwrite a keybinding was displaying a warning but propagating the change before the user acknowledged it.

## Validation Steps Performed
The overwrite key binding warning in the SUI works like before

## PR Checklist
- [x] Closes #17754 
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
