### PR TITLE
Revert "Dedup command history by default (#17852)"

### DIFF
--- a/src/host/settings.cpp
+++ b/src/host/settings.cpp
@@ -36,7 +36,7 @@ Settings::Settings() :
     _bAutoPosition(true),
     _uHistoryBufferSize(DEFAULT_NUMBER_OF_COMMANDS),
     _uNumberOfHistoryBuffers(DEFAULT_NUMBER_OF_BUFFERS),
-    _bHistoryNoDup(true),
+    _bHistoryNoDup(false),
     // ColorTable initialized below
     _uCodePage(ServiceLocator::LocateGlobals().uiOEMCP),
     _uScrollScale(1),
@@ -110,7 +110,7 @@ void Settings::ApplyDesktopSpecificDefaults()
     _bQuickEdit = TRUE;
     _uHistoryBufferSize = 50;
     _uNumberOfHistoryBuffers = 4;
-    _bHistoryNoDup = true;
+    _bHistoryNoDup = FALSE;
 
     _renderSettings.ResetColorTable();
 

--- a/src/propsheet/registry.cpp
+++ b/src/propsheet/registry.cpp
@@ -79,7 +79,7 @@ VOID InitRegistryValues(
     pStateInfo->CursorSize = 25;
     pStateInfo->HistoryBufferSize = 25;
     pStateInfo->NumberOfHistoryBuffers = 4;
-    pStateInfo->HistoryNoDup = 1;
+    pStateInfo->HistoryNoDup = 0;
 
     // clang-format off
     if (pStateInfo->fIsV2Console)


### PR DESCRIPTION
This reverts commit 5fdfd51209fc681e66657d6697ce031bc4319619,
because 3 people complained about this change VS 1 person
requesting the change to be made in the first place.

Closes #18138
Reopens #17797 for discussion