### PR TITLE
Disable PGO for Release builds

### DIFF
--- a/build/pipelines/ob-release.yml
+++ b/build/pipelines/ob-release.yml
@@ -27,7 +27,7 @@ parameters:
   - name: pgoBuildMode
     displayName: "PGO Build Mode"
     type: string
-    default: Optimize
+    default: None # BODGY - OneBranch is on VS 17.10, which is known to be the worst
     values:
       - Optimize
       - Instrument


### PR DESCRIPTION
Same justification as #17749.

We will revert this when either OneBranch Custom Pools become fit-for-purpose or they upgrade to VS 17.11. Or the heat death of the universe.