### PR TITLE
Add a policy for profile sources

### DIFF
--- a/.github/actions/spelling/expect/04cdb9b77d6827c0202f51acd4205b017015bfff.txt
+++ b/.github/actions/spelling/expect/04cdb9b77d6827c0202f51acd4205b017015bfff.txt
@@ -1,5 +1,0 @@
-EOB
-swrapped
-wordi
-wordiswrapped
-wrappe

--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -16,6 +16,8 @@ ADDALIAS
 ADDREF
 ADDSTRING
 ADDTOOL
+adml
+admx
 AFill
 AFX
 AHelper

--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -564,6 +564,7 @@ entrypoints
 ENU
 ENUMLOGFONT
 ENUMLOGFONTEX
+EOB
 EOK
 EPres
 EQU
@@ -782,6 +783,7 @@ HIWORD
 HKCU
 hkey
 hkl
+HKLM
 hlocal
 hlsl
 HMB
@@ -1735,6 +1737,7 @@ swapchain
 swapchainpanel
 SWMR
 SWP
+swrapped
 SYMED
 SYNCPAINT
 syscalls
@@ -2077,6 +2080,8 @@ WNDCLASSW
 Wndproc
 WNegative
 WNull
+wordi
+wordiswrapped
 workarea
 WOutside
 WOWARM
@@ -2090,6 +2095,7 @@ WPrep
 WPresent
 wprp
 wprpi
+wrappe
 wregex
 writeback
 WRITECONSOLE

--- a/policies/WindowsTerminal.admx
+++ b/policies/WindowsTerminal.admx
@@ -6,6 +6,11 @@
     <using prefix="windows" namespace="Microsoft.Policies.Windows" />
   </policyNamespaces>
   <resources minRequiredRevision="1.0" />
+  <supportedOn>
+    <definitions>
+      <definition name="SUPPORTED_WindowsTerminal_1_21" displayName="$(string.SUPPORTED_WindowsTerminal_1_21)" />
+    </definitions>
+  </supportedOn>
   <categories>
     <category name="WindowsTerminal" displayName="$(string.WindowsTerminal)">
       <parentCategory ref="windows:WindowsComponents" />
@@ -14,7 +19,7 @@
   <policies>
     <policy name="DisabledProfileSources" class="Both" displayName="$(string.DisabledProfileSources)" explainText="$(string.DisabledProfileSourcesText)" presentation="$(presentation.DisabledProfileSources)" key="Software\Policies\Microsoft\Windows\Terminal">
       <parentCategory ref="WindowsTerminal" />
-      <supportedOn ref="windows:SUPPORTED_Windows10_0_20H1" />
+      <supportedOn ref="terminal:SUPPORTED_WindowsTerminal_1_21" />
       <elements>
         <multiText id="DisabledProfileSources" valueName="DisabledProfileSources" required="true" />
       </elements>

--- a/policies/WindowsTerminal.admx
+++ b/policies/WindowsTerminal.admx
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--  (c) 2024 Microsoft Corporation  -->
+<policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
+  <policyNamespaces>
+    <target prefix="terminal" namespace="Microsoft.Policies.WindowsTerminal" />
+    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+  </policyNamespaces>
+  <resources minRequiredRevision="1.0" />
+  <categories>
+    <category name="WindowsTerminal" displayName="$(string.WindowsTerminal)">
+      <parentCategory ref="windows:WindowsComponents" />
+    </category>
+  </categories>
+  <policies>
+    <policy name="DisabledProfileSources" class="Both" displayName="$(string.DisabledProfileSources)" explainText="$(string.DisabledProfileSourcesText)" presentation="$(presentation.DisabledProfileSources)" key="Software\Policies\Microsoft\Windows\Terminal">
+      <parentCategory ref="WindowsTerminal" />
+      <supportedOn ref="windows:SUPPORTED_Windows10_0_20H1" />
+      <elements>
+        <multiText id="DisabledProfileSources" valueName="DisabledProfileSources" required="true" />
+      </elements>
+    </policy>
+  </policies>
+</policyDefinitions>

--- a/policies/WindowsTerminal.admx
+++ b/policies/WindowsTerminal.admx
@@ -17,9 +17,9 @@
     </category>
   </categories>
   <policies>
-    <policy name="DisabledProfileSources" class="Both" displayName="$(string.DisabledProfileSources)" explainText="$(string.DisabledProfileSourcesText)" presentation="$(presentation.DisabledProfileSources)" key="Software\Policies\Microsoft\Windows\Terminal">
+    <policy name="DisabledProfileSources" class="Both" displayName="$(string.DisabledProfileSources)" explainText="$(string.DisabledProfileSourcesText)" presentation="$(presentation.DisabledProfileSources)" key="Software\Policies\Microsoft\Windows Terminal">
       <parentCategory ref="WindowsTerminal" />
-      <supportedOn ref="terminal:SUPPORTED_WindowsTerminal_1_21" />
+      <supportedOn ref="SUPPORTED_WindowsTerminal_1_21" />
       <elements>
         <multiText id="DisabledProfileSources" valueName="DisabledProfileSources" required="true" />
       </elements>

--- a/policies/en-US/WindowsTerminal.adml
+++ b/policies/en-US/WindowsTerminal.adml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--  (c) 2024 Microsoft Corporation  -->
+<policyDefinitionResources xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
+  <displayName>Windows Terminal</displayName>
+  <description>Windows Terminal</description>
+  <resources>
+    <stringTable>
+      <string id="WindowsTerminal">Windows Terminal</string>
+      <string id="DisabledProfileSources">Disabled Profile Sources</string>
+      <string id="DisabledProfileSourcesText">Sources you specify here will not show up as profiles. Possible sources are, among others:
+- Windows.Terminal.Azure
+- Windows.Terminal.PowershellCore
+- Windows.Terminal.Wsl</string>
+    </stringTable>
+    <presentationTable>
+      <presentation id="DisabledProfileSources">
+        <multiTextBox refId="DisabledProfileSources">List of disabled sources</multiTextBox>
+      </presentation>
+    </presentationTable>
+  </resources>
+</policyDefinitionResources>

--- a/policies/en-US/WindowsTerminal.adml
+++ b/policies/en-US/WindowsTerminal.adml
@@ -6,15 +6,20 @@
   <resources>
     <stringTable>
       <string id="WindowsTerminal">Windows Terminal</string>
+      <string id="SUPPORTED_WindowsTerminal_1_21">At least Windows Terminal 1.21</string>
       <string id="DisabledProfileSources">Disabled Profile Sources</string>
-      <string id="DisabledProfileSourcesText">Sources you specify here will not show up as profiles. Possible sources are, among others:
+      <string id="DisabledProfileSourcesText">Profiles will not be generated from any sources listed here. Source names can be arbitrary strings. Potential candidates can be found as the "source" property in Windows Terminal's settings.json file.
+
+Common sources are:
 - Windows.Terminal.Azure
 - Windows.Terminal.PowershellCore
-- Windows.Terminal.Wsl</string>
+- Windows.Terminal.Wsl
+
+For instance, setting this policy to Windows.Terminal.Wsl will disable the builtin WSL integration of Windows Terminal.</string>
     </stringTable>
     <presentationTable>
       <presentation id="DisabledProfileSources">
-        <multiTextBox refId="DisabledProfileSources">List of disabled sources</multiTextBox>
+        <multiTextBox refId="DisabledProfileSources">List of disabled sources (one per line)</multiTextBox>
       </presentation>
     </presentationTable>
   </resources>

--- a/policies/en-US/WindowsTerminal.adml
+++ b/policies/en-US/WindowsTerminal.adml
@@ -8,14 +8,16 @@
       <string id="WindowsTerminal">Windows Terminal</string>
       <string id="SUPPORTED_WindowsTerminal_1_21">At least Windows Terminal 1.21</string>
       <string id="DisabledProfileSources">Disabled Profile Sources</string>
-      <string id="DisabledProfileSourcesText">Profiles will not be generated from any sources listed here. Source names can be arbitrary strings. Potential candidates can be found as the "source" property in Windows Terminal's settings.json file.
+      <string id="DisabledProfileSourcesText">Profiles will not be generated from any sources listed here. Source names can be arbitrary strings. Potential candidates can be found as the "source" property on profile definitions in Windows Terminal's settings.json file.
 
 Common sources are:
 - Windows.Terminal.Azure
 - Windows.Terminal.PowershellCore
 - Windows.Terminal.Wsl
 
-For instance, setting this policy to Windows.Terminal.Wsl will disable the builtin WSL integration of Windows Terminal.</string>
+For instance, setting this policy to Windows.Terminal.Wsl will disable the builtin WSL integration of Windows Terminal.
+
+Note: Existing profiles will disappear from Windows Terminal after adding their source to this policy.</string>
     </stringTable>
     <presentationTable>
       <presentation id="DisabledProfileSources">

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
@@ -96,7 +96,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         void _addOrMergeUserColorScheme(const winrt::com_ptr<implementation::ColorScheme>& colorScheme);
         void _executeGenerator(const IDynamicProfileGenerator& generator);
 
-        std::unordered_set<std::wstring_view> _ignoredNamespaces;
+        std::unordered_set<winrt::hstring, til::transparent_hstring_hash, til::transparent_hstring_equal_to> _ignoredNamespaces;
         std::set<std::string> themesChangeLog;
         // See _getNonUserOriginProfiles().
         size_t _userProfileCount = 0;

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -158,7 +158,7 @@ SettingsLoader::SettingsLoader(const std::string_view& userJSON, const std::stri
     {
         wchar_t buffer[512]; // "640K ought to be enough for anyone"
         DWORD bufferSize = sizeof(buffer);
-        if (RegGetValueW(key, LR"(Software\Policies\Microsoft\Windows\Terminal)", L"DisabledProfileSources", RRF_RT_REG_MULTI_SZ, nullptr, buffer, &bufferSize) == 0)
+        if (RegGetValueW(key, LR"(Software\Policies\Microsoft\Windows Terminal)", L"DisabledProfileSources", RRF_RT_REG_MULTI_SZ, nullptr, buffer, &bufferSize) == 0)
         {
             for (auto p = buffer; *p;)
             {

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -146,9 +146,27 @@ SettingsLoader::SettingsLoader(const std::string_view& userJSON, const std::stri
     if (const auto sources = userSettings.globals->DisabledProfileSources())
     {
         _ignoredNamespaces.reserve(sources.Size());
-        for (const auto& id : sources)
+        for (auto&& id : sources)
         {
-            _ignoredNamespaces.emplace(id);
+            _ignoredNamespaces.emplace(std::move(id));
+        }
+    }
+
+    // Apply DisabledProfileSources policy setting. Pick whatever policy is set first.
+    // In most cases HKCU settings take precedence over HKLM settings, but the inverse is true for policies.
+    for (const auto key : { HKEY_LOCAL_MACHINE, HKEY_CURRENT_USER })
+    {
+        wchar_t buffer[512]; // "640K ought to be enough for anyone"
+        DWORD bufferSize = sizeof(buffer);
+        if (RegGetValueW(key, LR"(Software\Policies\Microsoft\Windows\Terminal)", L"DisabledProfileSources", RRF_RT_REG_MULTI_SZ, nullptr, buffer, &bufferSize) == 0)
+        {
+            for (auto p = buffer; *p;)
+            {
+                const auto len = wcslen(p);
+                _ignoredNamespaces.emplace(p, gsl::narrow_cast<uint32_t>(len));
+                p += len + 1;
+            }
+            break;
         }
     }
 
@@ -260,7 +278,7 @@ void SettingsLoader::FindFragmentsAndMergeIntoUserSettings()
                 const auto filename = fragmentExtFolder.path().filename();
                 const auto& source = filename.native();
 
-                if (!_ignoredNamespaces.count(std::wstring_view{ source }) && fragmentExtFolder.is_directory())
+                if (!_ignoredNamespaces.contains(std::wstring_view{ source }) && fragmentExtFolder.is_directory())
                 {
                     parseAndLayerFragmentFiles(fragmentExtFolder.path(), winrt::hstring{ source });
                 }
@@ -295,7 +313,7 @@ void SettingsLoader::FindFragmentsAndMergeIntoUserSettings()
     for (const auto& ext : extensions)
     {
         const auto packageName = ext.Package().Id().FamilyName();
-        if (_ignoredNamespaces.count(std::wstring_view{ packageName }))
+        if (_ignoredNamespaces.contains(std::wstring_view{ packageName }))
         {
             continue;
         }
@@ -914,7 +932,7 @@ void SettingsLoader::_addOrMergeUserColorScheme(const winrt::com_ptr<implementat
 void SettingsLoader::_executeGenerator(const IDynamicProfileGenerator& generator)
 {
     const auto generatorNamespace = generator.GetNamespace();
-    if (_ignoredNamespaces.count(generatorNamespace))
+    if (_ignoredNamespaces.contains(generatorNamespace))
     {
         return;
     }

--- a/src/inc/til/winrt.h
+++ b/src/inc/til/winrt.h
@@ -109,4 +109,24 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
     //     Which is just silly
 
 #endif
+
+    struct transparent_hstring_hash
+    {
+        using is_transparent = void;
+
+        size_t operator()(const auto& hstr) const noexcept
+        {
+            return std::hash<std::wstring_view>{}(hstr);
+        }
+    };
+
+    struct transparent_hstring_equal_to
+    {
+        using is_transparent = void;
+
+        bool operator()(const auto& lhs, const auto& rhs) const noexcept
+        {
+            return lhs == rhs;
+        }
+    };
 }


### PR DESCRIPTION
This adds a basic policy check for DisabledProfileSources, so that
organizations can easily disable certain profiles like the Azure one.

Closes #17964

## Validation Steps Performed
* Add a policy to disable Azure under HKCU. Disabled ✅
* Add a policy to disable nothing under HKLM. Enabled ✅
  (...because it overrides the HKCU setting.)