### PR TITLE
Add a timeout for getting suggestions from the LMProvider

### DIFF
--- a/src/cascadia/QueryExtension/ExtensionPalette.cpp
+++ b/src/cascadia/QueryExtension/ExtensionPalette.cpp
@@ -159,7 +159,15 @@ namespace winrt::Microsoft::Terminal::Query::Extension::implementation
 
         if (_lmProvider)
         {
-            result = _lmProvider.GetResponseAsync(promptCopy).get();
+            const auto asyncOperation = _lmProvider.GetResponseAsync(promptCopy);
+            if (asyncOperation.wait_for(std::chrono::seconds(5)) == AsyncStatus::Completed)
+            {
+                result = asyncOperation.GetResults();
+            }
+            else
+            {
+                result = winrt::make<SystemResponse>(RS_(L"UnknownErrorMessage"), ErrorTypes::Unknown, winrt::hstring{});
+            }
         }
         else
         {

--- a/src/cascadia/QueryExtension/Resources/en-US/Resources.resw
+++ b/src/cascadia/QueryExtension/Resources/en-US/Resources.resw
@@ -126,7 +126,7 @@
     <comment>The message presented to the user when they attempt to use the AI chat feature without providing an AI endpoint and key.</comment>
   </data>
   <data name="UnknownErrorMessage" xml:space="preserve">
-    <value>An error occurred. Your AI provider might not be correctly configured, or the service might be temporarily unavailable.</value>
+    <value>An error occurred. The service might be temporarily unavailable or there might be network connectivity issues.</value>
     <comment>The error message presented to the user when we were unable to query the provided endpoint.</comment>
   </data>
   <data name="InvalidModelMessage" xml:space="preserve">

--- a/src/cascadia/QueryExtension/pch.h
+++ b/src/cascadia/QueryExtension/pch.h
@@ -53,6 +53,8 @@ TRACELOGGING_DECLARE_PROVIDER(g_hQueryExtensionProvider);
 
 #include <winrt/Windows.Data.Json.h>
 
+#include <chrono>
+
 // Manually include til after we include Windows.Foundation to give it winrt superpowers
 #include "til.h"
 


### PR DESCRIPTION
## Summary of the Pull Request
Adds a 5-second timeout to get a response from the LMProvider so we don't loop forever in the case of network issues/the service being unavailable

## Validation Steps Performed
User receives an error message if we don't get a response within 5 seconds

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
