### PR TITLE
Improve correctness of Sixel background fill

### DIFF
--- a/src/terminal/adapter/SixelParser.cpp
+++ b/src/terminal/adapter/SixelParser.cpp
@@ -712,20 +712,20 @@ void SixelParser::_fillImageBackgroundWhenScrolled()
     if (_filledBackgroundHeight && imageHeight > _filledBackgroundHeight) [[unlikely]]
     {
         _filledBackgroundHeight = (imageHeight + _cellSize.height - 1) / _cellSize.height * _cellSize.height;
-        const auto additionalFillHeight = _filledBackgroundHeight.value() - _imageCursor.y;
+        const auto additionalFillHeight = *_filledBackgroundHeight - _imageCursor.y;
         _resizeImageBuffer(additionalFillHeight);
         _fillImageBackground(additionalFillHeight);
     }
 }
 
-void SixelParser::_decreaseFilledBackgroundHeight(const int decreasedHeight)
+void SixelParser::_decreaseFilledBackgroundHeight(const int decreasedHeight) noexcept
 {
     // Sometimes the top of the image buffer may be clipped (e.g. when the image
     // scrolls off the top of a margin area). When that occurs, our record of
     // the filled height will need to be decreased to account for the new start.
     if (_filledBackgroundHeight) [[unlikely]]
     {
-        _filledBackgroundHeight = _filledBackgroundHeight.value() - decreasedHeight;
+        _filledBackgroundHeight = *_filledBackgroundHeight - decreasedHeight;
     }
 }
 

--- a/src/terminal/adapter/SixelParser.cpp
+++ b/src/terminal/adapter/SixelParser.cpp
@@ -380,6 +380,15 @@ void SixelParser::_updateRasterAttributes(const VTParameters& rasterAttributes)
     // back to the dimensions from an earlier raster attributes command.
     _backgroundSize.width = width > 0 ? width : _backgroundSize.width;
     _backgroundSize.height = height > 0 ? height : _backgroundSize.height;
+
+    // If the aspect ratio has changed, the image height may increase, and that
+    // could potentially trigger a scroll requiring the background to be filled.
+    _fillImageBackgroundWhenScrolled();
+
+    // And while not documented, we know from testing on a VT330 that the raster
+    // attributes command should also trigger a carriage return. This applies
+    // regardless of whether the requested aspect ratio is valid or not.
+    _executeCarriageReturn();
 }
 
 void SixelParser::_scrollTextBuffer(Page& page, const int scrollAmount)

--- a/src/terminal/adapter/SixelParser.hpp
+++ b/src/terminal/adapter/SixelParser.hpp
@@ -89,6 +89,7 @@ namespace Microsoft::Console::VirtualTerminal
         til::CoordType _pendingTextScrollCount = 0;
         til::size _backgroundSize;
         bool _backgroundFillRequired = false;
+        bool _resizeFillRequired = false;
 
         void _initColorMap(const VTParameter backgroundColor);
         void _defineColor(const VTParameters& colorParameters);
@@ -109,6 +110,7 @@ namespace Microsoft::Console::VirtualTerminal
         void _initImageBuffer();
         void _resizeImageBuffer(const til::CoordType requiredHeight);
         void _fillImageBackground();
+        void _fillImageBackground(const int backgroundHeight);
         void _writeToImageBuffer(const int sixelValue, const int repeatCount);
         void _eraseImageBufferRows(const int rowCount, const til::CoordType startRow = 0) noexcept;
         void _maybeFlushImageBuffer(const bool endOfSequence = false);

--- a/src/terminal/adapter/SixelParser.hpp
+++ b/src/terminal/adapter/SixelParser.hpp
@@ -89,7 +89,7 @@ namespace Microsoft::Console::VirtualTerminal
         til::CoordType _pendingTextScrollCount = 0;
         til::size _backgroundSize;
         bool _backgroundFillRequired = false;
-        bool _resizeFillRequired = false;
+        std::optional<til::CoordType> _filledBackgroundHeight;
 
         void _initColorMap(const VTParameter backgroundColor);
         void _defineColor(const VTParameters& colorParameters);
@@ -111,6 +111,8 @@ namespace Microsoft::Console::VirtualTerminal
         void _resizeImageBuffer(const til::CoordType requiredHeight);
         void _fillImageBackground();
         void _fillImageBackground(const int backgroundHeight);
+        void _fillImageBackgroundWhenScrolled();
+        void _decreaseFilledBackgroundHeight(const int decreasedHeight);
         void _writeToImageBuffer(const int sixelValue, const int repeatCount);
         void _eraseImageBufferRows(const int rowCount, const til::CoordType startRow = 0) noexcept;
         void _maybeFlushImageBuffer(const bool endOfSequence = false);

--- a/src/terminal/adapter/SixelParser.hpp
+++ b/src/terminal/adapter/SixelParser.hpp
@@ -112,7 +112,7 @@ namespace Microsoft::Console::VirtualTerminal
         void _fillImageBackground();
         void _fillImageBackground(const int backgroundHeight);
         void _fillImageBackgroundWhenScrolled();
-        void _decreaseFilledBackgroundHeight(const int decreasedHeight);
+        void _decreaseFilledBackgroundHeight(const int decreasedHeight) noexcept;
         void _writeToImageBuffer(const int sixelValue, const int repeatCount);
         void _eraseImageBufferRows(const int rowCount, const til::CoordType startRow = 0) noexcept;
         void _maybeFlushImageBuffer(const bool endOfSequence = false);


### PR DESCRIPTION
## Summary of the Pull Request

This is an attempt to improve the correctness of the background fill
that the Sixel parser performs when an image is scrolled because it
doesn't fit on the screen.

This new behavior may not be exactly correct, but does at least match
the VT330 and VT340 hardware more closely than it did before.

## References and Relevant Issues

The initial Sixel parser implementation was in PR #17421.

## Detailed Description of the Pull Request / Additional comments

When a Sixel image has the background select parameter set to 0 or 2, it
fills the background up to the active raster attribute dimensions prior
to writing out any actual pixel data. But this fill operation is clamped
at the boundaries of the screen, so if the image doesn't fit, and needs
to scroll, we have to perform an additional fill at that point to cover
the background of the newly revealed rows (this is something we weren't
doing before).

This later fill uses the width of the most recent raster attributes
command, which is not necessarily the same as the initial background
fill, and fills the entire height of the new rows, regardless of the
height specified in the raster attributes command.

## Validation Steps Performed

Thanks to @al20878 and @hackerb9, we've been able to test on both a
VT330 and a VT340, and I've confirmed that we're matching the behavior
of those terminals as closely as possible. There are some edge cases
where they don't agree with each other, so we can't always match both.

I've also confirmed that the test case in issue #17946 now matches what
the OP was expecting, and the test case in #17887 at least works more
consistently now when scrolling (this is not what the OP was expecting
though).

## PR Checklist
- [x] Closes #17887
- [x] Closes #17946
