### PR TITLE
Remove PackageES in favor of our own versioning package

### DIFF
--- a/build/pipelines/templates-v2/job-build-package-wpf.yml
+++ b/build/pipelines/templates-v2/job-build-package-wpf.yml
@@ -59,10 +59,7 @@ jobs:
     submodules: true
     persistCredentials: True
 
-  - task: PkgESSetupBuild@12
-    displayName: Package ES - Setup Build
-    inputs:
-      disableOutputRedirect: true
+  - template: steps-setup-versioning.ps1
 
   - template: steps-download-bin-dir-artifact.yml
     parameters:

--- a/build/pipelines/templates-v2/job-build-package-wpf.yml
+++ b/build/pipelines/templates-v2/job-build-package-wpf.yml
@@ -59,7 +59,7 @@ jobs:
     submodules: true
     persistCredentials: True
 
-  - template: steps-setup-versioning.ps1
+  - template: steps-setup-versioning.yml
 
   - template: steps-download-bin-dir-artifact.yml
     parameters:

--- a/build/pipelines/templates-v2/job-merge-msix-into-bundle.yml
+++ b/build/pipelines/templates-v2/job-merge-msix-into-bundle.yml
@@ -69,10 +69,9 @@ jobs:
     fetchTags: false # Tags still result in depth > 1 fetch; we don't need them here
     submodules: true
     persistCredentials: True
-  - task: PkgESSetupBuild@12
-    displayName: Package ES - Setup Build
-    inputs:
-      disableOutputRedirect: true
+
+  - template: steps-setup-versioning.ps1
+
   - template: steps-download-bin-dir-artifact.yml
     parameters:
       buildPlatforms: ${{ parameters.buildPlatforms }}

--- a/build/pipelines/templates-v2/job-merge-msix-into-bundle.yml
+++ b/build/pipelines/templates-v2/job-merge-msix-into-bundle.yml
@@ -70,7 +70,7 @@ jobs:
     submodules: true
     persistCredentials: True
 
-  - template: steps-setup-versioning.ps1
+  - template: steps-setup-versioning.yml
 
   - template: steps-download-bin-dir-artifact.yml
     parameters:

--- a/build/pipelines/templates-v2/job-package-conpty.yml
+++ b/build/pipelines/templates-v2/job-package-conpty.yml
@@ -57,7 +57,7 @@ jobs:
     submodules: true
     persistCredentials: True
 
-  - template: steps-setup-versioning.ps1
+  - template: steps-setup-versioning.yml
 
   - template: steps-download-bin-dir-artifact.yml
     parameters:

--- a/build/pipelines/templates-v2/job-package-conpty.yml
+++ b/build/pipelines/templates-v2/job-package-conpty.yml
@@ -57,10 +57,7 @@ jobs:
     submodules: true
     persistCredentials: True
 
-  - task: PkgESSetupBuild@12
-    displayName: Package ES - Setup Build
-    inputs:
-      disableOutputRedirect: true
+  - template: steps-setup-versioning.ps1
 
   - template: steps-download-bin-dir-artifact.yml
     parameters:

--- a/build/pipelines/templates-v2/job-publish-symbols-using-symbolrequestprod-api.yml
+++ b/build/pipelines/templates-v2/job-publish-symbols-using-symbolrequestprod-api.yml
@@ -44,10 +44,7 @@ jobs:
     submodules: true
     persistCredentials: True
 
-  - task: PkgESSetupBuild@12
-    displayName: Package ES - Setup Build
-    inputs:
-      disableOutputRedirect: true
+  - template: steps-setup-versioning.ps1
 
   - task: DownloadPipelineArtifact@2
     displayName: Download all PDBs from all prior build phases

--- a/build/pipelines/templates-v2/job-publish-symbols-using-symbolrequestprod-api.yml
+++ b/build/pipelines/templates-v2/job-publish-symbols-using-symbolrequestprod-api.yml
@@ -44,7 +44,7 @@ jobs:
     submodules: true
     persistCredentials: True
 
-  - template: steps-setup-versioning.ps1
+  - template: steps-setup-versioning.yml
 
   - task: DownloadPipelineArtifact@2
     displayName: Download all PDBs from all prior build phases

--- a/build/pipelines/templates-v2/job-publish-symbols.yml
+++ b/build/pipelines/templates-v2/job-publish-symbols.yml
@@ -43,7 +43,7 @@ jobs:
     submodules: true
     persistCredentials: True
 
-  - template: steps-setup-versioning.ps1
+  - template: steps-setup-versioning.yml
 
   - task: DownloadPipelineArtifact@2
     displayName: Download all PDBs from all prior build phases

--- a/build/pipelines/templates-v2/job-publish-symbols.yml
+++ b/build/pipelines/templates-v2/job-publish-symbols.yml
@@ -43,10 +43,7 @@ jobs:
     submodules: true
     persistCredentials: True
 
-  - task: PkgESSetupBuild@12
-    displayName: Package ES - Setup Build
-    inputs:
-      disableOutputRedirect: true
+  - template: steps-setup-versioning.ps1
 
   - task: DownloadPipelineArtifact@2
     displayName: Download all PDBs from all prior build phases

--- a/build/pipelines/templates-v2/job-submit-windows-vpack.yml
+++ b/build/pipelines/templates-v2/job-submit-windows-vpack.yml
@@ -38,7 +38,7 @@ jobs:
     submodules: true
     persistCredentials: True
 
-  - template: steps-setup-versioning.ps1
+  - template: steps-setup-versioning.yml
 
   - task: DownloadPipelineArtifact@2
     displayName: Download MSIX Bundle Artifact

--- a/build/pipelines/templates-v2/job-submit-windows-vpack.yml
+++ b/build/pipelines/templates-v2/job-submit-windows-vpack.yml
@@ -38,10 +38,7 @@ jobs:
     submodules: true
     persistCredentials: True
 
-  - task: PkgESSetupBuild@12
-    displayName: Package ES - Setup Build
-    inputs:
-      disableOutputRedirect: true
+  - template: steps-setup-versioning.ps1
 
   - task: DownloadPipelineArtifact@2
     displayName: Download MSIX Bundle Artifact

--- a/build/pipelines/templates-v2/pipeline-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-full-release-build.yml
@@ -92,10 +92,7 @@ stages:
           generateSbom: ${{ parameters.generateSbom }}
           codeSign: ${{ parameters.codeSign }}
           beforeBuildSteps: # Right before we build, lay down the universal package and localizations
-            - task: PkgESSetupBuild@12
-              displayName: Package ES - Setup Build
-              inputs:
-                disableOutputRedirect: true
+            - template: steps-setup-versioning.ps1
 
             - task: UniversalPackages@0
               displayName: Download terminal-internal Universal Package
@@ -119,10 +116,7 @@ stages:
             generateSbom: ${{ parameters.generateSbom }}
             codeSign: ${{ parameters.codeSign }}
             beforeBuildSteps:
-              - task: PkgESSetupBuild@12
-                displayName: Package ES - Setup Build
-                inputs:
-                  disableOutputRedirect: true
+              - template: steps-setup-versioning.ps1
               # WPF doesn't need the localizations or the universal package, but if it does... put them here.
 
   - stage: Package

--- a/build/pipelines/templates-v2/pipeline-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-full-release-build.yml
@@ -92,7 +92,7 @@ stages:
           generateSbom: ${{ parameters.generateSbom }}
           codeSign: ${{ parameters.codeSign }}
           beforeBuildSteps: # Right before we build, lay down the universal package and localizations
-            - template: ./build/pipelines/templates-v2/steps-setup-versioning.ps1@self
+            - template: ./build/pipelines/templates-v2/steps-setup-versioning.yml@self
 
             - task: UniversalPackages@0
               displayName: Download terminal-internal Universal Package
@@ -116,7 +116,7 @@ stages:
             generateSbom: ${{ parameters.generateSbom }}
             codeSign: ${{ parameters.codeSign }}
             beforeBuildSteps:
-              - template: ./build/pipelines/templates-v2/steps-setup-versioning.ps1@self
+              - template: ./build/pipelines/templates-v2/steps-setup-versioning.yml@self
               # WPF doesn't need the localizations or the universal package, but if it does... put them here.
 
   - stage: Package

--- a/build/pipelines/templates-v2/pipeline-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-full-release-build.yml
@@ -92,7 +92,7 @@ stages:
           generateSbom: ${{ parameters.generateSbom }}
           codeSign: ${{ parameters.codeSign }}
           beforeBuildSteps: # Right before we build, lay down the universal package and localizations
-            - template: steps-setup-versioning.ps1
+            - template: ./build/pipelines/templates-v2/steps-setup-versioning.ps1@self
 
             - task: UniversalPackages@0
               displayName: Download terminal-internal Universal Package
@@ -116,7 +116,7 @@ stages:
             generateSbom: ${{ parameters.generateSbom }}
             codeSign: ${{ parameters.codeSign }}
             beforeBuildSteps:
-              - template: steps-setup-versioning.ps1
+              - template: ./build/pipelines/templates-v2/steps-setup-versioning.ps1@self
               # WPF doesn't need the localizations or the universal package, but if it does... put them here.
 
   - stage: Package

--- a/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
@@ -130,7 +130,7 @@ extends:
               codeSign: ${{ parameters.codeSign }}
               signingIdentity: ${{ parameters.signingIdentity }}
               beforeBuildSteps: # Right before we build, lay down the universal package and localizations
-                - template: steps-setup-versioning.ps1
+                - template: ./build/pipelines/templates-v2/steps-setup-versioning.ps1@self
 
                 - task: UniversalPackages@0
                   displayName: Download terminal-internal Universal Package
@@ -164,7 +164,7 @@ extends:
                 codeSign: ${{ parameters.codeSign }}
                 signingIdentity: ${{ parameters.signingIdentity }}
                 beforeBuildSteps:
-                  - template: steps-setup-versioning.ps1
+                  - template: ./build/pipelines/templates-v2/steps-setup-versioning.ps1@self
                   # WPF doesn't need the localizations or the universal package, but if it does... put them here.
 
       - stage: Package

--- a/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
@@ -130,10 +130,7 @@ extends:
               codeSign: ${{ parameters.codeSign }}
               signingIdentity: ${{ parameters.signingIdentity }}
               beforeBuildSteps: # Right before we build, lay down the universal package and localizations
-                - task: PkgESSetupBuild@12
-                  displayName: Package ES - Setup Build
-                  inputs:
-                    disableOutputRedirect: true
+                - template: steps-setup-versioning.ps1
 
                 - task: UniversalPackages@0
                   displayName: Download terminal-internal Universal Package
@@ -167,10 +164,7 @@ extends:
                 codeSign: ${{ parameters.codeSign }}
                 signingIdentity: ${{ parameters.signingIdentity }}
                 beforeBuildSteps:
-                  - task: PkgESSetupBuild@12
-                    displayName: Package ES - Setup Build
-                    inputs:
-                      disableOutputRedirect: true
+                  - template: steps-setup-versioning.ps1
                   # WPF doesn't need the localizations or the universal package, but if it does... put them here.
 
       - stage: Package

--- a/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
@@ -130,7 +130,7 @@ extends:
               codeSign: ${{ parameters.codeSign }}
               signingIdentity: ${{ parameters.signingIdentity }}
               beforeBuildSteps: # Right before we build, lay down the universal package and localizations
-                - template: ./build/pipelines/templates-v2/steps-setup-versioning.ps1@self
+                - template: ./build/pipelines/templates-v2/steps-setup-versioning.yml@self
 
                 - task: UniversalPackages@0
                   displayName: Download terminal-internal Universal Package
@@ -164,7 +164,7 @@ extends:
                 codeSign: ${{ parameters.codeSign }}
                 signingIdentity: ${{ parameters.signingIdentity }}
                 beforeBuildSteps:
-                  - template: ./build/pipelines/templates-v2/steps-setup-versioning.ps1@self
+                  - template: ./build/pipelines/templates-v2/steps-setup-versioning.yml@self
                   # WPF doesn't need the localizations or the universal package, but if it does... put them here.
 
       - stage: Package

--- a/build/pipelines/templates-v2/steps-setup-versioning.yml
+++ b/build/pipelines/templates-v2/steps-setup-versioning.yml
@@ -1,0 +1,6 @@
+steps:
+  - pwsh: |-
+      nuget install Microsoft.Windows.Terminal.Versioning -OutputDirectory _versioning
+      $VersionRoot = (Get-Item _versioning\Microsoft.Windows.*).FullName
+      & "$VersionRoot\build\Setup.ps1" -ProjectDirectory "$(Build.SourcesDirectory)" -Verbose
+    displayName: Set up versioning via M.W.T.V


### PR DESCRIPTION
PackageES is deprecated by known scourge-on-earth OneBranch, and is now the cause of some non-compliance.

I got permission from them to open-source it, so that's coming next.

For now, we can just depend on a package based on our code based on theirs.

Tested and working for C++ (DLL, EXE), C#, NuGet and MSIX.