### PR TITLE
Prepend path to nuget in repo

### DIFF
--- a/tools/razzle.cmd
+++ b/tools/razzle.cmd
@@ -18,7 +18,7 @@ rem The opencon root is at ...\open\tools\, without the last 7 chars ('\tools\')
 set OPENCON=%OPENCON_TOOLS:~0,-7%
 
 rem Add nuget to PATH
-set PATH=%PATH%%OPENCON%\dep\nuget;
+set PATH=%OPENCON%\dep\nuget;%PATH%
 
 rem Run nuget restore so you can use vswhere
 nuget restore %OPENCON%\OpenConsole.sln -Verbosity quiet


### PR DESCRIPTION
## Summary of the Pull Request

This PR aims to fix issue #1111.

## References and Relevant Issues

* https://github.com/microsoft/terminal/issues/1111

## Detailed Description of the Pull Request / Additional comments

This PR makes it so the path to nuget in this repo is prepended. This will make it so the local `nuget.exe` is prioritised before looking for nuget in `PATH`.

## Validation Steps Performed

Run `razzle.cmd`, the local instance of nuget is utilised. 

Delete `nuget.exe`, `razzle.cmd` uses `nuget.exe` specificed in the `PATH`.

## PR Checklist
- [x] Closes [#1111](https://github.com/microsoft/terminal/issues/1111)
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
