### PR TITLE
Fix High Contrast mode in Command Palette

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.xaml
+++ b/src/cascadia/TerminalApp/CommandPalette.xaml
@@ -23,6 +23,31 @@
 
     <UserControl.Resources>
         <ResourceDictionary>
+            <!--  KeyChordText styles  -->
+            <Style x:Key="KeyChordBorderStyle"
+                   TargetType="Border">
+                <Setter Property="BorderThickness" Value="1" />
+                <Setter Property="CornerRadius" Value="2" />
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
+            </Style>
+            <Style x:Key="KeyChordTextBlockStyle"
+                   TargetType="TextBlock">
+                <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
+            </Style>
+            <!--  ParsedCommandLineText styles  -->
+            <Style x:Key="ParsedCommandLineBorderStyle"
+                   TargetType="Border">
+                <Setter Property="BorderThickness" Value="1" />
+                <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
+                <Setter Property="Background" Value="{ThemeResource CardBackgroundFillColorDefaultBrush}" />
+                <Setter Property="BorderBrush" Value="{ThemeResource CardStrokeColorDefaultBrush}" />
+            </Style>
+            <Style x:Key="ParsedCommandLineTextBlockStyle"
+                   TargetType="TextBlock">
+                <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
+            </Style>
+
             <DataTemplate x:Key="ListItemTemplate"
                           x:DataType="local:FilteredCommand">
                 <ListViewItem HorizontalContentAlignment="Stretch"
@@ -69,12 +94,12 @@
                             VerticalAlignment="Center"
                             AutomationProperties.AccessibilityView="Raw"
                             Background="{ThemeResource FlyoutPresenterBackground}"
-                            Style="{ThemeResource KeyChordBorderStyle}"
+                            Style="{StaticResource KeyChordBorderStyle}"
                             Visibility="{x:Bind mtu:Converters.StringNotEmptyToVisibility(Item.KeyChordText), Mode=OneWay}">
 
                         <TextBlock AutomationProperties.AccessibilityView="Raw"
                                    FontSize="12"
-                                   Style="{ThemeResource KeyChordTextBlockStyle}"
+                                   Style="{StaticResource KeyChordTextBlockStyle}"
                                    Text="{x:Bind Item.KeyChordText, Mode=OneWay}" />
                     </Border>
                 </Grid>
@@ -118,12 +143,12 @@
                             HorizontalAlignment="Right"
                             VerticalAlignment="Center"
                             AutomationProperties.AccessibilityView="Raw"
-                            Style="{ThemeResource KeyChordBorderStyle}"
+                            Style="{StaticResource KeyChordBorderStyle}"
                             Visibility="{x:Bind mtu:Converters.StringNotEmptyToVisibility(Item.KeyChordText), Mode=OneWay}">
 
                         <TextBlock AutomationProperties.AccessibilityView="Raw"
                                    FontSize="12"
-                                   Style="{ThemeResource KeyChordTextBlockStyle}"
+                                   Style="{StaticResource KeyChordTextBlockStyle}"
                                    Text="{x:Bind Item.KeyChordText, Mode=OneWay}" />
                     </Border>
 
@@ -219,79 +244,6 @@
                                                GeneralItemTemplate="{StaticResource GeneralItemTemplate}"
                                                NestedItemTemplate="{StaticResource NestedItemTemplate}"
                                                TabItemTemplate="{StaticResource TabItemTemplate}" />
-
-            <ResourceDictionary.ThemeDictionaries>
-                <ResourceDictionary x:Key="Dark">
-
-                    <!--  KeyChordText styles  -->
-                    <Style x:Key="KeyChordBorderStyle"
-                           TargetType="Border">
-                        <Setter Property="BorderThickness" Value="1" />
-                        <Setter Property="CornerRadius" Value="2" />
-                        <Setter Property="Background" Value="Transparent" />
-                        <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
-                    </Style>
-                    <Style x:Key="KeyChordTextBlockStyle"
-                           TargetType="TextBlock">
-                        <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
-                    </Style>
-
-                    <!--  ParsedCommandLineText styles  -->
-                    <Style x:Key="ParsedCommandLineBorderStyle"
-                           TargetType="Border">
-                        <Setter Property="BorderThickness" Value="1" />
-                        <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
-                        <Setter Property="Background" Value="{ThemeResource CardBackgroundFillColorDefaultBrush}" />
-                        <Setter Property="BorderBrush" Value="{ThemeResource CardStrokeColorDefaultBrush}" />
-                    </Style>
-                    <Style x:Key="ParsedCommandLineTextBlockStyle"
-                           TargetType="TextBlock">
-                        <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
-                    </Style>
-                </ResourceDictionary>
-                <ResourceDictionary x:Key="Light">
-
-                    <!--  KeyChordText styles  -->
-                    <Style x:Key="KeyChordBorderStyle"
-                           TargetType="Border">
-                        <Setter Property="BorderThickness" Value="1" />
-                        <Setter Property="CornerRadius" Value="2" />
-                        <Setter Property="Background" Value="Transparent" />
-                        <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
-                    </Style>
-                    <Style x:Key="KeyChordTextBlockStyle"
-                           TargetType="TextBlock">
-                        <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
-                    </Style>
-
-                    <!--  ParsedCommandLineText styles  -->
-                    <Style x:Key="ParsedCommandLineBorderStyle"
-                           TargetType="Border">
-                        <Setter Property="BorderThickness" Value="1" />
-                        <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
-                        <Setter Property="Background" Value="{ThemeResource CardBackgroundFillColorDefaultBrush}" />
-                        <Setter Property="BorderBrush" Value="{ThemeResource CardStrokeColorDefaultBrush}" />
-                    </Style>
-                    <Style x:Key="ParsedCommandLineTextBlockStyle"
-                           TargetType="TextBlock">
-                        <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
-                    </Style>
-                </ResourceDictionary>
-                <ResourceDictionary x:Key="HighContrast">
-
-                    <!--  KeyChordText styles (use XAML defaults for High Contrast theme)  -->
-                    <Style x:Key="KeyChordBorderStyle"
-                           TargetType="Border" />
-                    <Style x:Key="KeyChordTextBlockStyle"
-                           TargetType="TextBlock" />
-
-                    <!--  ParsedCommandLineText styles (use XAML defaults for High Contrast theme)  -->
-                    <Style x:Key="ParsedCommandLineBorderStyle"
-                           TargetType="Border" />
-                    <Style x:Key="ParsedCommandLineTextBlockStyle"
-                           TargetType="TextBlock" />
-                </ResourceDictionary>
-            </ResourceDictionary.ThemeDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -375,7 +327,7 @@
                     Padding="16,12"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Center"
-                    Style="{ThemeResource ParsedCommandLineBorderStyle}"
+                    Style="{StaticResource ParsedCommandLineBorderStyle}"
                     Visibility="{x:Bind mtu:Converters.StringNotEmptyToVisibility(ParsedCommandLineText), Mode=OneWay}">
 
                 <ScrollViewer MaxHeight="200"

--- a/src/cascadia/TerminalApp/CommandPalette.xaml
+++ b/src/cascadia/TerminalApp/CommandPalette.xaml
@@ -43,10 +43,6 @@
                 <Setter Property="Background" Value="{ThemeResource CardBackgroundFillColorDefaultBrush}" />
                 <Setter Property="BorderBrush" Value="{ThemeResource CardStrokeColorDefaultBrush}" />
             </Style>
-            <Style x:Key="ParsedCommandLineTextBlockStyle"
-                   TargetType="TextBlock">
-                <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
-            </Style>
 
             <DataTemplate x:Key="ListItemTemplate"
                           x:DataType="local:FilteredCommand">


### PR DESCRIPTION
Turns out that having the styles for the KeyChordText and ParsedCommandLineText be empty for high contrast mode caused the issue. Since we're already using theme resources for the colors, we automatically adjust properly to whatever the high contrast theme is (Thanks XAML!).

Bonus points:
- we didn't need the theme dictionaries anymore, so I just moved them to the ResourceDictionary directly
- ParsedCommandLineTextBlockStyle isn't used. So I removed it altogether.

Validated command palette with multiple high contrast themes. See PR thread for demo.

Closes #17914
