### PR TITLE
Add a Compatibility and Terminal page to the Settings UI

### DIFF
--- a/.github/actions/spelling/allow/apis.txt
+++ b/.github/actions/spelling/allow/apis.txt
@@ -35,7 +35,6 @@ dataobject
 dcomp
 debugbreak
 delayimp
-DECRQRCA
 DERR
 dlldata
 DNE

--- a/.github/actions/spelling/allow/apis.txt
+++ b/.github/actions/spelling/allow/apis.txt
@@ -35,6 +35,7 @@ dataobject
 dcomp
 debugbreak
 delayimp
+DECRQRCA
 DERR
 dlldata
 DNE

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2355,9 +2355,24 @@
           "description": "When set to true, the terminal will focus the pane on mouse hover.",
           "type": "boolean"
         },
+        "compatibility.allowHeadless": {
+          "default": false,
+          "description": "When set to true, Windows Terminal will run in the background. This allows globalSummon and quakeMode actions to work even when no windows are open.",
+          "type": "boolean"
+        },
         "compatibility.isolatedMode": {
           "default": false,
           "description": "When set to true, Terminal windows will not be able to interact with each other (including global hotkeys, tab drag/drop, running commandlines in existing windows, etc.). This is a compatibility escape hatch for users who are running into certain windowing issues.",
+          "type": "boolean"
+        },
+        "compatibility.allowVtChecksumReport": {
+          "default": false,
+          "description": "When set to true, the terminal will support the DECQRCA escape sequence.",
+          "type": "boolean"
+        },
+        "compatibility.allowKeypadMode": {
+          "default": false,
+          "description": "When set to true, the terminal will support the DECKPAM and DECKPNM escape sequences.",
           "type": "boolean"
         },
         "copyFormatting": {

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2367,7 +2367,7 @@
         },
         "compatibility.allowVtChecksumReport": {
           "default": false,
-          "description": "When set to true, the terminal will support the DECQRCA escape sequence.",
+          "description": "When set to true, the terminal will support the DECRQRCA escape sequence.",
           "type": "boolean"
         },
         "compatibility.allowKeypadMode": {

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2367,7 +2367,7 @@
         },
         "compatibility.allowVtChecksumReport": {
           "default": false,
-          "description": "When set to true, the terminal will support the DECRQRCA escape sequence.",
+          "description": "When set to true, the terminal will support the DECRQCRA escape sequence.",
           "type": "boolean"
         },
         "compatibility.allowKeypadMode": {

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2365,14 +2365,14 @@
           "description": "When set to true, Terminal windows will not be able to interact with each other (including global hotkeys, tab drag/drop, running commandlines in existing windows, etc.). This is a compatibility escape hatch for users who are running into certain windowing issues.",
           "type": "boolean"
         },
-        "compatibility.allowVtChecksumReport": {
+        "compatibility.allowDECRQCRA": {
           "default": false,
-          "description": "When set to true, the terminal will support the DECRQCRA escape sequence.",
+          "description": "When set to true, the terminal will support the DECRQCRA (Request Checksum of Rectangular Area) escape sequence.",
           "type": "boolean"
         },
-        "compatibility.allowKeypadMode": {
+        "compatibility.allowDECNKM": {
           "default": false,
-          "description": "When set to true, the terminal will support the DECKPAM and DECKPNM escape sequences.",
+          "description": "When set to true, the terminal will support the DECKPAM and DECKPNM (Keypad Numeric Mode) escape sequences.",
           "type": "boolean"
         },
         "copyFormatting": {

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2370,11 +2370,6 @@
           "description": "When set to true, the terminal will support the DECRQCRA (Request Checksum of Rectangular Area) escape sequence.",
           "type": "boolean"
         },
-        "compatibility.allowDECNKM": {
-          "default": false,
-          "description": "When set to true, the terminal will support the DECKPAM and DECKPNM (Keypad Numeric Mode) escape sequences.",
-          "type": "boolean"
-        },
         "copyFormatting": {
           "default": true,
           "description": "When set to `true`, the color and font formatting of selected text is also copied to your clipboard. When set to `false`, only plain text is copied to your clipboard. An array of specific formats can also be used. Supported array values include `html` and `rtf`. Plain text is always copied.",

--- a/src/cascadia/TerminalCore/ICoreSettings.idl
+++ b/src/cascadia/TerminalCore/ICoreSettings.idl
@@ -21,6 +21,7 @@ namespace Microsoft.Terminal.Core
         String WordDelimiters;
 
         Boolean ForceVTInput;
+        Boolean AllowVtChecksumReport;
         Boolean TrimBlockSelection;
         Boolean DetectURLs;
 

--- a/src/cascadia/TerminalCore/ICoreSettings.idl
+++ b/src/cascadia/TerminalCore/ICoreSettings.idl
@@ -22,7 +22,6 @@ namespace Microsoft.Terminal.Core
 
         Boolean ForceVTInput;
         Boolean AllowVtChecksumReport;
-        Boolean AllowKeypadMode;
         Boolean TrimBlockSelection;
         Boolean DetectURLs;
 

--- a/src/cascadia/TerminalCore/ICoreSettings.idl
+++ b/src/cascadia/TerminalCore/ICoreSettings.idl
@@ -22,6 +22,7 @@ namespace Microsoft.Terminal.Core
 
         Boolean ForceVTInput;
         Boolean AllowVtChecksumReport;
+        Boolean AllowKeypadMode;
         Boolean TrimBlockSelection;
         Boolean DetectURLs;
 

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -96,6 +96,7 @@ void Terminal::UpdateSettings(ICoreSettings settings)
     }
 
     _getTerminalInput().ForceDisableWin32InputMode(settings.ForceVTInput());
+    _getTerminalInput().SetKeypadModeSupport(settings.AllowKeypadMode());
 
     if (settings.TabColor() == nullptr)
     {

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -96,7 +96,6 @@ void Terminal::UpdateSettings(ICoreSettings settings)
     }
 
     _getTerminalInput().ForceDisableWin32InputMode(settings.ForceVTInput());
-    _getTerminalInput().SetKeypadModeSupport(settings.AllowKeypadMode());
 
     if (settings.TabColor() == nullptr)
     {
@@ -216,12 +215,6 @@ void Terminal::SetCursorStyle(const DispatchTypes::CursorStyle cursorStyle)
 {
     auto& engine = reinterpret_cast<OutputStateMachineEngine&>(_stateMachine->Engine());
     engine.Dispatch().SetCursorStyle(cursorStyle);
-}
-
-void Terminal::EraseScrollback()
-{
-    auto& engine = reinterpret_cast<OutputStateMachineEngine&>(_stateMachine->Engine());
-    engine.Dispatch().EraseInDisplay(DispatchTypes::EraseType::Scrollback);
 }
 
 void Terminal::SetVtChecksumReportSupport(const bool enabled)

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -90,6 +90,11 @@ void Terminal::UpdateSettings(ICoreSettings settings)
     _autoMarkPrompts = settings.AutoMarkPrompts();
     _rainbowSuggestions = settings.RainbowSuggestions();
 
+    if (_stateMachine)
+    {
+        SetVtChecksumReportSupport(settings.AllowVtChecksumReport());
+    }
+
     _getTerminalInput().ForceDisableWin32InputMode(settings.ForceVTInput());
 
     if (settings.TabColor() == nullptr)
@@ -213,6 +218,12 @@ void Terminal::EraseScrollback()
 {
     auto& engine = reinterpret_cast<OutputStateMachineEngine&>(_stateMachine->Engine());
     engine.Dispatch().EraseInDisplay(DispatchTypes::EraseType::Scrollback);
+}
+
+void Terminal::SetVtChecksumReportSupport(const bool enabled)
+{
+    auto& engine = reinterpret_cast<OutputStateMachineEngine&>(_stateMachine->Engine());
+    engine.Dispatch().SetVtChecksumReportSupport(enabled);
 }
 
 bool Terminal::IsXtermBracketedPasteModeEnabled() const noexcept

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -94,7 +94,6 @@ public:
     void UpdateAppearance(const winrt::Microsoft::Terminal::Core::ICoreAppearance& appearance);
     void SetFontInfo(const FontInfo& fontInfo);
     void SetCursorStyle(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::CursorStyle cursorStyle);
-    void EraseScrollback();
     void SetVtChecksumReportSupport(const bool enabled);
     bool IsXtermBracketedPasteModeEnabled() const noexcept;
     std::wstring_view GetWorkingDirectory() noexcept;

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -95,6 +95,7 @@ public:
     void SetFontInfo(const FontInfo& fontInfo);
     void SetCursorStyle(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::CursorStyle cursorStyle);
     void EraseScrollback();
+    void SetVtChecksumReportSupport(const bool enabled);
     bool IsXtermBracketedPasteModeEnabled() const noexcept;
     std::wstring_view GetWorkingDirectory() noexcept;
 

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.cpp
@@ -20,7 +20,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     bool CompatibilityViewModel::DebugFeaturesAvailable() const noexcept
     {
-        return Feature_DebugMode::IsEnabled();
+        return Feature_DebugModeUI::IsEnabled();
     }
 
     Compatibility::Compatibility()

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.cpp
@@ -18,9 +18,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         INITIALIZE_BINDABLE_ENUM_SETTING(TextMeasurement, TextMeasurement, winrt::Microsoft::Terminal::Control::TextMeasurement, L"Globals_TextMeasurement_", L"Text");
     }
 
-    bool CompatibilityViewModel::AllowKeypadModeAvailable() const noexcept
+    bool CompatibilityViewModel::DebugFeaturesAvailable() const noexcept
     {
-        return Feature_KeypadModeEnabled::IsEnabled();
+        return Feature_DebugMode::IsEnabled();
     }
 
     Compatibility::Compatibility()

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.cpp
@@ -16,6 +16,16 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
     }
 
+    bool CompatibilityViewModel::AllowVtChecksumReportAvailable() const noexcept
+    {
+        return Feature_VtChecksumReport::IsEnabled();
+    }
+
+    bool CompatibilityViewModel::AllowKeypadModeAvailable() const noexcept
+    {
+        return Feature_KeypadModeEnabled::IsEnabled();
+    }
+
     Compatibility::Compatibility()
     {
         InitializeComponent();

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.cpp
@@ -3,6 +3,7 @@
 
 #include "pch.h"
 #include "Compatibility.h"
+#include "EnumEntry.h"
 #include "Compatibility.g.cpp"
 #include "CompatibilityViewModel.g.cpp"
 
@@ -14,6 +15,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     CompatibilityViewModel::CompatibilityViewModel(Model::GlobalAppSettings globalSettings) :
         _GlobalSettings{ globalSettings }
     {
+        INITIALIZE_BINDABLE_ENUM_SETTING(TextMeasurement, TextMeasurement, winrt::Microsoft::Terminal::Control::TextMeasurement, L"Globals_TextMeasurement_", L"Text");
     }
 
     bool CompatibilityViewModel::AllowVtChecksumReportAvailable() const noexcept

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.cpp
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
+#include "Compatibility.h"
+#include "Compatibility.g.cpp"
+#include "CompatibilityViewModel.g.cpp"
+
+using namespace winrt::Windows::UI::Xaml::Navigation;
+using namespace winrt::Microsoft::Terminal::Settings::Model;
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
+{
+    CompatibilityViewModel::CompatibilityViewModel(Model::GlobalAppSettings globalSettings) :
+        _GlobalSettings{ globalSettings }
+    {
+    }
+
+    Compatibility::Compatibility()
+    {
+        InitializeComponent();
+    }
+
+    void Compatibility::OnNavigatedTo(const NavigationEventArgs& e)
+    {
+        _ViewModel = e.Parameter().as<Editor::CompatibilityViewModel>();
+    }
+}

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.cpp
@@ -18,11 +18,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         INITIALIZE_BINDABLE_ENUM_SETTING(TextMeasurement, TextMeasurement, winrt::Microsoft::Terminal::Control::TextMeasurement, L"Globals_TextMeasurement_", L"Text");
     }
 
-    bool CompatibilityViewModel::AllowVtChecksumReportAvailable() const noexcept
-    {
-        return Feature_VtChecksumReport::IsEnabled();
-    }
-
     bool CompatibilityViewModel::AllowKeypadModeAvailable() const noexcept
     {
         return Feature_KeypadModeEnabled::IsEnabled();

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.h
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.h
@@ -15,7 +15,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     public:
         CompatibilityViewModel(Model::GlobalAppSettings globalSettings);
 
-        bool AllowVtChecksumReportAvailable() const noexcept;
         bool AllowKeypadModeAvailable() const noexcept;
 
         // DON'T YOU DARE ADD A `WINRT_CALLBACK(PropertyChanged` TO A CLASS DERIVED FROM ViewModelHelper. Do this instead:

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.h
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.h
@@ -24,6 +24,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, ForceVTInput);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, AllowVtChecksumReport);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, AllowKeypadMode);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, AllowHeadless);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, IsolatedMode);
 
     private:
         Model::GlobalAppSettings _GlobalSettings;

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.h
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.h
@@ -15,11 +15,15 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     public:
         CompatibilityViewModel(Model::GlobalAppSettings globalSettings);
 
+        bool AllowVtChecksumReportAvailable() const noexcept;
+        bool AllowKeypadModeAvailable() const noexcept;
+
         // DON'T YOU DARE ADD A `WINRT_CALLBACK(PropertyChanged` TO A CLASS DERIVED FROM ViewModelHelper. Do this instead:
         using ViewModelHelper<CompatibilityViewModel>::PropertyChanged;
 
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, ForceVTInput);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, AllowVtChecksumReport);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, AllowKeypadMode);
 
     private:
         Model::GlobalAppSettings _GlobalSettings;

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.h
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.h
@@ -15,14 +15,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     public:
         CompatibilityViewModel(Model::GlobalAppSettings globalSettings);
 
-        bool AllowKeypadModeAvailable() const noexcept;
+        bool DebugFeaturesAvailable() const noexcept;
 
         // DON'T YOU DARE ADD A `WINRT_CALLBACK(PropertyChanged` TO A CLASS DERIVED FROM ViewModelHelper. Do this instead:
         using ViewModelHelper<CompatibilityViewModel>::PropertyChanged;
 
-        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, ForceVTInput);
-        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, AllowVtChecksumReport);
-        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, AllowKeypadMode);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, AllowHeadless);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, IsolatedMode);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, DebugFeaturesEnabled);

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.h
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.h
@@ -26,6 +26,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, AllowKeypadMode);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, AllowHeadless);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, IsolatedMode);
+        GETSET_BINDABLE_ENUM_SETTING(TextMeasurement, winrt::Microsoft::Terminal::Control::TextMeasurement, _GlobalSettings.TextMeasurement);
 
     private:
         Model::GlobalAppSettings _GlobalSettings;

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.h
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.h
@@ -19,6 +19,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         using ViewModelHelper<CompatibilityViewModel>::PropertyChanged;
 
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, ForceVTInput);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, AllowVtChecksumReport);
 
     private:
         Model::GlobalAppSettings _GlobalSettings;

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.h
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.h
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+
+#include "Compatibility.g.h"
+#include "CompatibilityViewModel.g.h"
+#include "ViewModelHelpers.h"
+#include "Utils.h"
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
+{
+    struct CompatibilityViewModel : CompatibilityViewModelT<CompatibilityViewModel>, ViewModelHelper<CompatibilityViewModel>
+    {
+    public:
+        CompatibilityViewModel(Model::GlobalAppSettings globalSettings);
+
+        // DON'T YOU DARE ADD A `WINRT_CALLBACK(PropertyChanged` TO A CLASS DERIVED FROM ViewModelHelper. Do this instead:
+        using ViewModelHelper<CompatibilityViewModel>::PropertyChanged;
+
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, ForceVTInput);
+
+    private:
+        Model::GlobalAppSettings _GlobalSettings;
+    };
+
+    struct Compatibility : public HasScrollViewer<Compatibility>, CompatibilityT<Compatibility>
+    {
+        Compatibility();
+
+        void OnNavigatedTo(const winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs& e);
+
+        til::property_changed_event PropertyChanged;
+        WINRT_OBSERVABLE_PROPERTY(Editor::CompatibilityViewModel, ViewModel, PropertyChanged.raise, nullptr);
+    };
+}
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::factory_implementation
+{
+    BASIC_FACTORY(Compatibility);
+    BASIC_FACTORY(CompatibilityViewModel);
+}

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.h
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.h
@@ -25,6 +25,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, AllowKeypadMode);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, AllowHeadless);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, IsolatedMode);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, DebugFeaturesEnabled);
         GETSET_BINDABLE_ENUM_SETTING(TextMeasurement, winrt::Microsoft::Terminal::Control::TextMeasurement, _GlobalSettings.TextMeasurement);
 
     private:

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.idl
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.idl
@@ -9,8 +9,12 @@ namespace Microsoft.Terminal.Settings.Editor
     {
         CompatibilityViewModel(Microsoft.Terminal.Settings.Model.GlobalAppSettings globalSettings);
 
+        Boolean AllowVtChecksumReportAvailable { get; };
+        Boolean AllowKeypadModeAvailable { get; };
+
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, ForceVTInput);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, AllowVtChecksumReport);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, AllowKeypadMode);
     }
 
     [default_interface] runtimeclass Compatibility : Windows.UI.Xaml.Controls.Page

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.idl
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.idl
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import "EnumEntry.idl";
+
 #include "ViewModelHelpers.idl.h"
 
 namespace Microsoft.Terminal.Settings.Editor
@@ -17,6 +19,9 @@ namespace Microsoft.Terminal.Settings.Editor
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, AllowKeypadMode);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, AllowHeadless);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, IsolatedMode);
+
+        IInspectable CurrentTextMeasurement;
+        Windows.Foundation.Collections.IObservableVector<Microsoft.Terminal.Settings.Editor.EnumEntry> TextMeasurementList { get; };
     }
 
     [default_interface] runtimeclass Compatibility : Windows.UI.Xaml.Controls.Page

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.idl
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.idl
@@ -10,6 +10,7 @@ namespace Microsoft.Terminal.Settings.Editor
         CompatibilityViewModel(Microsoft.Terminal.Settings.Model.GlobalAppSettings globalSettings);
 
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, ForceVTInput);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, AllowVtChecksumReport);
     }
 
     [default_interface] runtimeclass Compatibility : Windows.UI.Xaml.Controls.Page

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.idl
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.idl
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "ViewModelHelpers.idl.h"
+
+namespace Microsoft.Terminal.Settings.Editor
+{
+    runtimeclass CompatibilityViewModel : Windows.UI.Xaml.Data.INotifyPropertyChanged
+    {
+        CompatibilityViewModel(Microsoft.Terminal.Settings.Model.GlobalAppSettings globalSettings);
+
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, ForceVTInput);
+    }
+
+    [default_interface] runtimeclass Compatibility : Windows.UI.Xaml.Controls.Page
+    {
+        Compatibility();
+        CompatibilityViewModel ViewModel { get; };
+    }
+}

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.idl
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.idl
@@ -18,6 +18,7 @@ namespace Microsoft.Terminal.Settings.Editor
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, AllowKeypadMode);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, AllowHeadless);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, IsolatedMode);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, DebugFeaturesEnabled);
 
         IInspectable CurrentTextMeasurement;
         Windows.Foundation.Collections.IObservableVector<Microsoft.Terminal.Settings.Editor.EnumEntry> TextMeasurementList { get; };

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.idl
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.idl
@@ -11,7 +11,6 @@ namespace Microsoft.Terminal.Settings.Editor
     {
         CompatibilityViewModel(Microsoft.Terminal.Settings.Model.GlobalAppSettings globalSettings);
 
-        Boolean AllowVtChecksumReportAvailable { get; };
         Boolean AllowKeypadModeAvailable { get; };
 
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, ForceVTInput);

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.idl
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.idl
@@ -15,6 +15,8 @@ namespace Microsoft.Terminal.Settings.Editor
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, ForceVTInput);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, AllowVtChecksumReport);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, AllowKeypadMode);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, AllowHeadless);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, IsolatedMode);
     }
 
     [default_interface] runtimeclass Compatibility : Windows.UI.Xaml.Controls.Page

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.idl
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.idl
@@ -11,11 +11,8 @@ namespace Microsoft.Terminal.Settings.Editor
     {
         CompatibilityViewModel(Microsoft.Terminal.Settings.Model.GlobalAppSettings globalSettings);
 
-        Boolean AllowKeypadModeAvailable { get; };
+        Boolean DebugFeaturesAvailable { get; };
 
-        PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, ForceVTInput);
-        PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, AllowVtChecksumReport);
-        PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, AllowKeypadMode);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, AllowHeadless);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, IsolatedMode);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, DebugFeaturesEnabled);

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.xaml
@@ -50,8 +50,7 @@
         <local:SettingContainer x:Uid="Globals_DebugFeaturesEnabled"
                                 Visibility="{x:Bind ViewModel.DebugFeaturesAvailable}">
             <ToggleSwitch IsOn="{x:Bind ViewModel.DebugFeaturesEnabled, Mode=TwoWay}"
-                          Style="{StaticResource ToggleSwitchInExpanderStyle}"
-                          Visibility="{x:Bind ViewModel.DebugFeaturesEnabled}" />
+                          Style="{StaticResource ToggleSwitchInExpanderStyle}" />
         </local:SettingContainer>
     </StackPanel>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.xaml
@@ -1,0 +1,30 @@
+<!--
+    Copyright (c) Microsoft Corporation. All rights reserved. Licensed under
+    the MIT License. See LICENSE in the project root for license information.
+-->
+<Page x:Class="Microsoft.Terminal.Settings.Editor.Compatibility"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:local="using:Microsoft.Terminal.Settings.Editor"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+      mc:Ignorable="d">
+
+    <Page.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="CommonResources.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Page.Resources>
+
+    <StackPanel Style="{StaticResource SettingsStackStyle}">
+        <!-- TODO CARLOS -->
+        <!--  Force VT Input  -->
+         <local:SettingContainer x:Uid="Globals_ForceVTInput">
+            <ToggleSwitch IsOn="{x:Bind ViewModel.ForceVTInput, Mode=TwoWay}"
+                          Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+        </local:SettingContainer> 
+    </StackPanel>
+</Page>

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.xaml
@@ -29,7 +29,15 @@
         <!--  Allow VT Checksum Report  -->
         <local:SettingContainer x:Uid="Globals_AllowVtChecksumReport">
             <ToggleSwitch IsOn="{x:Bind ViewModel.AllowVtChecksumReport, Mode=TwoWay}"
-                          Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                          Style="{StaticResource ToggleSwitchInExpanderStyle}"
+                          Visibility="{x:Bind ViewModel.AllowVtChecksumReportAvailable}" />
+        </local:SettingContainer>
+
+        <!--  Allow Keypad Mode  -->
+        <local:SettingContainer x:Uid="Globals_AllowKeypadMode">
+            <ToggleSwitch IsOn="{x:Bind ViewModel.AllowKeypadMode, Mode=TwoWay}"
+                          Style="{StaticResource ToggleSwitchInExpanderStyle}"
+                          Visibility="{x:Bind ViewModel.AllowKeypadMode}" />
         </local:SettingContainer>
     </StackPanel>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.xaml
@@ -51,5 +51,14 @@
                           Style="{StaticResource ToggleSwitchInExpanderStyle}"
                           Visibility="{x:Bind ViewModel.AllowKeypadMode}" />
         </local:SettingContainer>
+
+        <!--  Text Measurement  -->
+        <local:SettingContainer x:Uid="Globals_TextMeasurement">
+            <ComboBox AutomationProperties.AccessibilityView="Content"
+                      ItemTemplate="{StaticResource EnumComboBoxTemplate}"
+                      ItemsSource="{x:Bind ViewModel.TextMeasurementList}"
+                      SelectedItem="{x:Bind ViewModel.CurrentTextMeasurement, Mode=TwoWay}"
+                      Style="{StaticResource ComboBoxSettingStyle}" />
+        </local:SettingContainer>
     </StackPanel>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.xaml
@@ -37,25 +37,6 @@
                           Style="{StaticResource ToggleSwitchInExpanderStyle}" />
         </local:SettingContainer>
 
-        <!--  Force VT Input  -->
-        <local:SettingContainer x:Uid="Globals_ForceVTInput">
-            <ToggleSwitch IsOn="{x:Bind ViewModel.ForceVTInput, Mode=TwoWay}"
-                          Style="{StaticResource ToggleSwitchInExpanderStyle}" />
-        </local:SettingContainer>
-
-        <!--  Allow VT Checksum Report  -->
-        <local:SettingContainer x:Uid="Globals_AllowVtChecksumReport">
-            <ToggleSwitch IsOn="{x:Bind ViewModel.AllowVtChecksumReport, Mode=TwoWay}"
-                          Style="{StaticResource ToggleSwitchInExpanderStyle}" />
-        </local:SettingContainer>
-
-        <!--  Allow Keypad Mode  -->
-        <local:SettingContainer x:Uid="Globals_AllowKeypadMode">
-            <ToggleSwitch IsOn="{x:Bind ViewModel.AllowKeypadMode, Mode=TwoWay}"
-                          Style="{StaticResource ToggleSwitchInExpanderStyle}"
-                          Visibility="{x:Bind ViewModel.AllowKeypadMode}" />
-        </local:SettingContainer>
-
         <!--  Text Measurement  -->
         <local:SettingContainer x:Uid="Globals_TextMeasurement">
             <ComboBox AutomationProperties.AccessibilityView="Content"
@@ -66,7 +47,8 @@
         </local:SettingContainer>
 
         <!--  Debug Features  -->
-        <local:SettingContainer x:Uid="Globals_DebugFeaturesEnabled">
+        <local:SettingContainer x:Uid="Globals_DebugFeaturesEnabled"
+                                Visibility="{x:Bind ViewModel.DebugFeaturesAvailable}">
             <ToggleSwitch IsOn="{x:Bind ViewModel.DebugFeaturesEnabled, Mode=TwoWay}"
                           Style="{StaticResource ToggleSwitchInExpanderStyle}"
                           Visibility="{x:Bind ViewModel.DebugFeaturesEnabled}" />

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.xaml
@@ -20,11 +20,16 @@
     </Page.Resources>
 
     <StackPanel Style="{StaticResource SettingsStackStyle}">
-        <!-- TODO CARLOS -->
         <!--  Force VT Input  -->
-         <local:SettingContainer x:Uid="Globals_ForceVTInput">
+        <local:SettingContainer x:Uid="Globals_ForceVTInput">
             <ToggleSwitch IsOn="{x:Bind ViewModel.ForceVTInput, Mode=TwoWay}"
                           Style="{StaticResource ToggleSwitchInExpanderStyle}" />
-        </local:SettingContainer> 
+        </local:SettingContainer>
+
+        <!--  Allow VT Checksum Report  -->
+        <local:SettingContainer x:Uid="Globals_AllowVtChecksumReport">
+            <ToggleSwitch IsOn="{x:Bind ViewModel.AllowVtChecksumReport, Mode=TwoWay}"
+                          Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+        </local:SettingContainer>
     </StackPanel>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.xaml
@@ -16,6 +16,11 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="CommonResources.xaml" />
             </ResourceDictionary.MergedDictionaries>
+
+            <DataTemplate x:Key="EnumComboBoxTemplate"
+                          x:DataType="local:EnumEntry">
+                <TextBlock Text="{x:Bind EnumName}" />
+            </DataTemplate>
         </ResourceDictionary>
     </Page.Resources>
 
@@ -58,6 +63,13 @@
                       ItemsSource="{x:Bind ViewModel.TextMeasurementList}"
                       SelectedItem="{x:Bind ViewModel.CurrentTextMeasurement, Mode=TwoWay}"
                       Style="{StaticResource ComboBoxSettingStyle}" />
+        </local:SettingContainer>
+
+        <!--  Debug Features  -->
+        <local:SettingContainer x:Uid="Globals_DebugFeaturesEnabled">
+            <ToggleSwitch IsOn="{x:Bind ViewModel.DebugFeaturesEnabled, Mode=TwoWay}"
+                          Style="{StaticResource ToggleSwitchInExpanderStyle}"
+                          Visibility="{x:Bind ViewModel.DebugFeaturesEnabled}" />
         </local:SettingContainer>
     </StackPanel>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.xaml
@@ -41,8 +41,7 @@
         <!--  Allow VT Checksum Report  -->
         <local:SettingContainer x:Uid="Globals_AllowVtChecksumReport">
             <ToggleSwitch IsOn="{x:Bind ViewModel.AllowVtChecksumReport, Mode=TwoWay}"
-                          Style="{StaticResource ToggleSwitchInExpanderStyle}"
-                          Visibility="{x:Bind ViewModel.AllowVtChecksumReportAvailable}" />
+                          Style="{StaticResource ToggleSwitchInExpanderStyle}" />
         </local:SettingContainer>
 
         <!--  Allow Keypad Mode  -->

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.xaml
@@ -20,6 +20,18 @@
     </Page.Resources>
 
     <StackPanel Style="{StaticResource SettingsStackStyle}">
+        <!--  Allow Headless  -->
+        <local:SettingContainer x:Uid="Globals_AllowHeadless">
+            <ToggleSwitch IsOn="{x:Bind ViewModel.AllowHeadless, Mode=TwoWay}"
+                          Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+        </local:SettingContainer>
+
+        <!--  Isolated Mode  -->
+        <local:SettingContainer x:Uid="Globals_IsolatedMode">
+            <ToggleSwitch IsOn="{x:Bind ViewModel.IsolatedMode, Mode=TwoWay}"
+                          Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+        </local:SettingContainer>
+
         <!--  Force VT Input  -->
         <local:SettingContainer x:Uid="Globals_ForceVTInput">
             <ToggleSwitch IsOn="{x:Bind ViewModel.ForceVTInput, Mode=TwoWay}"

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -6,6 +6,7 @@
 #include "MainPage.g.cpp"
 #include "Launch.h"
 #include "Interaction.h"
+#include "Compatibility.h"
 #include "Rendering.h"
 #include "RenderingViewModel.h"
 #include "Actions.h"
@@ -39,6 +40,7 @@ using namespace winrt::Windows::Foundation::Collections;
 static const std::wstring_view launchTag{ L"Launch_Nav" };
 static const std::wstring_view interactionTag{ L"Interaction_Nav" };
 static const std::wstring_view renderingTag{ L"Rendering_Nav" };
+static const std::wstring_view compatibilityTag{ L"Compatibility_Nav" };
 static const std::wstring_view actionsTag{ L"Actions_Nav" };
 static const std::wstring_view globalProfileTag{ L"GlobalProfile_Nav" };
 static const std::wstring_view addProfileTag{ L"AddProfile" };
@@ -370,6 +372,12 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         {
             contentFrame().Navigate(xaml_typename<Editor::Rendering>(), winrt::make<RenderingViewModel>(_settingsClone));
             const auto crumb = winrt::make<Breadcrumb>(box_value(clickedItemTag), RS_(L"Nav_Rendering/Content"), BreadcrumbSubPage::None);
+            _breadcrumbs.Append(crumb);
+        }
+        else if (clickedItemTag == compatibilityTag)
+        {
+            contentFrame().Navigate(xaml_typename<Editor::Compatibility>(), winrt::make<CompatibilityViewModel>(_settingsClone.GlobalSettings()));
+            const auto crumb = winrt::make<Breadcrumb>(box_value(clickedItemTag), RS_(L"Nav_Compatibility/Content"), BreadcrumbSubPage::None);
             _breadcrumbs.Append(crumb);
         }
         else if (clickedItemTag == actionsTag)

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -341,6 +341,13 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                     _breadcrumbs.Append(crumb);
                     SettingsMainPage_ScrollViewer().ScrollToVerticalOffset(0);
                 }
+                else if (currentPage == ProfileSubPage::Terminal)
+                {
+                    contentFrame().Navigate(xaml_typename<Editor::Profiles_Terminal>(), profile);
+                    const auto crumb = winrt::make<Breadcrumb>(breadcrumbTag, RS_(L"Profile_Terminal/Header"), BreadcrumbSubPage::Profile_Terminal);
+                    _breadcrumbs.Append(crumb);
+                    SettingsMainPage_ScrollViewer().ScrollToVerticalOffset(0);
+                }
                 else if (currentPage == ProfileSubPage::Advanced)
                 {
                     contentFrame().Navigate(xaml_typename<Editor::Profiles_Advanced>(), profile);
@@ -403,6 +410,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             {
                 profileVM.CurrentPage(ProfileSubPage::Appearance);
             }
+            else if (subPage == BreadcrumbSubPage::Profile_Terminal)
+            {
+                profileVM.CurrentPage(ProfileSubPage::Terminal);
+            }
             else if (subPage == BreadcrumbSubPage::Profile_Advanced)
             {
                 profileVM.CurrentPage(ProfileSubPage::Advanced);
@@ -459,6 +470,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         else if (subPage == BreadcrumbSubPage::Profile_Appearance)
         {
             profile.CurrentPage(ProfileSubPage::Appearance);
+        }
+        else if (subPage == BreadcrumbSubPage::Profile_Terminal)
+        {
+            profile.CurrentPage(ProfileSubPage::Terminal);
         }
         else if (subPage == BreadcrumbSubPage::Profile_Advanced)
         {

--- a/src/cascadia/TerminalSettingsEditor/MainPage.idl
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.idl
@@ -17,6 +17,7 @@ namespace Microsoft.Terminal.Settings.Editor
     {
         None = 0,
         Profile_Appearance,
+        Profile_Terminal,
         Profile_Advanced,
         ColorSchemes_Edit
     };

--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -135,6 +135,13 @@
                 </muxc:NavigationViewItem.Icon>
             </muxc:NavigationViewItem>
 
+            <muxc:NavigationViewItem x:Uid="Nav_Compatibility"
+                                     Tag="Compatibility_Nav">
+                <muxc:NavigationViewItem.Icon>
+                    <FontIcon Glyph="&#xEC7A;" />
+                </muxc:NavigationViewItem.Icon>
+            </muxc:NavigationViewItem>
+
             <muxc:NavigationViewItem x:Uid="Nav_Actions"
                                      Tag="Actions_Nav">
                 <muxc:NavigationViewItem.Icon>

--- a/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
+++ b/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
@@ -64,6 +64,9 @@
     <ClInclude Include="Interaction.h">
       <DependentUpon>Interaction.xaml</DependentUpon>
     </ClInclude>
+    <ClInclude Include="Compatibility.h">
+      <DependentUpon>Compatibility.xaml</DependentUpon>
+    </ClInclude>
     <ClInclude Include="KeyChordListener.h">
       <DependentUpon>KeyChordListener.xaml</DependentUpon>
     </ClInclude>
@@ -154,6 +157,9 @@
     <Page Include="Interaction.xaml">
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="Compatibility.xaml">
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="KeyChordListener.xaml">
       <SubType>Designer</SubType>
     </Page>
@@ -203,6 +209,9 @@
     </ClCompile>
     <ClCompile Include="Interaction.cpp">
       <DependentUpon>Interaction.xaml</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="Compatibility.cpp">
+      <DependentUpon>Compatibility.xaml</DependentUpon>
     </ClCompile>
     <ClCompile Include="KeyChordListener.cpp">
       <DependentUpon>KeyChordListener.xaml</DependentUpon>
@@ -309,6 +318,10 @@
     </Midl>
     <Midl Include="Interaction.idl">
       <DependentUpon>Interaction.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Midl>
+    <Midl Include="Compatibility.idl">
+      <DependentUpon>Compatibility.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Midl>
     <Midl Include="Rendering.idl">

--- a/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
+++ b/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
@@ -121,6 +121,10 @@
       <DependentUpon>Profiles_Appearance.xaml</DependentUpon>
       <SubType>Code</SubType>
     </ClInclude>
+    <ClInclude Include="Profiles_Terminal.h">
+      <DependentUpon>Profiles_Terminal.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
     <ClInclude Include="Appearances.h">
       <DependentUpon>Appearances.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -176,6 +180,9 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="Profiles_Appearance.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Profiles_Terminal.xaml">
       <SubType>Designer</SubType>
     </Page>
     <Page Include="Appearances.xaml">
@@ -270,6 +277,10 @@
       <DependentUpon>Profiles_Appearance.xaml</DependentUpon>
       <SubType>Code</SubType>
     </ClCompile>
+    <ClCompile Include="Profiles_Terminal.cpp">
+      <DependentUpon>Profiles_Terminal.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
     <ClCompile Include="Appearances.cpp">
       <DependentUpon>Appearances.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -349,6 +360,10 @@
     </Midl>
     <Midl Include="Profiles_Appearance.idl">
       <DependentUpon>Profiles_Appearance.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Midl>
+    <Midl Include="Profiles_Terminal.idl">
+      <DependentUpon>Profiles_Terminal.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Midl>
     <Midl Include="Appearances.idl">

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
@@ -281,6 +281,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         return Feature_ScrollbarMarks::IsEnabled();
     }
+    bool ProfileViewModel::AllowKeypadModeAvailable() const noexcept
+    {
+        return Feature_KeypadModeEnabled::IsEnabled();
+    }
 
     bool ProfileViewModel::UseParentProcessDirectory()
     {

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
@@ -281,10 +281,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         return Feature_ScrollbarMarks::IsEnabled();
     }
-    bool ProfileViewModel::AllowKeypadModeAvailable() const noexcept
-    {
-        return Feature_KeypadModeEnabled::IsEnabled();
-    }
 
     bool ProfileViewModel::UseParentProcessDirectory()
     {

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
@@ -84,7 +84,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         bool ShowMarksAvailable() const noexcept;
         bool AutoMarkPromptsAvailable() const noexcept;
         bool RepositionCursorWithMouseAvailable() const noexcept;
-        bool AllowKeypadModeAvailable() const noexcept;
 
         til::typed_event<Editor::ProfileViewModel, Editor::DeleteProfileEventArgs> DeleteProfileRequested;
 
@@ -123,7 +122,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         OBSERVABLE_PROJECTED_SETTING(_profile, RepositionCursorWithMouse);
         OBSERVABLE_PROJECTED_SETTING(_profile, ForceVTInput);
         OBSERVABLE_PROJECTED_SETTING(_profile, AllowVtChecksumReport);
-        OBSERVABLE_PROJECTED_SETTING(_profile, AllowKeypadMode);
         OBSERVABLE_PROJECTED_SETTING(_profile, AnswerbackMessage);
 
         WINRT_PROPERTY(bool, IsBaseLayer, false);

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
@@ -124,6 +124,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         OBSERVABLE_PROJECTED_SETTING(_profile, ForceVTInput);
         OBSERVABLE_PROJECTED_SETTING(_profile, AllowVtChecksumReport);
         OBSERVABLE_PROJECTED_SETTING(_profile, AllowKeypadMode);
+        OBSERVABLE_PROJECTED_SETTING(_profile, AnswerbackMessage);
 
         WINRT_PROPERTY(bool, IsBaseLayer, false);
         WINRT_PROPERTY(bool, FocusDeleteButton, false);

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
@@ -84,6 +84,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         bool ShowMarksAvailable() const noexcept;
         bool AutoMarkPromptsAvailable() const noexcept;
         bool RepositionCursorWithMouseAvailable() const noexcept;
+        bool AllowKeypadModeAvailable() const noexcept;
 
         til::typed_event<Editor::ProfileViewModel, Editor::DeleteProfileEventArgs> DeleteProfileRequested;
 
@@ -120,6 +121,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         OBSERVABLE_PROJECTED_SETTING(_profile, ShowMarks);
         OBSERVABLE_PROJECTED_SETTING(_profile, AutoMarkPrompts);
         OBSERVABLE_PROJECTED_SETTING(_profile, RepositionCursorWithMouse);
+        OBSERVABLE_PROJECTED_SETTING(_profile, ForceVTInput);
+        OBSERVABLE_PROJECTED_SETTING(_profile, AllowVtChecksumReport);
+        OBSERVABLE_PROJECTED_SETTING(_profile, AllowKeypadMode);
 
         WINRT_PROPERTY(bool, IsBaseLayer, false);
         WINRT_PROPERTY(bool, FocusDeleteButton, false);

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
@@ -29,7 +29,8 @@ namespace Microsoft.Terminal.Settings.Editor
     {
         Base = 0,
         Appearance = 1,
-        Advanced = 2
+        Terminal = 2,
+        Advanced = 3
     };
 
     runtimeclass ProfileViewModel : Windows.UI.Xaml.Data.INotifyPropertyChanged
@@ -74,6 +75,7 @@ namespace Microsoft.Terminal.Settings.Editor
         Boolean ShowMarksAvailable { get; };
         Boolean AutoMarkPromptsAvailable { get; };
         Boolean RepositionCursorWithMouseAvailable { get; };
+        Boolean AllowKeypadModeAvailable { get; };
 
         String EvaluatedIcon { get; };
 
@@ -111,5 +113,8 @@ namespace Microsoft.Terminal.Settings.Editor
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, ShowMarks);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, AutoMarkPrompts);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, RepositionCursorWithMouse);
+        OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, ForceVTInput);
+        OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, AllowVtChecksumReport);
+        OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, AllowKeypadMode);
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
@@ -116,5 +116,6 @@ namespace Microsoft.Terminal.Settings.Editor
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, ForceVTInput);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, AllowVtChecksumReport);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, AllowKeypadMode);
+        OBSERVABLE_PROJECTED_PROFILE_SETTING(String, AnswerbackMessage);
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
@@ -75,7 +75,6 @@ namespace Microsoft.Terminal.Settings.Editor
         Boolean ShowMarksAvailable { get; };
         Boolean AutoMarkPromptsAvailable { get; };
         Boolean RepositionCursorWithMouseAvailable { get; };
-        Boolean AllowKeypadModeAvailable { get; };
 
         String EvaluatedIcon { get; };
 
@@ -115,7 +114,6 @@ namespace Microsoft.Terminal.Settings.Editor
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, RepositionCursorWithMouse);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, ForceVTInput);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, AllowVtChecksumReport);
-        OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, AllowKeypadMode);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(String, AnswerbackMessage);
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.xaml
@@ -37,15 +37,6 @@
                    Visibility="{x:Bind Profile.IsBaseLayer}" />
         <StackPanel Grid.Row="1"
                     Style="{StaticResource SettingsStackStyle}">
-            <!--  Suppress Application Title  -->
-            <local:SettingContainer x:Uid="Profile_SuppressApplicationTitle"
-                                    ClearSettingValue="{x:Bind Profile.ClearSuppressApplicationTitle}"
-                                    HasSettingValue="{x:Bind Profile.HasSuppressApplicationTitle, Mode=OneWay}"
-                                    SettingOverrideSource="{x:Bind Profile.SuppressApplicationTitleOverrideSource, Mode=OneWay}">
-                <ToggleSwitch IsOn="{x:Bind Profile.SuppressApplicationTitle, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
-            </local:SettingContainer>
-
             <!--  Antialiasing Mode  -->
             <local:SettingContainer x:Uid="Profile_AntialiasingMode"
                                     ClearSettingValue="{x:Bind Profile.ClearAntialiasingMode}"

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.cpp
@@ -24,6 +24,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         Automation::AutomationProperties::SetName(DeleteButton(), RS_(L"Profile_DeleteButton/Text"));
         AppearanceNavigator().Content(box_value(RS_(L"Profile_Appearance/Header")));
+        TerminalNavigator().Content(box_value(RS_(L"Profile_Terminal/Header")));
         AdvancedNavigator().Content(box_value(RS_(L"Profile_Advanced/Header")));
     }
 
@@ -64,6 +65,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     void Profiles_Base::Appearance_Click(const IInspectable& /*sender*/, const RoutedEventArgs& /*args*/)
     {
         _Profile.CurrentPage(ProfileSubPage::Appearance);
+    }
+
+    void Profiles_Base::Terminal_Click(const IInspectable& /*sender*/, const RoutedEventArgs& /*args*/)
+    {
+        _Profile.CurrentPage(ProfileSubPage::Terminal);
     }
 
     void Profiles_Base::Advanced_Click(const IInspectable& /*sender*/, const RoutedEventArgs& /*args*/)

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.h
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.h
@@ -21,6 +21,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         safe_void_coroutine Icon_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& e);
         safe_void_coroutine Commandline_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& e);
         void Appearance_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& e);
+        void Terminal_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& e);
         void Advanced_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& e);
         void DeleteConfirmation_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& e);
 

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
@@ -159,16 +159,13 @@
 
             <Button x:Name="AppearanceNavigator"
                     Click="Appearance_Click"
-                    Style="{StaticResource NavigatorButtonStyle}">
-                Appearance
-            </Button>
+                    Style="{StaticResource NavigatorButtonStyle}" />
+            <Button x:Name="TerminalNavigator"
+                    Click="Terminal_Click"
+                    Style="{StaticResource NavigatorButtonStyle}" />
             <Button x:Name="AdvancedNavigator"
                     Click="Advanced_Click"
-                    Style="{StaticResource NavigatorButtonStyle}">
-                <TextBlock HorizontalAlignment="Left"
-                           VerticalAlignment="Center"
-                           Text="Advanced" />
-            </Button>
+                    Style="{StaticResource NavigatorButtonStyle}" />
             <!--  Delete Button  -->
             <Border MaxWidth="{StaticResource StandardControlMaxWidth}">
                 <Button x:Name="DeleteButton"

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Terminal.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Terminal.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
+#include "Profiles_Terminal.h"
+#include "Profiles_Terminal.g.cpp"
+#include "ProfileViewModel.h"
+
+#include "EnumEntry.h"
+#include <LibraryResources.h>
+#include "..\WinRTUtils\inc\Utils.h"
+
+using namespace winrt::Windows::UI::Xaml::Navigation;
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
+{
+    Profiles_Terminal::Profiles_Terminal()
+    {
+        InitializeComponent();
+    }
+
+    void Profiles_Terminal::OnNavigatedTo(const NavigationEventArgs& e)
+    {
+        _Profile = e.Parameter().as<Editor::ProfileViewModel>();
+    }
+
+    void Profiles_Terminal::OnNavigatedFrom(const NavigationEventArgs& /*e*/)
+    {
+        _ViewModelChangedRevoker.revoke();
+    }
+}

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Terminal.h
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Terminal.h
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+
+#include "Profiles_Terminal.g.h"
+#include "ViewModelHelpers.h"
+#include "Utils.h"
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
+{
+    struct Profiles_Terminal : public HasScrollViewer<Profiles_Terminal>, Profiles_TerminalT<Profiles_Terminal>
+    {
+    public:
+        Profiles_Terminal();
+
+        void OnNavigatedTo(const Windows::UI::Xaml::Navigation::NavigationEventArgs& e);
+        void OnNavigatedFrom(const Windows::UI::Xaml::Navigation::NavigationEventArgs& e);
+
+        til::property_changed_event PropertyChanged;
+        WINRT_PROPERTY(Editor::ProfileViewModel, Profile, nullptr);
+
+    private:
+        Windows::UI::Xaml::Data::INotifyPropertyChanged::PropertyChanged_revoker _ViewModelChangedRevoker;
+    };
+};
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::factory_implementation
+{
+    BASIC_FACTORY(Profiles_Terminal);
+}

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Terminal.idl
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Terminal.idl
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "ProfileViewModel.idl";
+
+namespace Microsoft.Terminal.Settings.Editor
+{
+    [default_interface] runtimeclass Profiles_Terminal : Windows.UI.Xaml.Controls.Page, Windows.UI.Xaml.Data.INotifyPropertyChanged
+    {
+        Profiles_Terminal();
+        ProfileViewModel Profile { get; };
+    }
+}

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Terminal.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Terminal.xaml
@@ -60,16 +60,6 @@
                               Style="{StaticResource ToggleSwitchInExpanderStyle}" />
             </local:SettingContainer>
 
-            <!--  Allow Keypad Mode  -->
-            <local:SettingContainer x:Uid="Profile_AllowKeypadMode"
-                                    ClearSettingValue="{x:Bind Profile.ClearAllowKeypadMode}"
-                                    HasSettingValue="{x:Bind Profile.HasAllowKeypadMode, Mode=OneWay}"
-                                    SettingOverrideSource="{x:Bind Profile.AllowKeypadModeOverrideSource, Mode=OneWay}"
-                                    Visibility="{x:Bind Profile.AllowKeypadModeAvailable}">
-                <ToggleSwitch IsOn="{x:Bind Profile.AllowKeypadMode, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
-            </local:SettingContainer>
-
             <!--  Answerback Message  -->
             <local:SettingContainer x:Uid="Profile_AnswerbackMessage"
                                     ClearSettingValue="{x:Bind Profile.ClearAnswerbackMessage}"

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Terminal.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Terminal.xaml
@@ -69,6 +69,17 @@
                 <ToggleSwitch IsOn="{x:Bind Profile.AllowKeypadMode, Mode=TwoWay}"
                               Style="{StaticResource ToggleSwitchInExpanderStyle}" />
             </local:SettingContainer>
+
+            <!--  Answerback Message  -->
+            <local:SettingContainer x:Uid="Profile_AnswerbackMessage"
+                                    ClearSettingValue="{x:Bind Profile.ClearAnswerbackMessage}"
+                                    CurrentValue="{x:Bind Profile.AnswerbackMessage, Mode=OneWay}"
+                                    HasSettingValue="{x:Bind Profile.HasAnswerbackMessage, Mode=OneWay}"
+                                    SettingOverrideSource="{x:Bind Profile.AnswerbackMessageOverrideSource, Mode=OneWay}"
+                                    Style="{StaticResource ExpanderSettingContainerStyle}">
+                <TextBox Style="{StaticResource TextBoxSettingStyle}"
+                         Text="{x:Bind Profile.AnswerbackMessage, Mode=TwoWay}" />
+            </local:SettingContainer>
         </StackPanel>
     </Grid>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Terminal.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Terminal.xaml
@@ -1,0 +1,74 @@
+<!--
+    Copyright (c) Microsoft Corporation. All rights reserved. Licensed under
+    the MIT License. See LICENSE in the project root for license information.
+-->
+<Page x:Class="Microsoft.Terminal.Settings.Editor.Profiles_Terminal"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:local="using:Microsoft.Terminal.Settings.Editor"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:model="using:Microsoft.Terminal.Settings.Model"
+      xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+      mc:Ignorable="d">
+
+    <Page.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="CommonResources.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Page.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <TextBlock x:Uid="Profile_BaseLayerDisclaimer"
+                   Grid.Row="0"
+                   Margin="{StaticResource StandardIndentMargin}"
+                   Style="{StaticResource DisclaimerStyle}"
+                   Visibility="{x:Bind Profile.IsBaseLayer}" />
+        <StackPanel Grid.Row="1"
+                    Style="{StaticResource SettingsStackStyle}">
+
+            <!--  Suppress Application Title  -->
+            <local:SettingContainer x:Uid="Profile_SuppressApplicationTitle"
+                                    ClearSettingValue="{x:Bind Profile.ClearSuppressApplicationTitle}"
+                                    HasSettingValue="{x:Bind Profile.HasSuppressApplicationTitle, Mode=OneWay}"
+                                    SettingOverrideSource="{x:Bind Profile.SuppressApplicationTitleOverrideSource, Mode=OneWay}">
+                <ToggleSwitch IsOn="{x:Bind Profile.SuppressApplicationTitle, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
+
+            <!--  Force VT Input  -->
+            <local:SettingContainer x:Uid="Profile_ForceVTInput"
+                                    ClearSettingValue="{x:Bind Profile.ClearForceVTInput}"
+                                    HasSettingValue="{x:Bind Profile.HasForceVTInput, Mode=OneWay}"
+                                    SettingOverrideSource="{x:Bind Profile.ForceVTInputOverrideSource, Mode=OneWay}">
+                <ToggleSwitch IsOn="{x:Bind Profile.ForceVTInput, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
+
+            <!--  Allow VT Checksum Report  -->
+            <local:SettingContainer x:Uid="Profile_AllowVtChecksumReport"
+                                    ClearSettingValue="{x:Bind Profile.ClearAllowVtChecksumReport}"
+                                    HasSettingValue="{x:Bind Profile.HasAllowVtChecksumReport, Mode=OneWay}"
+                                    SettingOverrideSource="{x:Bind Profile.AllowVtChecksumReportOverrideSource, Mode=OneWay}">
+                <ToggleSwitch IsOn="{x:Bind Profile.AllowVtChecksumReport, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
+
+            <!--  Allow Keypad Mode  -->
+            <local:SettingContainer x:Uid="Profile_AllowKeypadMode"
+                                    ClearSettingValue="{x:Bind Profile.ClearAllowKeypadMode}"
+                                    HasSettingValue="{x:Bind Profile.HasAllowKeypadMode, Mode=OneWay}"
+                                    SettingOverrideSource="{x:Bind Profile.AllowKeypadModeOverrideSource, Mode=OneWay}"
+                                    Visibility="{x:Bind Profile.AllowKeypadModeAvailable}">
+                <ToggleSwitch IsOn="{x:Bind Profile.AllowKeypadMode, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
+        </StackPanel>
+    </Grid>
+</Page>

--- a/src/cascadia/TerminalSettingsEditor/Rendering.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Rendering.xaml
@@ -41,13 +41,5 @@
             <ToggleSwitch IsOn="{x:Bind ViewModel.SoftwareRendering, Mode=TwoWay}"
                           Style="{StaticResource ToggleSwitchInExpanderStyle}" />
         </local:SettingContainer>
-
-        <local:SettingContainer x:Uid="Globals_TextMeasurement">
-            <ComboBox AutomationProperties.AccessibilityView="Content"
-                      ItemTemplate="{StaticResource EnumComboBoxTemplate}"
-                      ItemsSource="{x:Bind ViewModel.TextMeasurementList}"
-                      SelectedItem="{x:Bind ViewModel.CurrentTextMeasurement, Mode=TwoWay}"
-                      Style="{StaticResource ComboBoxSettingStyle}" />
-        </local:SettingContainer>
     </StackPanel>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/RenderingViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/RenderingViewModel.cpp
@@ -17,6 +17,5 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _settings{ std::move(settings) }
     {
         INITIALIZE_BINDABLE_ENUM_SETTING(GraphicsAPI, GraphicsAPI, winrt::Microsoft::Terminal::Control::GraphicsAPI, L"Globals_GraphicsAPI_", L"Text");
-        INITIALIZE_BINDABLE_ENUM_SETTING(TextMeasurement, TextMeasurement, winrt::Microsoft::Terminal::Control::TextMeasurement, L"Globals_TextMeasurement_", L"Text");
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/RenderingViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/RenderingViewModel.h
@@ -16,7 +16,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         GETSET_BINDABLE_ENUM_SETTING(GraphicsAPI, winrt::Microsoft::Terminal::Control::GraphicsAPI, _settings.GlobalSettings().GraphicsAPI);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_settings.GlobalSettings(), DisablePartialInvalidation);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_settings.GlobalSettings(), SoftwareRendering);
-        GETSET_BINDABLE_ENUM_SETTING(TextMeasurement, winrt::Microsoft::Terminal::Control::TextMeasurement, _settings.GlobalSettings().TextMeasurement);
 
     private:
         Model::CascadiaSettings _settings{ nullptr };

--- a/src/cascadia/TerminalSettingsEditor/RenderingViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/RenderingViewModel.idl
@@ -15,7 +15,5 @@ namespace Microsoft.Terminal.Settings.Editor
         Windows.Foundation.Collections.IObservableVector<Microsoft.Terminal.Settings.Editor.EnumEntry> GraphicsAPIList { get; };
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, DisablePartialInvalidation);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, SoftwareRendering);
-        IInspectable CurrentTextMeasurement;
-        Windows.Foundation.Collections.IObservableVector<Microsoft.Terminal.Settings.Editor.EnumEntry> TextMeasurementList { get; };
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -553,7 +553,7 @@
     <comment>Header for a control to toggle if the app will always be presented on top of other windows, or is treated normally (when disabled).</comment>
   </data>
   <data name="Profile_ForceVTInput.Header" xml:space="preserve">
-    <value>Force the terminal to use the legacy input encoding</value>
+    <value>Use the legacy input encoding</value>
     <comment>Header for a control to toggle legacy input encoding for the terminal.</comment>
   </data>
   <data name="Profile_AllowVtChecksumReport.Header" xml:space="preserve">
@@ -565,11 +565,11 @@
     <comment>Header for a control to toggle support for Windows Terminal to run in the background.</comment>
   </data>
   <data name="Globals_IsolatedMode.Header" xml:space="preserve">
-    <value>Force each window to be its own process</value>
+    <value>Force each window to run in its own process</value>
     <comment>Header for a control to toggle making each window be its own process.</comment>
   </data>
   <data name="Globals_DebugFeaturesEnabled.Header" xml:space="preserve">
-    <value>Debug Mode</value>
+    <value>Enable debugging features</value>
     <comment>Header for a control to toggle debug features.</comment>
   </data>
   <data name="Globals_AlwaysOnTop.HelpText" xml:space="preserve">
@@ -577,20 +577,16 @@
     <comment>A description for what the "always on top" setting does. Presented near "Globals_AlwaysOnTop.Header".</comment>
   </data>
   <data name="Profile_ForceVTInput.HelpText" xml:space="preserve">
-    <value>Certain keys in some applications may stop working when enabling this setting.</value>
+    <value>Certain keyboard input in some applications may stop working properly when this setting is enabled.</value>
     <comment>Additional description for what the "force vt input" setting does. Presented near "Globals_ForceVTInput.Header".</comment>
   </data>
   <data name="Globals_AllowHeadless.HelpText" xml:space="preserve">
-    <value>This allows Global Summon and Quake Mode actions to work even when no windows are open.</value>
+    <value>This allows actions such as Global Summon and Quake Mode actions to work even when no windows are open.</value>
     <comment>Additional description for what the "allow headless" setting does. Presented near "Globals_AllowHeadless.Header".</comment>
   </data>
   <data name="Globals_IsolatedMode.HelpText" xml:space="preserve">
-    <value>Certain features including but not limited to global hotkeys, tab drag and drop, and running commandlines in existing windows won't work.</value>
-    <comment>Additional description for what the "isolated mode" setting does. Presented near "Globals_IsolatedMode.Header".</comment>
-  </data>
-  <data name="Globals_DebugFeaturesEnabled.HelpText" xml:space="preserve">
-    <value>Enables features to help debug Windows Terminal</value>
-    <comment>Additional description for what the "debug features enabled" setting does. Presented near "Globals_DebugFeaturesEnabled.Header".</comment>
+    <value>Certain features will not work properly, including—but not limited to—global hotkeys, tab drag and drop, and wt.exe window targeting.</value>
+    <comment>{Locked="wt.exe"} Additional description for what the "isolated mode" setting does. Presented near "Globals_IsolatedMode.Header".</comment>
   </data>
   <data name="Globals_TabWidthMode.Header" xml:space="preserve">
     <value>Tab width mode</value>
@@ -701,7 +697,7 @@
     <comment>Header for a sub-page of profile settings focused on more advanced scenarios.</comment>
   </data>
   <data name="Profile_Terminal.Header" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Terminal Emulation</value>
     <comment>Header for a sub-page of profile settings focused on customizing the capabilities of the terminal.</comment>
   </data>
   <data name="Profile_AltGrAliasing.Header" xml:space="preserve">
@@ -1916,5 +1912,9 @@
   <data name="Profile_AnswerbackMessage.HelpText" xml:space="preserve">
     <value>The response that is sent when an ENQ control sequence is received.</value>
     <comment>{Locked=ENQ} A description for what the "ENQ response" setting does. Presented near "Profile_AnswerbackMessage".</comment>
+  </data>
+  <data name="Globals_DebugFeaturesEnabled.HelpText" xml:space="preserve">
+    <value>Useful for troubleshooting or developing Terminal.</value>
+    <comment>Additional description for what the "debug features enabled" setting does. Presented near "Globals_DebugFeaturesEnabled.Header".</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -547,6 +547,10 @@
     <value>Allow VT checksum report</value>
     <comment>Header for a control to toggle support for a virtual terminal (VT) sequence that reports a checksum of a portion of the terminal buffer.</comment>
   </data>
+  <data name="Globals_AllowKeypadMode.Header" xml:space="preserve">
+    <value>Allow keypad mode</value>
+    <comment>Header for a control to toggle support for VT keypad modes.</comment>
+  </data>
   <data name="Globals_AlwaysOnTop.HelpText" xml:space="preserve">
     <value>Terminal will always be the topmost window on the desktop.</value>
     <comment>A description for what the "always on top" setting does. Presented near "Globals_AlwaysOnTop.Header".</comment>
@@ -558,6 +562,10 @@
   <data name="Globals_AllowVtChecksumReport.HelpText" xml:space="preserve">
     <value>Enables support for the DECRQRCA escape sequence</value>
     <comment>Additional description for what the "allow vt checksum report" setting does. Presented near "Globals_AllowVtChecksumReport.Header".</comment>
+  </data>
+  <data name="Globals_AllowKeypadMode.HelpText" xml:space="preserve">
+    <value>Enables support for the DECKPAM and DECKPNM escape sequences to work as intended</value>
+    <comment>Additional description for what the "allow keypad mode" setting does. Presented near "Globals_AllowKeypadMode.Header".</comment>
   </data>
   <data name="Globals_TabWidthMode.Header" xml:space="preserve">
     <value>Tab width mode</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -1913,4 +1913,12 @@
     <value>Non-monospace fonts:</value>
     <comment>This is a label that is followed by a list of proportional fonts.</comment>
   </data>
+  <data name="Profile_AnswerbackMessage.Header" xml:space="preserve">
+    <value>ENQ (Request Terminal Status) response</value>
+    <comment>{Locked=ENQ}{Locked="Request Terminal Status"} Header for a control to determine the response to the ENQ escape sequence. This is represented using a text box.</comment>
+  </data>
+  <data name="Profile_AnswerbackMessage.HelpText" xml:space="preserve">
+    <value>The response that is sent when an ENQ control sequence is received.</value>
+    <comment>{Locked=ENQ} A description for what the "ENQ response" setting does. Presented near "Profile_AnswerbackMessage".</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -545,7 +545,7 @@
   </data>
   <data name="Profile_AllowVtChecksumReport.Header" xml:space="preserve">
     <value>Allow DECRQCRA (Request Checksum of Rectangular Area)</value>
-    <comment>{Locked="DECRQCRA"}{Locked="Request Checksum of Rectangular Area"}Header for a control to toggle support for the DECRQRCA control sequence.</comment>
+    <comment>{Locked="DECRQCRA"}{Locked="Request Checksum of Rectangular Area"}Header for a control to toggle support for the DECRQCRA control sequence.</comment>
   </data>
   <data name="Profile_AllowKeypadMode.Header" xml:space="preserve">
     <value>Allow DECKPAM and DECKPNM (Keypad Numeric Mode)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -544,12 +544,12 @@
     <comment>Header for a control to toggle legacy input encoding for the terminal.</comment>
   </data>
   <data name="Profile_AllowVtChecksumReport.Header" xml:space="preserve">
-    <value>Allow DECRQRCA</value>
-    <comment>{Locked="DECRQRCA"}Header for a control to toggle support for the DECRQRCA control sequence.</comment>
+    <value>Allow DECRQCRA (Request Checksum of Rectangular Area)</value>
+    <comment>{Locked="DECRQCRA"}{Locked="Request Checksum of Rectangular Area"}Header for a control to toggle support for the DECRQRCA control sequence.</comment>
   </data>
   <data name="Profile_AllowKeypadMode.Header" xml:space="preserve">
-    <value>Allow DECKPAM and DECKPNM</value>
-    <comment>Header for a control to toggle support for the DECKPAM and DECKPNM control sequences.</comment>
+    <value>Allow DECKPAM and DECKPNM (Keypad Numeric Mode)</value>
+    <comment>{Locked="DECKPAM"}{Locked="DECKPNM"}{Locked="Keypad Numeric Mode"}Header for a control to toggle support for the DECKPAM and DECKPNM control sequences.</comment>
   </data>
   <data name="Globals_AllowHeadless.Header" xml:space="preserve">
     <value>Allow Windows Terminal to run in the background</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -559,6 +559,10 @@
     <value>Force each window to be its own process</value>
     <comment>Header for a control to toggle making each window be its own process.</comment>
   </data>
+  <data name="Globals_DebugFeaturesEnabled.Header" xml:space="preserve">
+    <value>Debug Mode</value>
+    <comment>Header for a control to toggle debug features.</comment>
+  </data>
   <data name="Globals_AlwaysOnTop.HelpText" xml:space="preserve">
     <value>Terminal will always be the topmost window on the desktop.</value>
     <comment>A description for what the "always on top" setting does. Presented near "Globals_AlwaysOnTop.Header".</comment>
@@ -582,6 +586,10 @@
   <data name="Globals_IsolatedMode.HelpText" xml:space="preserve">
     <value>Certain features including but not limited to global hotkeys, tab drag and drop, and running commandlines in existing windows won't work.</value>
     <comment>Additional description for what the "isolated mode" setting does. Presented near "Globals_IsolatedMode.Header".</comment>
+  </data>
+  <data name="Globals_DebugFeaturesEnabled.HelpText" xml:space="preserve">
+    <value>Enables features to help debug Windows Terminal</value>
+    <comment>Additional description for what the "debug features enabled" setting does. Presented near "Globals_DebugFeaturesEnabled.Header".</comment>
   </data>
   <data name="Globals_TabWidthMode.Header" xml:space="preserve">
     <value>Tab width mode</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -551,6 +551,14 @@
     <value>Allow keypad mode</value>
     <comment>Header for a control to toggle support for VT keypad modes.</comment>
   </data>
+  <data name="Globals_AllowHeadless.Header" xml:space="preserve">
+    <value>Allow Windows Terminal to run in the background</value>
+    <comment>Header for a control to toggle support for Windows Terminal to run in the background.</comment>
+  </data>
+  <data name="Globals_IsolatedMode.Header" xml:space="preserve">
+    <value>Force each window to be its own process</value>
+    <comment>Header for a control to toggle making each window be its own process.</comment>
+  </data>
   <data name="Globals_AlwaysOnTop.HelpText" xml:space="preserve">
     <value>Terminal will always be the topmost window on the desktop.</value>
     <comment>A description for what the "always on top" setting does. Presented near "Globals_AlwaysOnTop.Header".</comment>
@@ -566,6 +574,14 @@
   <data name="Globals_AllowKeypadMode.HelpText" xml:space="preserve">
     <value>Enables support for the DECKPAM and DECKPNM escape sequences to work as intended</value>
     <comment>Additional description for what the "allow keypad mode" setting does. Presented near "Globals_AllowKeypadMode.Header".</comment>
+  </data>
+  <data name="Globals_AllowHeadless.HelpText" xml:space="preserve">
+    <value>This allows Global Summon and Quake Mode actions to work even when no windows are open.</value>
+    <comment>Additional description for what the "allow headless" setting does. Presented near "Globals_AllowHeadless.Header".</comment>
+  </data>
+  <data name="Globals_IsolatedMode.HelpText" xml:space="preserve">
+    <value>Certain features including but not limited to global hotkeys and tab tearout won't work.</value>
+    <comment>Additional description for what the "isolated mode" setting does. Presented near "Globals_IsolatedMode.Header".</comment>
   </data>
   <data name="Globals_TabWidthMode.Header" xml:space="preserve">
     <value>Tab width mode</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -539,9 +539,17 @@
     <value>Always on top</value>
     <comment>Header for a control to toggle if the app will always be presented on top of other windows, or is treated normally (when disabled).</comment>
   </data>
+  <data name="Globals_ForceVTInput.Header" xml:space="preserve">
+    <value>Force the terminal to use the legacy input encoding</value>
+    <comment>Header for a control to toggle legacy input encoding for the terminal.</comment>
+  </data>
   <data name="Globals_AlwaysOnTop.HelpText" xml:space="preserve">
     <value>Terminal will always be the topmost window on the desktop.</value>
     <comment>A description for what the "always on top" setting does. Presented near "Globals_AlwaysOnTop.Header".</comment>
+  </data>
+  <data name="Globals_ForceVTInput.HelpText" xml:space="preserve">
+    <value>Certain keys in some applications may stop working when enabling this setting.</value>
+    <comment>Additional description for what the "force vt input" setting does. Presented near "Globals_ForceVTInput.Header".</comment>
   </data>
   <data name="Globals_TabWidthMode.Header" xml:space="preserve">
     <value>Tab width mode</value>
@@ -610,6 +618,10 @@
   <data name="Nav_Interaction.Content" xml:space="preserve">
     <value>Interaction</value>
     <comment>Header for the "interaction" menu item. This navigates to a page that lets you see and modify settings related to the user's mouse and touch interactions with the app.</comment>
+  </data>
+  <data name="Nav_Compatibility.Content" xml:space="preserve">
+    <value>Compatibility</value>
+    <comment>Header for the "compatibility" menu item. This navigates to a page that lets you see and modify settings related to compatibility with command line scenarios.</comment>
   </data>
   <data name="Nav_Launch.Content" xml:space="preserve">
     <value>Startup</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -539,17 +539,17 @@
     <value>Always on top</value>
     <comment>Header for a control to toggle if the app will always be presented on top of other windows, or is treated normally (when disabled).</comment>
   </data>
-  <data name="Globals_ForceVTInput.Header" xml:space="preserve">
+  <data name="Profile_ForceVTInput.Header" xml:space="preserve">
     <value>Force the terminal to use the legacy input encoding</value>
     <comment>Header for a control to toggle legacy input encoding for the terminal.</comment>
   </data>
-  <data name="Globals_AllowVtChecksumReport.Header" xml:space="preserve">
-    <value>Allow VT checksum report</value>
-    <comment>Header for a control to toggle support for a virtual terminal (VT) sequence that reports a checksum of a portion of the terminal buffer.</comment>
+  <data name="Profile_AllowVtChecksumReport.Header" xml:space="preserve">
+    <value>Allow DECRQRCA</value>
+    <comment>{Locked="DECRQRCA"}Header for a control to toggle support for the DECRQRCA control sequence.</comment>
   </data>
-  <data name="Globals_AllowKeypadMode.Header" xml:space="preserve">
-    <value>Allow keypad mode</value>
-    <comment>Header for a control to toggle support for VT keypad modes.</comment>
+  <data name="Profile_AllowKeypadMode.Header" xml:space="preserve">
+    <value>Allow DECKPAM and DECKPNM</value>
+    <comment>Header for a control to toggle support for the DECKPAM and DECKPNM control sequences.</comment>
   </data>
   <data name="Globals_AllowHeadless.Header" xml:space="preserve">
     <value>Allow Windows Terminal to run in the background</value>
@@ -567,17 +567,9 @@
     <value>Terminal will always be the topmost window on the desktop.</value>
     <comment>A description for what the "always on top" setting does. Presented near "Globals_AlwaysOnTop.Header".</comment>
   </data>
-  <data name="Globals_ForceVTInput.HelpText" xml:space="preserve">
+  <data name="Profile_ForceVTInput.HelpText" xml:space="preserve">
     <value>Certain keys in some applications may stop working when enabling this setting.</value>
     <comment>Additional description for what the "force vt input" setting does. Presented near "Globals_ForceVTInput.Header".</comment>
-  </data>
-  <data name="Globals_AllowVtChecksumReport.HelpText" xml:space="preserve">
-    <value>Enables support for the DECRQRCA escape sequence</value>
-    <comment>Additional description for what the "allow vt checksum report" setting does. Presented near "Globals_AllowVtChecksumReport.Header".</comment>
-  </data>
-  <data name="Globals_AllowKeypadMode.HelpText" xml:space="preserve">
-    <value>Enables support for the DECKPAM and DECKPNM escape sequences to work as intended</value>
-    <comment>Additional description for what the "allow keypad mode" setting does. Presented near "Globals_AllowKeypadMode.Header".</comment>
   </data>
   <data name="Globals_AllowHeadless.HelpText" xml:space="preserve">
     <value>This allows Global Summon and Quake Mode actions to work even when no windows are open.</value>
@@ -698,6 +690,10 @@
   <data name="Profile_Advanced.Header" xml:space="preserve">
     <value>Advanced</value>
     <comment>Header for a sub-page of profile settings focused on more advanced scenarios.</comment>
+  </data>
+  <data name="Profile_Terminal.Header" xml:space="preserve">
+    <value>Terminal</value>
+    <comment>Header for a sub-page of profile settings focused on customizing the capabilities of the terminal.</comment>
   </data>
   <data name="Profile_AltGrAliasing.Header" xml:space="preserve">
     <value>AltGr aliasing</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -543,6 +543,10 @@
     <value>Force the terminal to use the legacy input encoding</value>
     <comment>Header for a control to toggle legacy input encoding for the terminal.</comment>
   </data>
+  <data name="Globals_AllowVtChecksumReport.Header" xml:space="preserve">
+    <value>Allow VT checksum report</value>
+    <comment>Header for a control to toggle support for a virtual terminal (VT) sequence that reports a checksum of a portion of the terminal buffer.</comment>
+  </data>
   <data name="Globals_AlwaysOnTop.HelpText" xml:space="preserve">
     <value>Terminal will always be the topmost window on the desktop.</value>
     <comment>A description for what the "always on top" setting does. Presented near "Globals_AlwaysOnTop.Header".</comment>
@@ -550,6 +554,10 @@
   <data name="Globals_ForceVTInput.HelpText" xml:space="preserve">
     <value>Certain keys in some applications may stop working when enabling this setting.</value>
     <comment>Additional description for what the "force vt input" setting does. Presented near "Globals_ForceVTInput.Header".</comment>
+  </data>
+  <data name="Globals_AllowVtChecksumReport.HelpText" xml:space="preserve">
+    <value>Enables support for the DECRQRCA escape sequence</value>
+    <comment>Additional description for what the "allow vt checksum report" setting does. Presented near "Globals_AllowVtChecksumReport.Header".</comment>
   </data>
   <data name="Globals_TabWidthMode.Header" xml:space="preserve">
     <value>Tab width mode</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -580,7 +580,7 @@
     <comment>Additional description for what the "allow headless" setting does. Presented near "Globals_AllowHeadless.Header".</comment>
   </data>
   <data name="Globals_IsolatedMode.HelpText" xml:space="preserve">
-    <value>Certain features including but not limited to global hotkeys and tab tearout won't work.</value>
+    <value>Certain features including but not limited to global hotkeys, tab drag and drop, and running commandlines in existing windows won't work.</value>
     <comment>Additional description for what the "isolated mode" setting does. Presented near "Globals_IsolatedMode.Header".</comment>
   </data>
   <data name="Globals_TabWidthMode.Header" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -560,10 +560,6 @@
     <value>Allow DECRQCRA (Request Checksum of Rectangular Area)</value>
     <comment>{Locked="DECRQCRA"}{Locked="Request Checksum of Rectangular Area"}Header for a control to toggle support for the DECRQCRA control sequence.</comment>
   </data>
-  <data name="Profile_AllowKeypadMode.Header" xml:space="preserve">
-    <value>Allow DECKPAM and DECKPNM (Keypad Numeric Mode)</value>
-    <comment>{Locked="DECKPAM"}{Locked="DECKPNM"}{Locked="Keypad Numeric Mode"}Header for a control to toggle support for the DECKPAM and DECKPNM control sequences.</comment>
-  </data>
   <data name="Globals_AllowHeadless.Header" xml:space="preserve">
     <value>Allow Windows Terminal to run in the background</value>
     <comment>Header for a control to toggle support for Windows Terminal to run in the background.</comment>

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -41,6 +41,7 @@ static constexpr std::string_view DefaultSettingsKey{ "defaults" };
 static constexpr std::string_view ProfilesListKey{ "list" };
 static constexpr std::string_view SchemesKey{ "schemes" };
 static constexpr std::string_view ThemesKey{ "themes" };
+static constexpr std::string_view LegacyForceVTInputKey{ "experimental.input.forceVT" };
 
 constexpr std::wstring_view systemThemeName{ L"system" };
 constexpr std::wstring_view darkThemeName{ L"dark" };
@@ -676,6 +677,13 @@ void SettingsLoader::_parse(const OriginTag origin, const winrt::hstring& source
         // That will hyper-explode, so just don't let them do that.
         settings.baseLayerProfile->ClearGuid();
         settings.baseLayerProfile->Origin(OriginTag::ProfilesDefaults);
+
+        // This got moved over from a global setting to a profile setting.
+        // If we encounter it, save it to the base layer.
+        if (auto val = JsonUtils::GetValueForKey<std::optional<bool>>(json.root, LegacyForceVTInputKey))
+        {
+            settings.baseLayerProfile->ForceVTInput(*val);
+        }
     }
 
     {

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -41,7 +41,6 @@ static constexpr std::string_view DefaultSettingsKey{ "defaults" };
 static constexpr std::string_view ProfilesListKey{ "list" };
 static constexpr std::string_view SchemesKey{ "schemes" };
 static constexpr std::string_view ThemesKey{ "themes" };
-static constexpr std::string_view LegacyForceVTInputKey{ "experimental.input.forceVT" };
 
 constexpr std::wstring_view systemThemeName{ L"system" };
 constexpr std::wstring_view darkThemeName{ L"dark" };

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -525,6 +525,15 @@ bool SettingsLoader::FixupUserSettings()
         fixedUp = true;
     }
 
+    // Terminal 1.23: Migrate the global
+    // `experimental.input.forceVT` to being a per-profile setting.
+    if (userSettings.globals->LegacyForceVTInput())
+    {
+        // migrate the user's opt-out to the profiles.defaults
+        userSettings.baseLayerProfile->ForceVTInput(true);
+        fixedUp = true;
+    }
+
     return fixedUp;
 }
 
@@ -677,13 +686,6 @@ void SettingsLoader::_parse(const OriginTag origin, const winrt::hstring& source
         // That will hyper-explode, so just don't let them do that.
         settings.baseLayerProfile->ClearGuid();
         settings.baseLayerProfile->Origin(OriginTag::ProfilesDefaults);
-
-        // This got moved over from a global setting to a profile setting.
-        // If we encounter it, save it to the base layer.
-        if (auto val = JsonUtils::GetValueForKey<std::optional<bool>>(json.root, LegacyForceVTInputKey))
-        {
-            settings.baseLayerProfile->ForceVTInput(*val);
-        }
     }
 
     {

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
@@ -23,6 +23,7 @@ static constexpr std::string_view ThemeKey{ "theme" };
 static constexpr std::string_view DefaultProfileKey{ "defaultProfile" };
 static constexpr std::string_view LegacyUseTabSwitcherModeKey{ "useTabSwitcher" };
 static constexpr std::string_view LegacyReloadEnvironmentVariablesKey{ "compatibility.reloadEnvironmentVariables" };
+static constexpr std::string_view LegacyForceVTInputKey{ "experimental.input.forceVT" };
 
 // Method Description:
 // - Copies any extraneous data from the parent before completing a CreateChild call
@@ -158,6 +159,12 @@ void GlobalAppSettings::LayerJson(const Json::Value& json, const OriginTag origi
     if (json[LegacyReloadEnvironmentVariablesKey.data()])
     {
         _logSettingSet(LegacyReloadEnvironmentVariablesKey);
+    }
+
+    JsonUtils::GetValueForKey(json, LegacyForceVTInputKey, _legacyForceVTInput);
+    if (json[LegacyForceVTInputKey.data()])
+    {
+        _logSettingSet(LegacyForceVTInputKey);
     }
 
     // Remove settings included in userDefaults

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
@@ -134,7 +134,7 @@ void GlobalAppSettings::LayerJson(const Json::Value& json, const OriginTag origi
     // "useTabSwitcher" to "tabSwitcherMode". Continue supporting
     // "useTabSwitcher", but prefer "tabSwitcherMode"
     JsonUtils::GetValueForKey(json, LegacyUseTabSwitcherModeKey, _TabSwitcherMode);
-    
+
     JsonUtils::GetValueForKey(json, LegacyForceVTInputKey, _ForceVTInput);
 
 #define GLOBAL_SETTINGS_LAYER_JSON(type, name, jsonKey, ...) \

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
@@ -23,7 +23,6 @@ static constexpr std::string_view ThemeKey{ "theme" };
 static constexpr std::string_view DefaultProfileKey{ "defaultProfile" };
 static constexpr std::string_view LegacyUseTabSwitcherModeKey{ "useTabSwitcher" };
 static constexpr std::string_view LegacyReloadEnvironmentVariablesKey{ "compatibility.reloadEnvironmentVariables" };
-static constexpr std::string_view LegacyForceVTInputKey{ "experimental.input.forceVT" };
 
 // Method Description:
 // - Copies any extraneous data from the parent before completing a CreateChild call
@@ -134,8 +133,6 @@ void GlobalAppSettings::LayerJson(const Json::Value& json, const OriginTag origi
     // "useTabSwitcher" to "tabSwitcherMode". Continue supporting
     // "useTabSwitcher", but prefer "tabSwitcherMode"
     JsonUtils::GetValueForKey(json, LegacyUseTabSwitcherModeKey, _TabSwitcherMode);
-
-    JsonUtils::GetValueForKey(json, LegacyForceVTInputKey, _ForceVTInput);
 
 #define GLOBAL_SETTINGS_LAYER_JSON(type, name, jsonKey, ...) \
     JsonUtils::GetValueForKey(json, jsonKey, _##name);       \

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
@@ -23,6 +23,7 @@ static constexpr std::string_view ThemeKey{ "theme" };
 static constexpr std::string_view DefaultProfileKey{ "defaultProfile" };
 static constexpr std::string_view LegacyUseTabSwitcherModeKey{ "useTabSwitcher" };
 static constexpr std::string_view LegacyReloadEnvironmentVariablesKey{ "compatibility.reloadEnvironmentVariables" };
+static constexpr std::string_view LegacyForceVTInputKey{ "experimental.input.forceVT" };
 
 // Method Description:
 // - Copies any extraneous data from the parent before completing a CreateChild call
@@ -133,6 +134,8 @@ void GlobalAppSettings::LayerJson(const Json::Value& json, const OriginTag origi
     // "useTabSwitcher" to "tabSwitcherMode". Continue supporting
     // "useTabSwitcher", but prefer "tabSwitcherMode"
     JsonUtils::GetValueForKey(json, LegacyUseTabSwitcherModeKey, _TabSwitcherMode);
+    
+    JsonUtils::GetValueForKey(json, LegacyForceVTInputKey, _ForceVTInput);
 
 #define GLOBAL_SETTINGS_LAYER_JSON(type, name, jsonKey, ...) \
     JsonUtils::GetValueForKey(json, jsonKey, _##name);       \

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.h
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.h
@@ -71,6 +71,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                             const Windows::Foundation::Collections::IMapView<winrt::hstring, Model::ColorScheme>& schemes);
 
         bool LegacyReloadEnvironmentVariables() const noexcept { return _legacyReloadEnvironmentVariables; }
+        bool LegacyForceVTInput() const noexcept { return _legacyForceVTInput; }
 
         void LogSettingChanges(std::set<std::string>& changes, const std::string_view& context) const;
 
@@ -90,6 +91,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         winrt::guid _defaultProfile{};
         bool _legacyReloadEnvironmentVariables{ true };
+        bool _legacyForceVTInput{ false };
         winrt::com_ptr<implementation::ActionMap> _actionMap{ winrt::make_self<implementation::ActionMap>() };
         std::set<std::string> _changeLog;
 

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
@@ -104,6 +104,7 @@ namespace Microsoft.Terminal.Settings.Model
         INHERITABLE_SETTING(Boolean, IsolatedMode);
         INHERITABLE_SETTING(Boolean, AllowHeadless);
         INHERITABLE_SETTING(String, SearchWebDefaultQueryUrl);
+        INHERITABLE_SETTING(Boolean, AllowVtChecksumReport);
 
         Windows.Foundation.Collections.IMapView<String, ColorScheme> ColorSchemes();
         void AddColorScheme(ColorScheme scheme);

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
@@ -81,7 +81,6 @@ namespace Microsoft.Terminal.Settings.Model
         INHERITABLE_SETTING(Boolean, SoftwareRendering);
         INHERITABLE_SETTING(Microsoft.Terminal.Control.TextMeasurement, TextMeasurement);
         INHERITABLE_SETTING(Boolean, UseBackgroundImageForWindow);
-        INHERITABLE_SETTING(Boolean, ForceVTInput);
         INHERITABLE_SETTING(Boolean, DebugFeaturesEnabled);
         INHERITABLE_SETTING(Boolean, StartOnUserLogin);
         INHERITABLE_SETTING(Boolean, AlwaysOnTop);
@@ -104,8 +103,6 @@ namespace Microsoft.Terminal.Settings.Model
         INHERITABLE_SETTING(Boolean, IsolatedMode);
         INHERITABLE_SETTING(Boolean, AllowHeadless);
         INHERITABLE_SETTING(String, SearchWebDefaultQueryUrl);
-        INHERITABLE_SETTING(Boolean, AllowVtChecksumReport);
-        INHERITABLE_SETTING(Boolean, AllowKeypadMode);
 
         Windows.Foundation.Collections.IMapView<String, ColorScheme> ColorSchemes();
         void AddColorScheme(ColorScheme scheme);

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
@@ -105,6 +105,7 @@ namespace Microsoft.Terminal.Settings.Model
         INHERITABLE_SETTING(Boolean, AllowHeadless);
         INHERITABLE_SETTING(String, SearchWebDefaultQueryUrl);
         INHERITABLE_SETTING(Boolean, AllowVtChecksumReport);
+        INHERITABLE_SETTING(Boolean, AllowKeypadMode);
 
         Windows.Foundation.Collections.IMapView<String, ColorScheme> ColorSchemes();
         void AddColorScheme(ColorScheme scheme);

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -70,7 +70,8 @@ Author(s):
     X(bool, AllowHeadless, "compatibility.allowHeadless", false)                                                                                                                                      \
     X(bool, IsolatedMode, "compatibility.isolatedMode", false)                                                                                                                                        \
     X(hstring, SearchWebDefaultQueryUrl, "searchWebDefaultQueryUrl", L"https://www.bing.com/search?q=%22%s%22")                                                                                       \
-    X(bool, AllowVtChecksumReport, "compatibility.allowVtChecksumReport", false)
+    X(bool, AllowVtChecksumReport, "compatibility.allowVtChecksumReport", false)                                                                                                                      \
+    X(bool, AllowKeypadMode, "compatibility.allowKeypadMode", false)
 
 // Also add these settings to:
 // * Profile.idl

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -29,7 +29,7 @@ Author(s):
     X(bool, SoftwareRendering, "rendering.software", false)                                                                                                                                           \
     X(winrt::Microsoft::Terminal::Control::TextMeasurement, TextMeasurement, "compatibility.textMeasurement")                                                                                         \
     X(bool, UseBackgroundImageForWindow, "experimental.useBackgroundImageForWindow", false)                                                                                                           \
-    X(bool, ForceVTInput, "compatibility.input.forceVT", false)                                                                                                                                        \
+    X(bool, ForceVTInput, "compatibility.input.forceVT", false)                                                                                                                                       \
     X(bool, TrimBlockSelection, "trimBlockSelection", true)                                                                                                                                           \
     X(bool, DetectURLs, "experimental.detectURLs", true)                                                                                                                                              \
     X(bool, AlwaysShowTabs, "alwaysShowTabs", true)                                                                                                                                                   \
@@ -69,7 +69,8 @@ Author(s):
     X(winrt::Windows::Foundation::Collections::IVector<Model::NewTabMenuEntry>, NewTabMenu, "newTabMenu", winrt::single_threaded_vector<Model::NewTabMenuEntry>({ Model::RemainingProfilesEntry{} })) \
     X(bool, AllowHeadless, "compatibility.allowHeadless", false)                                                                                                                                      \
     X(bool, IsolatedMode, "compatibility.isolatedMode", false)                                                                                                                                        \
-    X(hstring, SearchWebDefaultQueryUrl, "searchWebDefaultQueryUrl", L"https://www.bing.com/search?q=%22%s%22")
+    X(hstring, SearchWebDefaultQueryUrl, "searchWebDefaultQueryUrl", L"https://www.bing.com/search?q=%22%s%22")                                                                                       \
+    X(bool, AllowVtChecksumReport, "compatibility.allowVtChecksumReport", false)
 
 // Also add these settings to:
 // * Profile.idl

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -29,7 +29,6 @@ Author(s):
     X(bool, SoftwareRendering, "rendering.software", false)                                                                                                                                           \
     X(winrt::Microsoft::Terminal::Control::TextMeasurement, TextMeasurement, "compatibility.textMeasurement")                                                                                         \
     X(bool, UseBackgroundImageForWindow, "experimental.useBackgroundImageForWindow", false)                                                                                                           \
-    X(bool, ForceVTInput, "compatibility.input.forceVT", false)                                                                                                                                       \
     X(bool, TrimBlockSelection, "trimBlockSelection", true)                                                                                                                                           \
     X(bool, DetectURLs, "experimental.detectURLs", true)                                                                                                                                              \
     X(bool, AlwaysShowTabs, "alwaysShowTabs", true)                                                                                                                                                   \
@@ -69,9 +68,7 @@ Author(s):
     X(winrt::Windows::Foundation::Collections::IVector<Model::NewTabMenuEntry>, NewTabMenu, "newTabMenu", winrt::single_threaded_vector<Model::NewTabMenuEntry>({ Model::RemainingProfilesEntry{} })) \
     X(bool, AllowHeadless, "compatibility.allowHeadless", false)                                                                                                                                      \
     X(bool, IsolatedMode, "compatibility.isolatedMode", false)                                                                                                                                        \
-    X(hstring, SearchWebDefaultQueryUrl, "searchWebDefaultQueryUrl", L"https://www.bing.com/search?q=%22%s%22")                                                                                       \
-    X(bool, AllowVtChecksumReport, "compatibility.allowVtChecksumReport", false)                                                                                                                      \
-    X(bool, AllowKeypadMode, "compatibility.allowKeypadMode", false)
+    X(hstring, SearchWebDefaultQueryUrl, "searchWebDefaultQueryUrl", L"https://www.bing.com/search?q=%22%s%22")
 
 // Also add these settings to:
 // * Profile.idl
@@ -101,7 +98,10 @@ Author(s):
     X(bool, ShowMarks, "showMarksOnScrollbar", false)                                                                                                          \
     X(bool, RepositionCursorWithMouse, "experimental.repositionCursorWithMouse", false)                                                                        \
     X(bool, ReloadEnvironmentVariables, "compatibility.reloadEnvironmentVariables", true)                                                                      \
-    X(bool, RainbowSuggestions, "experimental.rainbowSuggestions", false)
+    X(bool, RainbowSuggestions, "experimental.rainbowSuggestions", false)                                                                                      \
+    X(bool, ForceVTInput, "compatibility.forceVT", false)                                                                                                      \
+    X(bool, AllowVtChecksumReport, "compatibility.allowDECRQCRA", false)                                                                                       \
+    X(bool, AllowKeypadMode, "compatibility.allowDECNKM", false)
 
 // Intentionally omitted Profile settings:
 // * Name

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -99,7 +99,7 @@ Author(s):
     X(bool, RepositionCursorWithMouse, "experimental.repositionCursorWithMouse", false)                                                                        \
     X(bool, ReloadEnvironmentVariables, "compatibility.reloadEnvironmentVariables", true)                                                                      \
     X(bool, RainbowSuggestions, "experimental.rainbowSuggestions", false)                                                                                      \
-    X(bool, ForceVTInput, "compatibility.forceVT", false)                                                                                                      \
+    X(bool, ForceVTInput, "compatibility.input.forceVT", false)                                                                                                \
     X(bool, AllowVtChecksumReport, "compatibility.allowDECRQCRA", false)                                                                                       \
     X(bool, AllowKeypadMode, "compatibility.allowDECNKM", false)
 

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -29,7 +29,7 @@ Author(s):
     X(bool, SoftwareRendering, "rendering.software", false)                                                                                                                                           \
     X(winrt::Microsoft::Terminal::Control::TextMeasurement, TextMeasurement, "compatibility.textMeasurement")                                                                                         \
     X(bool, UseBackgroundImageForWindow, "experimental.useBackgroundImageForWindow", false)                                                                                                           \
-    X(bool, ForceVTInput, "experimental.input.forceVT", false)                                                                                                                                        \
+    X(bool, ForceVTInput, "compatibility.input.forceVT", false)                                                                                                                                        \
     X(bool, TrimBlockSelection, "trimBlockSelection", true)                                                                                                                                           \
     X(bool, DetectURLs, "experimental.detectURLs", true)                                                                                                                                              \
     X(bool, AlwaysShowTabs, "alwaysShowTabs", true)                                                                                                                                                   \

--- a/src/cascadia/TerminalSettingsModel/Profile.idl
+++ b/src/cascadia/TerminalSettingsModel/Profile.idl
@@ -89,6 +89,8 @@ namespace Microsoft.Terminal.Settings.Model
 
         INHERITABLE_PROFILE_SETTING(Boolean, ReloadEnvironmentVariables);
         INHERITABLE_PROFILE_SETTING(Boolean, RainbowSuggestions);
-
+        INHERITABLE_PROFILE_SETTING(Boolean, ForceVTInput);
+        INHERITABLE_PROFILE_SETTING(Boolean, AllowVtChecksumReport);
+        INHERITABLE_PROFILE_SETTING(Boolean, AllowKeypadMode);
     }
 }

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
@@ -347,6 +347,9 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         _RepositionCursorWithMouse = profile.RepositionCursorWithMouse();
         _ReloadEnvironmentVariables = profile.ReloadEnvironmentVariables();
         _RainbowSuggestions = profile.RainbowSuggestions();
+        _ForceVTInput = profile.ForceVTInput();
+        _AllowVtChecksumReport = profile.AllowVtChecksumReport();
+        _AllowKeypadMode = profile.AllowKeypadMode();
     }
 
     // Method Description:
@@ -369,12 +372,9 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         _SoftwareRendering = globalSettings.SoftwareRendering();
         _TextMeasurement = globalSettings.TextMeasurement();
         _UseBackgroundImageForWindow = globalSettings.UseBackgroundImageForWindow();
-        _ForceVTInput = globalSettings.ForceVTInput();
         _TrimBlockSelection = globalSettings.TrimBlockSelection();
         _DetectURLs = globalSettings.DetectURLs();
         _EnableUnfocusedAcrylic = globalSettings.EnableUnfocusedAcrylic();
-        _AllowVtChecksumReport = globalSettings.AllowVtChecksumReport();
-        _AllowKeypadMode = globalSettings.AllowKeypadMode();
     }
 
     // Method Description:

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
@@ -374,6 +374,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         _DetectURLs = globalSettings.DetectURLs();
         _EnableUnfocusedAcrylic = globalSettings.EnableUnfocusedAcrylic();
         _AllowVtChecksumReport = globalSettings.AllowVtChecksumReport();
+        _AllowKeypadMode = globalSettings.AllowKeypadMode();
     }
 
     // Method Description:

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
@@ -349,7 +349,6 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         _RainbowSuggestions = profile.RainbowSuggestions();
         _ForceVTInput = profile.ForceVTInput();
         _AllowVtChecksumReport = profile.AllowVtChecksumReport();
-        _AllowKeypadMode = profile.AllowKeypadMode();
     }
 
     // Method Description:

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
@@ -373,6 +373,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         _TrimBlockSelection = globalSettings.TrimBlockSelection();
         _DetectURLs = globalSettings.DetectURLs();
         _EnableUnfocusedAcrylic = globalSettings.EnableUnfocusedAcrylic();
+        _AllowVtChecksumReport = globalSettings.AllowVtChecksumReport();
     }
 
     // Method Description:

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.h
@@ -94,6 +94,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         INHERITABLE_SETTING(Model::TerminalSettings, bool, CopyOnSelect, false);
         INHERITABLE_SETTING(Model::TerminalSettings, Microsoft::Terminal::Control::CopyFormat, CopyFormatting, 0);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, FocusFollowMouse, false);
+        INHERITABLE_SETTING(Model::TerminalSettings, bool, AllowVtChecksumReport, false);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, TrimBlockSelection, true);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, DetectURLs, true);
 

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.h
@@ -95,6 +95,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         INHERITABLE_SETTING(Model::TerminalSettings, Microsoft::Terminal::Control::CopyFormat, CopyFormatting, 0);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, FocusFollowMouse, false);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, AllowVtChecksumReport, false);
+        INHERITABLE_SETTING(Model::TerminalSettings, bool, AllowKeypadMode, false);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, TrimBlockSelection, true);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, DetectURLs, true);
 

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.h
@@ -95,7 +95,6 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         INHERITABLE_SETTING(Model::TerminalSettings, Microsoft::Terminal::Control::CopyFormat, CopyFormatting, 0);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, FocusFollowMouse, false);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, AllowVtChecksumReport, false);
-        INHERITABLE_SETTING(Model::TerminalSettings, bool, AllowKeypadMode, false);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, TrimBlockSelection, true);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, DetectURLs, true);
 

--- a/src/cascadia/UnitTests_SettingsModel/SerializationTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/SerializationTests.cpp
@@ -128,7 +128,7 @@ namespace SettingsModelUnitTests
                 "multiLinePasteWarning": true,
                 "trimPaste": true,
 
-                "experimental.input.forceVT": false,
+                "compatibility.input.forceVT": false,
 
                 "actions": [],
                 "keybindings": []

--- a/src/cascadia/UnitTests_SettingsModel/SerializationTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/SerializationTests.cpp
@@ -124,8 +124,6 @@ namespace SettingsModelUnitTests
 
                 "trimPaste": true,
 
-                "compatibility.input.forceVT": false,
-
                 "warning.confirmCloseAllTabs" : true,
                 "warning.inputService" : true,
                 "warning.largePaste" : true,

--- a/src/cascadia/inc/ControlProperties.h
+++ b/src/cascadia/inc/ControlProperties.h
@@ -51,7 +51,8 @@
     X(bool, DetectURLs, true)                                                                                     \
     X(bool, AutoMarkPrompts)                                                                                      \
     X(bool, RepositionCursorWithMouse, false)                                                                     \
-    X(bool, RainbowSuggestions)
+    X(bool, RainbowSuggestions)                                                                                   \
+    X(bool, AllowVtChecksumReport)
 
 // --------------------------- Control Settings ---------------------------
 //  All of these settings are defined in IControlSettings.

--- a/src/cascadia/inc/ControlProperties.h
+++ b/src/cascadia/inc/ControlProperties.h
@@ -52,8 +52,7 @@
     X(bool, AutoMarkPrompts)                                                                                      \
     X(bool, RepositionCursorWithMouse, false)                                                                     \
     X(bool, RainbowSuggestions)                                                                                   \
-    X(bool, AllowVtChecksumReport)                                                                                \
-    X(bool, AllowKeypadMode)
+    X(bool, AllowVtChecksumReport)
 
 // --------------------------- Control Settings ---------------------------
 //  All of these settings are defined in IControlSettings.

--- a/src/cascadia/inc/ControlProperties.h
+++ b/src/cascadia/inc/ControlProperties.h
@@ -52,7 +52,8 @@
     X(bool, AutoMarkPrompts)                                                                                      \
     X(bool, RepositionCursorWithMouse, false)                                                                     \
     X(bool, RainbowSuggestions)                                                                                   \
-    X(bool, AllowVtChecksumReport)
+    X(bool, AllowVtChecksumReport)                                                                                \
+    X(bool, AllowKeypadMode)
 
 // --------------------------- Control Settings ---------------------------
 //  All of these settings are defined in IControlSettings.

--- a/src/features.xml
+++ b/src/features.xml
@@ -180,8 +180,8 @@
     </feature>
 
     <feature>
-        <name>Feature_DebugMode</name>
-        <description>Enables the debug mode setting</description>
+        <name>Feature_DebugModeUI</name>
+        <description>Enables UI access to the debug mode setting</description>
         <stage>AlwaysEnabled</stage>
         <alwaysDisabledReleaseTokens/>
     </feature>

--- a/src/features.xml
+++ b/src/features.xml
@@ -125,6 +125,16 @@
     </feature>
 
     <feature>
+        <name>Feature_VtChecksumReport</name>
+        <description>Enables the DECRQCRA checksum report, which can be used to read the screen contents</description>
+        <id>14974</id>
+        <stage>AlwaysDisabled</stage>
+        <alwaysEnabledBrandingTokens>
+            <brandingToken>Dev</brandingToken>
+        </alwaysEnabledBrandingTokens>
+    </feature>
+
+    <feature>
         <name>Feature_ScratchpadPane</name>
         <description>Allow the user to create scratchpad panes. Mostly just exists to validate non-terminal panes.</description>
         <id>997</id>
@@ -165,6 +175,13 @@
             <brandingToken>Dev</brandingToken>
             <brandingToken>Canary</brandingToken>
         </alwaysEnabledBrandingTokens>
+    </feature>
+
+    <feature>
+        <name>Feature_DebugMode</name>
+        <description>Enables the debug mode setting</description>
+        <stage>AlwaysEnabled</stage>
+        <alwaysDisabledReleaseTokens/>
     </feature>
 
 </featureStaging>

--- a/src/features.xml
+++ b/src/features.xml
@@ -125,16 +125,6 @@
     </feature>
 
     <feature>
-        <name>Feature_VtChecksumReport</name>
-        <description>Enables the DECRQCRA checksum report, which can be used to read the screen contents</description>
-        <id>14974</id>
-        <stage>AlwaysDisabled</stage>
-        <alwaysEnabledBrandingTokens>
-            <brandingToken>Dev</brandingToken>
-        </alwaysEnabledBrandingTokens>
-    </feature>
-
-    <feature>
         <name>Feature_ScratchpadPane</name>
         <description>Allow the user to create scratchpad panes. Mostly just exists to validate non-terminal panes.</description>
         <id>997</id>

--- a/src/terminal/adapter/ITermDispatch.hpp
+++ b/src/terminal/adapter/ITermDispatch.hpp
@@ -129,6 +129,7 @@ public:
     virtual void ScreenAlignmentPattern() = 0; // DECALN
 
     virtual void SetCursorStyle(const DispatchTypes::CursorStyle cursorStyle) = 0; // DECSCUSR
+    virtual void SetVtChecksumReportSupport(const bool enabled) = 0;
 
     virtual void SetClipboard(wil::zwstring_view content) = 0; // OSCSetClipboard
 

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1304,7 +1304,7 @@ void AdaptDispatch::SelectAttributeChangeExtent(const DispatchTypes::ChangeExten
     }
 }
 
-void AdaptDispatch::SetVtChecksumReportSupport(const bool enabled)
+void AdaptDispatch::SetVtChecksumReportSupport(const bool enabled) noexcept
 {
     _vtChecksumReportEnabled = enabled;
 }

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1323,7 +1323,7 @@ void AdaptDispatch::RequestChecksumRectangularArea(const VTInt id, const VTInt p
 {
     uint16_t checksum = 0;
     // If this feature is not enabled, we'll just report a zero checksum.
-    if (Feature_VtChecksumReport::IsEnabled() && _vtChecksumReportEnabled)
+    if (_vtChecksumReportEnabled)
     {
         // If the page number is 0, then we're meant to return a checksum of all
         // of the pages, but we have no need for that, so we'll just return 0.

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1304,6 +1304,11 @@ void AdaptDispatch::SelectAttributeChangeExtent(const DispatchTypes::ChangeExten
     }
 }
 
+void AdaptDispatch::SetVtChecksumReportSupport(const bool enabled)
+{
+    _vtChecksumReportEnabled = enabled;
+}
+
 // Routine Description:
 // - DECRQCRA - Computes and reports a checksum of the specified area of
 //   the buffer memory.
@@ -1318,7 +1323,7 @@ void AdaptDispatch::RequestChecksumRectangularArea(const VTInt id, const VTInt p
 {
     uint16_t checksum = 0;
     // If this feature is not enabled, we'll just report a zero checksum.
-    if constexpr (Feature_VtChecksumReport::IsEnabled())
+    if (Feature_VtChecksumReport::IsEnabled() && _vtChecksumReportEnabled)
     {
         // If the page number is 0, then we're meant to return a checksum of all
         // of the pages, but we have no need for that, so we'll just return 0.

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1323,61 +1323,64 @@ void AdaptDispatch::RequestChecksumRectangularArea(const VTInt id, const VTInt p
 {
     uint16_t checksum = 0;
     // If this feature is not enabled, we'll just report a zero checksum.
-    if (_vtChecksumReportEnabled)
+    if constexpr (Feature_VtChecksumReport::IsEnabled())
     {
-        // If the page number is 0, then we're meant to return a checksum of all
-        // of the pages, but we have no need for that, so we'll just return 0.
-        if (page != 0)
+        if (_vtChecksumReportEnabled)
         {
-            // As part of the checksum, we need to include the color indices of each
-            // cell, and in the case of default colors, those indices come from the
-            // color alias table. But if they're not in the bottom 16 range, we just
-            // fallback to using white on black (7 and 0).
-            auto defaultFgIndex = _renderSettings.GetColorAliasIndex(ColorAlias::DefaultForeground);
-            auto defaultBgIndex = _renderSettings.GetColorAliasIndex(ColorAlias::DefaultBackground);
-            defaultFgIndex = defaultFgIndex < 16 ? defaultFgIndex : 7;
-            defaultBgIndex = defaultBgIndex < 16 ? defaultBgIndex : 0;
-
-            const auto target = _pages.Get(page);
-            const auto eraseRect = _CalculateRectArea(target, top, left, bottom, right);
-            for (auto row = eraseRect.top; row < eraseRect.bottom; row++)
+            // If the page number is 0, then we're meant to return a checksum of all
+            // of the pages, but we have no need for that, so we'll just return 0.
+            if (page != 0)
             {
-                for (auto col = eraseRect.left; col < eraseRect.right; col++)
+                // As part of the checksum, we need to include the color indices of each
+                // cell, and in the case of default colors, those indices come from the
+                // color alias table. But if they're not in the bottom 16 range, we just
+                // fallback to using white on black (7 and 0).
+                auto defaultFgIndex = _renderSettings.GetColorAliasIndex(ColorAlias::DefaultForeground);
+                auto defaultBgIndex = _renderSettings.GetColorAliasIndex(ColorAlias::DefaultBackground);
+                defaultFgIndex = defaultFgIndex < 16 ? defaultFgIndex : 7;
+                defaultBgIndex = defaultBgIndex < 16 ? defaultBgIndex : 0;
+
+                const auto target = _pages.Get(page);
+                const auto eraseRect = _CalculateRectArea(target, top, left, bottom, right);
+                for (auto row = eraseRect.top; row < eraseRect.bottom; row++)
                 {
-                    // The algorithm we're using here should match the DEC terminals
-                    // for the ASCII and Latin-1 range. Their other character sets
-                    // predate Unicode, though, so we'd need a custom mapping table
-                    // to lookup the correct checksums. Considering this is only for
-                    // testing at the moment, that doesn't seem worth the effort.
-                    const auto cell = target.Buffer().GetCellDataAt({ col, row });
-                    for (auto ch : cell->Chars())
+                    for (auto col = eraseRect.left; col < eraseRect.right; col++)
                     {
-                        // That said, I've made a special allowance for U+2426,
-                        // since that is widely used in a lot of character sets.
-                        checksum -= (ch == L'\u2426' ? 0x1B : ch);
+                        // The algorithm we're using here should match the DEC terminals
+                        // for the ASCII and Latin-1 range. Their other character sets
+                        // predate Unicode, though, so we'd need a custom mapping table
+                        // to lookup the correct checksums. Considering this is only for
+                        // testing at the moment, that doesn't seem worth the effort.
+                        const auto cell = target.Buffer().GetCellDataAt({ col, row });
+                        for (auto ch : cell->Chars())
+                        {
+                            // That said, I've made a special allowance for U+2426,
+                            // since that is widely used in a lot of character sets.
+                            checksum -= (ch == L'\u2426' ? 0x1B : ch);
+                        }
+
+                        // Since we're attempting to match the DEC checksum algorithm,
+                        // the only attributes affecting the checksum are the ones that
+                        // were supported by DEC terminals.
+                        const auto attr = cell->TextAttr();
+                        checksum -= attr.IsProtected() ? 0x04 : 0;
+                        checksum -= attr.IsInvisible() ? 0x08 : 0;
+                        checksum -= attr.IsUnderlined() ? 0x10 : 0;
+                        checksum -= attr.IsReverseVideo() ? 0x20 : 0;
+                        checksum -= attr.IsBlinking() ? 0x40 : 0;
+                        checksum -= attr.IsIntense() ? 0x80 : 0;
+
+                        // For the same reason, we only care about the eight basic ANSI
+                        // colors, although technically we also report the 8-16 index
+                        // range. Everything else gets mapped to the default colors.
+                        const auto colorIndex = [](const auto color, const auto defaultIndex) {
+                            return color.IsLegacy() ? color.GetIndex() : defaultIndex;
+                        };
+                        const auto fgIndex = colorIndex(attr.GetForeground(), defaultFgIndex);
+                        const auto bgIndex = colorIndex(attr.GetBackground(), defaultBgIndex);
+                        checksum -= gsl::narrow_cast<uint16_t>(fgIndex << 4);
+                        checksum -= gsl::narrow_cast<uint16_t>(bgIndex);
                     }
-
-                    // Since we're attempting to match the DEC checksum algorithm,
-                    // the only attributes affecting the checksum are the ones that
-                    // were supported by DEC terminals.
-                    const auto attr = cell->TextAttr();
-                    checksum -= attr.IsProtected() ? 0x04 : 0;
-                    checksum -= attr.IsInvisible() ? 0x08 : 0;
-                    checksum -= attr.IsUnderlined() ? 0x10 : 0;
-                    checksum -= attr.IsReverseVideo() ? 0x20 : 0;
-                    checksum -= attr.IsBlinking() ? 0x40 : 0;
-                    checksum -= attr.IsIntense() ? 0x80 : 0;
-
-                    // For the same reason, we only care about the eight basic ANSI
-                    // colors, although technically we also report the 8-16 index
-                    // range. Everything else gets mapped to the default colors.
-                    const auto colorIndex = [](const auto color, const auto defaultIndex) {
-                        return color.IsLegacy() ? color.GetIndex() : defaultIndex;
-                    };
-                    const auto fgIndex = colorIndex(attr.GetForeground(), defaultFgIndex);
-                    const auto bgIndex = colorIndex(attr.GetBackground(), defaultBgIndex);
-                    checksum -= gsl::narrow_cast<uint16_t>(fgIndex << 4);
-                    checksum -= gsl::narrow_cast<uint16_t>(bgIndex);
                 }
             }
         }

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -184,6 +184,8 @@ namespace Microsoft::Console::VirtualTerminal
 
         void PlaySounds(const VTParameters parameters) override; // DECPS
 
+        void SetVtChecksumReportSupport(const bool enabled) override;
+
     private:
         enum class Mode
         {
@@ -303,6 +305,7 @@ namespace Microsoft::Console::VirtualTerminal
         std::unique_ptr<FontBuffer> _fontBuffer;
         std::shared_ptr<MacroBuffer> _macroBuffer;
         std::optional<unsigned int> _initialCodePage;
+        bool _vtChecksumReportEnabled = false;
 
         // We have two instances of the saved cursor state, because we need
         // one for the main buffer (at index 0), and another for the alt buffer

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -184,7 +184,7 @@ namespace Microsoft::Console::VirtualTerminal
 
         void PlaySounds(const VTParameters parameters) override; // DECPS
 
-        void SetVtChecksumReportSupport(const bool enabled) override;
+        void SetVtChecksumReportSupport(const bool enabled) noexcept override;
 
     private:
         enum class Mode

--- a/src/terminal/adapter/termDispatch.hpp
+++ b/src/terminal/adapter/termDispatch.hpp
@@ -173,6 +173,8 @@ public:
     StringHandler RestorePresentationState(const DispatchTypes::PresentationReportFormat /*format*/) override { return nullptr; } // DECRSPS
 
     void PlaySounds(const VTParameters /*parameters*/) override{}; // DECPS
+
+    void SetVtChecksumReportSupport(const bool /*enabled*/) override{};
 };
 
 #pragma warning(default : 26440) // Restore "can be declared noexcept" warning

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -405,6 +405,7 @@ public:
             auto& renderer = _testGetSet->_renderer;
             auto& renderSettings = renderer._renderSettings;
             auto adapter = std::make_unique<AdaptDispatch>(*_testGetSet, &renderer, renderSettings, _terminalInput);
+            adapter->SetVtChecksumReportSupport(true);
 
             fSuccess = adapter.get() != nullptr;
             if (fSuccess)

--- a/src/terminal/input/terminalInput.cpp
+++ b/src/terminal/input/terminalInput.cpp
@@ -78,6 +78,11 @@ void TerminalInput::ForceDisableWin32InputMode(const bool win32InputMode) noexce
     _forceDisableWin32InputMode = win32InputMode;
 }
 
+void TerminalInput::SetKeypadModeSupport(const bool enabled) noexcept
+{
+    _keypadModeSupported = enabled;
+}
+
 TerminalInput::OutputType TerminalInput::MakeUnhandled() noexcept
 {
     return {};
@@ -438,7 +443,7 @@ try
         // the ASCII character assigned by the keyboard layout, but when set
         // they transmit SS3 escape sequences. When used with a modifier, the
         // modifier is embedded as a parameter value (not standard).
-        if (Feature_KeypadModeEnabled::IsEnabled() && _inputMode.test(Mode::Keypad))
+        if (Feature_KeypadModeEnabled::IsEnabled() && _keypadModeSupported && _inputMode.test(Mode::Keypad))
         {
             defineNumericKey(VK_MULTIPLY, L'j');
             defineNumericKey(VK_ADD, L'k');
@@ -490,7 +495,7 @@ try
 
         // Keypad keys also depend on Keypad mode, the same as ANSI mappings,
         // but the sequences use an ESC ? prefix instead of SS3.
-        if (Feature_KeypadModeEnabled::IsEnabled() && _inputMode.test(Mode::Keypad))
+        if (Feature_KeypadModeEnabled::IsEnabled() && _keypadModeSupported && _inputMode.test(Mode::Keypad))
         {
             defineKeyWithUnusedModifiers(VK_MULTIPLY, L"\033?j"s);
             defineKeyWithUnusedModifiers(VK_ADD, L"\033?k"s);

--- a/src/terminal/input/terminalInput.cpp
+++ b/src/terminal/input/terminalInput.cpp
@@ -443,27 +443,30 @@ try
         // the ASCII character assigned by the keyboard layout, but when set
         // they transmit SS3 escape sequences. When used with a modifier, the
         // modifier is embedded as a parameter value (not standard).
-        if (Feature_KeypadModeEnabled::IsEnabled() && _keypadModeSupported && _inputMode.test(Mode::Keypad))
+        if constexpr (Feature_KeypadModeEnabled::IsEnabled())
         {
-            defineNumericKey(VK_MULTIPLY, L'j');
-            defineNumericKey(VK_ADD, L'k');
-            defineNumericKey(VK_SEPARATOR, L'l');
-            defineNumericKey(VK_SUBTRACT, L'm');
-            defineNumericKey(VK_DECIMAL, L'n');
-            defineNumericKey(VK_DIVIDE, L'o');
+            if (_keypadModeSupported && _inputMode.test(Mode::Keypad))
+            {
+                defineNumericKey(VK_MULTIPLY, L'j');
+                defineNumericKey(VK_ADD, L'k');
+                defineNumericKey(VK_SEPARATOR, L'l');
+                defineNumericKey(VK_SUBTRACT, L'm');
+                defineNumericKey(VK_DECIMAL, L'n');
+                defineNumericKey(VK_DIVIDE, L'o');
 
-            defineNumericKey(VK_NUMPAD0, L'p');
-            defineNumericKey(VK_NUMPAD1, L'q');
-            defineNumericKey(VK_NUMPAD2, L'r');
-            defineNumericKey(VK_NUMPAD3, L's');
-            defineNumericKey(VK_NUMPAD4, L't');
-            defineNumericKey(VK_NUMPAD5, L'u');
-            defineNumericKey(VK_NUMPAD6, L'v');
-            defineNumericKey(VK_NUMPAD7, L'w');
-            defineNumericKey(VK_NUMPAD8, L'x');
-            defineNumericKey(VK_NUMPAD9, L'y');
+                defineNumericKey(VK_NUMPAD0, L'p');
+                defineNumericKey(VK_NUMPAD1, L'q');
+                defineNumericKey(VK_NUMPAD2, L'r');
+                defineNumericKey(VK_NUMPAD3, L's');
+                defineNumericKey(VK_NUMPAD4, L't');
+                defineNumericKey(VK_NUMPAD5, L'u');
+                defineNumericKey(VK_NUMPAD6, L'v');
+                defineNumericKey(VK_NUMPAD7, L'w');
+                defineNumericKey(VK_NUMPAD8, L'x');
+                defineNumericKey(VK_NUMPAD9, L'y');
 
-            defineNumericKey(Enhanced + VK_RETURN, L'M');
+                defineNumericKey(Enhanced + VK_RETURN, L'M');
+            }
         }
     }
     else
@@ -495,27 +498,30 @@ try
 
         // Keypad keys also depend on Keypad mode, the same as ANSI mappings,
         // but the sequences use an ESC ? prefix instead of SS3.
-        if (Feature_KeypadModeEnabled::IsEnabled() && _keypadModeSupported && _inputMode.test(Mode::Keypad))
+        if constexpr (Feature_KeypadModeEnabled::IsEnabled())
         {
-            defineKeyWithUnusedModifiers(VK_MULTIPLY, L"\033?j"s);
-            defineKeyWithUnusedModifiers(VK_ADD, L"\033?k"s);
-            defineKeyWithUnusedModifiers(VK_SEPARATOR, L"\033?l"s);
-            defineKeyWithUnusedModifiers(VK_SUBTRACT, L"\033?m"s);
-            defineKeyWithUnusedModifiers(VK_DECIMAL, L"\033?n"s);
-            defineKeyWithUnusedModifiers(VK_DIVIDE, L"\033?o"s);
+            if (_keypadModeSupported && _inputMode.test(Mode::Keypad))
+            {
+                defineKeyWithUnusedModifiers(VK_MULTIPLY, L"\033?j"s);
+                defineKeyWithUnusedModifiers(VK_ADD, L"\033?k"s);
+                defineKeyWithUnusedModifiers(VK_SEPARATOR, L"\033?l"s);
+                defineKeyWithUnusedModifiers(VK_SUBTRACT, L"\033?m"s);
+                defineKeyWithUnusedModifiers(VK_DECIMAL, L"\033?n"s);
+                defineKeyWithUnusedModifiers(VK_DIVIDE, L"\033?o"s);
 
-            defineKeyWithUnusedModifiers(VK_NUMPAD0, L"\033?p"s);
-            defineKeyWithUnusedModifiers(VK_NUMPAD1, L"\033?q"s);
-            defineKeyWithUnusedModifiers(VK_NUMPAD2, L"\033?r"s);
-            defineKeyWithUnusedModifiers(VK_NUMPAD3, L"\033?s"s);
-            defineKeyWithUnusedModifiers(VK_NUMPAD4, L"\033?t"s);
-            defineKeyWithUnusedModifiers(VK_NUMPAD5, L"\033?u"s);
-            defineKeyWithUnusedModifiers(VK_NUMPAD6, L"\033?v"s);
-            defineKeyWithUnusedModifiers(VK_NUMPAD7, L"\033?w"s);
-            defineKeyWithUnusedModifiers(VK_NUMPAD8, L"\033?x"s);
-            defineKeyWithUnusedModifiers(VK_NUMPAD9, L"\033?y"s);
+                defineKeyWithUnusedModifiers(VK_NUMPAD0, L"\033?p"s);
+                defineKeyWithUnusedModifiers(VK_NUMPAD1, L"\033?q"s);
+                defineKeyWithUnusedModifiers(VK_NUMPAD2, L"\033?r"s);
+                defineKeyWithUnusedModifiers(VK_NUMPAD3, L"\033?s"s);
+                defineKeyWithUnusedModifiers(VK_NUMPAD4, L"\033?t"s);
+                defineKeyWithUnusedModifiers(VK_NUMPAD5, L"\033?u"s);
+                defineKeyWithUnusedModifiers(VK_NUMPAD6, L"\033?v"s);
+                defineKeyWithUnusedModifiers(VK_NUMPAD7, L"\033?w"s);
+                defineKeyWithUnusedModifiers(VK_NUMPAD8, L"\033?x"s);
+                defineKeyWithUnusedModifiers(VK_NUMPAD9, L"\033?y"s);
 
-            defineKeyWithUnusedModifiers(Enhanced + VK_RETURN, L"\033?M"s);
+                defineKeyWithUnusedModifiers(Enhanced + VK_RETURN, L"\033?M"s);
+            }
         }
     }
 

--- a/src/terminal/input/terminalInput.cpp
+++ b/src/terminal/input/terminalInput.cpp
@@ -78,11 +78,6 @@ void TerminalInput::ForceDisableWin32InputMode(const bool win32InputMode) noexce
     _forceDisableWin32InputMode = win32InputMode;
 }
 
-void TerminalInput::SetKeypadModeSupport(const bool enabled) noexcept
-{
-    _keypadModeSupported = enabled;
-}
-
 TerminalInput::OutputType TerminalInput::MakeUnhandled() noexcept
 {
     return {};
@@ -443,30 +438,27 @@ try
         // the ASCII character assigned by the keyboard layout, but when set
         // they transmit SS3 escape sequences. When used with a modifier, the
         // modifier is embedded as a parameter value (not standard).
-        if constexpr (Feature_KeypadModeEnabled::IsEnabled())
+        if (Feature_KeypadModeEnabled::IsEnabled() && _inputMode.test(Mode::Keypad))
         {
-            if (_keypadModeSupported && _inputMode.test(Mode::Keypad))
-            {
-                defineNumericKey(VK_MULTIPLY, L'j');
-                defineNumericKey(VK_ADD, L'k');
-                defineNumericKey(VK_SEPARATOR, L'l');
-                defineNumericKey(VK_SUBTRACT, L'm');
-                defineNumericKey(VK_DECIMAL, L'n');
-                defineNumericKey(VK_DIVIDE, L'o');
+            defineNumericKey(VK_MULTIPLY, L'j');
+            defineNumericKey(VK_ADD, L'k');
+            defineNumericKey(VK_SEPARATOR, L'l');
+            defineNumericKey(VK_SUBTRACT, L'm');
+            defineNumericKey(VK_DECIMAL, L'n');
+            defineNumericKey(VK_DIVIDE, L'o');
 
-                defineNumericKey(VK_NUMPAD0, L'p');
-                defineNumericKey(VK_NUMPAD1, L'q');
-                defineNumericKey(VK_NUMPAD2, L'r');
-                defineNumericKey(VK_NUMPAD3, L's');
-                defineNumericKey(VK_NUMPAD4, L't');
-                defineNumericKey(VK_NUMPAD5, L'u');
-                defineNumericKey(VK_NUMPAD6, L'v');
-                defineNumericKey(VK_NUMPAD7, L'w');
-                defineNumericKey(VK_NUMPAD8, L'x');
-                defineNumericKey(VK_NUMPAD9, L'y');
+            defineNumericKey(VK_NUMPAD0, L'p');
+            defineNumericKey(VK_NUMPAD1, L'q');
+            defineNumericKey(VK_NUMPAD2, L'r');
+            defineNumericKey(VK_NUMPAD3, L's');
+            defineNumericKey(VK_NUMPAD4, L't');
+            defineNumericKey(VK_NUMPAD5, L'u');
+            defineNumericKey(VK_NUMPAD6, L'v');
+            defineNumericKey(VK_NUMPAD7, L'w');
+            defineNumericKey(VK_NUMPAD8, L'x');
+            defineNumericKey(VK_NUMPAD9, L'y');
 
-                defineNumericKey(Enhanced + VK_RETURN, L'M');
-            }
+            defineNumericKey(Enhanced + VK_RETURN, L'M');
         }
     }
     else
@@ -498,30 +490,27 @@ try
 
         // Keypad keys also depend on Keypad mode, the same as ANSI mappings,
         // but the sequences use an ESC ? prefix instead of SS3.
-        if constexpr (Feature_KeypadModeEnabled::IsEnabled())
+        if (Feature_KeypadModeEnabled::IsEnabled() && _inputMode.test(Mode::Keypad))
         {
-            if (_keypadModeSupported && _inputMode.test(Mode::Keypad))
-            {
-                defineKeyWithUnusedModifiers(VK_MULTIPLY, L"\033?j"s);
-                defineKeyWithUnusedModifiers(VK_ADD, L"\033?k"s);
-                defineKeyWithUnusedModifiers(VK_SEPARATOR, L"\033?l"s);
-                defineKeyWithUnusedModifiers(VK_SUBTRACT, L"\033?m"s);
-                defineKeyWithUnusedModifiers(VK_DECIMAL, L"\033?n"s);
-                defineKeyWithUnusedModifiers(VK_DIVIDE, L"\033?o"s);
+            defineKeyWithUnusedModifiers(VK_MULTIPLY, L"\033?j"s);
+            defineKeyWithUnusedModifiers(VK_ADD, L"\033?k"s);
+            defineKeyWithUnusedModifiers(VK_SEPARATOR, L"\033?l"s);
+            defineKeyWithUnusedModifiers(VK_SUBTRACT, L"\033?m"s);
+            defineKeyWithUnusedModifiers(VK_DECIMAL, L"\033?n"s);
+            defineKeyWithUnusedModifiers(VK_DIVIDE, L"\033?o"s);
 
-                defineKeyWithUnusedModifiers(VK_NUMPAD0, L"\033?p"s);
-                defineKeyWithUnusedModifiers(VK_NUMPAD1, L"\033?q"s);
-                defineKeyWithUnusedModifiers(VK_NUMPAD2, L"\033?r"s);
-                defineKeyWithUnusedModifiers(VK_NUMPAD3, L"\033?s"s);
-                defineKeyWithUnusedModifiers(VK_NUMPAD4, L"\033?t"s);
-                defineKeyWithUnusedModifiers(VK_NUMPAD5, L"\033?u"s);
-                defineKeyWithUnusedModifiers(VK_NUMPAD6, L"\033?v"s);
-                defineKeyWithUnusedModifiers(VK_NUMPAD7, L"\033?w"s);
-                defineKeyWithUnusedModifiers(VK_NUMPAD8, L"\033?x"s);
-                defineKeyWithUnusedModifiers(VK_NUMPAD9, L"\033?y"s);
+            defineKeyWithUnusedModifiers(VK_NUMPAD0, L"\033?p"s);
+            defineKeyWithUnusedModifiers(VK_NUMPAD1, L"\033?q"s);
+            defineKeyWithUnusedModifiers(VK_NUMPAD2, L"\033?r"s);
+            defineKeyWithUnusedModifiers(VK_NUMPAD3, L"\033?s"s);
+            defineKeyWithUnusedModifiers(VK_NUMPAD4, L"\033?t"s);
+            defineKeyWithUnusedModifiers(VK_NUMPAD5, L"\033?u"s);
+            defineKeyWithUnusedModifiers(VK_NUMPAD6, L"\033?v"s);
+            defineKeyWithUnusedModifiers(VK_NUMPAD7, L"\033?w"s);
+            defineKeyWithUnusedModifiers(VK_NUMPAD8, L"\033?x"s);
+            defineKeyWithUnusedModifiers(VK_NUMPAD9, L"\033?y"s);
 
-                defineKeyWithUnusedModifiers(Enhanced + VK_RETURN, L"\033?M"s);
-            }
+            defineKeyWithUnusedModifiers(Enhanced + VK_RETURN, L"\033?M"s);
         }
     }
 

--- a/src/terminal/input/terminalInput.hpp
+++ b/src/terminal/input/terminalInput.hpp
@@ -51,6 +51,7 @@ namespace Microsoft::Console::VirtualTerminal
         bool GetInputMode(const Mode mode) const noexcept;
         void ResetInputModes() noexcept;
         void ForceDisableWin32InputMode(const bool win32InputMode) noexcept;
+        void SetKeypadModeSupport(const bool enabled) noexcept;
 
 #pragma region MouseInput
         // These methods are defined in mouseInput.cpp
@@ -79,6 +80,7 @@ namespace Microsoft::Console::VirtualTerminal
 
         til::enumset<Mode> _inputMode{ Mode::Ansi, Mode::AutoRepeat, Mode::AlternateScroll };
         bool _forceDisableWin32InputMode{ false };
+        bool _keypadModeSupported{ false };
 
         // In the future, if we add support for "8-bit" input mode, these prefixes
         // will sometimes be replaced with equivalent C1 control characters.

--- a/src/terminal/input/terminalInput.hpp
+++ b/src/terminal/input/terminalInput.hpp
@@ -51,7 +51,6 @@ namespace Microsoft::Console::VirtualTerminal
         bool GetInputMode(const Mode mode) const noexcept;
         void ResetInputModes() noexcept;
         void ForceDisableWin32InputMode(const bool win32InputMode) noexcept;
-        void SetKeypadModeSupport(const bool enabled) noexcept;
 
 #pragma region MouseInput
         // These methods are defined in mouseInput.cpp
@@ -80,7 +79,6 @@ namespace Microsoft::Console::VirtualTerminal
 
         til::enumset<Mode> _inputMode{ Mode::Ansi, Mode::AutoRepeat, Mode::AlternateScroll };
         bool _forceDisableWin32InputMode{ false };
-        bool _keypadModeSupported{ false };
 
         // In the future, if we add support for "8-bit" input mode, these prefixes
         // will sometimes be replaced with equivalent C1 control characters.


### PR DESCRIPTION
## Summary of the Pull Request
Adds a global Compatibility page to the settings UI. This page exposes several existing settings and introduces a few new settings:
- compatibility.allowHeadless
- compatibility.isolatedMode
- compatibility.textMeasurement
- debugFeatures

This also adds a Terminal subpage for profiles in the settings UI. This page includes:
- suppressApplicationTitle
- compatibility.input.forceVT
- compatibility.allowDECRQCRA
- answerbackMessage

Several smaller changes were accomplished as a part of this PR:
- `experimental.input.forceVT` was renamed to `compatibility.input.forceVT`
- introduced the `compatibility.allowDECRQCRA` setting
- updated the schema for these new settings and `compatibility.allowHeadless` (which was missing)
- add `Feature_DebugModeUI` feature flag to control if debug features should be shown in the SUI

Verified accessible via Accessibility Insights

A part of #10000
Closes #16672 