### PR TITLE
Added lowerbound check for array enum

### DIFF
--- a/oss/fmt/include/fmt/core.h
+++ b/oss/fmt/include/fmt/core.h
@@ -1900,7 +1900,7 @@ template <typename Context> class basic_format_args {
       if (id < max_size()) arg = args_[id];
       return arg;
     }
-    if (id >= detail::max_packed_args) return arg;
+    if (id >= detail::max_packed_args || id < 0) return arg;
     arg.type_ = type(id);
     if (arg.type_ == detail::type::none_type) return arg;
     arg.value_ = values_[id];


### PR DESCRIPTION
## Summary of the Pull Request
CodeQL raised a bug regarding an array enumerator not being checked for lower bound. 

## References and Relevant Issues
CodeQL bug link: https://liquid.microsoft.com/codeql/issues/0d211448-e38b-41b4-8d31-0c49ab313e37?copilot_promptid=E91B0CE9-0C1B-4AC2-8A46-33F49B67E058

## Detailed Description of the Pull Request / Additional comments
Adds lower bound check for an array index.

## Validation Steps Performed

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
