### PR TITLE
Remove unnecessary FMT

### DIFF
--- a/src/cascadia/TerminalSettingsModel/Command.cpp
+++ b/src/cascadia/TerminalSettingsModel/Command.cpp
@@ -774,7 +774,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                 // covers actions w/out args
                 // - "command": "unbound" --> "unbound"
                 // - "command": "copy"    --> "copy"
-                changes.emplace(fmt::format(FMT_COMPILE("{}"), json.asString()));
+                changes.emplace(json.asString());
             }
             else
             {


### PR DESCRIPTION
There's an unnecessary `fmt::format` here caught in the code review: https://github.com/microsoft/terminal/pull/17678#discussion_r1729426705

This simply removes it.