### PR TITLE
Fix tab contrast colors when in high contrast

### DIFF
--- a/src/cascadia/TerminalApp/TabBase.cpp
+++ b/src/cascadia/TerminalApp/TabBase.cpp
@@ -572,25 +572,16 @@ namespace winrt::TerminalApp::implementation
             L"TabViewItemHeaderCloseButtonBorderBrushSelected"
         };
 
-        const auto& tabItemResources{ TabViewItem().Resources() };
-        const auto& tabItemThemeResources{ tabItemResources.ThemeDictionaries() };
+        const auto& tabItemThemeResources{ TabViewItem().Resources().ThemeDictionaries() };
 
         // simply clear any of the colors in the tab's dict
         for (const auto& keyString : keys)
         {
-            auto key = winrt::box_value(keyString);
-            if (tabItemResources.HasKey(key))
+            const auto key = winrt::box_value(keyString);
+            for (const auto& [_, v] : tabItemThemeResources)
             {
-                tabItemResources.Remove(key);
-            }
-
-            for (const auto& [k, v] : tabItemThemeResources)
-            {
-                const auto& currentDictionary = v.as<ResourceDictionary>();
-                if (currentDictionary.HasKey(key))
-                {
-                    currentDictionary.Remove(key);
-                }
+                const auto& themeDictionary = v.as<ResourceDictionary>();
+                themeDictionary.Remove(key);
             }
         }
 

--- a/src/cascadia/TerminalApp/TabBase.cpp
+++ b/src/cascadia/TerminalApp/TabBase.cpp
@@ -471,6 +471,7 @@ namespace winrt::TerminalApp::implementation
         const auto& tabItemResources{ TabViewItem().Resources() };
 
         TabViewItem().Background(deselectedTabBrush);
+        tabItemResources.Insert(winrt::box_value(L"TabViewItemHeaderBackground"), deselectedTabBrush);
         tabItemResources.Insert(winrt::box_value(L"TabViewItemHeaderBackgroundSelected"), selectedTabBrush);
         tabItemResources.Insert(winrt::box_value(L"TabViewItemHeaderBackgroundPointerOver"), hoverTabBrush);
         tabItemResources.Insert(winrt::box_value(L"TabViewItemHeaderBackgroundPressed"), selectedTabBrush);


### PR DESCRIPTION
## Summary of the Pull Request
Originally, the XAML resources were being applied on the TabView's ResourceDictionary directly. However, high contrast mode has a few weird scenarios as it basically reduces the color palette to just a few colors to ensure high contrast. This PR now stores the resources onto the ThemeDictionaries so that we have more control over the colors used.

## References and Relevant Issues
Closes #17913
Closes #13067 (fixed by 5be0056)

## Validation Steps Performed
Compared the following scenarios to WinUI 2 gallery's TabView when in High Contrast mode:
✅ (Un)selected tab
✅ hover over x of (un)selected tab
✅ hover over unselected tab