### PR TITLE
Check EnableHexNumpad before enabling it

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1631,12 +1631,29 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                 {
                     if (vkey == VK_ADD)
                     {
-                        // Alt '+' <number> is used to input Unicode code points.
-                        // Every time you press + it resets the entire state
-                        // in the original OS implementation as well.
-                        s.encoding = AltNumpadEncoding::Unicode;
-                        s.accumulator = 0;
-                        s.active = true;
+                        static const auto enabled = []() {
+                            wchar_t buffer[4]{};
+                            DWORD size = sizeof(buffer);
+                            RegGetValueW(
+                                HKEY_CURRENT_USER,
+                                L"Control Panel\\Input Method",
+                                L"EnableHexNumpad",
+                                RRF_RT_REG_SZ,
+                                nullptr,
+                                &buffer[0],
+                                &size);
+                            return size == 4 && memcmp(&buffer[0], L"1", 4) == 0;
+                        }();
+
+                        if (enabled)
+                        {
+                            // Alt '+' <number> is used to input Unicode code points.
+                            // Every time you press + it resets the entire state
+                            // in the original OS implementation as well.
+                            s.encoding = AltNumpadEncoding::Unicode;
+                            s.accumulator = 0;
+                            s.active = true;
+                        }
                     }
                     else if (vkey == VK_NUMPAD0 && s.encoding == AltNumpadEncoding::OEM && s.accumulator == 0)
                     {


### PR DESCRIPTION
This just adds a quick registry check for `EnableHexNumpad`.

Depends on #17774
Closes #17762 (again)

## Validation Steps Performed
* Alt + NumpadAdd + 221E doesn't do anything ✅
* Set the `EnableHexNumpad` registry key
* Restart
* Alt + NumpadAdd + 221E inserts ∞ ✅