### PR TITLE
Avoid dropping Esc characters from VT responses

### DIFF
--- a/src/terminal/adapter/IInteractDispatch.hpp
+++ b/src/terminal/adapter/IInteractDispatch.hpp
@@ -33,6 +33,7 @@ namespace Microsoft::Console::VirtualTerminal
         virtual void WriteInput(const std::span<const INPUT_RECORD>& inputEvents) = 0;
         virtual void WriteCtrlKey(const INPUT_RECORD& event) = 0;
         virtual void WriteString(std::wstring_view string) = 0;
+        virtual void WriteStringRaw(std::wstring_view string) = 0;
         virtual void WindowManipulation(DispatchTypes::WindowManipulationType function, VTParameter parameter1, VTParameter parameter2) = 0;
         virtual void MoveCursor(VTInt row, VTInt col) = 0;
         virtual void FocusChanged(bool focused) = 0;

--- a/src/terminal/adapter/InteractDispatch.cpp
+++ b/src/terminal/adapter/InteractDispatch.cpp
@@ -59,18 +59,8 @@ void InteractDispatch::WriteCtrlKey(const INPUT_RECORD& event)
 // - string : a string to write to the console.
 void InteractDispatch::WriteString(const std::wstring_view string)
 {
-    if (!string.empty())
-    {
-        const auto codepage = _api.GetConsoleOutputCP();
-        InputEventQueue keyEvents;
-
-        for (const auto& wch : string)
-        {
-            CharToKeyEvents(wch, codepage, keyEvents);
-        }
-
-        WriteInput(keyEvents);
-    }
+    const auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
+    gci.GetActiveInputBuffer()->WriteString(string);
 }
 
 //Method Description:

--- a/src/terminal/adapter/InteractDispatch.cpp
+++ b/src/terminal/adapter/InteractDispatch.cpp
@@ -53,14 +53,25 @@ void InteractDispatch::WriteCtrlKey(const INPUT_RECORD& event)
     HandleGenericKeyEvent(event, false);
 }
 
-// Method Description:
-// - Writes a string of input to the host.
-// Arguments:
-// - string : a string to write to the console.
+// Call this method to write some plain text to the InputBuffer.
+//
+// Since the hosting terminal for ConPTY may not support win32-input-mode,
+// it may send an "A" key as an "A", for which we need to generate up/down events.
+// Because of this, we cannot simply call InputBuffer::WriteString directly.
 void InteractDispatch::WriteString(const std::wstring_view string)
 {
-    const auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
-    gci.GetActiveInputBuffer()->WriteString(string);
+    if (!string.empty())
+    {
+        const auto codepage = _api.GetConsoleOutputCP();
+        InputEventQueue keyEvents;
+
+        for (const auto& wch : string)
+        {
+            CharToKeyEvents(wch, codepage, keyEvents);
+        }
+
+        WriteInput(keyEvents);
+    }
 }
 
 //Method Description:

--- a/src/terminal/adapter/InteractDispatch.cpp
+++ b/src/terminal/adapter/InteractDispatch.cpp
@@ -74,6 +74,12 @@ void InteractDispatch::WriteString(const std::wstring_view string)
     }
 }
 
+void InteractDispatch::WriteStringRaw(std::wstring_view string)
+{
+    const auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
+    gci.GetActiveInputBuffer()->WriteString(string);
+}
+
 //Method Description:
 // Window Manipulation - Performs a variety of actions relating to the window,
 //      such as moving the window position, resizing the window, querying

--- a/src/terminal/adapter/InteractDispatch.hpp
+++ b/src/terminal/adapter/InteractDispatch.hpp
@@ -30,6 +30,7 @@ namespace Microsoft::Console::VirtualTerminal
         void WriteInput(const std::span<const INPUT_RECORD>& inputEvents) override;
         void WriteCtrlKey(const INPUT_RECORD& event) override;
         void WriteString(std::wstring_view string) override;
+        void WriteStringRaw(std::wstring_view string) override;
         void WindowManipulation(DispatchTypes::WindowManipulationType function, VTParameter parameter1, VTParameter parameter2) override;
         void MoveCursor(VTInt row, VTInt col) override;
         void FocusChanged(bool focused) override;

--- a/src/terminal/parser/InputStateMachineEngine.cpp
+++ b/src/terminal/parser/InputStateMachineEngine.cpp
@@ -293,28 +293,7 @@ bool InputStateMachineEngine::ActionPrintString(const std::wstring_view string)
 // - true iff we successfully dispatched the sequence.
 bool InputStateMachineEngine::ActionPassThroughString(const std::wstring_view string)
 {
-    if (string.empty())
-    {
-        return true;
-    }
-
-    if (_pDispatch->IsVtInputEnabled())
-    {
-        // Synthesize string into key events that we'll write to the buffer
-        // similar to TerminalInput::_SendInputSequence
-        InputEventQueue inputEvents;
-        for (const auto& wch : string)
-        {
-            inputEvents.push_back(SynthesizeKeyEvent(true, 1, 0, 0, wch, 0));
-        }
-        _pDispatch->WriteInput(inputEvents);
-    }
-    else
-    {
-        _pDispatch->WriteString(string);
-    }
-
-    return true;
+    return ActionPrintString(string);
 }
 
 // Method Description:

--- a/src/terminal/parser/InputStateMachineEngine.cpp
+++ b/src/terminal/parser/InputStateMachineEngine.cpp
@@ -293,7 +293,11 @@ bool InputStateMachineEngine::ActionPrintString(const std::wstring_view string)
 // - true iff we successfully dispatched the sequence.
 bool InputStateMachineEngine::ActionPassThroughString(const std::wstring_view string)
 {
-    return ActionPrintString(string);
+    if (!string.empty())
+    {
+        _pDispatch->WriteStringRaw(string);
+    }
+    return true;
 }
 
 // Method Description:

--- a/src/terminal/parser/ut_parser/InputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/InputEngineTest.cpp
@@ -322,6 +322,7 @@ public:
                                     const VTParameter parameter1,
                                     const VTParameter parameter2) override; // DTTERM_WindowManipulation
     virtual void WriteString(const std::wstring_view string) override;
+    virtual void WriteStringRaw(const std::wstring_view string) override;
 
     virtual void MoveCursor(const VTInt row,
                             const VTInt col) override;
@@ -372,6 +373,18 @@ void TestInteractDispatch::WriteString(const std::wstring_view string)
         // We're forcing the translation to CP_USA, so that it'll be constant
         //  regardless of the CP the test is running in
         Microsoft::Console::Interactivity::CharToKeyEvents(wch, CP_USA, keyEvents);
+    }
+
+    WriteInput(keyEvents);
+}
+
+void TestInteractDispatch::WriteStringRaw(const std::wstring_view string)
+{
+    InputEventQueue keyEvents;
+
+    for (const auto& wch : string)
+    {
+        keyEvents.push_back(SynthesizeKeyEvent(true, 1, 0, 0, wch, 0));
     }
 
     WriteInput(keyEvents);

--- a/src/tools/vtpipeterm/main.cpp
+++ b/src/tools/vtpipeterm/main.cpp
@@ -184,7 +184,7 @@ static int run(int argc, const wchar_t* argv[])
             if (write != 0)
             {
                 DWORD written;
-                if (!WriteFile(pipe.server.get(), &inputConptyBuffer[0], write, &written, nullptr) || written != read)
+                if (!WriteFile(pipe.server.get(), &inputConptyBuffer[0], write, &written, nullptr) || written != write)
                 {
                     return 0;
                 }


### PR DESCRIPTION
`GetChar` checks if the vkey is VK_ESCAPE. `CharToKeyEvents` however
tries really hard to figure out the vkeys of all characters.
To avoid these issues all we need to do is to simply use the existing
`WriteString` function we already use for all other VT responses.
If it's good for conhost responses, it's good for ConPTY responses.

Additionally, this removes another `IsVtInputEnabled` which was
redundant with `WriteString` which worked exactly the same internally.

Closes #17813
Closes #17851
Probably also related to #17823

## Validation Steps Performed
* Wrote a small app to send and receive a DA1 request. It works ✅
* WSL already worked to begin with (and still works now) ✅
* No double-encoding of mouse input events ✅