### PR TITLE
Fix tag for SessionBecameInteractive event

### DIFF
--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -395,7 +395,8 @@ void WindowEmperor::HandleCommandlineArgs(int nCmdShow)
                 TraceLoggingWrite(
                     g_hWindowsTerminalProvider,
                     "SessionBecameInteractive",
-                    TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                    TraceLoggingDescription("Event emitted when the session was interacted with"),
+                    TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
                     TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
                 loggedInteraction = true;
             }


### PR DESCRIPTION
Adds a description and keyword for the `SessionBecameInteractive` event

Follow-up from #17682