### PR TITLE
Fix copy/paste when Terminal Chat is open

### DIFF
--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -452,8 +452,15 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_HandlePasteText(const IInspectable& /*sender*/,
                                         const ActionEventArgs& args)
     {
-        _PasteText();
-        args.Handled(true);
+        if (ExtensionPresenter().Visibility() == Visibility::Visible)
+        {
+            args.Handled(false);
+        }
+        else
+        {
+            _PasteText();
+            args.Handled(true);
+        }
     }
 
     void TerminalPage::_HandleNewTab(const IInspectable& /*sender*/,
@@ -547,7 +554,11 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_HandleCopyText(const IInspectable& /*sender*/,
                                        const ActionEventArgs& args)
     {
-        if (const auto& realArgs = args.ActionArgs().try_as<CopyTextArgs>())
+        if (ExtensionPresenter().Visibility() == Visibility::Visible)
+        {
+            args.Handled(false);
+        }
+        else if (const auto& realArgs = args.ActionArgs().try_as<CopyTextArgs>())
         {
             const auto handled = _CopyText(realArgs.DismissSelection(), realArgs.SingleLine(), realArgs.WithControlSequences(), realArgs.CopyFormatting());
             args.Handled(handled);


### PR DESCRIPTION
## Summary of the Pull Request
TerminalPage was handling the copy/paste actions even when TerminalChat was open, preventing the command from reaching the palette. This commit checks the visibility of the chat pane before handling these actions. 

## Validation Steps Performed
Paste/copy are handled appropriately if the chat is open.

## PR Checklist
- [x] Closes #16589
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
