### PR TITLE
No longer clear the input box when Terminal chat is dismissed

### DIFF
--- a/src/cascadia/QueryExtension/ExtensionPalette.cpp
+++ b/src/cascadia/QueryExtension/ExtensionPalette.cpp
@@ -432,9 +432,6 @@ namespace winrt::Microsoft::Terminal::Query::Extension::implementation
     void ExtensionPalette::_close()
     {
         Visibility(Visibility::Collapsed);
-
-        // Clear the text box each time we close the dialog. This is consistent with VsCode.
-        _queryBox().Text(winrt::hstring{});
     }
 
     ChatMessage::ChatMessage(winrt::hstring content, bool isQuery) :


### PR DESCRIPTION
## Summary of the Pull Request
Keeps any text in the input box around if Terminal Chat is dismissed. The original behaviour was consistent with the way the command palette works but it does not quite make sense for the chat. 

## Validation Steps Performed
Input is not lost when the chat pane is closed

## PR Checklist
- [x] Closes #18151 
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
