### PR TITLE
Avoid focus loops in ConPTY

### DIFF
--- a/.github/actions/spelling/allow/apis.txt
+++ b/.github/actions/spelling/allow/apis.txt
@@ -96,6 +96,7 @@ IGraphics
 IImage
 IInheritable
 IMap
+imm
 IMonarch
 IObject
 iosfwd

--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -307,6 +307,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         struct SharedState
         {
             std::unique_ptr<til::debounced_func_trailing<>> outputIdle;
+            std::unique_ptr<til::debounced_func_trailing<bool>> focusChanged;
             std::shared_ptr<ThrottledFuncTrailing<Control::ScrollPositionChangedArgs>> updateScrollBar;
         };
 

--- a/src/cascadia/UnitTests_TerminalCore/UnitTests.vcxproj
+++ b/src/cascadia/UnitTests_TerminalCore/UnitTests.vcxproj
@@ -57,7 +57,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>WindowsApp.lib;WinMM.Lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>WindowsApp.lib;winmm.Lib;imm32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <!-- Careful reordering these. Some default props (contained in these files) are order sensitive. -->

--- a/src/host/PtySignalInputThread.cpp
+++ b/src/host/PtySignalInputThread.cpp
@@ -74,8 +74,6 @@ void PtySignalInputThread::ConnectConsole() noexcept
     {
         _DoShowHide(*_initialShowHide);
     }
-
-    // We should have successfully used the _earlyReparent message in CreatePseudoWindow.
 }
 
 // Method Description:
@@ -87,8 +85,7 @@ void PtySignalInputThread::ConnectConsole() noexcept
 // - Refer to GH#13066 for details.
 void PtySignalInputThread::CreatePseudoWindow()
 {
-    HWND owner = _earlyReparent.has_value() ? reinterpret_cast<HWND>((*_earlyReparent).handle) : HWND_DESKTOP;
-    ServiceLocator::LocatePseudoWindow(owner);
+    ServiceLocator::LocatePseudoWindow();
 }
 
 // Method Description:
@@ -220,7 +217,7 @@ void PtySignalInputThread::_DoShowHide(const ShowHideData& data)
         return;
     }
 
-    _api.ShowWindow(data.show);
+    ServiceLocator::SetPseudoWindowVisibility(data.show);
 }
 
 // Method Description:
@@ -237,44 +234,7 @@ void PtySignalInputThread::_DoSetWindowParent(const SetParentData& data)
     LockConsole();
     auto Unlock = wil::scope_exit([&] { UnlockConsole(); });
 
-    // If the client app hasn't yet connected, stash the new owner.
-    // We'll later (PtySignalInputThread::ConnectConsole) use the value
-    // to set up the owner of the conpty window.
-    if (!_consoleConnected)
-    {
-        _earlyReparent = data;
-        return;
-    }
-
-    const auto owner{ reinterpret_cast<HWND>(data.handle) };
-    // This will initialize s_interactivityFactory for us. It will also
-    // conveniently return 0 when we're on OneCore.
-    //
-    // If the window hasn't been created yet, by some other call to
-    // LocatePseudoWindow, then this will also initialize the owner of the
-    // window.
-    if (const auto pseudoHwnd{ ServiceLocator::LocatePseudoWindow(owner) })
-    {
-        // SetWindowLongPtrW may call back into the message handler and wait for it to finish,
-        // similar to SendMessageW(). If the conhost message handler is already processing and
-        // waiting to acquire the console lock, which we're currently holding, we'd deadlock.
-        // --> Release the lock now.
-        Unlock.reset();
-
-        // DO NOT USE SetParent HERE!
-        //
-        // Calling SetParent on a window that is WS_VISIBLE will cause the OS to
-        // hide the window, make it a _child_ window, then call SW_SHOW on the
-        // window to re-show it. SW_SHOW, however, will cause the OS to also set
-        // that window as the _foreground_ window, which would result in the
-        // pty's hwnd stealing the foreground away from the owning terminal
-        // window. That's bad.
-        //
-        // SetWindowLongPtr seems to do the job of changing who the window owner
-        // is, without all the other side effects of reparenting the window.
-        // See #13066
-        ::SetWindowLongPtrW(pseudoHwnd, GWLP_HWNDPARENT, reinterpret_cast<LONG_PTR>(owner));
-    }
+    ServiceLocator::SetPseudoWindowOwner(reinterpret_cast<HWND>(data.handle));
 }
 
 // Method Description:

--- a/src/host/PtySignalInputThread.hpp
+++ b/src/host/PtySignalInputThread.hpp
@@ -75,8 +75,5 @@ namespace Microsoft::Console
         std::optional<ResizeWindowData> _earlyResize;
         std::optional<ShowHideData> _initialShowHide;
         ConhostInternalGetSet _api;
-
-    public:
-        std::optional<SetParentData> _earlyReparent;
     };
 }

--- a/src/host/exe/Host.EXE.vcxproj
+++ b/src/host/exe/Host.EXE.vcxproj
@@ -86,7 +86,7 @@
     </ClCompile>
     <Link>
       <AllowIsolation>true</AllowIsolation>
-      <AdditionalDependencies>WinMM.Lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>winmm.lib;imm32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <!-- Careful reordering these. Some default props (contained in these files) are order sensitive. -->

--- a/src/host/ft_fuzzer/Host.FuzzWrapper.vcxproj
+++ b/src/host/ft_fuzzer/Host.FuzzWrapper.vcxproj
@@ -69,7 +69,7 @@
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>winmm.lib;imm32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
     </Link>
   </ItemDefinitionGroup>
@@ -77,7 +77,7 @@
     <!-- In theory, we may want to build with a normal main() when Fuzzing is not enabled. -->
     <!-- So, let's only add the fuzzer to the link line when we're building for Fuzzing. -->
     <Link>
-      <AdditionalDependencies>WinMM.Lib;clang_rt.fuzzer_MT-$(OCClangArchitectureName).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>winmm.lib;imm32.lib;clang_rt.fuzzer_MT-$(OCClangArchitectureName).lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <!-- Careful reordering these. Some default props (contained in these files) are order sensitive. -->

--- a/src/host/sources.inc
+++ b/src/host/sources.inc
@@ -132,6 +132,7 @@ TARGETLIBS = \
     $(ONECOREUAP_EXTERNAL_SDK_LIB_PATH)\dxgi.lib \
     $(ONECOREUAP_EXTERNAL_SDK_LIB_PATH)\d3d11.lib \
     $(MODERNCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\api-ms-win-mm-playsound-l1.lib \
+    $(MODERNCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-imm-l1-1-0.lib \
     $(ONECORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-dwmapi-ext-l1.lib \
     $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-gdi-dc-l1.lib \
     $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-gdi-dc-create-l1.lib \
@@ -195,6 +196,7 @@ DELAYLOAD = \
     api-ms-win-core-com-l1.dll; \
     api-ms-win-core-registry-l2.dll; \
     api-ms-win-mm-playsound-l1.dll; \
+    ext-ms-win-imm-l1-1-0.lib; \
     api-ms-win-shcore-obsolete-l1.dll; \
     api-ms-win-shcore-scaling-l1.dll; \
     api-ms-win-shell-dataobject-l1.dll; \

--- a/src/host/ut_host/Host.UnitTests.vcxproj
+++ b/src/host/ut_host/Host.UnitTests.vcxproj
@@ -87,7 +87,7 @@
       <AdditionalIncludeDirectories>..;$(SolutionDir)src\inc;$(SolutionDir)src\inc\test;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>WinMM.Lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>winmm.lib;imm32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <!-- Careful reordering these. Some default props (contained in these files) are order sensitive. -->

--- a/src/interactivity/base/InteractivityFactory.hpp
+++ b/src/interactivity/base/InteractivityFactory.hpp
@@ -27,7 +27,10 @@ namespace Microsoft::Console::Interactivity
         [[nodiscard]] NTSTATUS CreateAccessibilityNotifier(_Inout_ std::unique_ptr<IAccessibilityNotifier>& notifier);
         [[nodiscard]] NTSTATUS CreateSystemConfigurationProvider(_Inout_ std::unique_ptr<ISystemConfigurationProvider>& provider);
 
-        [[nodiscard]] NTSTATUS CreatePseudoWindow(HWND& hwnd, const HWND owner);
+        [[nodiscard]] NTSTATUS CreatePseudoWindow(HWND& hwnd);
+
+        void SetOwner(HWND owner) noexcept;
+        void SetVisibility(const bool isVisible) noexcept;
 
         // Wndproc
         [[nodiscard]] static LRESULT CALLBACK s_PseudoWindowProc(_In_ HWND hwnd,
@@ -43,6 +46,8 @@ namespace Microsoft::Console::Interactivity
         void _WritePseudoWindowCallback(bool showOrHide);
 
         HWND _pseudoConsoleWindowHwnd{ nullptr };
+        std::atomic<HWND> _owner{ HWND_DESKTOP };
+        std::atomic<bool> _suppressVisibilityChange{ false };
         WRL::ComPtr<PseudoConsoleWindowAccessibilityProvider> _pPseudoConsoleUiaProvider{ nullptr };
     };
 }

--- a/src/interactivity/base/ServiceLocator.cpp
+++ b/src/interactivity/base/ServiceLocator.cpp
@@ -322,7 +322,7 @@ Globals& ServiceLocator::LocateGlobals()
 //   owner of the pseudo window.
 // Return Value:
 // - a reference to the pseudoconsole window.
-HWND ServiceLocator::LocatePseudoWindow(const HWND owner)
+HWND ServiceLocator::LocatePseudoWindow()
 {
     auto status = STATUS_SUCCESS;
     if (!s_pseudoWindowInitialized)
@@ -335,7 +335,7 @@ HWND ServiceLocator::LocatePseudoWindow(const HWND owner)
         if (SUCCEEDED_NTSTATUS(status))
         {
             HWND hwnd;
-            status = s_interactivityFactory->CreatePseudoWindow(hwnd, owner);
+            status = s_interactivityFactory->CreatePseudoWindow(hwnd);
             s_pseudoWindow.reset(hwnd);
         }
 
@@ -343,6 +343,38 @@ HWND ServiceLocator::LocatePseudoWindow(const HWND owner)
     }
     LOG_IF_NTSTATUS_FAILED(status);
     return s_pseudoWindow.get();
+}
+
+void ServiceLocator::SetPseudoWindowOwner(HWND owner)
+{
+    auto status = STATUS_SUCCESS;
+    if (!s_interactivityFactory)
+    {
+        status = ServiceLocator::LoadInteractivityFactory();
+    }
+
+    if (s_interactivityFactory)
+    {
+        static_cast<InteractivityFactory*>(s_interactivityFactory.get())->SetOwner(owner);
+    }
+
+    LOG_IF_NTSTATUS_FAILED(status);
+}
+
+void ServiceLocator::SetPseudoWindowVisibility(bool showOrHide)
+{
+    auto status = STATUS_SUCCESS;
+    if (!s_interactivityFactory)
+    {
+        status = ServiceLocator::LoadInteractivityFactory();
+    }
+
+    if (s_interactivityFactory)
+    {
+        static_cast<InteractivityFactory*>(s_interactivityFactory.get())->SetVisibility(showOrHide);
+    }
+
+    LOG_IF_NTSTATUS_FAILED(status);
 }
 
 #pragma endregion

--- a/src/interactivity/inc/IInteractivityFactory.hpp
+++ b/src/interactivity/inc/IInteractivityFactory.hpp
@@ -40,6 +40,6 @@ namespace Microsoft::Console::Interactivity
         [[nodiscard]] virtual NTSTATUS CreateAccessibilityNotifier(_Inout_ std::unique_ptr<IAccessibilityNotifier>& notifier) = 0;
         [[nodiscard]] virtual NTSTATUS CreateSystemConfigurationProvider(_Inout_ std::unique_ptr<ISystemConfigurationProvider>& provider) = 0;
 
-        [[nodiscard]] virtual NTSTATUS CreatePseudoWindow(HWND& hwnd, const HWND owner) = 0;
+        [[nodiscard]] virtual NTSTATUS CreatePseudoWindow(HWND& hwnd) = 0;
     };
 }

--- a/src/interactivity/inc/ServiceLocator.hpp
+++ b/src/interactivity/inc/ServiceLocator.hpp
@@ -84,7 +84,9 @@ namespace Microsoft::Console::Interactivity
 
         static Globals& LocateGlobals();
 
-        static HWND LocatePseudoWindow(const HWND owner = nullptr /*HWND_DESKTOP = 0*/);
+        static HWND LocatePseudoWindow();
+        static void SetPseudoWindowOwner(HWND owner);
+        static void SetPseudoWindowVisibility(bool showOrHide);
 
         ServiceLocator(const ServiceLocator&) = delete;
         ServiceLocator& operator=(const ServiceLocator&) = delete;

--- a/src/interactivity/win32/ut_interactivity_win32/Interactivity.Win32.UnitTests.vcxproj
+++ b/src/interactivity/win32/ut_interactivity_win32/Interactivity.Win32.UnitTests.vcxproj
@@ -68,7 +68,7 @@
       <AdditionalIncludeDirectories>..;$(SolutionDir)src\inc;$(Solutiondir)src\inc\test;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>WinMM.Lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>winmm.lib;imm32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <!-- Careful reordering these. Some default props (contained in these files) are order sensitive. -->

--- a/src/interactivity/win32/ut_interactivity_win32/sources
+++ b/src/interactivity/win32/ut_interactivity_win32/sources
@@ -50,6 +50,7 @@ TARGETLIBS = \
     $(ONECOREUAP_EXTERNAL_SDK_LIB_PATH)\dxgi.lib \
     $(ONECOREUAP_EXTERNAL_SDK_LIB_PATH)\propsys.lib \
     $(MODERNCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\api-ms-win-mm-playsound-l1.lib \
+    $(MODERNCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-imm-l1-1-0.lib \
     $(ONECORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-dwmapi-ext-l1.lib \
     $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-gdi-dc-l1.lib \
     $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-gdi-dc-create-l1.lib \
@@ -111,6 +112,7 @@ DELAYLOAD = \
     OLEAUT32.dll; \
     icu.dll; \
     api-ms-win-mm-playsound-l1.dll; \
+    ext-ms-win-imm-l1-1-0.lib; \
     api-ms-win-shcore-scaling-l1.dll; \
     api-ms-win-shell-dataobject-l1.dll; \
     api-ms-win-shell-namespace-l1.dll; \

--- a/src/interactivity/win32/ut_interactivity_win32/sources
+++ b/src/interactivity/win32/ut_interactivity_win32/sources
@@ -43,12 +43,12 @@ TARGETLIBS = \
     $(ONECORE_INTERNAL_SDK_LIB_PATH)\onecoreuuid.lib \
     $(ONECOREUAP_INTERNAL_SDK_LIB_PATH)\onecoreuapuuid.lib \
     $(ONECORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\onecore_internal.lib \
-    $(ONECOREUAP_EXTERNAL_SDK_LIB_PATH)\propsys.lib \
     $(ONECOREUAP_EXTERNAL_SDK_LIB_PATH)\d2d1.lib \
-    $(ONECOREUAP_EXTERNAL_SDK_LIB_PATH)\dwrite.lib \
-    $(ONECOREUAP_EXTERNAL_SDK_LIB_PATH)\dxgi.lib \
     $(ONECOREUAP_EXTERNAL_SDK_LIB_PATH)\d3d11.lib \
     $(ONECOREUAP_EXTERNAL_SDK_LIB_PATH)\d3dcompiler.lib \
+    $(ONECOREUAP_EXTERNAL_SDK_LIB_PATH)\dwrite.lib \
+    $(ONECOREUAP_EXTERNAL_SDK_LIB_PATH)\dxgi.lib \
+    $(ONECOREUAP_EXTERNAL_SDK_LIB_PATH)\propsys.lib \
     $(MODERNCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\api-ms-win-mm-playsound-l1.lib \
     $(ONECORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-dwmapi-ext-l1.lib \
     $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-gdi-dc-l1.lib \

--- a/src/terminal/adapter/InteractDispatch.cpp
+++ b/src/terminal/adapter/InteractDispatch.cpp
@@ -162,59 +162,8 @@ void InteractDispatch::FocusChanged(const bool focused)
     // InteractDispatch outside ConPTY mode, but just in case...
     if (gci.IsInVtIoMode())
     {
-        auto shouldActuallyFocus = false;
-
-        // From https://github.com/microsoft/terminal/pull/12799#issuecomment-1086289552
-        // Make sure that the process that's telling us it's focused, actually
-        // _is_ in the FG. We don't want to allow malicious.exe to say "yep I'm
-        // in the foreground, also, here's a popup" if it isn't actually in the
-        // FG.
-        if (focused)
-        {
-            if (const auto pseudoHwnd{ ServiceLocator::LocatePseudoWindow() })
-            {
-                // They want focus, we found a pseudo hwnd.
-
-                // BODGY
-                //
-                // This needs to be GA_ROOTOWNER here. Not GA_ROOT, GA_PARENT,
-                // or GetParent. The ConPTY hwnd is an owned, top-level, popup,
-                // non-parented window. It does not have a parent set. It does
-                // have an owner set. It is not a WS_CHILD window. This
-                // combination of things allows us to find the owning window
-                // with GA_ROOTOWNER. GA_ROOT will get us ourselves, and
-                // GA_PARENT will return the desktop HWND.
-                //
-                // See GH#13066
-
-                if (const auto ownerHwnd{ ::GetAncestor(pseudoHwnd, GA_ROOTOWNER) })
-                {
-                    // We have an owner from a previous call to ReparentWindow
-
-                    if (const auto currentFgWindow{ ::GetForegroundWindow() })
-                    {
-                        // There is a window in the foreground (it's possible there
-                        // isn't one)
-
-                        // Get the PID of the current FG window, and compare with our owner's PID.
-                        DWORD currentFgPid{ 0 };
-                        DWORD ownerPid{ 0 };
-                        GetWindowThreadProcessId(currentFgWindow, &currentFgPid);
-                        GetWindowThreadProcessId(ownerHwnd, &ownerPid);
-
-                        if (ownerPid == currentFgPid)
-                        {
-                            // Huzzah, the app that owns us is actually the FG
-                            // process. They're allowed to grand FG rights.
-                            shouldActuallyFocus = true;
-                        }
-                    }
-                }
-            }
-        }
-
-        WI_UpdateFlag(gci.Flags, CONSOLE_HAS_FOCUS, shouldActuallyFocus);
-        gci.ProcessHandleList.ModifyConsoleProcessFocus(shouldActuallyFocus);
+        WI_UpdateFlag(gci.Flags, CONSOLE_HAS_FOCUS, focused);
+        gci.ProcessHandleList.ModifyConsoleProcessFocus(focused);
         gci.pInputBuffer->WriteFocusEvent(focused);
     }
     // Does nothing outside of ConPTY. If there's a real HWND, then the HWND is solely in charge.

--- a/src/terminal/adapter/ut_adapter/sources
+++ b/src/terminal/adapter/ut_adapter/sources
@@ -48,6 +48,7 @@ TARGETLIBS = \
     $(ONECOREUAP_EXTERNAL_SDK_LIB_PATH)\d3d11.lib \
     $(ONECOREUAP_EXTERNAL_SDK_LIB_PATH)\d3dcompiler.lib \
     $(MODERNCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\api-ms-win-mm-playsound-l1.lib \
+    $(MODERNCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-imm-l1-1-0.lib \
     $(ONECORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-dwmapi-ext-l1.lib \
     $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-gdi-dc-l1.lib \
     $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-gdi-dc-create-l1.lib \
@@ -106,6 +107,7 @@ DELAYLOAD = \
     OLEAUT32.dll; \
     icu.dll; \
     api-ms-win-mm-playsound-l1.dll; \
+    ext-ms-win-imm-l1-1-0.lib; \
     api-ms-win-shcore-scaling-l1.dll; \
     api-ms-win-shell-dataobject-l1.dll; \
     api-ms-win-shell-namespace-l1.dll; \
@@ -152,4 +154,3 @@ DLOAD_ERROR_HANDLER = kernelbase
 #                                    $(ONECORESDKTOOLS_INTERNAL_LIB_PATH_L)\WexTest\Cue\Wex.Logger.lib \
 #                                    $(ONECORESDKTOOLS_INTERNAL_LIB_PATH_L)\WexTest\Cue\Te.Common.lib \
 #                                    $(SDKTOOLS_LIB_PATH)\WexTest\Cue\Mock10.lib \
-

--- a/src/terminal/parser/ut_parser/sources
+++ b/src/terminal/parser/ut_parser/sources
@@ -38,6 +38,7 @@ TARGETLIBS = \
     $(ONECOREUAP_EXTERNAL_SDK_LIB_PATH)\d3d11.lib \
     $(ONECOREUAP_EXTERNAL_SDK_LIB_PATH)\d3dcompiler.lib \
     $(MODERNCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\api-ms-win-mm-playsound-l1.lib \
+    $(MODERNCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-imm-l1-1-0.lib \
     $(ONECORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-dwmapi-ext-l1.lib \
     $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-gdi-dc-l1.lib \
     $(MINCORE_INTERNAL_PRIV_SDK_LIB_VPATH_L)\ext-ms-win-gdi-dc-create-l1.lib \
@@ -97,6 +98,7 @@ DELAYLOAD = \
     OLEAUT32.dll; \
     icu.dll; \
     api-ms-win-mm-playsound-l1.dll; \
+    ext-ms-win-imm-l1-1-0.lib; \
     api-ms-win-shcore-scaling-l1.dll; \
     api-ms-win-shell-dataobject-l1.dll; \
     api-ms-win-shell-namespace-l1.dll; \
@@ -133,4 +135,3 @@ DELAYLOAD = \
     ext-ms-win-uxtheme-themes-l1.dll; \
 
 DLOAD_ERROR_HANDLER = kernelbase
-


### PR DESCRIPTION
This fixes a lot of subtle issues:
* Avoid emitting another de-/iconify VT sequence when
  we encounter a (de)iconify VT sequence during parsing.
* Avoid emitting a de-/iconify VT sequence when
  a focus event is received on the signal pipe.
* Avoid emitting such sequences on startup.
* Avoid emitting multiple such sequences
  when rapidly un-/focusing the window.

It's also a minor cleanup, because the `GA_ROOTOWNER` is not security
relevant. It was added because there was concern that someone can just
spawn a ConPTY session, tell it that it's focused, and spawn a child
which is now focused. But why would someone do that, when the console
IOCTLs to do so are not just publicly available but also documented?

I also disabled the IME window.

## Validation Steps Performed
* First:
  ```cpp
  int main() {
      for (bool show = false;; show = !show) {
          printf(show ? "Show in 3s...\n" : "Hide in 3s...\n");
          Sleep(3000);
          ShowWindow(GetConsoleWindow(), show ? SW_SHOW : SW_HIDE);
      }
  }
  ```
* PowerShell 5's `Get-Credential` gains focus ✅
* `sleep 5; Get-Credential` and focus another app. WT should start
  blinking in the taskbar. Restore it. The popup has focus ✅
* Run `:hardcopy` in vim: Window is shown centered at (0,0) ✖️
  But that's okay because it does that already anyway ✅
* `Connect-AzAccount` doesn't crash PowerShell ✅