### PR TITLE
OpenConsole.psm1 PSVersion check

### DIFF
--- a/tools/OpenConsole.psm1
+++ b/tools/OpenConsole.psm1
@@ -1,10 +1,4 @@
-# throw error if Powershell version is lower than 7
-if ($PSVersionTable.PSVersion.Major -lt 7) {
-    throw "This script requires PowerShell 7 or higher. Current version: $($PSVersionTable.PSVersion)"
-    exit
-} 
-
-
+#Requires -Version 7
 
 # The project's root directory.
 $script:OpenConsoleFallbackRoot="$PSScriptRoot\.."

--- a/tools/OpenConsole.psm1
+++ b/tools/OpenConsole.psm1
@@ -1,3 +1,10 @@
+# throw error if Powershell version is lower than 7
+if ($PSVersionTable.PSVersion.Major -lt 7) {
+    throw "This script requires PowerShell 7 or higher. Current version: $($PSVersionTable.PSVersion)"
+    exit
+} 
+
+
 
 # The project's root directory.
 $script:OpenConsoleFallbackRoot="$PSScriptRoot\.."


### PR DESCRIPTION
## Summary of the Pull Request
Added a check in OpenConsole.psm1 to throw an error if the Powershell version is <7.

## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed
![powershell_error](https://github.com/user-attachments/assets/9022012b-7f5e-4842-adf3-741214787df5) \
Confirmed that attempting to `Import-Module .\tools\OpenConsole.psm1` throws an error on Powershell 5.

## PR Checklist
- [x] Closes #17505
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
