### PR TITLE
build: fix arm64 vcpkg triplet selection error

### DIFF
--- a/src/common.build.pre.props
+++ b/src/common.build.pre.props
@@ -275,6 +275,9 @@
     <VcpkgOSTarget>windows</VcpkgOSTarget>
     <VcpkgUseStatic>true</VcpkgUseStatic>
 
+    <!-- BODGY - work around DD#2302065. vcpkg now validates target triplets, and is *case sensitive* -->
+    <VcpkgPlatformTarget Condition="'$(Platform)'=='ARM64'">arm64</VcpkgPlatformTarget>
+
     <VcpkgAdditionalInstallOptions>--x-feature=terminal</VcpkgAdditionalInstallOptions>
     <!--
       Since we link everything statically, we don't need to copy anything.


### PR DESCRIPTION
microsoft/vcpkg-tool#1474 now validates that the target triplet is valid. Unfortunately, `ARM64` is not valid... despite VS defaulting to it.

VS 17.12 moved to the newer version of the vcpkg tool.

Given that we still want to build on VS 17.12, this commit adds a local workaround.

See DD-2302065 for the internal tracking bug.
 
See microsoft/vcpkg#42182 for the upstream fix.