### PR TITLE
[needs gcs linkage] Modify the Chinese translation of 亚克力材料 to 亚克力效果

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
@@ -517,7 +517,7 @@
     <comment>A description for what the "show titlebar" setting does. Presented near "Globals_ShowTitlebar.Header".</comment>
   </data>
   <data name="Globals_AcrylicTabRow.Header" xml:space="preserve">
-    <value>在选项卡行中使用亚克力材料</value>
+    <value>在选项卡行中使用亚克力效果</value>
     <comment>Header for a control to toggle whether "acrylic material" is used. "Acrylic material" is a Microsoft-specific term: https://docs.microsoft.com/en-us/windows/apps/design/style/acrylic</comment>
   </data>
   <data name="Globals_ShowTitleInTitlebar.Header" xml:space="preserve">
@@ -1250,7 +1250,7 @@
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
   </data>
   <data name="Profile_UseAcrylic.Header" xml:space="preserve">
-    <value>启用亚克力材料</value>
+    <value>启用亚克力效果</value>
     <comment>Header for a control to toggle the use of acrylic material for the background. "Acrylic material" is a Microsoft-specific term: https://docs.microsoft.com/en-us/windows/apps/design/style/acrylic</comment>
   </data>
   <data name="Profile_UseAcrylic.HelpText" xml:space="preserve">
@@ -1950,7 +1950,7 @@
     <comment>Additional text for a control to toggle adding a set of key bindings that can be used to apply coloring to selected text in a terminal session. Presented near "Globals_EnableColorSelection.Header".</comment>
   </data>
   <data name="Globals_EnableUnfocusedAcrylic.Header" xml:space="preserve">
-    <value>允许非聚焦窗口使用亚克力材料</value>
+    <value>允许非聚焦窗口使用亚克力效果</value>
     <comment>Header for a control to toggle allowing unfocused windows to have an acrylic background.</comment>
   </data>
   <data name="Globals_ShowAdminShield.Header" xml:space="preserve">


### PR DESCRIPTION
## Summary of the Pull Request

![image](https://github.com/user-attachments/assets/225a9d54-67d3-4f48-915b-024ebbd0b9ec)
When I used the Microsoft Terminal again, I found that the translation of "在选项卡行中使用亚克力材料" in the settings was not accurate, and it was more reasonable to translate it as "在选项卡行中使用亚克力效果"

## Validation Steps Performed

翻译除了要表单准确的意思 还要利于理解！
Translation requires not only the exact meaning of the form, but also easy to understand!

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
