### PR TITLE
Bump XamlStyler.Console to 3.2404.2

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "XamlStyler.Console": {
-      "version": "3.2311.2",
+      "version": "3.2404.2",
       "commands": [
         "xstyler"
       ]


### PR DESCRIPTION
## XamlStyler.Console 3.2311.2 -> 3.2404.2

- Better handle internal VS exceptions relating to .csproj files
- Expand console support for axaml 
- Handle unhandled FileNotFoundException in XamlStylerConsole.cs
- Fix entry in About window 
- Set minimum install target to match version of referenced SDK
- This release adds support for Rider 2023.3
