### PR TITLE
copilot: ensure that we wait for auth to complete before retrying

### DIFF
--- a/src/cascadia/QueryExtension/GithubCopilotLLMProvider.cpp
+++ b/src/cascadia/QueryExtension/GithubCopilotLLMProvider.cpp
@@ -154,7 +154,7 @@ namespace winrt::Microsoft::Terminal::Query::Extension::implementation
                 break;
             }
 
-            _refreshAuthTokens();
+            co_await _refreshAuthTokens();
             refreshAttempted = true;
         }
         co_return;
@@ -305,7 +305,7 @@ namespace winrt::Microsoft::Terminal::Query::Extension::implementation
                 break;
             }
 
-            _refreshAuthTokens();
+            co_await _refreshAuthTokens();
             refreshAttempted = true;
         }
 


### PR DESCRIPTION
If we don't, we'll print auth tokens to the screen.
