### PR TITLE
Update README to remove reference to submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,15 +362,6 @@ If you would like to ask a question that you feel doesn't warrant an issue
 
 ## Building the Code
 
-This repository uses [git
-submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) for some of its
-dependencies. To make sure submodules are restored or updated, be sure to run
-the following prior to building:
-
-```shell
-git submodule update --init --recursive
-```
-
 OpenConsole.sln may be built from within Visual Studio or from the command-line
 using a set of convenience scripts & tools in the **/tools** directory:
 


### PR DESCRIPTION
## Summary of the Pull Request

After #15855, this repo no longer uses submodules. Removing instruction about needing to initialize them. 

## References and Relevant Issues

#15855

## Detailed Description of the Pull Request / Additional comments

N/A

## Validation Steps Performed

Read the revised README and was able to F5 without running the submodule command.

## PR Checklist
- [ ] Closes #xxx
N/A
- [ ] Tests added/passed
N/A
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here

Repo docs, not real docs
- [ ] Schema updated (if necessary)
N/A
