### PR TITLE
Fix typo in Czech translation

### DIFF
--- a/src/cascadia/CascadiaPackage/Resources/cs-CZ/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/cs-CZ/Resources.resw
@@ -164,11 +164,11 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Canary version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
-    <value>Otevřít náhled &amp;aplikace Terminal</value>
+    <value>Otevřít náhled &amp;aplikace Terminál</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Otevřít v aplikaci &amp;Terminal</value>
+    <value>Otevřít v aplikaci &amp;Terminál</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/cs-CZ/ContextMenu.resw
+++ b/src/cascadia/TerminalApp/Resources/cs-CZ/ContextMenu.resw
@@ -164,11 +164,11 @@
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Canary version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
-    <value>Otevřít náhled &amp;aplikace Terminal</value>
+    <value>Otevřít náhled &amp;aplikace Terminál</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
   <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
-    <value>Otevřít v aplikaci &amp;Terminal</value>
+    <value>Otevřít v aplikaci &amp;Terminál</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
 </root>


### PR DESCRIPTION
## Summary of the Pull Request
This PR fixes the typo in Czech translation mentioned in #17752.

## References and Relevant Issues
#17752

## Detailed Description of the Pull Request / Additional comments
Correct translation for the word "Terminal" is "Terminál". See the [Google Translate result](https://translate.google.com/?sl=en&tl=cs&text=Terminal&op=translate).

Also, this word is already translated as "Terminál" in other strings. For example the app name:

```
<data name="AppShortName" xml:space="preserve">
  <value>Terminál</value>
  <comment>{Locked=qps-ploc,qps-ploca,qps-plocm}</comment>
</data>
```

## Validation Steps Performed
None.

## PR Checklist
- [x] Closes #17752
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
