### PR TITLE
A trio of snippets pane fixes

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -1204,8 +1204,6 @@ namespace winrt::TerminalApp::implementation
     {
         Visibility(Visibility::Collapsed);
 
-        PreviewAction.raise(*this, nullptr);
-
         // Reset visibility in case anchor mode tab switcher just finished.
         _searchBox().Visibility(Visibility::Visible);
 
@@ -1216,6 +1214,7 @@ namespace winrt::TerminalApp::implementation
 
         ParentCommandName(L"");
         _currentNestedCommands.Clear();
+        PreviewAction.raise(*this, nullptr);
     }
 
     void CommandPalette::EnableTabSwitcherMode(const uint32_t startIdx, TabSwitcherMode tabSwitcherMode)

--- a/src/cascadia/TerminalApp/SnippetsPaneContent.cpp
+++ b/src/cascadia/TerminalApp/SnippetsPaneContent.cpp
@@ -21,7 +21,8 @@ namespace winrt
 
 namespace winrt::TerminalApp::implementation
 {
-    SnippetsPaneContent::SnippetsPaneContent()
+    SnippetsPaneContent::SnippetsPaneContent() :
+        _allTasks { winrt::single_threaded_observable_vector<TerminalApp::FilteredTask>() }
     {
         InitializeComponent();
 
@@ -54,7 +55,7 @@ namespace winrt::TerminalApp::implementation
         const auto tasks = co_await _settings.GlobalSettings().ActionMap().FilterToSnippets(winrt::hstring{}, winrt::hstring{}); // IVector<Model::Command>
         co_await wil::resume_foreground(Dispatcher());
 
-        _allTasks = winrt::single_threaded_observable_vector<TerminalApp::FilteredTask>();
+        _allTasks.Clear();
         for (const auto& t : tasks)
         {
             const auto& filtered{ winrt::make<FilteredTask>(t) };

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -1615,6 +1615,12 @@ void Terminal::PreviewText(std::wstring_view input)
     static constexpr TextAttribute previewAttrs{ CharacterAttributes::Italics, TextColor{}, TextColor{}, 0u, TextColor{} };
 
     auto lock = LockForWriting();
+
+    if (_mainBuffer == nullptr)
+    {
+        return;
+    }
+
     if (input.empty())
     {
         snippetPreview.text = L"";


### PR DESCRIPTION

1. Don't crash on a cmdpal "duplicate pane" of a snippets pane
   * Found while trying to solve bug the third. 
   * "Duplicate pane" with a snippets pane would crash. This was due to us attempting to `PreviewText` when there was no buffer yet. (`_activeBuffer()` strikes again)
2. dismiss the preview from cmdpal correctly too
   * Again while looking for part the third, I hit this
   * I have a `sendInput(input: "a")` command. This is the first command in the palette. And opening a new pane would... preview that command in the new pane? weird. Moving the line in `CommandPalette::_close` fixes this
3. Don't crash when we're restoring a snippets pane and there's a bunch of windows 
   * This was the real bug I was trying to fix
   * Looks like if you have enough panes  & windows, there's enough of a delay between ctoring a snippets pane and actually calling `_UpdateSettings` on it, that the XAML loads and tries to bind to `_allTasks`, which _hadn't been constructed yet_
   * closes #17793 