### PR TITLE
Fix two ConPTY HWND focus issues

### DIFF
--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -510,6 +510,7 @@ long IslandWindow::_calculateTotalSize(const bool isWidth, const long clientSize
         _HandleCreateWindow(wparam, lparam);
         return 0;
     }
+    case WM_ENABLE:
     case WM_SETFOCUS:
     {
         if (_interopWindowHandle != nullptr)

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -511,6 +511,14 @@ long IslandWindow::_calculateTotalSize(const bool isWidth, const long clientSize
         return 0;
     }
     case WM_ENABLE:
+    {
+        if (_interopWindowHandle != nullptr)
+        {
+            // send focus to the child window
+            SetFocus(_interopWindowHandle);
+        }
+        break;
+    }
     case WM_SETFOCUS:
     {
         if (_interopWindowHandle != nullptr)

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -171,7 +171,6 @@ LRESULT NonClientIslandWindow::_InputSinkMessageHandler(UINT const message,
         // is absolutely critical to making sure Snap Layouts (GH#9443) works!
         return _dragBarNcHitTest({ GET_X_LPARAM(lparam), GET_Y_LPARAM(lparam) });
     }
-
     break;
 
     case WM_NCMOUSEMOVE:

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -171,6 +171,7 @@ LRESULT NonClientIslandWindow::_InputSinkMessageHandler(UINT const message,
         // is absolutely critical to making sure Snap Layouts (GH#9443) works!
         return _dragBarNcHitTest({ GET_X_LPARAM(lparam), GET_Y_LPARAM(lparam) });
     }
+
     break;
 
     case WM_NCMOUSEMOVE:

--- a/src/interactivity/base/InteractivityFactory.cpp
+++ b/src/interactivity/base/InteractivityFactory.cpp
@@ -463,7 +463,7 @@ using namespace Microsoft::Console::Interactivity;
         {
             _WritePseudoWindowCallback((bool)wParam);
         }
-        break;
+        return 0;
     }
     case WM_GETOBJECT:
     {

--- a/src/interactivity/base/InteractivityFactory.cpp
+++ b/src/interactivity/base/InteractivityFactory.cpp
@@ -463,6 +463,7 @@ using namespace Microsoft::Console::Interactivity;
         {
             _WritePseudoWindowCallback((bool)wParam);
         }
+        break;
     }
     case WM_GETOBJECT:
     {
@@ -475,6 +476,15 @@ using namespace Microsoft::Console::Interactivity;
             return UiaReturnRawElementProvider(hWnd, wParam, lParam, _pPseudoConsoleUiaProvider.Get());
         }
         return 0;
+    }
+    case WM_ACTIVATE:
+    {
+        if (const auto ownerHwnd{ ::GetAncestor(hWnd, GA_ROOTOWNER) })
+        {
+            SetFocus(ownerHwnd);
+            return 0;
+        }
+        break;
     }
     }
     // If we get this far, call the default window proc


### PR DESCRIPTION
Worked with @ekoschik on this one. 

## Bug the first: the MSAL window `ixptools` spawns

> The auth prompt in pwsh.exe is disabling the terminal window while its opened and re-enabling it when the window closes. BUT it is enabling Terminal after dismissing itself, instead of before, which means terminal is disabled when activated.
> 
> Terminal wants focus on the ISLAND window (a grandchild; island is parented to bridge, which is parented to terminal’s TLW). When it is activated, it gets a `WM_SETFOCUS` (in response to DefWindowProc `WM_ACTIVATE`). From `WM_SETFOCUS` it calls `SetFocus` on the bridge window, and similarly the bridge calls `SetFocus` on the island.
> 
> If the TLW is disabled, these `SetFocus` calls fail (see [this check](#internal-link-redacted) in `SetFocus`). In the case above, this leaves Terminal’s TLW as focus, and it doesn’t handle keyboard input. Note that the window IS foreground/active, but because focus is not on the island it doesn’t see the keyboard input. Another thing to note is that clicking on the space to the right of the tabs does NOT revive keyboard input, but clicking on the tabs or main area does.

> **I recommend having the TLW handle WM_ENABLE and call SetFocus on the island window.**

And guess what, that works!

## Bug the second: When sublime text is the git `EDITOR`, it doesn't toss focus back to the Terminal


> In this case, Sublime is calling SFW on the pseudo console window. I don’t have its code, but it is presumably doing something like SetForegroundWindow(GetConsoleWindow()). This queues an event to the pseudo window, and when that event is processed the pseudo window becomes the active and focus window on the queue (which is shared with Terminal).
> 
> The sublime window dismisses itself and does the above SFW call. Dismissing immediately activates the Terminal TLW, which does the triple-focus dance (TLW sets focus on itself, then bridge, then island). This completes but is overwritten immediately when the pseudo window activates itself. Note that the pseudo window is active at this point (not the terminal window).

> **I recommend having the Pseudo console window handle WM_ACTIVATE by calling SetFocus on the island window (and not passing the message to DefWindowProc).**

And guess what, that works!


----

Closes #15956 (I did test this)
This might be related to #13388, we'll have folks try canary and check