### PR TITLE
Make sure a blank title string resets the title

### DIFF
--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -86,7 +86,7 @@ void Terminal::SetWindowTitle(const std::wstring_view title)
     _assertLocked();
     if (!_suppressApplicationTitle)
     {
-        _title.emplace(title);
+        _title.emplace(title.empty() ? _startingTitle : title);
         _pfnTitleChanged(_title.value());
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

When a VT title sequence sets the title to a blank string, that is meant
to trigger a reset to the default starting value. This used to work in
the past because the blank value was dealt with by conhost, so Windows
Terminal never received a blank title, but that's no longer the case
with the new VT passthrough. This PR fixes the issue by getting Windows
Terminal to handle the blank title strings itself. 

## References and Relevant Issues

VT passthrough was introduced in PR #17510.

## Validation Steps Performed

I've manually verified that the `OSC 0`, `OSC 2`, and `DECSWT` sequences
now correctly reset the title when passed a blank title string. 

## PR Checklist
- [x] Closes #17800
