### PR TITLE
Add miscellaneous simple settings to the settings UI

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Appearances.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.cpp
@@ -573,7 +573,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
     }
 
-    double AppearanceViewModel::_extractCellSizeValue(const hstring val) const
+    double AppearanceViewModel::_parseCellSizeValue(const hstring& val) const
     {
         const auto str = val.c_str();
 
@@ -589,13 +589,13 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     double AppearanceViewModel::LineHeight() const
     {
         const auto cellHeight = _appearance.SourceProfile().FontInfo().CellHeight();
-        return _extractCellSizeValue(cellHeight);
+        return _parseCellSizeValue(cellHeight);
     }
 
     double AppearanceViewModel::CellWidth() const
     {
-        const auto cellWidth = _appearance.SourceProfile().FontInfo().CellHeight();
-        return _extractCellSizeValue(cellWidth);
+        const auto cellWidth = _appearance.SourceProfile().FontInfo().CellWidth();
+        return _parseCellSizeValue(cellWidth);
     }
 
 #define CELL_SIZE_SETTER(modelName, viewModelName)                 \
@@ -603,7 +603,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                                                                    \
     if (value >= 0.1 && value <= 10.0)                             \
     {                                                              \
-        str = fmt::format(FMT_STRING(L"{:.6g}"), value);           \
+        str = fmt::format(FMT_COMPILE(L"{:.6g}"), value);          \
     }                                                              \
                                                                    \
     const auto fontInfo = _appearance.SourceProfile().FontInfo();  \

--- a/src/cascadia/TerminalSettingsEditor/Appearances.h
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.h
@@ -92,6 +92,12 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void ClearLineHeight();
         Model::FontConfig LineHeightOverrideSource() const;
 
+        double CellWidth() const;
+        void CellWidth(const double value);
+        bool HasCellWidth() const;
+        void ClearCellWidth();
+        Model::FontConfig CellWidthOverrideSource() const;
+
         void SetFontWeightFromDouble(double fontWeight);
 
         const FontFaceDependentsData& FontFaceDependents();
@@ -160,6 +166,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void _notifyChangesForFontSettingsReactive(FontSettingIndex fontSettingsIndex);
         void _deleteAllFontKeyValuePairs(FontSettingIndex index);
         void _addMenuFlyoutItemToUnused(FontSettingIndex index, Windows::UI::Xaml::Controls::MenuFlyoutItemBase item);
+
+        double _extractCellSizeValue(const hstring val) const;
 
         Model::AppearanceConfig _appearance;
         winrt::hstring _lastBgImagePath;

--- a/src/cascadia/TerminalSettingsEditor/Appearances.h
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.h
@@ -167,7 +167,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void _deleteAllFontKeyValuePairs(FontSettingIndex index);
         void _addMenuFlyoutItemToUnused(FontSettingIndex index, Windows::UI::Xaml::Controls::MenuFlyoutItemBase item);
 
-        double _extractCellSizeValue(const hstring val) const;
+        double _parseCellSizeValue(const hstring& val) const;
 
         Model::AppearanceConfig _appearance;
         winrt::hstring _lastBgImagePath;

--- a/src/cascadia/TerminalSettingsEditor/Appearances.idl
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.idl
@@ -62,6 +62,7 @@ namespace Microsoft.Terminal.Settings.Editor
         OBSERVABLE_PROJECTED_APPEARANCE_SETTING(String, FontFace);
         OBSERVABLE_PROJECTED_APPEARANCE_SETTING(Single, FontSize);
         OBSERVABLE_PROJECTED_APPEARANCE_SETTING(Double, LineHeight);
+        OBSERVABLE_PROJECTED_APPEARANCE_SETTING(Double, CellWidth);
         OBSERVABLE_PROJECTED_APPEARANCE_SETTING(Windows.UI.Text.FontWeight, FontWeight);
         OBSERVABLE_PROJECTED_APPEARANCE_SETTING(Boolean, EnableBuiltinGlyphs);
         OBSERVABLE_PROJECTED_APPEARANCE_SETTING(Boolean, EnableColorGlyphs);

--- a/src/cascadia/TerminalSettingsEditor/Appearances.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.xaml
@@ -264,6 +264,22 @@
                                 Value="{x:Bind Appearance.LineHeight, Mode=TwoWay}" />
             </local:SettingContainer>
 
+            <!--  Cell Width  -->
+            <local:SettingContainer x:Uid="Profile_CellWidth"
+                                    ClearSettingValue="{x:Bind Appearance.ClearCellWidth}"
+                                    HasSettingValue="{x:Bind Appearance.HasCellWidth, Mode=OneWay}"
+                                    SettingOverrideSource="{x:Bind Appearance.CellWidthOverrideSource, Mode=OneWay}"
+                                    Visibility="{x:Bind Appearance.IsDefault, Mode=OneWay}">
+                <muxc:NumberBox x:Name="_cellWidthBox"
+                                x:Uid="Profile_CellWidthBox"
+                                LargeChange="0.1"
+                                Maximum="10"
+                                Minimum="0.1"
+                                SmallChange="0.1"
+                                Style="{StaticResource NumberBoxSettingStyle}"
+                                Value="{x:Bind Appearance.CellWidth, Mode=TwoWay}" />
+            </local:SettingContainer>
+
             <!--  Font Weight  -->
             <local:SettingContainer x:Uid="Profile_FontWeight"
                                     ClearSettingValue="{x:Bind Appearance.ClearFontWeight}"

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
@@ -115,5 +115,17 @@
             <ToggleSwitch IsOn="{x:Bind ViewModel.AutoHideWindow, Mode=TwoWay}"
                           Style="{StaticResource ToggleSwitchInExpanderStyle}" />
         </local:SettingContainer>
+
+        <!--  Show Admin Shield  -->
+        <local:SettingContainer x:Uid="Globals_ShowAdminShield">
+            <ToggleSwitch IsOn="{x:Bind ViewModel.ShowAdminShield, Mode=TwoWay}"
+                          Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+        </local:SettingContainer>
+
+        <!--  Enable Unfocused Acrylic  -->
+        <local:SettingContainer x:Uid="Globals_EnableUnfocusedAcrylic">
+            <ToggleSwitch IsOn="{x:Bind ViewModel.EnableUnfocusedAcrylic, Mode=TwoWay}"
+                          Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+        </local:SettingContainer>
     </StackPanel>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearanceViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearanceViewModel.h
@@ -39,6 +39,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, AutoHideWindow);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, AlwaysShowNotificationIcon);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, MinimizeToNotificationArea);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, ShowAdminShield);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, EnableUnfocusedAcrylic);
 
     private:
         Model::GlobalAppSettings _GlobalSettings;

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearanceViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearanceViewModel.idl
@@ -33,5 +33,7 @@ namespace Microsoft.Terminal.Settings.Editor
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, AutoHideWindow);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, AlwaysShowNotificationIcon);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, MinimizeToNotificationArea);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, ShowAdminShield);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, EnableUnfocusedAcrylic);
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Interaction.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Interaction.xaml
@@ -88,6 +88,21 @@
                 <ToggleSwitch IsOn="{x:Bind ViewModel.DetectURLs, Mode=TwoWay}"
                               Style="{StaticResource ToggleSwitchInExpanderStyle}" />
             </local:SettingContainer>
+
+            <!--  Search Web Default Query URL  -->
+            <local:SettingContainer x:Uid="Globals_SearchWebDefaultQueryUrl"
+                                    CurrentValue="{x:Bind ViewModel.SearchWebDefaultQueryUrl, Mode=OneWay}"
+                                    Style="{StaticResource ExpanderSettingContainerStyle}">
+                <TextBox IsSpellCheckEnabled="False"
+                         Style="{StaticResource TextBoxSettingStyle}"
+                         Text="{x:Bind ViewModel.SearchWebDefaultQueryUrl, Mode=TwoWay}" />
+            </local:SettingContainer>
+
+            <!--  Enable Color Selection  -->
+            <local:SettingContainer x:Uid="Globals_EnableColorSelection">
+                <ToggleSwitch IsOn="{x:Bind ViewModel.EnableColorSelection, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
         </StackPanel>
 
         <StackPanel Style="{StaticResource SettingsStackStyle}">

--- a/src/cascadia/TerminalSettingsEditor/InteractionViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/InteractionViewModel.h
@@ -26,11 +26,13 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, SnapToGridOnResize);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, FocusFollowMouse);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, DetectURLs);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, SearchWebDefaultQueryUrl);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, WordDelimiters);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, ConfirmCloseAllTabs);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, InputServiceWarning);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, WarnAboutLargePaste);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, WarnAboutMultiLinePaste);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, EnableColorSelection);
 
     private:
         Model::GlobalAppSettings _GlobalSettings;

--- a/src/cascadia/TerminalSettingsEditor/InteractionViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/InteractionViewModel.idl
@@ -23,10 +23,12 @@ namespace Microsoft.Terminal.Settings.Editor
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, SnapToGridOnResize);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, FocusFollowMouse);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, DetectURLs);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(String, SearchWebDefaultQueryUrl);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(String, WordDelimiters);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, ConfirmCloseAllTabs);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, InputServiceWarning);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, WarnAboutLargePaste);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, WarnAboutMultiLinePaste);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, EnableColorSelection);
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
@@ -120,6 +120,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         OBSERVABLE_PROJECTED_SETTING(_profile, ShowMarks);
         OBSERVABLE_PROJECTED_SETTING(_profile, AutoMarkPrompts);
         OBSERVABLE_PROJECTED_SETTING(_profile, RepositionCursorWithMouse);
+        OBSERVABLE_PROJECTED_SETTING(_profile, RainbowSuggestions);
 
         WINRT_PROPERTY(bool, IsBaseLayer, false);
         WINRT_PROPERTY(bool, FocusDeleteButton, false);

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
@@ -111,5 +111,6 @@ namespace Microsoft.Terminal.Settings.Editor
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, ShowMarks);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, AutoMarkPrompts);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, RepositionCursorWithMouse);
+        OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, RainbowSuggestions);
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.xaml
@@ -165,6 +165,14 @@
                               Style="{StaticResource ToggleSwitchInExpanderStyle}" />
             </local:SettingContainer>
 
+            <!--  RainbowSuggestions  -->
+            <local:SettingContainer x:Uid="Profile_RainbowSuggestions"
+                                    ClearSettingValue="{x:Bind Profile.ClearRainbowSuggestions}"
+                                    HasSettingValue="{x:Bind Profile.HasRainbowSuggestions, Mode=OneWay}"
+                                    SettingOverrideSource="{x:Bind Profile.RainbowSuggestionsOverrideSource, Mode=OneWay}">
+                <ToggleSwitch IsOn="{x:Bind Profile.RainbowSuggestions, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
         </StackPanel>
     </Grid>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -294,6 +294,14 @@
     <value>Automatically detect URLs and make them clickable</value>
     <comment>Header for a control to toggle whether the terminal should automatically detect URLs and make them clickable, or not.</comment>
   </data>
+  <data name="Globals_SearchWebDefaultQueryUrl.Header" xml:space="preserve">
+    <value>URL used for the "Search web" action</value>
+    <comment>Header for a control to set the query URL when using the "search web" action.</comment>
+  </data>
+  <data name="Globals_SearchWebDefaultQueryUrl.HelpText" xml:space="preserve">
+    <value>"%s" is replaced with the selected text.</value>
+    <comment>{Locked="%s"} Additional text presented near "Globals_SearchWebDefaultQueryUrl.Header".</comment>
+  </data>
   <data name="Globals_TrimBlockSelection.Header" xml:space="preserve">
     <value>Remove trailing white-space in rectangular selection</value>
     <comment>Header for a control to toggle whether a text selected with block selection should be trimmed of white spaces when copied to the clipboard, or not.</comment>
@@ -945,17 +953,33 @@
     <value>Line height</value>
     <comment>Header for a control that sets the text line height.</comment>
   </data>
+  <data name="Profile_CellWidth.Header" xml:space="preserve">
+    <value>Cell width</value>
+    <comment>Header for a control that sets the text character width.</comment>
+  </data>
   <data name="Profile_LineHeightBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Line height</value>
     <comment>Header for a control that sets the text line height.</comment>
+  </data>
+  <data name="Profile_CellWidthBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Cell width</value>
+    <comment>Header for a control that sets the text character width.</comment>
   </data>
   <data name="Profile_LineHeight.HelpText" xml:space="preserve">
     <value>Override the line height of the terminal. Measured as a multiple of the font size. The default value depends on your font and is usually around 1.2.</value>
     <comment>A description for what the "line height" setting does. Presented near "Profile_LineHeight".</comment>
   </data>
+  <data name="Profile_CellWidth.HelpText" xml:space="preserve">
+    <value>Override the cell width of the terminal. Measured as a multiple of the font size. The default value depends on your font and is usually around 0.6.</value>
+    <comment>A description for what the "cell width" setting does. Presented near "Profile_CellWidth".</comment>
+  </data>
   <data name="Profile_LineHeightBox.PlaceholderText" xml:space="preserve">
     <value>1.2</value>
     <comment>"1.2" is a decimal number.</comment>
+  </data>
+  <data name="Profile_CellWidthBox.PlaceholderText" xml:space="preserve">
+    <value>0.6</value>
+    <comment>"0.6" is a decimal number.</comment>
   </data>
   <data name="Profile_EnableBuiltinGlyphs.Header" xml:space="preserve">
     <value>Builtin Glyphs</value>
@@ -1864,5 +1888,21 @@
   <data name="Profile_ProportionalFontFaces.Header" xml:space="preserve">
     <value>Non-monospace fonts:</value>
     <comment>This is a label that is followed by a list of proportional fonts.</comment>
+  </data>
+  <data name="Profile_RainbowSuggestions.Header" xml:space="preserve">
+    <value>Display suggestions UI preview text in rainbow colors</value>
+    <comment>This is a label for a setting that, when enabled, applies a rainbow coloring to the preview text from the suggestions UI.</comment>
+  </data>
+  <data name="Globals_EnableColorSelection.Header" xml:space="preserve">
+    <value>Experimental: Add key bindings to color selected text</value>
+    <comment>Header for a control to toggle adding a set of key bindings that can be used to apply coloring to selected text in a terminal session.</comment>
+  </data>
+  <data name="Globals_EnableUnfocusedAcrylic.Header" xml:space="preserve">
+    <value>Allow acrylic background in unfocused windows</value>
+    <comment>Header for a control to toggle allowing unfocused windows to have an acrylic background.</comment>
+  </data>
+  <data name="Globals_ShowAdminShield.Header" xml:space="preserve">
+    <value>Display a shield in the title bar for sessions as Admin</value>
+    <comment>Header for a control to toggle displaying a shield in the title bar of the app. "Admin" refers to elevated sessions like "run as Admin"</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -295,11 +295,11 @@
     <comment>Header for a control to toggle whether the terminal should automatically detect URLs and make them clickable, or not.</comment>
   </data>
   <data name="Globals_SearchWebDefaultQueryUrl.Header" xml:space="preserve">
-    <value>URL used for the "Search web" action</value>
+    <value>Default URL to use for the "Search web" action</value>
     <comment>Header for a control to set the query URL when using the "search web" action.</comment>
   </data>
   <data name="Globals_SearchWebDefaultQueryUrl.HelpText" xml:space="preserve">
-    <value>"%s" is replaced with the selected text.</value>
+    <value>The placeholder "%s" will replaced with the search query.</value>
     <comment>{Locked="%s"} Additional text presented near "Globals_SearchWebDefaultQueryUrl.Header".</comment>
   </data>
   <data name="Globals_TrimBlockSelection.Header" xml:space="preserve">
@@ -1890,19 +1890,19 @@
     <comment>This is a label that is followed by a list of proportional fonts.</comment>
   </data>
   <data name="Profile_RainbowSuggestions.Header" xml:space="preserve">
-    <value>Display suggestions UI preview text in rainbow colors</value>
+    <value>Experimental: Display suggested input in rainbow colors</value>
     <comment>This is a label for a setting that, when enabled, applies a rainbow coloring to the preview text from the suggestions UI.</comment>
   </data>
   <data name="Globals_EnableColorSelection.Header" xml:space="preserve">
-    <value>Experimental: Add key bindings to color selected text</value>
+    <value>Experimental: Add key bindings to highlight selected text and to search for and highlight all instances of selected text</value>
     <comment>Header for a control to toggle adding a set of key bindings that can be used to apply coloring to selected text in a terminal session.</comment>
   </data>
   <data name="Globals_EnableUnfocusedAcrylic.Header" xml:space="preserve">
-    <value>Allow acrylic background in unfocused windows</value>
+    <value>Allow acrylic material in unfocused windows</value>
     <comment>Header for a control to toggle allowing unfocused windows to have an acrylic background.</comment>
   </data>
   <data name="Globals_ShowAdminShield.Header" xml:space="preserve">
-    <value>Display a shield in the title bar for sessions as Admin</value>
+    <value>Display a shield in the title bar when Windows Terminal is running as Administrator</value>
     <comment>Header for a control to toggle displaying a shield in the title bar of the app. "Admin" refers to elevated sessions like "run as Admin"</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -1894,8 +1894,12 @@
     <comment>This is a label for a setting that, when enabled, applies a rainbow coloring to the preview text from the suggestions UI.</comment>
   </data>
   <data name="Globals_EnableColorSelection.Header" xml:space="preserve">
-    <value>Experimental: Add key bindings to highlight selected text and to search for and highlight all instances of selected text</value>
+    <value>Experimental: Add key bindings to color selected text</value>
     <comment>Header for a control to toggle adding a set of key bindings that can be used to apply coloring to selected text in a terminal session.</comment>
+  </data>
+  <data name="Globals_EnableColorSelection.HelpText" xml:space="preserve">
+    <value>These key bindings can highlight the selected text or all instances of the selected text with a specified color.</value>
+    <comment>Additional text for a control to toggle adding a set of key bindings that can be used to apply coloring to selected text in a terminal session. Presented near "Globals_EnableColorSelection.Header".</comment>
   </data>
   <data name="Globals_EnableUnfocusedAcrylic.Header" xml:space="preserve">
     <value>Allow acrylic material in unfocused windows</value>

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -93,14 +93,14 @@ Author(s):
     X(hstring, TabTitle, "tabTitle")                                                                                                                           \
     X(Model::BellStyle, BellStyle, "bellStyle", BellStyle::Audible)                                                                                            \
     X(IEnvironmentVariableMap, EnvironmentVariables, "environment", nullptr)                                                                                   \
-    X(bool, RightClickContextMenu, "experimental.rightClickContextMenu", false)                                                                                \
+    X(bool, RightClickContextMenu, "rightClickContextMenu", false)                                                                                             \
     X(Windows::Foundation::Collections::IVector<winrt::hstring>, BellSound, "bellSound", nullptr)                                                              \
     X(bool, Elevate, "elevate", false)                                                                                                                         \
     X(bool, AutoMarkPrompts, "autoMarkPrompts", true)                                                                                                          \
     X(bool, ShowMarks, "showMarksOnScrollbar", false)                                                                                                          \
     X(bool, RepositionCursorWithMouse, "experimental.repositionCursorWithMouse", false)                                                                        \
     X(bool, ReloadEnvironmentVariables, "compatibility.reloadEnvironmentVariables", true)                                                                      \
-    X(bool, RainbowSuggestions, "experimental.rainbowSuggestions", false)
+    X(bool, RainbowSuggestions, "rainbowSuggestions", false)
 
 // Intentionally omitted Profile settings:
 // * Name

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -100,7 +100,7 @@ Author(s):
     X(bool, ShowMarks, "showMarksOnScrollbar", false)                                                                                                          \
     X(bool, RepositionCursorWithMouse, "experimental.repositionCursorWithMouse", false)                                                                        \
     X(bool, ReloadEnvironmentVariables, "compatibility.reloadEnvironmentVariables", true)                                                                      \
-    X(bool, RainbowSuggestions, "rainbowSuggestions", false)
+    X(bool, RainbowSuggestions, "experimental.rainbowSuggestions", false)
 
 // Intentionally omitted Profile settings:
 // * Name

--- a/src/cascadia/TerminalSettingsModel/Profile.cpp
+++ b/src/cascadia/TerminalSettingsModel/Profile.cpp
@@ -36,6 +36,8 @@ static constexpr std::string_view UnfocusedAppearanceKey{ "unfocusedAppearance" 
 
 static constexpr std::string_view LegacyAutoMarkPromptsKey{ "experimental.autoMarkPrompts" };
 static constexpr std::string_view LegacyShowMarksKey{ "experimental.showMarksOnScrollbar" };
+static constexpr std::string_view LegacyRightClickContextMenuKey{ "experimental.rightClickContextMenu" };
+static constexpr std::string_view LegacyRainbowSuggestionsKey{ "experimental.rainbowSuggestions" };
 
 Profile::Profile(guid guid) noexcept :
     _Guid(guid)
@@ -196,6 +198,8 @@ void Profile::LayerJson(const Json::Value& json)
     // Done _before_ the MTSM_PROFILE_SETTINGS, which have the updated keys.
     JsonUtils::GetValueForKey(json, LegacyShowMarksKey, _ShowMarks);
     JsonUtils::GetValueForKey(json, LegacyAutoMarkPromptsKey, _AutoMarkPrompts);
+    JsonUtils::GetValueForKey(json, LegacyRightClickContextMenuKey, _RightClickContextMenu);
+    JsonUtils::GetValueForKey(json, LegacyRainbowSuggestionsKey, _RainbowSuggestions);
 
 #define PROFILE_SETTINGS_LAYER_JSON(type, name, jsonKey, ...) \
     JsonUtils::GetValueForKey(json, jsonKey, _##name);        \

--- a/src/cascadia/TerminalSettingsModel/Profile.cpp
+++ b/src/cascadia/TerminalSettingsModel/Profile.cpp
@@ -37,7 +37,6 @@ static constexpr std::string_view UnfocusedAppearanceKey{ "unfocusedAppearance" 
 static constexpr std::string_view LegacyAutoMarkPromptsKey{ "experimental.autoMarkPrompts" };
 static constexpr std::string_view LegacyShowMarksKey{ "experimental.showMarksOnScrollbar" };
 static constexpr std::string_view LegacyRightClickContextMenuKey{ "experimental.rightClickContextMenu" };
-static constexpr std::string_view LegacyRainbowSuggestionsKey{ "experimental.rainbowSuggestions" };
 
 Profile::Profile(guid guid) noexcept :
     _Guid(guid)
@@ -199,7 +198,6 @@ void Profile::LayerJson(const Json::Value& json)
     JsonUtils::GetValueForKey(json, LegacyShowMarksKey, _ShowMarks);
     JsonUtils::GetValueForKey(json, LegacyAutoMarkPromptsKey, _AutoMarkPrompts);
     JsonUtils::GetValueForKey(json, LegacyRightClickContextMenuKey, _RightClickContextMenu);
-    JsonUtils::GetValueForKey(json, LegacyRainbowSuggestionsKey, _RainbowSuggestions);
 
 #define PROFILE_SETTINGS_LAYER_JSON(type, name, jsonKey, ...) \
     JsonUtils::GetValueForKey(json, jsonKey, _##name);        \


### PR DESCRIPTION
## Summary of the Pull Request
Adds the following settings to the settings UI:
- $profile.RainbowSuggestions
- $profile.CellWidth
- $global.SearchWebDefaultQueryUrl
- $global.EnableColorSelection
- $global.ShowAdminShield
- $global.EnableUnfocusedAcrylic

Additionally, the following settings have graduated from experimental 🎓:
- $profile.rightClickContextMenu
- $profile.RainbowSuggestions

Part of #10000