### PR TITLE
Add Mica Alt support (#17650)

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -716,7 +716,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // that our theme is different than the app's.
         const bool actuallyUseMica = isMicaAvailable && (appTheme == requestedTheme);
 
-        const auto bgKey = (theme.Window() != nullptr && theme.Window().UseMica()) && actuallyUseMica ?
+        const auto bgKey = (theme.Window() != nullptr && theme.Window().MicaStyle() != MicaStyle::Default) && actuallyUseMica ?
                                L"SettingsPageMicaBackground" :
                                L"SettingsPageBackground";
 

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -696,7 +696,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             const auto hr = DwmGetWindowAttribute(*_hostingHwnd, DWMWA_SYSTEMBACKDROP_TYPE, &attribute, sizeof(attribute));
             if (SUCCEEDED(hr))
             {
-                isMicaAvailable = attribute == DWMSBT_MAINWINDOW;
+                isMicaAvailable = (attribute == DWMSBT_MAINWINDOW) || (attribute == DWMSBT_TABBEDWINDOW);
             }
         }
 

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -150,7 +150,7 @@ Author(s):
     X(winrt::Microsoft::Terminal::Settings::Model::ThemeColor, Frame, "frame", nullptr)                                            \
     X(winrt::Microsoft::Terminal::Settings::Model::ThemeColor, UnfocusedFrame, "unfocusedFrame", nullptr)                          \
     X(bool, RainbowFrame, "experimental.rainbowFrame", false)                                                                      \
-    X(bool, UseMica, "useMica", false)
+    X(winrt::Microsoft::Terminal::Settings::Model::MicaStyle, MicaStyle, "micaStyle", winrt::Microsoft::Terminal::Settings::Model::MicaStyle::Default)
 
 #define MTSM_THEME_SETTINGS_SETTINGS(X) \
     X(winrt::Windows::UI::Xaml::ElementTheme, RequestedTheme, "theme", winrt::Windows::UI::Xaml::ElementTheme::Default)

--- a/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
@@ -666,6 +666,15 @@ JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::IconStyle)
     };
 };
 
+JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::MicaStyle)
+{
+    JSON_MAPPINGS(3) = {
+        pair_type{ "default", ValueType::Default },
+        pair_type{ "original", ValueType::Original },
+        pair_type{ "alt", ValueType::Alt },
+    };
+};
+
 // Possible ScrollToMarkDirection values
 JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Control::ScrollToMarkDirection)
 {

--- a/src/cascadia/TerminalSettingsModel/Theme.idl
+++ b/src/cascadia/TerminalSettingsModel/Theme.idl
@@ -26,6 +26,13 @@ namespace Microsoft.Terminal.Settings.Model
         ActiveOnly
     };
 
+    enum MicaStyle
+    {
+        Default,
+        Original,
+        Alt
+    };
+
     [default_interface] runtimeclass ThemePair
     {
         ThemePair();
@@ -60,7 +67,7 @@ namespace Microsoft.Terminal.Settings.Model
 
     runtimeclass WindowTheme {
         Windows.UI.Xaml.ElementTheme RequestedTheme { get; };
-        Boolean UseMica { get; };
+        MicaStyle MicaStyle { get; };
         Boolean RainbowFrame { get; };
         ThemeColor Frame { get; };
         ThemeColor UnfocusedFrame { get; };

--- a/src/cascadia/UnitTests_SettingsModel/ThemeTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/ThemeTests.cpp
@@ -52,7 +52,7 @@ namespace SettingsModelUnitTests
             "window":
             {
                 "applicationTheme": "light",
-                "useMica": true
+                "micaStyle": "original"
             }
         })" };
 
@@ -68,7 +68,7 @@ namespace SettingsModelUnitTests
 
         VERIFY_IS_NOT_NULL(theme->Window());
         VERIFY_ARE_EQUAL(winrt::Windows::UI::Xaml::ElementTheme::Light, theme->Window().RequestedTheme());
-        VERIFY_ARE_EQUAL(true, theme->Window().UseMica());
+        VERIFY_ARE_NOT_EQUAL(MicaStyle::Default, theme->Window().MicaStyle());
     }
 
     void ThemeTests::ParseEmptyTheme()
@@ -151,7 +151,7 @@ namespace SettingsModelUnitTests
                     "window":
                     {
                         "applicationTheme": "light",
-                        "useMica": true
+                        "micaStyle": "orginal"
                     }
                 },
                 {
@@ -163,7 +163,7 @@ namespace SettingsModelUnitTests
                     "window":
                     {
                         "applicationTheme": "light",
-                        "useMica": true
+                        "micaStyle": "original"
                     }
                 },
                 {
@@ -171,7 +171,7 @@ namespace SettingsModelUnitTests
                     "window":
                     {
                         "applicationTheme": "light",
-                        "useMica": true
+                        "micaStyle": "original"
                     }
                 }
             ]
@@ -227,7 +227,7 @@ namespace SettingsModelUnitTests
                     "window":
                     {
                         "applicationTheme": "light",
-                        "useMica": true
+                        "micaStyle": "original"
                     }
                 }
             ]

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -1130,7 +1130,7 @@ void AppHost::_updateTheme()
     const auto colorOpacity = b ? color.A / 255.0 : 0.0;
     const auto brushOpacity = _opacityFromBrush(b);
     const auto opacity = std::min(colorOpacity, brushOpacity);
-    _window->UseMica(windowTheme ? windowTheme.UseMica() : false, opacity);
+    _window->SetMicaStyle(windowTheme ? windowTheme.MicaStyle() : MicaStyle::Default, opacity);
 
     // This is a hack to make the window borders dark instead of light.
     // It must be done before WM_NCPAINT so that the borders are rendered with

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -1940,7 +1940,7 @@ void IslandWindow::UseDarkTheme(const bool v)
     std::ignore = DwmSetWindowAttribute(GetHandle(), DWMWA_USE_IMMERSIVE_DARK_MODE, &attribute, sizeof(attribute));
 }
 
-void IslandWindow::UseMica(const bool newValue, const double /*titlebarOpacity*/)
+void IslandWindow::SetMicaStyle(const winrt::Microsoft::Terminal::Settings::Model::MicaStyle newValue, const double /*titlebarOpacity*/)
 {
     // This block of code enables Mica for our window. By all accounts, this
     // version of the code will only work on Windows 11, SV2. There's a slightly
@@ -1948,8 +1948,15 @@ void IslandWindow::UseMica(const bool newValue, const double /*titlebarOpacity*/
     //
     // This API was only publicly supported as of Windows 11 SV2, 22621. Before
     // that version, this API will just return an error and do nothing silently.
-
-    const int attribute = newValue ? DWMSBT_MAINWINDOW : DWMSBT_NONE;
+    int attribute = DWMSBT_NONE;
+    if (newValue == MicaStyle::Original)
+    {
+        attribute = DWMSBT_MAINWINDOW;
+    }
+    else if (newValue == MicaStyle::Alt)
+    {
+        attribute = DWMSBT_TABBEDWINDOW;
+    }
     std::ignore = DwmSetWindowAttribute(GetHandle(), DWMWA_SYSTEMBACKDROP_TYPE, &attribute, sizeof(attribute));
 }
 

--- a/src/cascadia/WindowsTerminal/IslandWindow.h
+++ b/src/cascadia/WindowsTerminal/IslandWindow.h
@@ -70,7 +70,7 @@ public:
     void RemoveFromSystemMenu(const winrt::hstring& itemLabel);
 
     void UseDarkTheme(const bool v);
-    virtual void UseMica(const bool newValue, const double titlebarOpacity);
+    virtual void SetMicaStyle(const winrt::Microsoft::Terminal::Settings::Model::MicaStyle newValue, const double titlebarOpacity);
 
     til::event<winrt::delegate<>> DragRegionClicked;
     til::event<winrt::delegate<>> WindowCloseButtonClicked;

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -941,7 +941,7 @@ void NonClientIslandWindow::_UpdateFrameMargins() const noexcept
         //   use NCHITTEST to determine where to place the Snap Flyout. The drag
         //   rect will handle that.
 
-        margins.cyTopHeight = (_useMica || _titlebarOpacity < 1.0) ? 0 : -frame.top;
+        margins.cyTopHeight = (_micaStyle != winrt::Microsoft::Terminal::Settings::Model::MicaStyle::Default || _titlebarOpacity < 1.0) ? 0 : -frame.top;
     }
 
     // Extend the frame into the client area. microsoft/terminal#2735 - Just log
@@ -1174,15 +1174,15 @@ void NonClientIslandWindow::SetTitlebarBackground(winrt::Windows::UI::Xaml::Medi
     _titlebar.Background(brush);
 }
 
-void NonClientIslandWindow::UseMica(const bool newValue, const double titlebarOpacity)
+void NonClientIslandWindow::SetMicaStyle(const winrt::Microsoft::Terminal::Settings::Model::MicaStyle newValue, const double titlebarOpacity)
 {
     // Stash internally if we're using Mica. If we aren't, we don't want to
     // totally blow away our titlebar with DwmExtendFrameIntoClientArea,
     // especially on Windows 10
-    _useMica = newValue;
+    _micaStyle = newValue;
     _titlebarOpacity = titlebarOpacity;
 
-    IslandWindow::UseMica(newValue, titlebarOpacity);
+    IslandWindow::SetMicaStyle(newValue, titlebarOpacity);
 
     _UpdateFrameMargins();
 }

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.h
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.h
@@ -52,7 +52,7 @@ public:
 
     void SetTitlebarBackground(winrt::Windows::UI::Xaml::Media::Brush brush);
 
-    virtual void UseMica(const bool newValue, const double titlebarOpacity) override;
+    virtual void SetMicaStyle(const winrt::Microsoft::Terminal::Settings::Model::MicaStyle newValue, const double titlebarOpacity) override;
 
 private:
     std::optional<til::point> _oldIslandPos;
@@ -67,7 +67,8 @@ private:
 
     winrt::Windows::UI::Xaml::ElementTheme _theme;
 
-    bool _useMica{ false };
+    winrt::Microsoft::Terminal::Settings::Model::MicaStyle _micaStyle{ winrt::Microsoft::Terminal::Settings::Model::MicaStyle::Default };
+
     double _titlebarOpacity{ 1.0 };
 
     bool _isMaximized;


### PR DESCRIPTION
## Summary of the Pull Request
 1. Changing the existing $theme.$window.useMica property in the settings from a straight boolean to a string enum $theme.$window.micaStyle
- "default" (stands for not using mica)
- "original" (stands for using original mica)
- "alt" (stands for using mica alt)
2. Implement mica alt by using **DWMSBT_TABBEDWINDOW** in [DWM_SYSTEMBACKDROP_TYPE enumeration](https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwm_systembackdrop_type)  
## References and Relevant Issues
#17650 
## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed
Change $theme.$window.micaStyle property in the setting.json, see the performances of the window theme
- "default" (performs the same as useMica=false)
- "original" (performs the same as useMica=true)
- "alt" (performs Mica Alt theme)
## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
