### PR TITLE
AtlasEngine: Better builtin glyphs

### DIFF
--- a/src/renderer/atlas/BackendD3D.cpp
+++ b/src/renderer/atlas/BackendD3D.cpp
@@ -588,7 +588,10 @@ void BackendD3D::_recreateConstBuffer(const RenderingPayload& p) const
         data.underlineWidth = p.s->font->underline.height;
         data.doubleUnderlineWidth = p.s->font->doubleUnderline[0].height;
         data.curlyLineHalfHeight = _curlyLineHalfHeight;
-        data.shadedGlyphDotSize = std::max(1.0f, std::roundf(std::max(p.s->font->cellSize.x / 16.0f, p.s->font->cellSize.y / 32.0f)));
+        // The lightLineWidth used for drawing the built-in glyphs is `cellSize.x / 6.0f`.
+        // So this ends up using a quarter line width for the dotted glyphs.
+        // We use half that for the `cellSize.y`, because usually cells have an aspect ratio of 1:2.
+        data.shadedGlyphDotSize = std::max(1.0f, std::roundf(std::max(p.s->font->cellSize.x / 12.0f, p.s->font->cellSize.y / 24.0f)));
         p.deviceContext->UpdateSubresource(_psConstantBuffer.get(), 0, nullptr, &data, 0, 0);
     }
 }

--- a/src/renderer/atlas/BuiltinGlyphs.cpp
+++ b/src/renderer/atlas/BuiltinGlyphs.cpp
@@ -1099,7 +1099,10 @@ void BuiltinGlyphs::DrawBuiltinGlyph(ID2D1Factory* factory, ID2D1DeviceContext* 
     const auto rectY = rect.top;
     const auto rectW = rect.right - rect.left;
     const auto rectH = rect.bottom - rect.top;
-    const auto lightLineWidth = std::max(1.0f, roundf(rectW / 8.0f));
+    // 1/6th of the cell width roughly matches the thin line width that Cascadia Mono
+    // uses for its box drawing characters. Same for the corner radius factor.
+    const auto lightLineWidth = std::max(1.0f, roundf(rectW / 6.0f));
+    const auto cornerRadius = std::min(lightLineWidth * 5.0f, std::min(rectW, rectH) * 0.5f);
     D2D1_POINT_2F geometryPoints[2 * InstructionsPerGlyph];
     size_t geometryPointsCount = 0;
 
@@ -1176,7 +1179,7 @@ void BuiltinGlyphs::DrawBuiltinGlyph(ID2D1Factory* factory, ID2D1DeviceContext* 
         }
         case Shape_RoundRect:
         {
-            const D2D1_ROUNDED_RECT rr{ { begXabs, begYabs, endXabs, endYabs }, lightLineWidth * 2, lightLineWidth * 2 };
+            const D2D1_ROUNDED_RECT rr{ { begXabs, begYabs, endXabs, endYabs }, cornerRadius, cornerRadius };
             renderTarget->DrawRoundedRectangle(&rr, brush, lineWidth, nullptr);
             break;
         }


### PR DESCRIPTION
This slightly modifies the builtin glyph width and corner radius to
more closely match Cascadia Mono. Previously, at low DPI (100% scale),
the corner radius was barely noticeable which looked kind of bad.