### PR TITLE
Add support for tabbing to embedded hyperlinks

### DIFF
--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -601,19 +601,16 @@ void Terminal::SelectHyperlink(const SearchDirection dir)
     {
         return;
     }
-    else
-    {
-        auto selection{ _selection.write() };
-        wil::hide_name _selection;
-        selection->start = result->first;
-        selection->pivot = result->first;
-        selection->end = result->second;
-        _selectionIsTargetingUrl = true;
-        _selectionEndpoint = SelectionEndpoint::End;
-    }
+    auto selection{ _selection.write() };
+    wil::hide_name _selection;
+    selection->start = result->first;
+    selection->pivot = result->first;
+    selection->end = result->second;
+    _selectionIsTargetingUrl = true;
+    _selectionEndpoint = SelectionEndpoint::End;
 
     // 4. Scroll to the selected area (if necessary)
-    _ScrollToPoint(_selection->end);
+    _ScrollToPoint(selection->end);
 }
 
 Terminal::UpdateSelectionParams Terminal::ConvertKeyEventToUpdateSelectionParams(const ControlKeyStates mods, const WORD vkey) const noexcept


### PR DESCRIPTION
## Summary of the Pull Request
There's already logic to tab to a hyperlink when we're in mark mode. We do this by looking at the automatically detected hyperlinks and finding the next one of interest. This adds an extra step afterwards to find any embedded hyperlinks and tab to them too.

Since embedded hyperlinks are stored as text attributes, we need to iterate through the buffer to find the hyperlink and it's buffer boundaries. This PR tries to reduce the workload of that by first finding the automatically detected hyperlinks (since that's a fairly quick process), then using the reduced search area to find the embedded hyperlink (if one exists).

## Validation Steps Performed
In PowerShell, add an embedded hyperlink as such:
```powershell
${ESC}=[char]27
Write-Host "${ESC}]8;;https://github.com/microsoft/terminal${ESC}\This is a link!${ESC}]8;;${ESC}\"
```
Enter mark mode (ctrl+shift+m) then shift+tab to it.
✅ The "This is a link!" is selected
✅ Verified that this works when searching forwards and backwards

Closes #18310
Closes #15194 
Follow-up from #13405
OSC 8 support added in #7251