### PR TITLE
[<= 1.22] Retain (BUT DON'T INDICATE) orphaned dynamic profiles

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/LaunchViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/LaunchViewModel.cpp
@@ -332,7 +332,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // from menus, but still work as the startup profile for instance.
         for (const auto& profile : allProfiles)
         {
-            if (!profile.Deleted())
+            if (!profile.Deleted() && !profile.Orphaned() /* BACKPORT GH#18188 - DO NOT DISPLAY ORPHANED PROFILES */)
             {
                 profiles.emplace_back(profile);
             }

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -526,7 +526,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // profile changes.
         for (const auto& profile : _settingsClone.AllProfiles())
         {
-            if (!profile.Deleted())
+            if (!profile.Deleted() && !profile.Orphaned() /* BACKPORT GH#18188 - DO NOT DISPLAY ORPHANED PROFILES */)
             {
                 auto profileVM = _viewModelForProfile(profile, _settingsClone);
                 profileVM.SetupAppearances(_colorSchemesPageVM.AllColorSchemes());

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -103,7 +103,7 @@ Model::CascadiaSettings CascadiaSettings::Copy() const
             for (const auto& profile : targetProfiles)
             {
                 allProfiles.emplace_back(*profile);
-                if (!profile->Hidden())
+                if (!profile->Hidden() && !profile->Orphaned())
                 {
                     activeProfiles.emplace_back(*profile);
                 }

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -1217,12 +1217,12 @@ CascadiaSettings::CascadiaSettings(SettingsLoader&& loader) :
             const auto& parents = profile->Parents();
             if (std::none_of(parents.begin(), parents.end(), [&](const auto& parent) { return parent->Source() == source; }))
             {
-                continue;
+                profile->Orphaned(true);
             }
         }
 
         allProfiles.emplace_back(*profile);
-        if (!profile->Hidden())
+        if (!profile->Hidden() && !profile->Orphaned())
         {
             activeProfiles.emplace_back(*profile);
         }

--- a/src/cascadia/TerminalSettingsModel/Profile.cpp
+++ b/src/cascadia/TerminalSettingsModel/Profile.cpp
@@ -103,6 +103,7 @@ winrt::com_ptr<Profile> Profile::CopySettings() const
     const auto defaultAppearance = AppearanceConfig::CopyAppearance(winrt::get_self<AppearanceConfig>(_DefaultAppearance), weakProfile);
 
     profile->_Deleted = _Deleted;
+    profile->_Orphaned = _Orphaned;
     profile->_Updates = _Updates;
     profile->_Guid = _Guid;
     profile->_Name = _Name;

--- a/src/cascadia/TerminalSettingsModel/Profile.h
+++ b/src/cascadia/TerminalSettingsModel/Profile.h
@@ -115,6 +115,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         void Icon(const hstring& value);
 
         WINRT_PROPERTY(bool, Deleted, false);
+        WINRT_PROPERTY(bool, Orphaned, false);
         WINRT_PROPERTY(OriginTag, Origin, OriginTag::None);
         WINRT_PROPERTY(guid, Updates);
 

--- a/src/cascadia/TerminalSettingsModel/Profile.idl
+++ b/src/cascadia/TerminalSettingsModel/Profile.idl
@@ -41,6 +41,8 @@ namespace Microsoft.Terminal.Settings.Model
 
         // True if the user explicitly removed this Profile from settings.json.
         Boolean Deleted { get; };
+        // True if the user *kept* this Profile, but it disappeared from the system.
+        Boolean Orphaned { get; };
 
         // Helper for magically using a commandline for an icon for a profile
         // without an explicit icon.


### PR DESCRIPTION
The original intent with dynamic profiles was that they could be uninstalled but that Terminal would remember your settings in case they ever came back.

After we implemented dynamic profile _deletion_, however, we accidentally made it so that saving your settings after a dynamic profile disappeared scoured it from the planet _forever_ (since we remembered that we generated it, but now it was no longer in the settings file).

This pull request implements:

- Tracking for orphaned dynamic profiles

Closes #14061
Closes #11510
Refs #13916
Refs #9997

Modified for 1.22. I am not including any of the UI affordances.

(cherry picked from commit 90866c7c93c4743926d481b07d66a3e3e4eb1da8)
Service-Card-Id: PVTI_lADOAF3p4s4AmhmQzgU1-p4
Service-Version: 1.22