### PR TITLE
New tokenization & integer parsing helpers

### DIFF
--- a/src/cascadia/TerminalApp/Jumplist.cpp
+++ b/src/cascadia/TerminalApp/Jumplist.cpp
@@ -162,10 +162,9 @@ winrt::com_ptr<IShellLinkW> Jumplist::_createShellLink(const std::wstring_view n
         const std::wstring iconPath{ path.substr(0, commaPosition) };
 
         // We dont want the comma included so add 1 to its position
-        int iconIndex = til::to_int(path.substr(commaPosition + 1));
-        if (iconIndex != til::to_int_error)
+        if (const auto iconIndex = til::parse_signed<int>(path.substr(commaPosition + 1)))
         {
-            THROW_IF_FAILED(sh->SetIconLocation(iconPath.data(), iconIndex));
+            THROW_IF_FAILED(sh->SetIconLocation(iconPath.data(), *iconIndex));
         }
     }
     else if (til::ends_with(path, L"exe") || til::ends_with(path, L"dll"))

--- a/src/cascadia/TerminalSettingsModel/KeyChordSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/KeyChordSerialization.cpp
@@ -101,10 +101,10 @@ static int32_t parseNumericCode(const std::wstring_view& str, const std::wstring
         return 0;
     }
 
-    const auto value = til::to_ulong({ str.data() + prefix.size(), str.size() - prefix.size() - suffix.size() });
-    if (value > 0 && value < 256)
+    const auto value = til::parse_unsigned<uint8_t>({ str.data() + prefix.size(), str.size() - prefix.size() - suffix.size() });
+    if (value)
     {
-        return gsl::narrow_cast<int32_t>(value);
+        return gsl::narrow_cast<int32_t>(*value);
     }
 
     throw winrt::hresult_invalid_argument(L"Invalid numeric argument to vk() or sc()");
@@ -151,10 +151,8 @@ static KeyChord _fromString(std::wstring_view wstr)
     auto vkey = 0;
     auto scanCode = 0;
 
-    while (!wstr.empty())
+    for (auto&& part : til::split_iterator{ wstr, L'+' })
     {
-        const auto part = til::prefix_split(wstr, L'+');
-
         if (til::equals_insensitive_ascii(part, CTRL_KEY))
         {
             modifiers |= VirtualKeyModifiers::Control;

--- a/src/cascadia/TerminalSettingsModel/KeyChordSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/KeyChordSerialization.cpp
@@ -151,7 +151,7 @@ static KeyChord _fromString(std::wstring_view wstr)
     auto vkey = 0;
     auto scanCode = 0;
 
-    for (auto&& part : til::split_iterator{ wstr, L'+' })
+    for (const auto part : til::split_iterator{ wstr, L'+' })
     {
         if (til::equals_insensitive_ascii(part, CTRL_KEY))
         {

--- a/src/cascadia/TerminalSettingsModel/KeyChordSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/KeyChordSerialization.cpp
@@ -151,7 +151,7 @@ static KeyChord _fromString(std::wstring_view wstr)
     auto vkey = 0;
     auto scanCode = 0;
 
-    for (const auto part : til::split_iterator{ wstr, L'+' })
+    for (const auto& part : til::split_iterator{ wstr, L'+' })
     {
         if (til::equals_insensitive_ascii(part, CTRL_KEY))
         {

--- a/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
@@ -719,8 +719,8 @@ struct ::Microsoft::Terminal::Settings::Model::JsonUtils::ConversionTrait<::winr
         if (isIndexed16)
         {
             const auto indexStr = string.substr(1);
-            const auto idx = til::to_ulong(indexStr, 16);
-            color.r = gsl::narrow_cast<uint8_t>(std::min(idx, 15ul));
+            const auto idx = til::parse_unsigned<uint8_t>(indexStr, 16);
+            color.r = std::min<uint8_t>(idx.value_or(255), 15);
         }
         else
         {

--- a/src/cascadia/UIHelpers/Converters.cpp
+++ b/src/cascadia/UIHelpers/Converters.cpp
@@ -82,7 +82,7 @@ namespace winrt::Microsoft::Terminal::UI::implementation
         // Non-numeral values detected will default to 0
         // std::stod will throw invalid_argument exception if the input is an invalid double value
         // std::stod will throw out_of_range exception if the input value is more than DBL_MAX
-        for (const auto part : til::split_iterator{ paddingString, L',' })
+        for (const auto& part : til::split_iterator{ paddingString, L',' })
         {
             buffer.assign(part);
 

--- a/src/cascadia/UIHelpers/Converters.cpp
+++ b/src/cascadia/UIHelpers/Converters.cpp
@@ -71,7 +71,7 @@ namespace winrt::Microsoft::Terminal::UI::implementation
         return fontWeight.Weight;
     }
 
-    double Converters::MaxValueFromPaddingString(const std::wstring_view paddingString)
+    double Converters::MaxValueFromPaddingString(const winrt::hstring& paddingString)
     {
         std::wstring buffer;
         double maxVal = 0;
@@ -82,7 +82,7 @@ namespace winrt::Microsoft::Terminal::UI::implementation
         // Non-numeral values detected will default to 0
         // std::stod will throw invalid_argument exception if the input is an invalid double value
         // std::stod will throw out_of_range exception if the input value is more than DBL_MAX
-        for (const auto& part : til::split_iterator{ paddingString, L',' })
+        for (const auto& part : til::split_iterator{ std::wstring_view{ paddingString }, L',' })
         {
             buffer.assign(part);
 

--- a/src/cascadia/UIHelpers/Converters.cpp
+++ b/src/cascadia/UIHelpers/Converters.cpp
@@ -71,9 +71,8 @@ namespace winrt::Microsoft::Terminal::UI::implementation
         return fontWeight.Weight;
     }
 
-    double Converters::MaxValueFromPaddingString(const winrt::hstring& paddingString)
+    double Converters::MaxValueFromPaddingString(const std::wstring_view paddingString)
     {
-        std::wstring_view input{ paddingString };
         std::wstring buffer;
         double maxVal = 0;
 
@@ -83,7 +82,7 @@ namespace winrt::Microsoft::Terminal::UI::implementation
         // Non-numeral values detected will default to 0
         // std::stod will throw invalid_argument exception if the input is an invalid double value
         // std::stod will throw out_of_range exception if the input value is more than DBL_MAX
-        for (auto&& part : til::split_iterator{ input, L',' })
+        for (const auto part : til::split_iterator{ paddingString, L',' })
         {
             buffer.assign(part);
 

--- a/src/cascadia/UIHelpers/Converters.cpp
+++ b/src/cascadia/UIHelpers/Converters.cpp
@@ -73,34 +73,32 @@ namespace winrt::Microsoft::Terminal::UI::implementation
 
     double Converters::MaxValueFromPaddingString(const winrt::hstring& paddingString)
     {
-        std::wstring_view remaining{ paddingString };
+        std::wstring_view input{ paddingString };
+        std::wstring buffer;
         double maxVal = 0;
+
+        auto& errnoRef = errno; // Nonzero cost, pay it once
 
         // Get padding values till we run out of delimiter separated values in the stream
         // Non-numeral values detected will default to 0
         // std::stod will throw invalid_argument exception if the input is an invalid double value
         // std::stod will throw out_of_range exception if the input value is more than DBL_MAX
-        try
+        for (auto&& part : til::split_iterator{ input, L',' })
         {
-            while (!remaining.empty())
+            buffer.assign(part);
+
+            // wcstod handles whitespace prefix (which is ignored) & stops the
+            // scan when first char outside the range of radix is encountered.
+            // We'll be permissive till the extent that stod function allows us to be by default
+            // Ex. a value like 100.3#535w2 will be read as 100.3, but ;df25 will fail
+            errnoRef = 0;
+            wchar_t* end;
+            const double val = wcstod(buffer.c_str(), &end);
+
+            if (end != buffer.c_str() && errnoRef != ERANGE)
             {
-                const std::wstring token{ til::prefix_split(remaining, L',') };
-                // std::stod internally calls wcstod which handles whitespace prefix (which is ignored)
-                //  & stops the scan when first char outside the range of radix is encountered
-                // We'll be permissive till the extent that stod function allows us to be by default
-                // Ex. a value like 100.3#535w2 will be read as 100.3, but ;df25 will fail
-                const auto curVal = std::stod(token);
-                if (curVal > maxVal)
-                {
-                    maxVal = curVal;
-                }
+                maxVal = std::max(maxVal, val);
             }
-        }
-        catch (...)
-        {
-            // If something goes wrong, even if due to a single bad padding value, we'll return default 0 padding
-            maxVal = 0;
-            LOG_CAUGHT_EXCEPTION();
         }
 
         return maxVal;

--- a/src/cascadia/UIHelpers/Converters.h
+++ b/src/cascadia/UIHelpers/Converters.h
@@ -28,7 +28,7 @@ namespace winrt::Microsoft::Terminal::UI::implementation
         static winrt::Windows::UI::Text::FontWeight DoubleToFontWeight(double value);
         static winrt::Windows::UI::Xaml::Media::SolidColorBrush ColorToBrush(winrt::Windows::UI::Color color);
         static double FontWeightToDouble(winrt::Windows::UI::Text::FontWeight fontWeight);
-        static double MaxValueFromPaddingString(const winrt::hstring& paddingString);
+        static double MaxValueFromPaddingString(std::wstring_view paddingString);
     };
 }
 

--- a/src/cascadia/UIHelpers/Converters.h
+++ b/src/cascadia/UIHelpers/Converters.h
@@ -28,7 +28,7 @@ namespace winrt::Microsoft::Terminal::UI::implementation
         static winrt::Windows::UI::Text::FontWeight DoubleToFontWeight(double value);
         static winrt::Windows::UI::Xaml::Media::SolidColorBrush ColorToBrush(winrt::Windows::UI::Color color);
         static double FontWeightToDouble(winrt::Windows::UI::Text::FontWeight fontWeight);
-        static double MaxValueFromPaddingString(std::wstring_view paddingString);
+        static double MaxValueFromPaddingString(const winrt::hstring& paddingString);
     };
 }
 

--- a/src/cascadia/UIHelpers/IconPathConverter.cpp
+++ b/src/cascadia/UIHelpers/IconPathConverter.cpp
@@ -271,12 +271,7 @@ namespace winrt::Microsoft::Terminal::UI::implementation
         if (commaIndex != std::wstring::npos)
         {
             // Convert the string iconIndex to a signed int to support negative numbers which represent an Icon's ID.
-            const auto index{ til::to_int(pathView.substr(commaIndex + 1)) };
-            if (index == til::to_int_error)
-            {
-                return std::nullopt;
-            }
-            return static_cast<int>(index);
+            return til::parse_signed<int>(pathView.substr(commaIndex + 1));
         }
 
         // We had a binary path, but no index. Default to 0.

--- a/src/common.build.pre.props
+++ b/src/common.build.pre.props
@@ -150,7 +150,17 @@
       <RemoveUnreferencedCodeData>true</RemoveUnreferencedCodeData>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
-      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:__cplusplus /Zc:__STDC__ /Zc:enumTypes /Zc:externConstexpr /Zc:templateScope /Zc:throwingNew</AdditionalOptions>
+      <!--
+        Conformance options that are off by default at the time of writing:
+          /Zc:__cplusplus    Enable the __cplusplus macro to report the supported standard.
+          /Zc:__STDC__       Enable the __STDC__ macro to report the C standard is supported.
+          /Zc:enumTypes      Enable Standard C++ rules for enum type deduction.
+          /Zc:inline         Remove unreferenced functions or data if they're COMDAT or have internal linkage only.
+          /Zc:templateScope  Enforce Standard C++ template parameter shadowing rules.
+          /Zc:throwingNew    Assume operator new throws on failure.
+        /diagnostics:caret   Places ^^^^^ under the exact location of the issue. The default only shows the line number.
+      -->
+      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:__cplusplus /Zc:__STDC__ /Zc:enumTypes /Zc:inline /Zc:templateScope /Zc:throwingNew /diagnostics:caret</AdditionalOptions>
       <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <ResourceCompile>

--- a/src/inc/til/string.h
+++ b/src/inc/til/string.h
@@ -352,6 +352,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
             // * ptr != end, when parsing the characters; if ptr is null, length will be 0 and thus end == ptr
 #pragma warning(push)
 #pragma warning(disable : 26429) // Symbol 'ptr' is never tested for nullness, it can be marked as not_null
+#pragma warning(disable : 26451) // Arithmetic overflow: Using operator '+' on a 4 byte value and then casting the result to a 8 byte value. [...]
 #pragma warning(disable : 26481) // Don't use pointer arithmetic. Use span instead
             auto ptr = str.data();
             const auto end = ptr + str.length();
@@ -445,7 +446,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
             }
 
             const auto opt = details::parse_u64<>(str, base);
-            const auto max = uint64_t{ std::numeric_limits<R>::max() } + hasSign;
+            const auto max = gsl::narrow_cast<uint64_t>(std::numeric_limits<R>::max()) + hasSign;
             if (!opt || *opt > max)
             {
                 return {};

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -1009,7 +1009,7 @@ bool OutputStateMachineEngine::_GetOscSetColor(const std::wstring_view string,
     }
 
     std::vector<DWORD> newRgbs;
-    for (auto&& part : parts)
+    for (const auto part : parts)
     {
         if (part == L"?"sv) [[unlikely]]
         {

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -1015,7 +1015,7 @@ bool OutputStateMachineEngine::_GetOscSetColor(const std::wstring_view string,
     }
 
     std::vector<DWORD> newRgbs;
-    for (const auto part : parts)
+    for (const auto& part : parts)
     {
         if (part == L"?"sv) [[unlikely]]
         {

--- a/src/til/ut_til/string.cpp
+++ b/src/til/ut_til/string.cpp
@@ -72,9 +72,9 @@ class StringTests
         VERIFY_IS_TRUE(til::ends_with("0abc", "abc"));
     }
 
-    // Normally this would be the spot where you'd find a TEST_METHOD(to_ulong).
+    // Normally this would be the spot where you'd find a TEST_METHOD(parse_u64).
     // I didn't quite trust my coding skills and thus opted to use fuzz-testing.
-    // The below function was used to test to_ulong for unsafety and conformance with clang's strtoul.
+    // The below function was used to test parse_u64 for unsafety and conformance with clang's strtoul.
     // The test was run as:
     //   clang++ -fsanitize=address,undefined,fuzzer -std=c++17 file.cpp
     // and was run for 20min across 16 jobs in parallel.
@@ -112,7 +112,7 @@ class StringTests
             return 0;
         }
 
-        const auto actual = to_ulong({ wide_buffer, size });
+        const auto actual = parse_u64({ wide_buffer, size });
         if (expected != actual)
         {
             __builtin_trap();
@@ -147,64 +147,39 @@ class StringTests
         VERIFY_IS_TRUE(til::equals_insensitive_ascii("cOUnterStriKE", "COuntERStRike"));
     }
 
-    TEST_METHOD(prefix_split)
+    TEST_METHOD(split_iterator)
     {
-        {
-            std::string_view s{ "" };
-            VERIFY_ARE_EQUAL("", til::prefix_split(s, ""));
-            VERIFY_ARE_EQUAL("", s);
-        }
-        {
-            std::string_view s{ "" };
-            VERIFY_ARE_EQUAL("", til::prefix_split(s, " "));
-            VERIFY_ARE_EQUAL("", s);
-        }
-        {
-            std::string_view s{ " " };
-            VERIFY_ARE_EQUAL(" ", til::prefix_split(s, ""));
-            VERIFY_ARE_EQUAL("", s);
-        }
-        {
-            std::string_view s{ "foo" };
-            VERIFY_ARE_EQUAL("foo", til::prefix_split(s, ""));
-            VERIFY_ARE_EQUAL("", s);
-        }
-        {
-            std::string_view s{ "foo bar baz" };
-            VERIFY_ARE_EQUAL("foo", til::prefix_split(s, " "));
-            VERIFY_ARE_EQUAL("bar baz", s);
-            VERIFY_ARE_EQUAL("bar", til::prefix_split(s, " "));
-            VERIFY_ARE_EQUAL("baz", s);
-            VERIFY_ARE_EQUAL("baz", til::prefix_split(s, " "));
-            VERIFY_ARE_EQUAL("", s);
-        }
-        {
-            std::string_view s{ "foo123barbaz123" };
-            VERIFY_ARE_EQUAL("foo", til::prefix_split(s, "123"));
-            VERIFY_ARE_EQUAL("barbaz123", s);
-            VERIFY_ARE_EQUAL("barbaz", til::prefix_split(s, "123"));
-            VERIFY_ARE_EQUAL("", s);
-            VERIFY_ARE_EQUAL("", til::prefix_split(s, ""));
-            VERIFY_ARE_EQUAL("", s);
-        }
-    }
+        static constexpr auto split = [](const std::string_view& str, const char needle) {
+            std::vector<std::string_view> substrings;
+            for (auto&& s : til::split_iterator{ str, needle })
+            {
+                substrings.emplace_back(s);
+            }
+            return substrings;
+        };
 
-    TEST_METHOD(prefix_split_char)
-    {
-        {
-            std::string_view s{ "" };
-            VERIFY_ARE_EQUAL("", til::prefix_split(s, ' '));
-            VERIFY_ARE_EQUAL("", s);
-        }
-        {
-            std::string_view s{ "foo bar baz" };
-            VERIFY_ARE_EQUAL("foo", til::prefix_split(s, ' '));
-            VERIFY_ARE_EQUAL("bar baz", s);
-            VERIFY_ARE_EQUAL("bar", til::prefix_split(s, ' '));
-            VERIFY_ARE_EQUAL("baz", s);
-            VERIFY_ARE_EQUAL("baz", til::prefix_split(s, ' '));
-            VERIFY_ARE_EQUAL("", s);
-        }
+        std::vector<std::string_view> expected;
+        std::vector<std::string_view> actual;
+
+        expected = { "foo" };
+        actual = split("foo", ' ');
+        VERIFY_ARE_EQUAL(expected, actual);
+
+        expected = { "", "foo" };
+        actual = split(" foo", ' ');
+        VERIFY_ARE_EQUAL(expected, actual);
+
+        expected = { "foo", "" };
+        actual = split("foo ", ' ');
+        VERIFY_ARE_EQUAL(expected, actual);
+
+        expected = { "foo", "bar", "baz" };
+        actual = split("foo bar baz", ' ');
+        VERIFY_ARE_EQUAL(expected, actual);
+
+        expected = { "", "", "foo", "", "bar", "", "" };
+        actual = split(";;foo;;bar;;", ';');
+        VERIFY_ARE_EQUAL(expected, actual);
     }
 
     TEST_METHOD(CleanPathAndFilename)


### PR DESCRIPTION
Reading through our existing patterns for integer parsing, I noticed
that we'd be better off returning them as optionals.
This also allowed me to improve the implementation to support integers
all the way up to their absolute maximum/minimum.

Furthermore, I noticed that `prefix_split` was unsound:
If the last needle character was the last character in the remaining
text, the remaining text would be updated to an empty string view.
The caller would then have no idea if there's 1 more token left
or if the string is truly empty.
To solve this, this PR introduces an iterator class. This will allow
it to be used in our VT parser code.