### PR TITLE
Restore off-the-top behavior for VT mouse mode

### DIFF
--- a/src/cascadia/TerminalControl/ControlInteractivity.cpp
+++ b/src/cascadia/TerminalControl/ControlInteractivity.cpp
@@ -685,13 +685,10 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                                                      const SHORT wheelDelta,
                                                      Control::MouseButtonState buttonState)
     {
-        const auto adjustment = _core->ScrollOffset() > 0 ? _core->BufferHeight() - _core->ScrollOffset() - _core->ViewHeight() : 0;
-        // If the click happened outside the active region, just don't send any mouse event
-        if (const auto adjustedY = terminalPosition.y - adjustment; adjustedY >= 0)
-        {
-            return _core->SendMouseEvent({ terminalPosition.x, adjustedY }, pointerUpdateKind, modifiers, wheelDelta, toInternalMouseState(buttonState));
-        }
-        return false;
+        const auto adjustment = _core->BufferHeight() - _core->ScrollOffset() - _core->ViewHeight();
+        // If the click happened outside the active region, core should get a chance to filter it out or clamp it.
+        const auto adjustedY = terminalPosition.y - adjustment;
+        return _core->SendMouseEvent({ terminalPosition.x, adjustedY }, pointerUpdateKind, modifiers, wheelDelta, toInternalMouseState(buttonState));
     }
 
     // Method Description:

--- a/src/cascadia/TerminalControl/ControlInteractivity.cpp
+++ b/src/cascadia/TerminalControl/ControlInteractivity.cpp
@@ -334,14 +334,17 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                                             const ::Microsoft::Terminal::Core::ControlKeyStates modifiers,
                                             const bool focused,
                                             const Core::Point pixelPosition,
-                                            const bool pointerPressedInBounds)
+                                            const bool pointerPressedInBounds,
+                                            bool& suppressFurtherHandling)
     {
         const auto terminalPosition = _getTerminalPosition(til::point{ pixelPosition });
+        suppressFurtherHandling = false;
 
         // Short-circuit isReadOnly check to avoid warning dialog
         if (focused && !_core->IsInReadOnlyMode() && _canSendVTMouseInput(modifiers))
         {
             _sendMouseEventHelper(terminalPosition, pointerUpdateKind, modifiers, 0, buttonState);
+            suppressFurtherHandling = true;
         }
         // GH#4603 - don't modify the selection if the pointer press didn't
         // actually start _in_ the control bounds. Case in point - someone drags

--- a/src/cascadia/TerminalControl/ControlInteractivity.h
+++ b/src/cascadia/TerminalControl/ControlInteractivity.h
@@ -58,13 +58,12 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                             const Core::Point pixelPosition);
         void TouchPressed(const Core::Point contactPoint);
 
-        void PointerMoved(Control::MouseButtonState buttonState,
+        bool PointerMoved(Control::MouseButtonState buttonState,
                           const unsigned int pointerUpdateKind,
                           const ::Microsoft::Terminal::Core::ControlKeyStates modifiers,
                           const bool focused,
                           const Core::Point pixelPosition,
-                          const bool pointerPressedInBounds,
-                          bool& suppressFurtherHandling);
+                          const bool pointerPressedInBounds);
         void TouchMoved(const Core::Point newTouchPoint,
                         const bool focused);
 

--- a/src/cascadia/TerminalControl/ControlInteractivity.h
+++ b/src/cascadia/TerminalControl/ControlInteractivity.h
@@ -63,7 +63,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                           const ::Microsoft::Terminal::Core::ControlKeyStates modifiers,
                           const bool focused,
                           const Core::Point pixelPosition,
-                          const bool pointerPressedInBounds);
+                          const bool pointerPressedInBounds,
+                          bool& suppressFurtherHandling);
         void TouchMoved(const Core::Point newTouchPoint,
                         const bool focused);
 

--- a/src/cascadia/TerminalControl/ControlInteractivity.idl
+++ b/src/cascadia/TerminalControl/ControlInteractivity.idl
@@ -48,7 +48,8 @@ namespace Microsoft.Terminal.Control
                           Microsoft.Terminal.Core.ControlKeyStates modifiers,
                           Boolean focused,
                           Microsoft.Terminal.Core.Point pixelPosition,
-                          Boolean pointerPressedInBounds);
+                          Boolean pointerPressedInBounds,
+                          out Boolean suppressFurtherHandling);
 
         void TouchMoved(Microsoft.Terminal.Core.Point newTouchPoint,
                         Boolean focused);

--- a/src/cascadia/TerminalControl/ControlInteractivity.idl
+++ b/src/cascadia/TerminalControl/ControlInteractivity.idl
@@ -43,13 +43,12 @@ namespace Microsoft.Terminal.Control
                             Microsoft.Terminal.Core.Point pixelPosition);
         void TouchPressed(Microsoft.Terminal.Core.Point contactPoint);
 
-        void PointerMoved(MouseButtonState buttonState,
-                          UInt32 pointerUpdateKind,
-                          Microsoft.Terminal.Core.ControlKeyStates modifiers,
-                          Boolean focused,
-                          Microsoft.Terminal.Core.Point pixelPosition,
-                          Boolean pointerPressedInBounds,
-                          out Boolean suppressFurtherHandling);
+        Boolean PointerMoved(MouseButtonState buttonState,
+                             UInt32 pointerUpdateKind,
+                             Microsoft.Terminal.Core.ControlKeyStates modifiers,
+                             Boolean focused,
+                             Microsoft.Terminal.Core.Point pixelPosition,
+                             Boolean pointerPressedInBounds);
 
         void TouchMoved(Microsoft.Terminal.Core.Point newTouchPoint,
                         Boolean focused);

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1910,18 +1910,20 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         if (type == Windows::Devices::Input::PointerDeviceType::Mouse ||
             type == Windows::Devices::Input::PointerDeviceType::Pen)
         {
+            bool suppressFurtherHandling{ false };
             _interactivity.PointerMoved(TermControl::GetPressedMouseButtons(point),
                                         TermControl::GetPointerUpdateKind(point),
                                         ControlKeyStates(args.KeyModifiers()),
                                         _focused,
                                         pixelPosition.to_core_point(),
-                                        _pointerPressedInBounds);
+                                        _pointerPressedInBounds,
+                                        /* out */ suppressFurtherHandling);
 
             // GH#9109 - Only start an auto-scroll when the drag actually
             // started within our bounds. Otherwise, someone could start a drag
             // outside the terminal control, drag into the padding, and trick us
             // into starting to scroll.
-            if (_focused && _pointerPressedInBounds && point.Properties().IsLeftButtonPressed())
+            if (!suppressFurtherHandling && _focused && _pointerPressedInBounds && point.Properties().IsLeftButtonPressed())
             {
                 // We want to find the distance relative to the bounds of the
                 // SwapChainPanel, not the entire control. If they drag out of

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1910,14 +1910,12 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         if (type == Windows::Devices::Input::PointerDeviceType::Mouse ||
             type == Windows::Devices::Input::PointerDeviceType::Pen)
         {
-            bool suppressFurtherHandling{ false };
-            _interactivity.PointerMoved(TermControl::GetPressedMouseButtons(point),
-                                        TermControl::GetPointerUpdateKind(point),
-                                        ControlKeyStates(args.KeyModifiers()),
-                                        _focused,
-                                        pixelPosition.to_core_point(),
-                                        _pointerPressedInBounds,
-                                        /* out */ suppressFurtherHandling);
+            auto suppressFurtherHandling = _interactivity.PointerMoved(TermControl::GetPressedMouseButtons(point),
+                                                                       TermControl::GetPointerUpdateKind(point),
+                                                                       ControlKeyStates(args.KeyModifiers()),
+                                                                       _focused,
+                                                                       pixelPosition.to_core_point(),
+                                                                       _pointerPressedInBounds);
 
             // GH#9109 - Only start an auto-scroll when the drag actually
             // started within our bounds. Otherwise, someone could start a drag

--- a/src/cascadia/UnitTests_Control/ControlInteractivityTests.cpp
+++ b/src/cascadia/UnitTests_Control/ControlInteractivityTests.cpp
@@ -998,16 +998,15 @@ namespace ControlUnitTests
         VERIFY_IS_GREATER_THAN(core->ScrollOffset(), 0);
 
         // Viewport is now above the mutable viewport, so the mouse event
-        // straight up won't be sent to the terminal.
+        // will be clamped to the top line.
 
-        expectedOutput.push_back(L"sentinel"); // Clearly, it won't be this string
+        expectedOutput.push_back(L"\x1b[M &!"); // 5, 1
         interactivity->PointerPressed(leftMouseDown,
                                       WM_LBUTTONDOWN, //pointerUpdateKind
                                       0, // timestamp
                                       modifiers,
                                       cursorPosition0.to_core_point());
         // Flush it out.
-        conn->WriteInput(winrt_wstring_to_array_view(L"sentinel"));
         VERIFY_ARE_EQUAL(0u, expectedOutput.size(), L"Validate we drained all the expected output");
 
         // This is the part as mentioned in GH#12719

--- a/src/cascadia/UnitTests_Control/ControlInteractivityTests.cpp
+++ b/src/cascadia/UnitTests_Control/ControlInteractivityTests.cpp
@@ -298,6 +298,8 @@ namespace ControlUnitTests
             TEST_METHOD_PROPERTY(L"IsolationLevel", L"Method")
         END_TEST_METHOD_PROPERTIES()
 
+        bool unused{};
+
         // This is a test for GH#9725
         WEX::TestExecution::DisableVerifyExceptions disableVerifyExceptions{};
 
@@ -333,7 +335,8 @@ namespace ControlUnitTests
                                     modifiers,
                                     true, // focused,
                                     cursorPosition1.to_core_point(),
-                                    true);
+                                    true,
+                                    unused);
         Log::Comment(L"Verify that there's one selection");
         VERIFY_IS_TRUE(core->HasSelection());
 
@@ -345,7 +348,8 @@ namespace ControlUnitTests
                                     modifiers,
                                     true, // focused,
                                     cursorPosition2.to_core_point(),
-                                    true);
+                                    true,
+                                    unused);
         Log::Comment(L"Verify that there's now two selections (one on each row)");
         VERIFY_IS_TRUE(core->HasSelection());
 
@@ -376,7 +380,8 @@ namespace ControlUnitTests
                                     modifiers,
                                     true, // focused,
                                     cursorPosition4.to_core_point(),
-                                    true);
+                                    true,
+                                    unused);
         Log::Comment(L"Verify that there's now one selection");
         VERIFY_IS_TRUE(core->HasSelection());
     }
@@ -389,6 +394,8 @@ namespace ControlUnitTests
         _standardInit(core, interactivity);
         // For the sake of this test, scroll one line at a time
         interactivity->_rowsToScroll = 1;
+
+        bool unused{};
 
         Log::Comment(L"Add some test to the terminal so we can scroll");
         for (auto i = 0; i < 40; ++i)
@@ -430,7 +437,8 @@ namespace ControlUnitTests
                                     modifiers,
                                     true, // focused,
                                     cursorPosition1.to_core_point(),
-                                    true);
+                                    true,
+                                    unused);
         Log::Comment(L"Verify that there's one selection");
         VERIFY_IS_TRUE(core->HasSelection());
 
@@ -550,6 +558,8 @@ namespace ControlUnitTests
         auto [core, interactivity] = _createCoreAndInteractivity(*settings, *conn);
         _standardInit(core, interactivity);
 
+        bool unused{};
+
         // For this test, don't use any modifiers
         const auto modifiers = ControlKeyStates();
         const auto leftMouseDown{ Control::MouseButtonState::IsLeftButtonDown };
@@ -577,7 +587,8 @@ namespace ControlUnitTests
                                     modifiers,
                                     true, // focused,
                                     cursorPosition1.to_core_point(),
-                                    true);
+                                    true,
+                                    unused);
         Log::Comment(L"Verify that there's one selection");
         VERIFY_IS_TRUE(core->HasSelection());
 
@@ -593,6 +604,8 @@ namespace ControlUnitTests
         auto [settings, conn] = _createSettingsAndConnection();
         auto [core, interactivity] = _createCoreAndInteractivity(*settings, *conn);
         _standardInit(core, interactivity);
+
+        bool unused {}
 
         // For this test, don't use any modifiers
         const auto modifiers = ControlKeyStates();
@@ -621,7 +634,8 @@ namespace ControlUnitTests
                                     modifiers,
                                     true, // focused,
                                     cursorPosition1.to_core_point(),
-                                    true);
+                                    true,
+                                    unused);
         Log::Comment(L"Verify that there's one selection");
         VERIFY_IS_TRUE(core->HasSelection());
 
@@ -646,7 +660,8 @@ namespace ControlUnitTests
                                     modifiers,
                                     true, // focused,
                                     cursorPosition2.to_core_point(),
-                                    false);
+                                    false,
+                                    unused);
 
         Log::Comment(L"The selection should be unchanged.");
         VERIFY_ARE_EQUAL(expectedAnchor, core->_terminal->GetSelectionAnchor());
@@ -661,6 +676,8 @@ namespace ControlUnitTests
         auto [settings, conn] = _createSettingsAndConnection();
         auto [core, interactivity] = _createCoreAndInteractivity(*settings, *conn);
         _standardInit(core, interactivity);
+
+        bool unused{};
 
         // For this test, don't use any modifiers
         const auto modifiers = ControlKeyStates();
@@ -737,7 +754,8 @@ namespace ControlUnitTests
                                     modifiers,
                                     true, // focused,
                                     cursorPosition1.to_core_point(),
-                                    true);
+                                    true,
+                                    unused);
         Log::Comment(L"Verify that there's still no selection");
         VERIFY_IS_FALSE(core->HasSelection());
     }
@@ -750,6 +768,8 @@ namespace ControlUnitTests
         auto [settings, conn] = _createSettingsAndConnection();
         auto [core, interactivity] = _createCoreAndInteractivity(*settings, *conn);
         _standardInit(core, interactivity);
+
+        bool unused{};
 
         Log::Comment(L"Fill up the history buffer");
         const auto scrollbackLength = settings->HistorySize();
@@ -790,7 +810,8 @@ namespace ControlUnitTests
                                     modifiers,
                                     true, // focused,
                                     cursorPosition1.to_core_point(),
-                                    true);
+                                    true,
+                                    unused);
         Log::Comment(L"Verify that there's one selection");
         VERIFY_IS_TRUE(core->HasSelection());
 
@@ -849,7 +870,8 @@ namespace ControlUnitTests
                                     modifiers,
                                     true, // focused,
                                     cursorPosition0.to_core_point(),
-                                    true);
+                                    true,
+                                    unused);
         VERIFY_IS_TRUE(core->HasSelection());
         {
             const auto anchor{ core->_terminal->GetSelectionAnchor() };
@@ -873,7 +895,8 @@ namespace ControlUnitTests
                                     modifiers,
                                     true, // focused,
                                     cursorPosition1.to_core_point(),
-                                    true);
+                                    true,
+                                    unused);
         VERIFY_IS_TRUE(core->HasSelection());
         {
             const auto anchor{ core->_terminal->GetSelectionAnchor() };

--- a/src/cascadia/UnitTests_Control/ControlInteractivityTests.cpp
+++ b/src/cascadia/UnitTests_Control/ControlInteractivityTests.cpp
@@ -298,8 +298,6 @@ namespace ControlUnitTests
             TEST_METHOD_PROPERTY(L"IsolationLevel", L"Method")
         END_TEST_METHOD_PROPERTIES()
 
-        bool unused{};
-
         // This is a test for GH#9725
         WEX::TestExecution::DisableVerifyExceptions disableVerifyExceptions{};
 
@@ -335,8 +333,7 @@ namespace ControlUnitTests
                                     modifiers,
                                     true, // focused,
                                     cursorPosition1.to_core_point(),
-                                    true,
-                                    unused);
+                                    true);
         Log::Comment(L"Verify that there's one selection");
         VERIFY_IS_TRUE(core->HasSelection());
 
@@ -348,8 +345,7 @@ namespace ControlUnitTests
                                     modifiers,
                                     true, // focused,
                                     cursorPosition2.to_core_point(),
-                                    true,
-                                    unused);
+                                    true);
         Log::Comment(L"Verify that there's now two selections (one on each row)");
         VERIFY_IS_TRUE(core->HasSelection());
 
@@ -380,8 +376,7 @@ namespace ControlUnitTests
                                     modifiers,
                                     true, // focused,
                                     cursorPosition4.to_core_point(),
-                                    true,
-                                    unused);
+                                    true);
         Log::Comment(L"Verify that there's now one selection");
         VERIFY_IS_TRUE(core->HasSelection());
     }
@@ -394,8 +389,6 @@ namespace ControlUnitTests
         _standardInit(core, interactivity);
         // For the sake of this test, scroll one line at a time
         interactivity->_rowsToScroll = 1;
-
-        bool unused{};
 
         Log::Comment(L"Add some test to the terminal so we can scroll");
         for (auto i = 0; i < 40; ++i)
@@ -437,8 +430,7 @@ namespace ControlUnitTests
                                     modifiers,
                                     true, // focused,
                                     cursorPosition1.to_core_point(),
-                                    true,
-                                    unused);
+                                    true);
         Log::Comment(L"Verify that there's one selection");
         VERIFY_IS_TRUE(core->HasSelection());
 
@@ -558,8 +550,6 @@ namespace ControlUnitTests
         auto [core, interactivity] = _createCoreAndInteractivity(*settings, *conn);
         _standardInit(core, interactivity);
 
-        bool unused{};
-
         // For this test, don't use any modifiers
         const auto modifiers = ControlKeyStates();
         const auto leftMouseDown{ Control::MouseButtonState::IsLeftButtonDown };
@@ -587,8 +577,7 @@ namespace ControlUnitTests
                                     modifiers,
                                     true, // focused,
                                     cursorPosition1.to_core_point(),
-                                    true,
-                                    unused);
+                                    true);
         Log::Comment(L"Verify that there's one selection");
         VERIFY_IS_TRUE(core->HasSelection());
 
@@ -604,8 +593,6 @@ namespace ControlUnitTests
         auto [settings, conn] = _createSettingsAndConnection();
         auto [core, interactivity] = _createCoreAndInteractivity(*settings, *conn);
         _standardInit(core, interactivity);
-
-        bool unused {}
 
         // For this test, don't use any modifiers
         const auto modifiers = ControlKeyStates();
@@ -634,8 +621,7 @@ namespace ControlUnitTests
                                     modifiers,
                                     true, // focused,
                                     cursorPosition1.to_core_point(),
-                                    true,
-                                    unused);
+                                    true);
         Log::Comment(L"Verify that there's one selection");
         VERIFY_IS_TRUE(core->HasSelection());
 
@@ -660,8 +646,7 @@ namespace ControlUnitTests
                                     modifiers,
                                     true, // focused,
                                     cursorPosition2.to_core_point(),
-                                    false,
-                                    unused);
+                                    false);
 
         Log::Comment(L"The selection should be unchanged.");
         VERIFY_ARE_EQUAL(expectedAnchor, core->_terminal->GetSelectionAnchor());
@@ -676,8 +661,6 @@ namespace ControlUnitTests
         auto [settings, conn] = _createSettingsAndConnection();
         auto [core, interactivity] = _createCoreAndInteractivity(*settings, *conn);
         _standardInit(core, interactivity);
-
-        bool unused{};
 
         // For this test, don't use any modifiers
         const auto modifiers = ControlKeyStates();
@@ -754,8 +737,7 @@ namespace ControlUnitTests
                                     modifiers,
                                     true, // focused,
                                     cursorPosition1.to_core_point(),
-                                    true,
-                                    unused);
+                                    true);
         Log::Comment(L"Verify that there's still no selection");
         VERIFY_IS_FALSE(core->HasSelection());
     }
@@ -768,8 +750,6 @@ namespace ControlUnitTests
         auto [settings, conn] = _createSettingsAndConnection();
         auto [core, interactivity] = _createCoreAndInteractivity(*settings, *conn);
         _standardInit(core, interactivity);
-
-        bool unused{};
 
         Log::Comment(L"Fill up the history buffer");
         const auto scrollbackLength = settings->HistorySize();
@@ -810,8 +790,7 @@ namespace ControlUnitTests
                                     modifiers,
                                     true, // focused,
                                     cursorPosition1.to_core_point(),
-                                    true,
-                                    unused);
+                                    true);
         Log::Comment(L"Verify that there's one selection");
         VERIFY_IS_TRUE(core->HasSelection());
 
@@ -870,8 +849,7 @@ namespace ControlUnitTests
                                     modifiers,
                                     true, // focused,
                                     cursorPosition0.to_core_point(),
-                                    true,
-                                    unused);
+                                    true);
         VERIFY_IS_TRUE(core->HasSelection());
         {
             const auto anchor{ core->_terminal->GetSelectionAnchor() };
@@ -895,8 +873,7 @@ namespace ControlUnitTests
                                     modifiers,
                                     true, // focused,
                                     cursorPosition1.to_core_point(),
-                                    true,
-                                    unused);
+                                    true);
         VERIFY_IS_TRUE(core->HasSelection());
         {
             const auto anchor{ core->_terminal->GetSelectionAnchor() };


### PR DESCRIPTION
PR #10642 and #11290 introduced an adjustment for the cursor position used to generate VT mouse mode events.

One of the decisions made in those PRs was to only send coordinates where Y was >= 0, so if you were off the top of the screen you wouldn't get any events. However, terminal emulators are expected to send _clamped_ events when the mouse is off the screen. This decision broke clamping Y to 0 when the mouse was above the screen.

The other decision was to only adjust the Y coordinate if the core's `ScrollOffset` was greater than 0. It turns out that `ScrollOffset` _is 0_ when you are scrolled all the way back in teh buffer. With this check, we would clamp coordinates properly _until the top line of the scrollback was visible_, at which point we would send those coordinates over directly. This resulted in the same weird behavior as observed in #10190.

I've fixed both of those things. Core is expected to receive negative coordinates and clamp them to the viewport. ScrollOffset should never be below 0, as it refers to the top visible buffer line.

In addition to that, #17744 uncovered that we were allowing autoscrolling to happen even when VT mouse events were being generated. I added a way for `ControlInteractivity` to halt further event processing. It's crude.

Refs #10190
Closes #17744