### PR TITLE
Add Warnings to Settings UI

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2340,7 +2340,7 @@
           "description": "When set to `true`, the terminal window will auto-center itself on the display it opens on. The terminal will use the \"initialPosition\" to determine which display to open on.",
           "type": "boolean"
         },
-        "inputServiceWarning": {
+        "warning.inputService": {
           "default": true,
           "description": "Warning if 'Touch Keyboard and Handwriting Panel Service' is disabled.",
           "type": "boolean"
@@ -2390,12 +2390,12 @@
           "description": "When set to `true`, visual animations will be disabled across the application.",
           "type": "boolean"
         },
-        "largePasteWarning": {
+        "warning.largePaste": {
           "default": true,
           "description": "When set to true, trying to paste text with more than 5 KiB of characters will display a warning asking you whether to continue or not with the paste.",
           "type": "boolean"
         },
-        "multiLinePasteWarning": {
+        "warning.multiLinePaste": {
           "default": true,
           "description": "When set to true, trying to paste text with a \"new line\" character will display a warning asking you whether to continue or not with the paste.",
           "type": "boolean"
@@ -2593,7 +2593,7 @@
           "description": "Determines the delimiters used in a double click selection.",
           "type": "string"
         },
-        "confirmCloseAllTabs": {
+        "warning.confirmCloseAllTabs": {
           "default": true,
           "description": "When set to \"true\" closing a window with multiple tabs open will require confirmation.  When set to \"false\", the confirmation dialog will not appear.",
           "type": "boolean"

--- a/src/cascadia/TerminalSettingsEditor/Interaction.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Interaction.xaml
@@ -24,73 +24,101 @@
         </ResourceDictionary>
     </Page.Resources>
 
-    <StackPanel Style="{StaticResource SettingsStackStyle}">
-        <!--  Copy On Select  -->
-        <local:SettingContainer x:Uid="Globals_CopyOnSelect">
-            <ToggleSwitch IsOn="{x:Bind ViewModel.CopyOnSelect, Mode=TwoWay}"
-                          Style="{StaticResource ToggleSwitchInExpanderStyle}" />
-        </local:SettingContainer>
+    <StackPanel>
+        <StackPanel Style="{StaticResource SettingsStackStyle}">
+            <!--  Copy On Select  -->
+            <local:SettingContainer x:Uid="Globals_CopyOnSelect">
+                <ToggleSwitch IsOn="{x:Bind ViewModel.CopyOnSelect, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
 
-        <!--  Copy Format  -->
-        <local:SettingContainer x:Uid="Globals_CopyFormat">
-            <ComboBox AutomationProperties.AccessibilityView="Content"
-                      ItemTemplate="{StaticResource EnumComboBoxTemplate}"
-                      ItemsSource="{x:Bind ViewModel.CopyFormatList, Mode=OneWay}"
-                      SelectedItem="{x:Bind ViewModel.CurrentCopyFormat, Mode=TwoWay}"
-                      Style="{StaticResource ComboBoxSettingStyle}" />
-        </local:SettingContainer>
+            <!--  Copy Format  -->
+            <local:SettingContainer x:Uid="Globals_CopyFormat">
+                <ComboBox AutomationProperties.AccessibilityView="Content"
+                          ItemTemplate="{StaticResource EnumComboBoxTemplate}"
+                          ItemsSource="{x:Bind ViewModel.CopyFormatList, Mode=OneWay}"
+                          SelectedItem="{x:Bind ViewModel.CurrentCopyFormat, Mode=TwoWay}"
+                          Style="{StaticResource ComboBoxSettingStyle}" />
+            </local:SettingContainer>
 
-        <!--  Trim Block Selection  -->
-        <local:SettingContainer x:Uid="Globals_TrimBlockSelection">
-            <ToggleSwitch IsOn="{x:Bind ViewModel.TrimBlockSelection, Mode=TwoWay}"
-                          Style="{StaticResource ToggleSwitchInExpanderStyle}" />
-        </local:SettingContainer>
+            <!--  Trim Block Selection  -->
+            <local:SettingContainer x:Uid="Globals_TrimBlockSelection">
+                <ToggleSwitch IsOn="{x:Bind ViewModel.TrimBlockSelection, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
 
-        <!--  Trim Paste  -->
-        <local:SettingContainer x:Uid="Globals_TrimPaste">
-            <ToggleSwitch IsOn="{x:Bind ViewModel.TrimPaste, Mode=TwoWay}"
-                          Style="{StaticResource ToggleSwitchInExpanderStyle}" />
-        </local:SettingContainer>
+            <!--  Trim Paste  -->
+            <local:SettingContainer x:Uid="Globals_TrimPaste">
+                <ToggleSwitch IsOn="{x:Bind ViewModel.TrimPaste, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
 
-        <!--  Word Delimiters  -->
-        <local:SettingContainer x:Uid="Globals_WordDelimiters"
-                                CurrentValue="{x:Bind ViewModel.WordDelimiters, Mode=OneWay}"
-                                Style="{StaticResource ExpanderSettingContainerStyle}">
-            <TextBox IsSpellCheckEnabled="False"
-                     Style="{StaticResource TextBoxSettingStyle}"
-                     Text="{x:Bind ViewModel.WordDelimiters, Mode=TwoWay}" />
-        </local:SettingContainer>
+            <!--  Word Delimiters  -->
+            <local:SettingContainer x:Uid="Globals_WordDelimiters"
+                                    CurrentValue="{x:Bind ViewModel.WordDelimiters, Mode=OneWay}"
+                                    Style="{StaticResource ExpanderSettingContainerStyle}">
+                <TextBox IsSpellCheckEnabled="False"
+                         Style="{StaticResource TextBoxSettingStyle}"
+                         Text="{x:Bind ViewModel.WordDelimiters, Mode=TwoWay}" />
+            </local:SettingContainer>
 
-        <!--  Snap On Resize  -->
-        <local:SettingContainer x:Uid="Globals_SnapToGridOnResize">
-            <ToggleSwitch IsOn="{x:Bind ViewModel.SnapToGridOnResize, Mode=TwoWay}"
-                          Style="{StaticResource ToggleSwitchInExpanderStyle}" />
-        </local:SettingContainer>
+            <!--  Snap On Resize  -->
+            <local:SettingContainer x:Uid="Globals_SnapToGridOnResize">
+                <ToggleSwitch IsOn="{x:Bind ViewModel.SnapToGridOnResize, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
 
-        <!--  Tab Switcher Mode  -->
-        <local:SettingContainer x:Uid="Globals_TabSwitcherMode">
-            <ComboBox AutomationProperties.AccessibilityView="Content"
-                      ItemTemplate="{StaticResource EnumComboBoxTemplate}"
-                      ItemsSource="{x:Bind ViewModel.TabSwitcherModeList}"
-                      SelectedItem="{x:Bind ViewModel.CurrentTabSwitcherMode, Mode=TwoWay}"
-                      Style="{StaticResource ComboBoxSettingStyle}" />
-        </local:SettingContainer>
+            <!--  Tab Switcher Mode  -->
+            <local:SettingContainer x:Uid="Globals_TabSwitcherMode">
+                <ComboBox AutomationProperties.AccessibilityView="Content"
+                          ItemTemplate="{StaticResource EnumComboBoxTemplate}"
+                          ItemsSource="{x:Bind ViewModel.TabSwitcherModeList}"
+                          SelectedItem="{x:Bind ViewModel.CurrentTabSwitcherMode, Mode=TwoWay}"
+                          Style="{StaticResource ComboBoxSettingStyle}" />
+            </local:SettingContainer>
 
-        <!--  Focus Follow Mouse Mode  -->
-        <local:SettingContainer x:Uid="Globals_FocusFollowMouse">
-            <ToggleSwitch IsOn="{x:Bind ViewModel.FocusFollowMouse, Mode=TwoWay}"
-                          Style="{StaticResource ToggleSwitchInExpanderStyle}" />
-        </local:SettingContainer>
+            <!--  Focus Follow Mouse Mode  -->
+            <local:SettingContainer x:Uid="Globals_FocusFollowMouse">
+                <ToggleSwitch IsOn="{x:Bind ViewModel.FocusFollowMouse, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
 
-        <!--  Detect URLs  -->
-        <local:SettingContainer x:Uid="Globals_DetectURLs">
-            <ToggleSwitch IsOn="{x:Bind ViewModel.DetectURLs, Mode=TwoWay}"
-                          Style="{StaticResource ToggleSwitchInExpanderStyle}" />
-        </local:SettingContainer>
+            <!--  Detect URLs  -->
+            <local:SettingContainer x:Uid="Globals_DetectURLs">
+                <ToggleSwitch IsOn="{x:Bind ViewModel.DetectURLs, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
+        </StackPanel>
 
-        <local:SettingContainer x:Uid="Globals_ConfirmCloseAllTabs">
-            <ToggleSwitch IsOn="{x:Bind ViewModel.ConfirmCloseAllTabs, Mode=TwoWay}"
-                          Style="{StaticResource ToggleSwitchInExpanderStyle}" />
-        </local:SettingContainer>
+        <StackPanel Style="{StaticResource SettingsStackStyle}">
+            <!--  Grouping: Warnings  -->
+            <TextBlock x:Uid="Globals_WarningsHeader"
+                       Style="{StaticResource TextBlockSubHeaderStyle}" />
+
+            <!--  Close All Tabs Warning  -->
+            <local:SettingContainer x:Uid="Globals_ConfirmCloseAllTabs">
+                <ToggleSwitch IsOn="{x:Bind ViewModel.ConfirmCloseAllTabs, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
+
+            <!--  Input Service Warning  -->
+            <local:SettingContainer x:Uid="Globals_InputServiceWarning">
+                <ToggleSwitch IsOn="{x:Bind ViewModel.InputServiceWarning, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
+
+            <!--  Large Paste Warning  -->
+            <local:SettingContainer x:Uid="Globals_WarnAboutLargePaste">
+                <ToggleSwitch IsOn="{x:Bind ViewModel.WarnAboutLargePaste, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
+
+            <!--  Multi Line Paste Warning  -->
+            <local:SettingContainer x:Uid="Globals_WarnAboutMultiLinePaste">
+                <ToggleSwitch IsOn="{x:Bind ViewModel.WarnAboutMultiLinePaste, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
+
+        </StackPanel>
     </StackPanel>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/InteractionViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/InteractionViewModel.h
@@ -28,6 +28,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, DetectURLs);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, WordDelimiters);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, ConfirmCloseAllTabs);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, InputServiceWarning);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, WarnAboutLargePaste);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, WarnAboutMultiLinePaste);
 
     private:
         Model::GlobalAppSettings _GlobalSettings;

--- a/src/cascadia/TerminalSettingsEditor/InteractionViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/InteractionViewModel.idl
@@ -25,5 +25,8 @@ namespace Microsoft.Terminal.Settings.Editor
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, DetectURLs);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(String, WordDelimiters);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, ConfirmCloseAllTabs);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, InputServiceWarning);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, WarnAboutLargePaste);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, WarnAboutMultiLinePaste);
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -1825,15 +1825,12 @@
   </data>
   <data name="Globals_InputServiceWarning.Header" xml:space="preserve">
     <value>Warn when "Touch Keyboard and Handwriting Panel Service" is disabled</value>
-    <comment>Header for a control to toggle whether to warn the user when the "Touch Keyboard and Handwriting Panel Service" OS setting is disabled.</comment>
   </data>
   <data name="Globals_WarnAboutLargePaste.Header" xml:space="preserve">
     <value>Warn when trying to paste more than 5 KiB of characters</value>
-    <comment>Header for a control to toggle whether to warn the user when they are trying to paste content greater than 5 kilobytes to the terminal.</comment>
   </data>
   <data name="Globals_WarnAboutMultiLinePaste.Header" xml:space="preserve">
     <value>Warn when trying to paste a "new line" character</value>
-    <comment>Header for a control to toggle whether to warn the user when they are trying to paste content with a newline character in it to the terminal.</comment>
   </data>
   <data name="Settings_PortableModeNote.Text" xml:space="preserve">
     <value>Windows Terminal is running in portable mode.</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -1539,6 +1539,10 @@
     <value>Text</value>
     <comment>Header for a group of settings that control the appearance of text in the app.</comment>
   </data>
+  <data name="Globals_WarningsHeader.Text" xml:space="preserve">
+    <value>Warnings</value>
+    <comment>Header for a group of settings that control the warnings in the app.</comment>
+  </data>
   <data name="Profile_WindowHeader.Text" xml:space="preserve">
     <value>Window</value>
     <comment>Header for a group of settings that control the appearance of the window frame of the app.</comment>
@@ -1818,6 +1822,18 @@
   <data name="Globals_ConfirmCloseAllTabs.Header" xml:space="preserve">
     <value>Warn when closing more than one tab</value>
     <comment>Header for a control to toggle whether to show a confirm dialog box when closing the application with multiple tabs open.</comment>
+  </data>
+  <data name="Globals_InputServiceWarning.Header" xml:space="preserve">
+    <value>Warn when "Touch Keyboard and Handwriting Panel Service" is disabled</value>
+    <comment>Header for a control to toggle whether to warn the user when the "Touch Keyboard and Handwriting Panel Service" OS setting is disabled.</comment>
+  </data>
+  <data name="Globals_WarnAboutLargePaste.Header" xml:space="preserve">
+    <value>Warn when trying to paste more than 5 KiB of characters</value>
+    <comment>Header for a control to toggle whether to warn the user when they are trying to paste content greater than 5 kilobytes to the terminal.</comment>
+  </data>
+  <data name="Globals_WarnAboutMultiLinePaste.Header" xml:space="preserve">
+    <value>Warn when trying to paste a "new line" character</value>
+    <comment>Header for a control to toggle whether to warn the user when they are trying to paste content with a newline character in it to the terminal.</comment>
   </data>
   <data name="Settings_PortableModeNote.Text" xml:space="preserve">
     <value>Windows Terminal is running in portable mode.</value>

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
@@ -23,6 +23,10 @@ static constexpr std::string_view ThemeKey{ "theme" };
 static constexpr std::string_view DefaultProfileKey{ "defaultProfile" };
 static constexpr std::string_view LegacyUseTabSwitcherModeKey{ "useTabSwitcher" };
 static constexpr std::string_view LegacyReloadEnvironmentVariablesKey{ "compatibility.reloadEnvironmentVariables" };
+static constexpr std::string_view LegacyInputServiceWarningKey{ "inputServiceWarning" };
+static constexpr std::string_view LegacyWarnAboutLargePasteKey{ "largePasteWarning" };
+static constexpr std::string_view LegacyWarnAboutMultiLinePasteKey{ "multiLinePasteWarning" };
+static constexpr std::string_view LegacyConfirmCloseAllTabsKey{ "confirmCloseAllTabs" };
 
 // Method Description:
 // - Copies any extraneous data from the parent before completing a CreateChild call
@@ -133,6 +137,11 @@ void GlobalAppSettings::LayerJson(const Json::Value& json, const OriginTag origi
     // "useTabSwitcher" to "tabSwitcherMode". Continue supporting
     // "useTabSwitcher", but prefer "tabSwitcherMode"
     JsonUtils::GetValueForKey(json, LegacyUseTabSwitcherModeKey, _TabSwitcherMode);
+
+    JsonUtils::GetValueForKey(json, LegacyInputServiceWarningKey, _InputServiceWarning);
+    JsonUtils::GetValueForKey(json, LegacyWarnAboutLargePasteKey, _WarnAboutLargePaste);
+    JsonUtils::GetValueForKey(json, LegacyWarnAboutMultiLinePasteKey, _WarnAboutMultiLinePaste);
+    JsonUtils::GetValueForKey(json, LegacyConfirmCloseAllTabsKey, _ConfirmCloseAllTabs);
 
 #define GLOBAL_SETTINGS_LAYER_JSON(type, name, jsonKey, ...) \
     JsonUtils::GetValueForKey(json, jsonKey, _##name);       \

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
@@ -136,12 +136,12 @@ void GlobalAppSettings::LayerJson(const Json::Value& json, const OriginTag origi
     // GH#8076 - when adding enum values to this key, we also changed it from
     // "useTabSwitcher" to "tabSwitcherMode". Continue supporting
     // "useTabSwitcher", but prefer "tabSwitcherMode"
-    JsonUtils::GetValueForKey(json, LegacyUseTabSwitcherModeKey, _TabSwitcherMode);
+    _fixupsAppliedDuringLoad = JsonUtils::GetValueForKey(json, LegacyUseTabSwitcherModeKey, _TabSwitcherMode) || _fixupsAppliedDuringLoad;
 
-    JsonUtils::GetValueForKey(json, LegacyInputServiceWarningKey, _InputServiceWarning);
-    JsonUtils::GetValueForKey(json, LegacyWarnAboutLargePasteKey, _WarnAboutLargePaste);
-    JsonUtils::GetValueForKey(json, LegacyWarnAboutMultiLinePasteKey, _WarnAboutMultiLinePaste);
-    JsonUtils::GetValueForKey(json, LegacyConfirmCloseAllTabsKey, _ConfirmCloseAllTabs);
+    _fixupsAppliedDuringLoad = JsonUtils::GetValueForKey(json, LegacyInputServiceWarningKey, _InputServiceWarning) || _fixupsAppliedDuringLoad;
+    _fixupsAppliedDuringLoad = JsonUtils::GetValueForKey(json, LegacyWarnAboutLargePasteKey, _WarnAboutLargePaste) || _fixupsAppliedDuringLoad;
+    _fixupsAppliedDuringLoad = JsonUtils::GetValueForKey(json, LegacyWarnAboutMultiLinePasteKey, _WarnAboutMultiLinePaste) || _fixupsAppliedDuringLoad;
+    _fixupsAppliedDuringLoad = JsonUtils::GetValueForKey(json, LegacyConfirmCloseAllTabsKey, _ConfirmCloseAllTabs) || _fixupsAppliedDuringLoad;
 
 #define GLOBAL_SETTINGS_LAYER_JSON(type, name, jsonKey, ...) \
     JsonUtils::GetValueForKey(json, jsonKey, _##name);       \
@@ -163,6 +163,8 @@ void GlobalAppSettings::LayerJson(const Json::Value& json, const OriginTag origi
     }
     LayerActionsFrom(json, origin, true);
 
+    // No need to update _fixupsAppliedDuringLoad here.
+    // We already handle this in SettingsLoader::FixupUserSettings().
     JsonUtils::GetValueForKey(json, LegacyReloadEnvironmentVariablesKey, _legacyReloadEnvironmentVariables);
     if (json[LegacyReloadEnvironmentVariablesKey.data()])
     {
@@ -305,7 +307,7 @@ Json::Value GlobalAppSettings::ToJson()
 
 bool GlobalAppSettings::FixupsAppliedDuringLoad()
 {
-    return _actionMap->FixupsAppliedDuringLoad();
+    return _fixupsAppliedDuringLoad || _actionMap->FixupsAppliedDuringLoad();
 }
 
 winrt::Microsoft::Terminal::Settings::Model::Theme GlobalAppSettings::CurrentTheme() noexcept

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.h
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.h
@@ -89,6 +89,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 #endif
 
         winrt::guid _defaultProfile{};
+        bool _fixupsAppliedDuringLoad{ false };
         bool _legacyReloadEnvironmentVariables{ true };
         winrt::com_ptr<implementation::ActionMap> _actionMap{ winrt::make_self<implementation::ActionMap>() };
         std::set<std::string> _changeLog;

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -35,16 +35,16 @@ Author(s):
     X(bool, AlwaysShowTabs, "alwaysShowTabs", true)                                                                                                                                                   \
     X(Model::NewTabPosition, NewTabPosition, "newTabPosition", Model::NewTabPosition::AfterLastTab)                                                                                                   \
     X(bool, ShowTitleInTitlebar, "showTerminalTitleInTitlebar", true)                                                                                                                                 \
-    X(bool, ConfirmCloseAllTabs, "confirmCloseAllTabs", true)                                                                                                                                         \
+    X(bool, ConfirmCloseAllTabs, "warning.confirmCloseAllTabs", true)                                                                                                                                 \
     X(Model::ThemePair, Theme, "theme")                                                                                                                                                               \
     X(hstring, Language, "language")                                                                                                                                                                  \
     X(winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode, TabWidthMode, "tabWidthMode", winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode::Equal)                                            \
     X(bool, UseAcrylicInTabRow, "useAcrylicInTabRow", false)                                                                                                                                          \
     X(bool, ShowTabsInTitlebar, "showTabsInTitlebar", true)                                                                                                                                           \
-    X(bool, InputServiceWarning, "inputServiceWarning", true)                                                                                                                                         \
+    X(bool, InputServiceWarning, "warning.inputService", true)                                                                                                                                        \
     X(winrt::Microsoft::Terminal::Control::CopyFormat, CopyFormatting, "copyFormatting", 0)                                                                                                           \
-    X(bool, WarnAboutLargePaste, "largePasteWarning", true)                                                                                                                                           \
-    X(bool, WarnAboutMultiLinePaste, "multiLinePasteWarning", true)                                                                                                                                   \
+    X(bool, WarnAboutLargePaste, "warning.largePaste", true)                                                                                                                                          \
+    X(bool, WarnAboutMultiLinePaste, "warning.multiLinePaste", true)                                                                                                                                  \
     X(Model::LaunchPosition, InitialPosition, "initialPosition", nullptr, nullptr)                                                                                                                    \
     X(bool, CenterOnLaunch, "centerOnLaunch", false)                                                                                                                                                  \
     X(Model::FirstWindowPreference, FirstWindowPreference, "firstWindowPreference", FirstWindowPreference::DefaultProfile)                                                                            \

--- a/src/cascadia/UnitTests_SettingsModel/SerializationTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/SerializationTests.cpp
@@ -107,7 +107,6 @@ namespace SettingsModelUnitTests
                 "initialPosition": ",",
                 "launchMode": "default",
                 "alwaysOnTop": false,
-                "inputServiceWarning": true,
                 "copyOnSelect": false,
                 "copyFormatting": "all",
                 "wordDelimiters": " /\\()\"'-.,:;<>~!@#$%^&*|+=[]{}~?\u2502",
@@ -123,12 +122,14 @@ namespace SettingsModelUnitTests
                 "snapToGridOnResize": true,
                 "disableAnimations": false,
 
-                "confirmCloseAllTabs": true,
-                "largePasteWarning": true,
-                "multiLinePasteWarning": true,
                 "trimPaste": true,
 
                 "experimental.input.forceVT": false,
+
+                "warning.confirmCloseAllTabs" : true,
+                "warning.inputService" : true,
+                "warning.largePaste" : true,
+                "warning.multiLinePaste" : true,
 
                 "actions": [],
                 "keybindings": []


### PR DESCRIPTION
Adds the following settings to the Interaction page under a Warnings subsection:
- ConfirmCloseAllTabs
- InputServiceWarning
- WarnAboutLargePaste
- WarnAboutMultiLinePaste

This also changes the JSON keys of those settings to be in the `warning` namespace as a QOL change for JSON users. We still handle the legacy keys, don't worry 😉.

#10000