### PR TITLE
Fix schema description

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2907,7 +2907,7 @@
         },
         "experimental.rightClickContextMenu": {
           "default": false,
-          "description": "When set to true, right-clicking on the terminal will show a context menu. When set to false, right-click will copy",
+          "description": "When set to true, right-click will show a context menu. When set to false, right-click will paste.",
           "type": "boolean"
         },
         "experimental.repositionCursorWithMouse": {

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2907,7 +2907,7 @@
         },
         "experimental.rightClickContextMenu": {
           "default": false,
-          "description": "When set to true, right-click will show a context menu. When set to false, right-click will paste.",
+          "description": "When true, right-click shows a context menu; otherwise, it pastes from the clipboard or copies selection.",
           "type": "boolean"
         },
         "experimental.repositionCursorWithMouse": {


### PR DESCRIPTION
## Summary of the Pull Request
Fixes typo in `experimental.rightClickContextMenu` property description. Description should say right-click **pastes**, rather than **copies**.

## PR Checklist
- [x] Schema updated