### PR TITLE
Guard Control UpdateAppearance/Settings against UAF

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -717,11 +717,14 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // terminal.
         co_await wil::resume_foreground(Dispatcher());
 
-        _core.UpdateSettings(settings, unfocusedAppearance);
+        if (auto strongThis{ weakThis.get() })
+        {
+            _core.UpdateSettings(settings, unfocusedAppearance);
 
-        _UpdateSettingsFromUIThread();
+            _UpdateSettingsFromUIThread();
 
-        _UpdateAppearanceFromUIThread(_focused ? _core.FocusedAppearance() : _core.UnfocusedAppearance());
+            _UpdateAppearanceFromUIThread(_focused ? _core.FocusedAppearance() : _core.UnfocusedAppearance());
+        }
     }
 
     // Method Description:
@@ -730,10 +733,15 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - newAppearance: the new appearance to set
     winrt::fire_and_forget TermControl::UpdateAppearance(IControlAppearance newAppearance)
     {
+        auto weakThis{ get_weak() };
+
         // Dispatch a call to the UI thread
         co_await wil::resume_foreground(Dispatcher());
 
-        _UpdateAppearanceFromUIThread(newAppearance);
+        if (auto strongThis{ weakThis.get() })
+        {
+            _UpdateAppearanceFromUIThread(newAppearance);
+        }
     }
 
     // Method Description:


### PR DESCRIPTION
When you close a window, it naturally loses focus.

We were trying to use members of the control to update its appearance on focus loss after it got torn down.

Closes #17520 