### PR TITLE
During Alt+Numpad composition, stash keys in case we bail out

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -256,13 +256,20 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         };
         struct AltNumpadState
         {
+            struct CachedKey
+            {
+                WORD vkey;
+                WORD scanCode;
+                ::Microsoft::Terminal::Core::ControlKeyStates modifiers;
+                bool keyDown;
+            };
             AltNumpadEncoding encoding = AltNumpadEncoding::OEM;
             uint32_t accumulator = 0;
             // Checking for accumulator != 0 to see if we have an ongoing Alt+Numpad composition is insufficient.
             // The state can be active, while the accumulator is 0, if the user pressed Alt+Numpad0 which enabled
             // the OEM encoding mode (= active), and then pressed Numpad0 again (= accumulator is still 0).
             bool active = false;
-            til::small_vector<std::tuple<WORD, WORD, ::Microsoft::Terminal::Core::ControlKeyStates, bool>, 4> cachedKeyEvents;
+            til::small_vector<CachedKey, 4> cachedKeyEvents;
         };
         AltNumpadState _altNumpadState;
 

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -262,6 +262,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             // The state can be active, while the accumulator is 0, if the user pressed Alt+Numpad0 which enabled
             // the OEM encoding mode (= active), and then pressed Numpad0 again (= accumulator is still 0).
             bool active = false;
+            til::small_vector<std::tuple<WORD, WORD, ::Microsoft::Terminal::Core::ControlKeyStates, bool>, 4> cachedKeyEvents;
         };
         AltNumpadState _altNumpadState;
 


### PR DESCRIPTION
We were erroneously eating Alt followed by VK_ADD. This change makes sure we cache key presses and releases that happen once a numpad composition is active so that we can send them when you release Alt.

Right now, we only send them when you release Alt after composing Alt and VK_ADD (entering hex mode) and only if you haven't inserted an actual hex numpad code. This does mean that `Alt VK_ADD 0 0 H I` will result in an input of "+hi". That... seems like a small price to pay for Alt VK_ADD working again.

Closes #17762