### PR TITLE
Open current working directory action.

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -423,6 +423,7 @@
         "newWindow",
         "nextTab",
         "openAbout",
+        "openCWD",
         "openNewTabDropdown",
         "openSettings",
         "openSystemMenu",

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -1129,7 +1129,7 @@ namespace winrt::TerminalApp::implementation
     }
 
     void TerminalPage::_HandleOpenCWD(const IInspectable& /*sender*/,
-                                            const ActionEventArgs& args)
+                                      const ActionEventArgs& args)
     {
         if (const auto& control{ _GetActiveControl() })
         {

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -1128,6 +1128,16 @@ namespace winrt::TerminalApp::implementation
         }
     }
 
+    void TerminalPage::_HandleOpenCWD(const IInspectable& /*sender*/,
+                                            const ActionEventArgs& args)
+    {
+        if (const auto& control{ _GetActiveControl() })
+        {
+            control.OpenCWD();
+            args.Handled(true);
+        }
+    }
+
     void TerminalPage::_HandleGlobalSummon(const IInspectable& /*sender*/,
                                            const ActionEventArgs& args)
     {

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -1643,6 +1643,12 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         SearchMissingCommand.raise(*this, make<implementation::SearchMissingCommandEventArgs>(hstring{ missingCommand }, bufferRow));
     }
 
+    void ControlCore::OpenCWD()
+    {
+        const auto workingDirectory = WorkingDirectory();
+        ShellExecute(nullptr, nullptr, L"explorer", workingDirectory.c_str(), nullptr, SW_SHOW);
+    }
+
     void ControlCore::ClearQuickFix()
     {
         _cachedQuickFixes = nullptr;

--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -157,6 +157,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         void ClearQuickFix();
 
+        void OpenCWD();
+
 #pragma region ICoreState
         const size_t TaskbarState() const noexcept;
         const size_t TaskbarProgress() const noexcept;

--- a/src/cascadia/TerminalControl/ControlCore.idl
+++ b/src/cascadia/TerminalControl/ControlCore.idl
@@ -178,6 +178,8 @@ namespace Microsoft.Terminal.Control
         Boolean ShouldShowSelectCommand();
         Boolean ShouldShowSelectOutput();
 
+        void OpenCWD();
+
         void ClearQuickFix();
 
         // These events are called from some background thread

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2594,6 +2594,11 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         }
     }
 
+    void TermControl::OpenCWD()
+    {
+        _core.OpenCWD();
+    }
+
     void TermControl::Close()
     {
         if (!_IsClosing())

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -69,6 +69,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         bool ExpandSelectionToWord();
         void RestoreFromPath(winrt::hstring path);
         void PersistToPath(const winrt::hstring& path) const;
+        void OpenCWD();
         void Close();
         Windows::Foundation::Size CharacterDimensions() const;
         Windows::Foundation::Size MinimumSize();

--- a/src/cascadia/TerminalControl/TermControl.idl
+++ b/src/cascadia/TerminalControl/TermControl.idl
@@ -97,6 +97,7 @@ namespace Microsoft.Terminal.Control
         void ClearBuffer(ClearBufferType clearType);
         void RestoreFromPath(String path);
         void PersistToPath(String path);
+        void OpenCWD();
         void Close();
         Windows.Foundation.Size CharacterDimensions { get; };
         Windows.Foundation.Size MinimumSize { get; };

--- a/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
@@ -100,6 +100,7 @@ static constexpr std::string_view ToggleBroadcastInputKey{ "toggleBroadcastInput
 static constexpr std::string_view OpenScratchpadKey{ "experimental.openScratchpad" };
 static constexpr std::string_view OpenAboutKey{ "openAbout" };
 static constexpr std::string_view QuickFixKey{ "quickFix" };
+static constexpr std::string_view OpenCWDKey{ "openCWD" };
 
 static constexpr std::string_view ActionKey{ "action" };
 
@@ -437,6 +438,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                 { ShortcutAction::OpenScratchpad, RS_(L"OpenScratchpadKey") },
                 { ShortcutAction::OpenAbout, RS_(L"OpenAboutCommandKey") },
                 { ShortcutAction::QuickFix, RS_(L"QuickFixCommandKey") },
+                { ShortcutAction::OpenCWD, RS_(L"OpenCWDCommandKey") },
             };
         }();
 

--- a/src/cascadia/TerminalSettingsModel/AllShortcutActions.h
+++ b/src/cascadia/TerminalSettingsModel/AllShortcutActions.h
@@ -112,7 +112,8 @@
     ON_ALL_ACTIONS(ToggleBroadcastInput)    \
     ON_ALL_ACTIONS(OpenScratchpad)          \
     ON_ALL_ACTIONS(OpenAbout)               \
-    ON_ALL_ACTIONS(QuickFix)
+    ON_ALL_ACTIONS(QuickFix)                \
+    ON_ALL_ACTIONS(OpenCWD)
 
 #define ALL_SHORTCUT_ACTIONS_WITH_ARGS             \
     ON_ALL_ACTIONS_WITH_ARGS(AdjustFontSize)       \

--- a/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
@@ -734,4 +734,7 @@
   <data name="QuickFixCommandKey" xml:space="preserve">
     <value>Open quick fix menu</value>
   </data>
+  <data name="OpenCWDCommandKey" xml:space="preserve">
+    <value>Open current working directory</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -449,6 +449,7 @@
         { "command": "experimental.openTasks", "id": "Terminal.OpenTasks" },
         { "command": "quickFix", "id": "Terminal.QuickFix" },
         { "command": { "action": "showSuggestions", "source": "all"}, "id": "Terminal.Suggestions" },
+        { "command": "openCWD" },
 
         // Tab Management
         // "command": "closeTab" is unbound by default.

--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -449,7 +449,7 @@
         { "command": "experimental.openTasks", "id": "Terminal.OpenTasks" },
         { "command": "quickFix", "id": "Terminal.QuickFix" },
         { "command": { "action": "showSuggestions", "source": "all"}, "id": "Terminal.Suggestions" },
-        { "command": "openCWD" },
+        { "command": "openCWD", "id": "Terminal.OpenCWD" },
 
         // Tab Management
         // "command": "closeTab" is unbound by default.


### PR DESCRIPTION
## Summary of the Pull Request
Added open current directory action.
## References and Relevant Issues
Need to set this: https://learn.microsoft.com/en-us/windows/terminal/tutorials/new-tab-same-directory

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed
- Ensure shell has been configured
- Run "Open current working directory" action in command palette
- File explorer opens the correct directory

## PR Checklist
- [x] Closes #12859
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
