### PR TITLE
Fix colored tab losing color when unselected

### DIFF
--- a/src/cascadia/TerminalApp/TabBase.cpp
+++ b/src/cascadia/TerminalApp/TabBase.cpp
@@ -528,6 +528,9 @@ namespace winrt::TerminalApp::implementation
         tabItemThemeResources.Insert(winrt::box_value(L"Dark"), darkThemeDictionary);
         tabItemThemeResources.Insert(winrt::box_value(L"HighContrast"), highContrastThemeDictionary);
 
+        // Apply the color to the tab
+        TabViewItem().Background(deselectedTabBrush);
+
         // Now actually set the resources we want in them.
         // Before, we used to put these on the ResourceDictionary directly.
         // However, HighContrast mode may require some adjustments. So let's just add
@@ -560,7 +563,6 @@ namespace winrt::TerminalApp::implementation
             currentDictionary.Insert(winrt::box_value(L"TabViewItemHeaderSelectedCloseButtonForeground"), fontBrush);
 
             // TabViewItem.CloseButton.Background (aka X button)
-            currentDictionary.Insert(winrt::box_value(L"TabViewItemHeaderCloseButtonBackground"), deselectedTabBrush);
             currentDictionary.Insert(winrt::box_value(L"TabViewItemHeaderCloseButtonBackgroundPressed"), isHighContrast ? selectedTabBrush : subtleFillColorTertiaryBrush);
             currentDictionary.Insert(winrt::box_value(L"TabViewItemHeaderCloseButtonBackgroundPointerOver"), isHighContrast ? selectedTabBrush : subtleFillColorSecondaryBrush);
 


### PR DESCRIPTION
If we colored a tab, then switched to another tab, there's a bug that the unselected tab loses its color. This was introduced in PR #18109. This PR fixes that by actually applying the selected color to the tab (whoops). Additionally, I removed setting the "TabViewItemHeaderCloseButtonBackground" resource because it looked weird (see comment in PR).

Closes #18226
