### PR TITLE
Allow shift+enter in Terminal Chat's text box

### DIFF
--- a/src/cascadia/QueryExtension/ExtensionPalette.cpp
+++ b/src/cascadia/QueryExtension/ExtensionPalette.cpp
@@ -382,6 +382,7 @@ namespace winrt::Microsoft::Terminal::Query::Extension::implementation
         const auto key = e.OriginalKey();
         const auto coreWindow = CoreWindow::GetForCurrentThread();
         const auto ctrlDown = WI_IsFlagSet(coreWindow.GetKeyState(winrt::Windows::System::VirtualKey::Control), CoreVirtualKeyStates::Down);
+        const auto shiftDown = WI_IsFlagSet(coreWindow.GetKeyState(winrt::Windows::System::VirtualKey::Shift), CoreVirtualKeyStates::Down);
 
         if (key == VirtualKey::Escape)
         {
@@ -393,7 +394,7 @@ namespace winrt::Microsoft::Terminal::Query::Extension::implementation
 
             e.Handled(true);
         }
-        else if (key == VirtualKey::Enter)
+        else if (key == VirtualKey::Enter && !shiftDown)
         {
             if (const auto& textBox = e.OriginalSource().try_as<TextBox>())
             {

--- a/src/cascadia/QueryExtension/ExtensionPalette.xaml
+++ b/src/cascadia/QueryExtension/ExtensionPalette.xaml
@@ -395,6 +395,7 @@
                      IsSpellCheckEnabled="False"
                      PlaceholderText="{x:Bind QueryBoxPlaceholderText}"
                      Text=""
+                     AcceptsReturn="True"
                      TextWrapping="Wrap" />
             <TextBlock Grid.Row="2"
                        Margin="20,0,0,16"

--- a/src/cascadia/QueryExtension/ExtensionPalette.xaml
+++ b/src/cascadia/QueryExtension/ExtensionPalette.xaml
@@ -392,10 +392,10 @@
                      Height="100"
                      Margin="16,0,16,4"
                      Padding="18,8,8,8"
+                     AcceptsReturn="True"
                      IsSpellCheckEnabled="False"
                      PlaceholderText="{x:Bind QueryBoxPlaceholderText}"
                      Text=""
-                     AcceptsReturn="True"
                      TextWrapping="Wrap" />
             <TextBlock Grid.Row="2"
                        Margin="20,0,0,16"


### PR DESCRIPTION
You can now press shift+enter in the Terminal Chat query box to enter newlines

Closes #17940 