### PR TITLE
Fix hiding the icon when it's set to "none"

### DIFF
--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -532,7 +532,7 @@ void CascadiaSettings::_validateMediaResources()
         // want to blow up if we fell back to the commandline and the
         // commandline _isn't an icon_.
         // GH #17943: "none" is a special value interpreted as "remove the icon"
-        static hstring HideIconValue{ L"none" };
+        static constexpr std::wstring_view HideIconValue{ L"none" };
         if (const auto icon = profile.Icon(); icon.size() > 2 && icon != HideIconValue)
         {
             const auto iconPath{ wil::ExpandEnvironmentStringsW<std::wstring>(icon.c_str()) };

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -531,7 +531,9 @@ void CascadiaSettings::_validateMediaResources()
         // Explicitly just use the Icon here, not the EvaluatedIcon. We don't
         // want to blow up if we fell back to the commandline and the
         // commandline _isn't an icon_.
-        if (const auto icon = profile.Icon(); icon.size() > 2)
+        // GH #17943: "none" is a special value interpreted as "remove the icon"
+        static hstring HideIconValue{ L"none" };
+        if (const auto icon = profile.Icon(); icon.size() > 2 && icon != HideIconValue)
         {
             const auto iconPath{ wil::ExpandEnvironmentStringsW<std::wstring>(icon.c_str()) };
             try


### PR DESCRIPTION
The settings UI and settings model allow you to set the icon to "none" to hide the icon (you can actually see this effect in the settings UI when changing the value of the profile icon). However, during settings validation, "none" is considered a file path, which is then failed to be parsed, resulting in the icon being marked as invalid and immediately clearing the value.

This PR fixes this issue by considering "none" to be an accepted value during validation.

Related to #15843
Closes #17943

## Validation Steps Performed
When an icon is set to "none", ...
✅ no more warning
✅ the icon is hidden