### PR TITLE
Changed new tab index on tab close to next tab

### DIFF
--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -498,7 +498,7 @@ namespace winrt::TerminalApp::implementation
                 // * B (tabIndex=1): We'll want to focus tab A (now in index 0)
                 // * C (tabIndex=2): We'll want to focus tab B (now in index 1)
                 // * D (tabIndex=3): We'll want to focus tab C (now in index 2)
-                const auto newSelectedIndex = std::clamp<int32_t>(tabIndex - 1, 0, _tabs.Size() - 1);
+                const auto newSelectedIndex = std::clamp<int32_t>(tabIndex, 0, _tabs.Size() - 1);
                 // _UpdatedSelectedTab will do the work of setting up the new tab as
                 // the focused one, and unfocusing all the others.
                 auto newSelectedTab{ _tabs.GetAt(newSelectedIndex) };

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -491,12 +491,12 @@ namespace winrt::TerminalApp::implementation
                 // Because this will always return -1 in this scenario unfortunately.
                 //
                 // So, what we're going to try to do is move the focus to the tab
-                // to the left, within the bounds of how many tabs we have.
+                // to the right, within the bounds of how many tabs we have.
                 //
                 // EX: we have 4 tabs: [A, B, C, D]. If we close:
                 // * A (tabIndex=0): We'll want to focus tab B (now in index 0)
-                // * B (tabIndex=1): We'll want to focus tab A (now in index 0)
-                // * C (tabIndex=2): We'll want to focus tab B (now in index 1)
+                // * B (tabIndex=1): We'll want to focus tab C (now in index 1)
+                // * C (tabIndex=2): We'll want to focus tab D (now in index 2)
                 // * D (tabIndex=3): We'll want to focus tab C (now in index 2)
                 const auto newSelectedIndex = std::clamp<int32_t>(tabIndex, 0, _tabs.Size() - 1);
                 // _UpdatedSelectedTab will do the work of setting up the new tab as


### PR DESCRIPTION
## Summary of the Pull Request
Changed newSelectedIndex on tab close to tabIndex instead of tabIndex - 1.

## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed
![tab_close_focus_right](https://github.com/user-attachments/assets/91ae7e61-1bba-4548-aac8-b5f4fa823429)

## PR Checklist
- [x] Closes #17244
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
