### PR TITLE
Fix Microsoft.Windows.Console.ConPTY package runtime identifiers

### DIFF
--- a/src/winconpty/package/native/Microsoft.Windows.Console.ConPTY.targets
+++ b/src/winconpty/package/native/Microsoft.Windows.Console.ConPTY.targets
@@ -5,11 +5,11 @@
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)..\..\inc\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(ConptyNativePlatform)\lib\uap10.0\conpty.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(MSBuildThisFileDirectory)..\..\runtimes\win-$(ConptyNativePlatform)\lib\uap10.0\conpty.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(ConptyNativePlatform)\native\conpty.dll" />
+    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-$(ConptyNativePlatform)\native\conpty.dll" />
     <ReferenceCopyLocalPaths Condition="'$(ConptyRequiresx86Host)'=='true'" Include="$(MSBuildThisFileDirectory)\runtimes\x86\OpenConsole.exe">
       <DestinationSubDirectory>x86\</DestinationSubDirectory>
     </ReferenceCopyLocalPaths>

--- a/src/winconpty/package/winconpty.nuspec
+++ b/src/winconpty/package/winconpty.nuspec
@@ -19,16 +19,16 @@
 
     <file src="../../../src/inc/conpty-static.h" target="inc/conpty.h" />
 
-    <file src="../../../bin/Win32/Release/conpty.dll" target="runtimes/win10-x86/native" />
-    <file src="../../../bin/Win32/Release/conpty.lib" target="runtimes/win10-x86/lib/uap10.0" />
+    <file src="../../../bin/Win32/Release/conpty.dll" target="runtimes/win-x86/native" />
+    <file src="../../../bin/Win32/Release/conpty.lib" target="runtimes/win-x86/lib/uap10.0" />
     <file src="../../../bin/Win32/Release/OpenConsole.exe" target="build/native/runtimes/x86" />
 
-    <file src="../../../bin/x64/Release/conpty.dll" target="runtimes/win10-x64/native" />
-    <file src="../../../bin/x64/Release/conpty.lib" target="runtimes/win10-x64/lib/uap10.0" />
+    <file src="../../../bin/x64/Release/conpty.dll" target="runtimes/win-x64/native" />
+    <file src="../../../bin/x64/Release/conpty.lib" target="runtimes/win-x64/lib/uap10.0" />
     <file src="../../../bin/x64/Release/OpenConsole.exe" target="build/native/runtimes/x64" />
 
-    <file src="../../../bin/ARM64/Release/conpty.lib" target="runtimes/win10-arm64/lib/uap10.0" />
-    <file src="../../../bin/ARM64/Release/conpty.dll" target="runtimes/win10-arm64/native" />
+    <file src="../../../bin/ARM64/Release/conpty.lib" target="runtimes/win-arm64/lib/uap10.0" />
+    <file src="../../../bin/ARM64/Release/conpty.dll" target="runtimes/win-arm64/native" />
     <file src="../../../bin/ARM64/Release/OpenConsole.exe" target="build/native/runtimes/arm64" />
   </files>
 </package>


### PR DESCRIPTION
win10-* is no longer a valid rid

https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/rid-graph

## Summary of the Pull Request

This package would fail to install the dependencies to the correct location in .net 8 and later by default.  win-x64 is a valid runtime id in prior .net versions so I think this should be back compat.   


Without this the package fails to do its job on newer builds unless `  <UseRidGraph>true</UseRidGraph>` and the user sets `win10-x64` as their RID in their project file.