### PR TITLE
Fix High Contrast mode in Settings UI

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -705,6 +705,12 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     // can have mica too.
     void MainPage::_UpdateBackgroundForMica()
     {
+        // If we're in high contrast mode, don't override the theme.
+        if (Windows::UI::ViewManagement::AccessibilitySettings accessibilitySettings; accessibilitySettings.HighContrast())
+        {
+            return;
+        }
+
         bool isMicaAvailable = false;
 
         // Check to see if our hosting window supports Mica at all. We'll check

--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -44,11 +44,10 @@
                         <ResourceDictionary x:Key="HighContrast">
                             <!--  Define resources for HighContrast mode here  -->
                             <StaticResource x:Key="SettingsPageBackground"
-                                            ResourceKey="SystemColorWindowColorBrush" />
+                                            ResourceKey="SystemColorWindowBrush" />
                             <StaticResource x:Key="SettingsPageMicaBackground"
-                                            ResourceKey="SystemColorWindowColorBrush" />
+                                            ResourceKey="SystemColorWindowBrush" />
                         </ResourceDictionary>
-
                     </ResourceDictionary.ThemeDictionaries>
                 </ResourceDictionary>
 

--- a/src/cascadia/TerminalSettingsEditor/pch.h
+++ b/src/cascadia/TerminalSettingsEditor/pch.h
@@ -31,6 +31,7 @@
 #include <winrt/Windows.UI.Input.h>
 #include <winrt/Windows.UI.Popups.h>
 #include <winrt/Windows.UI.Text.h>
+#include <winrt/Windows.UI.ViewManagement.h>
 #include <winrt/Windows.UI.Xaml.h>
 #include <winrt/Windows.UI.Xaml.Automation.h>
 #include <winrt/Windows.UI.Xaml.Automation.Peers.h>


### PR DESCRIPTION
"HighContrast" is not a possible requested theme. So `_UpdateBackgroundForMica()` would force the settings UI to be light or dark. To fix this, we just check if we're in high contrast mode and, if so, we don't bother setting the requested theme. 