### PR TITLE
Fix multiple regressions since #18215

### DIFF
--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -815,7 +815,7 @@ void AppHost::_WindowActivated(bool activated)
 {
     _windowLogic.WindowActivated(activated);
 
-    if (activated && _isWindowInitialized != WindowInitializedState::NotInitialized)
+    if (activated)
     {
         QueryPerformanceCounter(&_lastActivatedTime);
         _virtualDesktopId = {};

--- a/src/cascadia/WindowsTerminal/WindowEmperor.h
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.h
@@ -50,6 +50,7 @@ private:
     AppHost* _mostRecentWindow() const noexcept;
     bool _summonWindow(const SummonWindowSelectionArgs& args) const;
     void _summonAllWindows() const;
+    void _dispatchSpecialKey(MSG& msg) const;
     void _dispatchCommandline(winrt::TerminalApp::CommandlineArgs args);
     safe_void_coroutine _dispatchCommandlineCurrentDesktop(winrt::TerminalApp::CommandlineArgs args);
     LRESULT _messageHandler(HWND window, UINT message, WPARAM wParam, LPARAM lParam) noexcept;


### PR DESCRIPTION
Fixes
* Cursor vanishing, because
  ```cpp
  CoreWindow::GetForCurrentThread().PointerCursor()
  ```
  returned a non-null, but still invisible cursor.
* Alt/F7 not dispatching to newly created windows, because the
  `WM_ACTIVATE` message now arrives before the `AppHost` is initialized.
  This caused the messages to be delivered to old windows.
* Windows Terminal blocking expedited shutdown,
  because we return `FALSE` on non-`ENDSESSION_CLOSEAPP` messages.

Closes #18331
Closes #18335

## Validation Steps Performed
* Cursor still doesn't really vanish for me in the first place ✅
* Alt/F7 work in new windows without triggering old ones ✅