### PR TITLE
GSL 3.1.0 -> 4.0.0

### DIFF
--- a/src/inc/LibraryIncludes.h
+++ b/src/inc/LibraryIncludes.h
@@ -66,7 +66,7 @@
 // Block GSL Multi Span include because it both has C++17 deprecated iterators
 // and uses the C-namespaced "max" which conflicts with Windows definitions.
 #include <gsl/gsl>
-#include <gsl/gsl_util>
+#include <gsl/util>
 #include <gsl/pointers>
 
 // CppCoreCheck

--- a/src/renderer/atlas/pch.h
+++ b/src/renderer/atlas/pch.h
@@ -24,7 +24,7 @@
 #include <VersionHelpers.h>
 #include <wincodec.h>
 
-#include <gsl/gsl_util>
+#include <gsl/util>
 #include <gsl/pointers>
 #include <wil/com.h>
 #include <wil/filesystem.h>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "ms-gsl",
-      "version": "3.1.0"
+      "version": "4.0.0"
     },
     {
       "name": "jsoncpp",


### PR DESCRIPTION
## GSL 3.1.0 -> 4.0.0

- Deprecation of gsl::string_span
- Removal of <gsl/multi_span>
- Header files dropped the gsl_ prefix
- Changes to not_null
- gsl::span and std::span now use the correct specialization of gsl::at
- The zstring family no longer requires empty brackets to be used
- gsl::narrowing_error now has a helpful what() message
- finally and final_action are now [[nodiscard]]
- GSL will work in environments where exceptions are disabled, with some caveats
- GSL will work in environments which do not support ios, via the addition of the GSL_NO_IOSTREAMS flag
- GSL Install logic is now guarded by a cmake option GSL_INSTALL
- Fix bug which prevented the library from being built on a 32-bit host and then being used on a 64-bit machine
- Build will now use CMAKE_CXX_STANDARD if it's provided
- Clean up GSL_SUPPRESS warning for intel compilers
- Fix build failure for C++20 compilers which don't have std::span
- Cleaned up some static analysis warnings
- The cmake cache variable VS_ADD_NATIVE_VISUALIZERS has been renamed to GSL_VS_ADD_NATIVE_VISUALIZERS

