### PR TITLE
Restore contents when a screen info is closed

### DIFF
--- a/src/host/VtIo.hpp
+++ b/src/host/VtIo.hpp
@@ -44,6 +44,7 @@ namespace Microsoft::Console::VirtualTerminal
             void WriteWindowTitle(std::wstring_view title) const;
             void WriteAttributes(const TextAttribute& attributes) const;
             void WriteInfos(til::point target, std::span<const CHAR_INFO> infos) const;
+            void WriteScreenInfo(SCREEN_INFORMATION& newContext, til::size oldSize) const;
 
         private:
             VtIo* _io = nullptr;

--- a/src/server/ObjectHandle.cpp
+++ b/src/server/ObjectHandle.cpp
@@ -273,7 +273,18 @@ INPUT_READ_HANDLE_DATA* ConsoleHandleData::GetClientInput() const
     LOG_IF_FAILED(pScreenInfo->FreeIoHandle(this));
     if (!pScreenInfo->HasAnyOpenHandles())
     {
+        auto& gci = Microsoft::Console::Interactivity::ServiceLocator::LocateGlobals().getConsoleInformation();
+        const auto oldSize = gci.GetActiveOutputBuffer().GetBufferSize().Dimensions();
+        auto writer = gci.GetVtWriter();
+
         SCREEN_INFORMATION::s_RemoveScreenBuffer(pScreenInfo);
+
+        if (writer && gci.HasActiveOutputBuffer())
+        {
+            auto& newContext = gci.GetActiveOutputBuffer();
+            writer.WriteScreenInfo(newContext, oldSize);
+            writer.Submit();
+        }
     }
 
     return S_OK;


### PR DESCRIPTION
This moves the `SetConsoleActiveScreenBufferImpl` into `VtIo` which
allows us to use the code when the screen info handle is closed.

Closes #17817

## Validation Steps Performed
* Calling `CreateConsoleScreenBuffer` + `SetConsoleActiveScreenBuffer`
  + `CloseHandle` results in no obvious screen changes ✅