### PR TITLE
Reduce likelihood of races between stdout and cooked stdin reads

### DIFF
--- a/src/host/readDataCooked.hpp
+++ b/src/host/readDataCooked.hpp
@@ -36,7 +36,7 @@ public:
     void SetInsertMode(bool insertMode) noexcept;
     bool IsEmpty() const noexcept;
     bool PresentingPopup() const noexcept;
-    til::point_span GetBoundaries() const noexcept;
+    til::point_span GetBoundaries() noexcept;
 
 private:
     static constexpr size_t CommandNumberMaxInputLength = 5;
@@ -129,6 +129,7 @@ private:
     void _handlePostCharInputLoop(bool isUnicode, size_t& numBytes, ULONG& controlKeyState);
     void _transitionState(State state) noexcept;
     til::point _getViewportCursorPosition() const noexcept;
+    til::point _getOriginInViewport() noexcept;
     void _replace(size_t offset, size_t remove, const wchar_t* input, size_t count);
     void _replace(const std::wstring_view& str);
     std::wstring_view _slice(size_t from, size_t to) const noexcept;
@@ -166,7 +167,7 @@ private:
     bool _redrawPending = false;
     bool _clearPending = false;
 
-    til::point _originInViewport;
+    std::optional<til::point> _originInViewport;
     // This value is in the pager coordinate space. (0,0) is the first character of the
     // first line, independent on where the prompt actually appears on the screen.
     // The coordinate is "end exclusive", so the last character is 1 in front of it.

--- a/src/host/selectionInput.cpp
+++ b/src/host/selectionInput.cpp
@@ -926,7 +926,7 @@ bool Selection::_HandleMarkModeSelectionNav(const INPUT_KEY_INFO* const pInputKe
 // - If true, the boundaries returned are valid. If false, they should be discarded.
 [[nodiscard]] bool Selection::s_GetInputLineBoundaries(_Out_opt_ til::point* const pcoordInputStart, _Out_opt_ til::point* const pcoordInputEnd)
 {
-    const auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
+    auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
 
     if (gci.HasPendingCookedRead())
     {


### PR DESCRIPTION
As explained in the comment on `_getViewportCursorPosition`, printing
to stdout after initiating a cooked stdin reads is a race condition
between the application and the terminal. But we can significantly
reduce the likelihood of this being obvious with this change.

Related to #18265
Possibly related to #18081

## Validation Steps Performed

Execute the following Go code and start typing:
```go
package main

import (
	"fmt"
	"time"
)

func main() {
	go func() {
		time.Sleep(50 * time.Millisecond)
		fmt.Printf("Here is a prompt! >")
	}()

	var text string
	fmt.Scanln(&text)
}
```

Without this change the prompt will disappear,
and with this change in place, it'll work as expected. ✅