### PR TITLE
Clip the "current commandline" at the cursor position

### DIFF
--- a/.wt.json
+++ b/.wt.json
@@ -23,6 +23,12 @@
             "name": "Upload package to nuget feed",
             "icon": "\uE898",
             "description": "Go download a .nupkg, put it in ~/Downloads, and use this to push to our private feed."
+        },
+        {
+            "input": "runut /name:**\u001b[D",
+            "name": "Run a test",
+            "icon": "",
+            "description": "Enter the name of a test to run"
         }
     ]
 }

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -326,7 +326,7 @@ private:
     til::point _GetWordEndForSelection(const til::point target, const std::wstring_view wordDelimiters) const;
     void _PruneHyperlinks();
 
-    std::wstring _commandForRow(const til::CoordType rowOffset, const til::CoordType bottomInclusive) const;
+    std::wstring _commandForRow(const til::CoordType rowOffset, const til::CoordType bottomInclusive, const bool clipAtCursor = false) const;
     MarkExtents _scrollMarkExtentForRow(const til::CoordType rowOffset, const til::CoordType bottomInclusive) const;
     bool _createPromptMarkIfNeeded();
 

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -2285,7 +2285,10 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // If the very last thing in the list of recent commands, is exactly the
         // same as the current command, then let's not include it in the
         // history. It's literally the thing the user has typed, RIGHT now.
-        if (!commands.empty() && commands.back() == trimmedCurrentCommand)
+        // (also account for the fact that the cursor may be in the middle of a commandline)
+        if (!commands.empty() &&
+            !trimmedCurrentCommand.empty() &&
+            std::wstring{ commands.back() }.substr(0, trimmedCurrentCommand.size()) == trimmedCurrentCommand)
         {
             commands.pop_back();
         }

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -2288,7 +2288,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // (also account for the fact that the cursor may be in the middle of a commandline)
         if (!commands.empty() &&
             !trimmedCurrentCommand.empty() &&
-            std::wstring{ commands.back() }.substr(0, trimmedCurrentCommand.size()) == trimmedCurrentCommand)
+            std::wstring_view{ commands.back() }.substr(0, trimmedCurrentCommand.size()) == trimmedCurrentCommand)
         {
             commands.pop_back();
         }

--- a/src/host/ut_host/ScreenBufferTests.cpp
+++ b/src/host/ut_host/ScreenBufferTests.cpp
@@ -8337,6 +8337,10 @@ void ScreenBufferTests::SimpleMarkCommand()
 
 void ScreenBufferTests::SimpleWrappedCommand()
 {
+    BEGIN_TEST_METHOD_PROPERTIES()
+        TEST_METHOD_PROPERTY(L"IsolationLevel", L"Method")
+    END_TEST_METHOD_PROPERTIES()
+
     auto& g = ServiceLocator::LocateGlobals();
     auto& gci = g.getConsoleInformation();
     auto& si = gci.GetActiveOutputBuffer();


### PR DESCRIPTION
This is particularly relevant to pwsh with the "ghost text" enabled. In that scenario, pwsh writes out the predicted command to the right of the cursor. With `showSuggestions(useCommandline=true)`, we'd auto-include that text in the filter, and that was effectively useless.

This instead defaults us to not use anything to the right of the cursor (inclusive) for what we consider "the current commandline"

closes #17772