### PR TITLE
[<= 1.22] Do path translation for multiple types of WSL

### DIFF
--- a/src/cascadia/TerminalControl/ControlInteractivity.cpp
+++ b/src/cascadia/TerminalControl/ControlInteractivity.cpp
@@ -735,6 +735,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - true if the connection we were created with was a WSL profile.
     bool ControlInteractivity::ManglePathsForWsl()
     {
-        return _core->Settings().ProfileSource() == L"Windows.Terminal.Wsl";
+        const auto source{ _core->Settings().ProfileSource() };
+        return til::equals_insensitive_ascii(source, L"Windows.Terminal.Wsl") || til::equals_insensitive_ascii(source, L"Microsoft.WSL");
     }
 }


### PR DESCRIPTION
In #18195, we introduced a real `pathTranslationStyle` setting.

I'm not backporting that whole thing.