### PR TITLE
Replace MarkKind::None with MarkKind::Output

### DIFF
--- a/src/buffer/out/TextAttribute.cpp
+++ b/src/buffer/out/TextAttribute.cpp
@@ -393,5 +393,5 @@ void TextAttribute::SetStandardErase() noexcept
 {
     _attrs = CharacterAttributes::Normal;
     _hyperlinkId = 0;
-    _markKind = MarkKind::None;
+    _markKind = MarkKind::Output;
 }

--- a/src/buffer/out/TextAttribute.hpp
+++ b/src/buffer/out/TextAttribute.hpp
@@ -41,10 +41,9 @@ enum class UnderlineStyle
 // We only need a few bits, but uint8_t apparently doesn't satisfy std::has_unique_object_representations_v
 enum class MarkKind : uint16_t
 {
-    None = 0,
+    Output = 0,
     Prompt = 1,
     Command = 2,
-    Output = 3,
 };
 
 class TextAttribute final
@@ -56,7 +55,7 @@ public:
         _background{},
         _hyperlinkId{ 0 },
         _underlineColor{},
-        _markKind{ MarkKind::None }
+        _markKind{ MarkKind::Output }
     {
     }
 
@@ -66,7 +65,7 @@ public:
         _background{ gsl::at(s_legacyBackgroundColorMap, (wLegacyAttr & BG_ATTRS) >> 4) },
         _hyperlinkId{ 0 },
         _underlineColor{},
-        _markKind{ MarkKind::None }
+        _markKind{ MarkKind::Output }
     {
     }
 
@@ -78,7 +77,7 @@ public:
         _background{ rgbBackground },
         _hyperlinkId{ 0 },
         _underlineColor{ rgbUnderline },
-        _markKind{ MarkKind::None }
+        _markKind{ MarkKind::Output }
     {
     }
 
@@ -88,7 +87,7 @@ public:
         _background{ background },
         _hyperlinkId{ hyperlinkId },
         _underlineColor{ underlineColor },
-        _markKind{ MarkKind::None }
+        _markKind{ MarkKind::Output }
     {
     }
 

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -3221,7 +3221,7 @@ void TextBuffer::ClearMarksInRange(
         row.SetScrollbarData(std::nullopt);
         for (auto& [attr, length] : runs)
         {
-            attr.SetMarkAttributes(MarkKind::None);
+            attr.SetMarkAttributes(MarkKind::Output);
         }
     }
 }
@@ -3246,7 +3246,6 @@ MarkExtents TextBuffer::_scrollMarkExtentForRow(const til::CoordType rowOffset,
     bool startedPrompt = false;
     bool startedCommand = false;
     bool startedOutput = false;
-    MarkKind lastMarkKind = MarkKind::Output;
 
     const auto endThisMark = [&](auto x, auto y) {
         if (startedOutput)
@@ -3280,7 +3279,7 @@ MarkExtents TextBuffer::_scrollMarkExtentForRow(const til::CoordType rowOffset,
             const auto nextX = gsl::narrow_cast<uint16_t>(x + length);
             const auto markKind{ attr.GetMarkAttributes() };
 
-            if (markKind != MarkKind::None)
+            if (markKind != MarkKind::Output)
             {
                 lastMarkedText = { nextX, y };
 
@@ -3316,8 +3315,6 @@ MarkExtents TextBuffer::_scrollMarkExtentForRow(const til::CoordType rowOffset,
 
                     endThisMark(lastMarkedText.x, lastMarkedText.y);
                 }
-                // Otherwise, we've changed from any state -> any state, and it doesn't really matter.
-                lastMarkKind = markKind;
             }
             // advance to next run of text
             x = nextX;
@@ -3510,7 +3507,7 @@ bool TextBuffer::StartOutput()
 // the exit code on that row's scroll mark.
 void TextBuffer::EndCurrentCommand(std::optional<unsigned int> error)
 {
-    _currentAttributes.SetMarkAttributes(MarkKind::None);
+    _currentAttributes.SetMarkAttributes(MarkKind::Output);
 
     for (auto y = GetCursor().GetPosition().y; y >= 0; y--)
     {


### PR DESCRIPTION
During the development of #18290 I noticed that we caused a performance
regression due to the storage of marks in attributes. Since the default
attribute is None and any output sets it to Output, this meant that
every row of output would at least temporarily allocate heap memory.
This caused cls on a huge history to take twice as long as before.

## Validation Steps Performed
* How do I test this? ❓