### PR TITLE
Fix a crash on pane close

### DIFF
--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -2956,13 +2956,13 @@ bool Pane::ContainsReadOnly() const
 // - <none>
 void Pane::CollectTaskbarStates(std::vector<winrt::TerminalApp::TaskbarState>& states)
 {
-    if (_IsLeaf())
+    if (_content)
     {
         auto tbState{ winrt::make<winrt::TerminalApp::implementation::TaskbarState>(_content.TaskbarState(),
                                                                                     _content.TaskbarProgress()) };
         states.push_back(tbState);
     }
-    else
+    else if (_firstChild && _secondChild)
     {
         _firstChild->CollectTaskbarStates(states);
         _secondChild->CollectTaskbarStates(states);


### PR DESCRIPTION
The underlying issue is that the "Pane" is used both as a model and as
a UI element and so a pane loses its content as soon as it is closed,
but the tree only gets reordered after the animation has finished.
This PR is truly just a hotfix, because it doesn't solve this issue,
it only adds checks to the function that crashes.

Closes #17869
Closes #17871

## Validation Steps Performed
* `Split pane` a few times
* Run the "Close all other panes" action
* Doesn't crash ✅