### PR TITLE
Defuse throttled_func when it's accidentally engaged

### DIFF
--- a/src/cascadia/WinRTUtils/inc/ThrottledFunc.h
+++ b/src/cascadia/WinRTUtils/inc/ThrottledFunc.h
@@ -113,7 +113,7 @@ private:
                 {
                     try
                     {
-                        std::apply(self->_func, self->_storage.take());
+                        self->_storage.apply(self->_func);
                     }
                     CATCH_LOG();
                 }


### PR DESCRIPTION
This change prevents `throttled_func` from reading uninitialized memory
under some yet-unkown circumstances. The tl;dr is:
This simply moves the callback invocation into the storage.
That way we can centrally avoid invoking the callback accidentally.