### PR TITLE
[Enterprise, GPO] Add "Default Terminal app" policy to definition template

### DIFF
--- a/policies/WindowsTerminal.admx
+++ b/policies/WindowsTerminal.admx
@@ -1,85 +1,85 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--  (c) 2024 Microsoft Corporation  -->
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
-	<policyNamespaces>
-		<target prefix="terminal" namespace="Microsoft.Policies.WindowsTerminal"/>
-		<using prefix="windows" namespace="Microsoft.Policies.Windows"/>
-	</policyNamespaces>
-	<resources minRequiredRevision="1.0"/>
-	<supportedOn>
-		<definitions>
-			<definition name="SUPPORTED_WindowsTerminal_1_21" displayName="$(string.SUPPORTED_WindowsTerminal_1_21)"/>
-			<definition name="SUPPORTED_DefaultTerminalApplication" displayName="$(string.SUPPORTED_DefaultTerminalApplication)"/>
-		</definitions>
-	</supportedOn>
-	<categories>
-		<category name="WindowsTerminal" displayName="$(string.WindowsTerminal)">
-			<parentCategory ref="windows:WindowsComponents"/>
-		</category>
-	</categories>
-	<policies>
-		<policy name="DisabledProfileSources" class="Both" displayName="$(string.DisabledProfileSources)" explainText="$(string.DisabledProfileSourcesText)" presentation="$(presentation.DisabledProfileSources)" key="Software\Policies\Microsoft\Windows Terminal">
-			<parentCategory ref="WindowsTerminal"/>
-			<supportedOn ref="SUPPORTED_WindowsTerminal_1_21"/>
-			<elements>
-				<multiText id="DisabledProfileSources" valueName="DisabledProfileSources" required="true"/>
-			</elements>
-		</policy>
-		<policy name="DefaultTerminalApplication" class="User" displayName="$(string.DefaultTerminalApplication)" explainText="$(string.DefaultTerminalApplicationText)" presentation="$(presentation.TermAppSelection)" key="Console\%%Startup">
-			<parentCategory ref="WindowsTerminal"/>
-			<supportedOn ref="SUPPORTED_DefaultTerminalApplication"/>
-			<elements>
-				<enum id="TermAppSelect" required="true" valueName="DelegationTerminal">
-					<item displayName="$(string.TermAppAutomatic)">
-						<value>
-							<string>{00000000-0000-0000-0000-000000000000}</string>
-						</value>
-						<valueList>
-							<item key="Console\%%Startup" valueName="DelegationConsole">
-								<value>
-									<string>{00000000-0000-0000-0000-000000000000}</string>
-								</value>
-							</item>
-						</valueList>
-					</item>
-					<item displayName="$(string.TermAppConsoleHost)">
-						<value>
-							<string>{B23D10C0-E52E-411E-9D5B-C09FDF709C7D}</string>
-						</value>
-						<valueList>
-							<item key="Console\%%Startup" valueName="DelegationConsole">
-								<value>
-									<string>{B23D10C0-E52E-411E-9D5B-C09FDF709C7D}</string>
-								</value>
-							</item>
-						</valueList>
-					</item>
-					<item displayName="$(string.TermAppWindowsTerminal)">
-						<value>
-							<string>{E12CFF52-A866-4C77-9A90-F570A7AA2C6B}</string>
-						</value>
-						<valueList>
-							<item key="Console\%%Startup" valueName="DelegationConsole">
-								<value>
-									<string>{2EACA947-7F5F-4CFA-BA87-8F7FBEEFBE69}</string>
-								</value>
-							</item>
-						</valueList>
-					</item>
-					<item displayName="$(string.TermAppWindowsTerminalPreview)">
-						<value>
-							<string>{86633F1F-6454-40EC-89CE-DA4EBA977EE2}</string>
-						</value>
-						<valueList>
-							<item key="Console\%%Startup" valueName="DelegationConsole">
-								<value>
-									<string>{06EC847C-C0A5-46B8-92CB-7C92F6E35CD5}</string>
-								</value>
-							</item>
-						</valueList>
-					</item>
-				</enum>
-			</elements>
-		</policy>
-	</policies>
+  <policyNamespaces>
+    <target prefix="terminal" namespace="Microsoft.Policies.WindowsTerminal" />
+    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+  </policyNamespaces>
+  <resources minRequiredRevision="1.0" />
+  <supportedOn>
+    <definitions>
+      <definition name="SUPPORTED_WindowsTerminal_1_21" displayName="$(string.SUPPORTED_WindowsTerminal_1_21)" />
+      <definition name="SUPPORTED_DefaultTerminalApplication" displayName="$(string.SUPPORTED_DefaultTerminalApplication)" />
+    </definitions>
+  </supportedOn>
+  <categories>
+    <category name="WindowsTerminal" displayName="$(string.WindowsTerminal)">
+      <parentCategory ref="windows:WindowsComponents" />
+    </category>
+  </categories>
+  <policies>
+    <policy name="DisabledProfileSources" class="Both" displayName="$(string.DisabledProfileSources)" explainText="$(string.DisabledProfileSourcesText)" presentation="$(presentation.DisabledProfileSources)" key="Software\Policies\Microsoft\Windows Terminal">
+      <parentCategory ref="WindowsTerminal" />
+      <supportedOn ref="SUPPORTED_WindowsTerminal_1_21" />
+      <elements>
+        <multiText id="DisabledProfileSources" valueName="DisabledProfileSources" required="true" />
+      </elements>
+    </policy>
+    <policy name="DefaultTerminalApplication" class="User" displayName="$(string.DefaultTerminalApplication)" explainText="$(string.DefaultTerminalApplicationText)" presentation="$(presentation.TermAppSelection)" key="Console\%%Startup">
+      <parentCategory ref="WindowsTerminal" />
+      <supportedOn ref="SUPPORTED_DefaultTerminalApplication" />
+      <elements>
+        <enum id="TermAppSelect" required="true" valueName="DelegationTerminal">
+          <item displayName="$(string.TermAppAutomatic)">
+            <value>
+              <string>{00000000-0000-0000-0000-000000000000}</string>
+            </value>
+            <valueList>
+              <item key="Console\%%Startup" valueName="DelegationConsole">
+                <value>
+                  <string>{00000000-0000-0000-0000-000000000000}</string>
+                </value>
+              </item>
+            </valueList>
+          </item>
+          <item displayName="$(string.TermAppConsoleHost)">
+            <value>
+              <string>{B23D10C0-E52E-411E-9D5B-C09FDF709C7D}</string>
+            </value>
+            <valueList>
+              <item key="Console\%%Startup" valueName="DelegationConsole">
+                <value>
+                  <string>{B23D10C0-E52E-411E-9D5B-C09FDF709C7D}</string>
+                </value>
+              </item>
+            </valueList>
+          </item>
+          <item displayName="$(string.TermAppWindowsTerminal)">
+            <value>
+              <string>{E12CFF52-A866-4C77-9A90-F570A7AA2C6B}</string>
+            </value>
+            <valueList>
+              <item key="Console\%%Startup" valueName="DelegationConsole">
+                <value>
+                  <string>{2EACA947-7F5F-4CFA-BA87-8F7FBEEFBE69}</string>
+                </value>
+              </item>
+            </valueList>
+          </item>
+          <item displayName="$(string.TermAppWindowsTerminalPreview)">
+            <value>
+              <string>{86633F1F-6454-40EC-89CE-DA4EBA977EE2}</string>
+            </value>
+            <valueList>
+              <item key="Console\%%Startup" valueName="DelegationConsole">
+                <value>
+                  <string>{06EC847C-C0A5-46B8-92CB-7C92F6E35CD5}</string>
+                </value>
+              </item>
+            </valueList>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+  </policies>
 </policyDefinitions>

--- a/policies/WindowsTerminal.admx
+++ b/policies/WindowsTerminal.admx
@@ -1,28 +1,85 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--  (c) 2024 Microsoft Corporation  -->
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
-  <policyNamespaces>
-    <target prefix="terminal" namespace="Microsoft.Policies.WindowsTerminal" />
-    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
-  </policyNamespaces>
-  <resources minRequiredRevision="1.0" />
-  <supportedOn>
-    <definitions>
-      <definition name="SUPPORTED_WindowsTerminal_1_21" displayName="$(string.SUPPORTED_WindowsTerminal_1_21)" />
-    </definitions>
-  </supportedOn>
-  <categories>
-    <category name="WindowsTerminal" displayName="$(string.WindowsTerminal)">
-      <parentCategory ref="windows:WindowsComponents" />
-    </category>
-  </categories>
-  <policies>
-    <policy name="DisabledProfileSources" class="Both" displayName="$(string.DisabledProfileSources)" explainText="$(string.DisabledProfileSourcesText)" presentation="$(presentation.DisabledProfileSources)" key="Software\Policies\Microsoft\Windows Terminal">
-      <parentCategory ref="WindowsTerminal" />
-      <supportedOn ref="SUPPORTED_WindowsTerminal_1_21" />
-      <elements>
-        <multiText id="DisabledProfileSources" valueName="DisabledProfileSources" required="true" />
-      </elements>
-    </policy>
-  </policies>
+	<policyNamespaces>
+		<target prefix="terminal" namespace="Microsoft.Policies.WindowsTerminal"/>
+		<using prefix="windows" namespace="Microsoft.Policies.Windows"/>
+	</policyNamespaces>
+	<resources minRequiredRevision="1.0"/>
+	<supportedOn>
+		<definitions>
+			<definition name="SUPPORTED_WindowsTerminal_1_21" displayName="$(string.SUPPORTED_WindowsTerminal_1_21)"/>
+			<definition name="SUPPORTED_DefaultTerminalApplication" displayName="$(string.SUPPORTED_DefaultTerminalApplication)"/>
+		</definitions>
+	</supportedOn>
+	<categories>
+		<category name="WindowsTerminal" displayName="$(string.WindowsTerminal)">
+			<parentCategory ref="windows:WindowsComponents"/>
+		</category>
+	</categories>
+	<policies>
+		<policy name="DisabledProfileSources" class="Both" displayName="$(string.DisabledProfileSources)" explainText="$(string.DisabledProfileSourcesText)" presentation="$(presentation.DisabledProfileSources)" key="Software\Policies\Microsoft\Windows Terminal">
+			<parentCategory ref="WindowsTerminal"/>
+			<supportedOn ref="SUPPORTED_WindowsTerminal_1_21"/>
+			<elements>
+				<multiText id="DisabledProfileSources" valueName="DisabledProfileSources" required="true"/>
+			</elements>
+		</policy>
+		<policy name="DefaultTerminalApplication" class="User" displayName="$(string.DefaultTerminalApplication)" explainText="$(string.DefaultTerminalApplicationText)" presentation="$(presentation.TermAppSelection)" key="Console\%%Startup">
+			<parentCategory ref="WindowsTerminal"/>
+			<supportedOn ref="SUPPORTED_DefaultTerminalApplication"/>
+			<elements>
+				<enum id="TermAppSelect" required="true" valueName="DelegationTerminal">
+					<item displayName="$(string.TermAppAutomatic)">
+						<value>
+							<string>{00000000-0000-0000-0000-000000000000}</string>
+						</value>
+						<valueList>
+							<item key="Console\%%Startup" valueName="DelegationConsole">
+								<value>
+									<string>{00000000-0000-0000-0000-000000000000}</string>
+								</value>
+							</item>
+						</valueList>
+					</item>
+					<item displayName="$(string.TermAppConsoleHost)">
+						<value>
+							<string>{B23D10C0-E52E-411E-9D5B-C09FDF709C7D}</string>
+						</value>
+						<valueList>
+							<item key="Console\%%Startup" valueName="DelegationConsole">
+								<value>
+									<string>{B23D10C0-E52E-411E-9D5B-C09FDF709C7D}</string>
+								</value>
+							</item>
+						</valueList>
+					</item>
+					<item displayName="$(string.TermAppWindowsTerminal)">
+						<value>
+							<string>{E12CFF52-A866-4C77-9A90-F570A7AA2C6B}</string>
+						</value>
+						<valueList>
+							<item key="Console\%%Startup" valueName="DelegationConsole">
+								<value>
+									<string>{2EACA947-7F5F-4CFA-BA87-8F7FBEEFBE69}</string>
+								</value>
+							</item>
+						</valueList>
+					</item>
+					<item displayName="$(string.TermAppWindowsTerminalPreview)">
+						<value>
+							<string>{86633F1F-6454-40EC-89CE-DA4EBA977EE2}</string>
+						</value>
+						<valueList>
+							<item key="Console\%%Startup" valueName="DelegationConsole">
+								<value>
+									<string>{06EC847C-C0A5-46B8-92CB-7C92F6E35CD5}</string>
+								</value>
+							</item>
+						</valueList>
+					</item>
+				</enum>
+			</elements>
+		</policy>
+	</policies>
 </policyDefinitions>

--- a/policies/en-US/WindowsTerminal.adml
+++ b/policies/en-US/WindowsTerminal.adml
@@ -23,10 +23,10 @@ Note: Existing profiles will disappear from Windows Terminal after adding their 
       <string id="DefaultTerminalApplicationText">Select the default terminal application used in Windows.
 
 If you select Windows Terminal Preview and it is not installed the system will fallback to the legacy Windows Console Host. (Please note that the settings interfaces showing "Let windows decide" in this case as configuration.)</string>
-	  <string id="TermAppAutomatic">Automatic selection (Windows Terminal, if available)</string>
-	  <string id="TermAppConsoleHost">Windows Console Host (legacy)</string>
-	  <string id="TermAppWindowsTerminal">Windows Terminal</string>
-	  <string id="TermAppWindowsTerminalPreview">Windows Terminal Preview (if available)</string>
+      <string id="TermAppAutomatic">Automatic selection (Windows Terminal, if available)</string>
+      <string id="TermAppConsoleHost">Windows Console Host (legacy)</string>
+      <string id="TermAppWindowsTerminal">Windows Terminal</string>
+      <string id="TermAppWindowsTerminalPreview">Windows Terminal Preview (if available)</string>
     </stringTable>
     <presentationTable>
       <presentation id="DisabledProfileSources">

--- a/policies/en-US/WindowsTerminal.adml
+++ b/policies/en-US/WindowsTerminal.adml
@@ -7,6 +7,7 @@
     <stringTable>
       <string id="WindowsTerminal">Windows Terminal</string>
       <string id="SUPPORTED_WindowsTerminal_1_21">At least Windows Terminal 1.21</string>
+      <string id="SUPPORTED_DefaultTerminalApplication">At least Windows 11 22H2 or Windows 10 22H2 (Build 19045.3031, KB5026435) with Windows Terminal 1.17</string>
       <string id="DisabledProfileSources">Disabled Profile Sources</string>
       <string id="DisabledProfileSourcesText">Profiles will not be generated from any sources listed here. Source names can be arbitrary strings. Potential candidates can be found as the "source" property on profile definitions in Windows Terminal's settings.json file.
 
@@ -18,10 +19,21 @@ Common sources are:
 For instance, setting this policy to Windows.Terminal.Wsl will disable the builtin WSL integration of Windows Terminal.
 
 Note: Existing profiles will disappear from Windows Terminal after adding their source to this policy.</string>
+      <string id="DefaultTerminalApplication">Default terminal application</string>
+      <string id="DefaultTerminalApplicationText">Select the default terminal application used in Windows.
+
+If you select Windows Terminal Preview and it is not installed the system will fallback to Windows Console Host (legacy). (Please note that the settings interfaces showing "Let windows decide" in this case as configuration.)</string>
+	  <string id="TermAppAutomatic">Automatic selection (Windows Terminal, if available)</string>
+	  <string id="TermAppConsoleHost">Windows Console Host (legacy)</string>
+	  <string id="TermAppWindowsTerminal">Windows Terminal</string>
+	  <string id="TermAppWindowsTerminalPreview">Windows Terminal Preview (if available)</string>
     </stringTable>
     <presentationTable>
       <presentation id="DisabledProfileSources">
         <multiTextBox refId="DisabledProfileSources">List of disabled sources (one per line)</multiTextBox>
+      </presentation>
+      <presentation id="TermAppSelection">
+        <dropdownList refId="TermAppSelect" noSort="true" defaultItem="0">Select from the following options:</dropdownList>
       </presentation>
     </presentationTable>
   </resources>

--- a/policies/en-US/WindowsTerminal.adml
+++ b/policies/en-US/WindowsTerminal.adml
@@ -22,7 +22,7 @@ Note: Existing profiles will disappear from Windows Terminal after adding their 
       <string id="DefaultTerminalApplication">Default terminal application</string>
       <string id="DefaultTerminalApplicationText">Select the default terminal application used in Windows.
 
-If you select Windows Terminal Preview and it is not installed the system will fallback to Windows Console Host (legacy). (Please note that the settings interfaces showing "Let windows decide" in this case as configuration.)</string>
+If you select Windows Terminal Preview and it is not installed the system will fallback to the legacy Windows Console Host. (Please note that the settings interfaces showing "Let windows decide" in this case as configuration.)</string>
 	  <string id="TermAppAutomatic">Automatic selection (Windows Terminal, if available)</string>
 	  <string id="TermAppConsoleHost">Windows Console Host (legacy)</string>
 	  <string id="TermAppWindowsTerminal">Windows Terminal</string>


### PR DESCRIPTION
## Summary of the Pull Request

This PR implements a policy definition for setting/enforcing the default terminal application.

![image](https://github.com/user-attachments/assets/4607166c-0c17-4057-9ec9-fb9761f8a219)


## References and Relevant Issues

GitHub (issues):
- https://github.com/microsoft/terminal/issues/18302
- https://github.com/microsoft/terminal/discussions/18303

Docs:
- https://support.microsoft.com/en-us/windows/command-prompt-and-windows-powershell-for-windows-11-6453ce98-da91-476f-8651-5c14d5777c20
- https://github.com/microsoft/terminal/discussions/13153#discussioncomment-6064759

## Detailed Description of the Pull Request / Additional comments

This PR adds a new policy definition to the ADMX templates for settings the default Terminal application in Windows.

> [!Note]
> This PR does not change any code of Windows, Console Host or WIndows Terminal. It only adds the definiton for a new policy to the templates.

I got the registry values form the documentation and by testing the values.

The policy is only available as user policy because the registry values have to be in HKCU.

The Policy is implemented as preference (not inside the Policy key) and therefore keeps it's value on removing (not configured) it. You can see this in `gpedit.msc` on the policy symbol and the hint in the description.
![image](https://github.com/user-attachments/assets/749945ab-7e23-4cc7-98f9-41ec45bf33c3)


## Validation Steps Performed

Manual testing the policy.

## PR Checklist
- [x] Closes #18302
- [ ] Tests added/passed
- [x] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: MicrosoftDocs/terminal/pull/823
- [ ] Schema updated (if necessary)
