### PR TITLE
ci: fix the code formatting job

### DIFF
--- a/build/pipelines/templates-v2/job-check-code-format.yml
+++ b/build/pipelines/templates-v2/job-check-code-format.yml
@@ -10,6 +10,6 @@ jobs:
     submodules: false
     clean: true
 
-  - powershell: |-
+  - pwsh: |-
       .\build\scripts\Invoke-FormattingCheck.ps1
     displayName: 'Run formatters'


### PR DESCRIPTION
We started requiring PowerShell 7+ in #18021

We did not update the code formatting task.