### PR TITLE
Added CodeQL supression comment

### DIFF
--- a/src/propsheet/console.cpp
+++ b/src/propsheet/console.cpp
@@ -115,7 +115,7 @@ void SaveConsoleSettingsIfNeeded(const HWND hwnd)
                 LoadStringW(ghInstance, IDS_LINKERROR, awchBuffer, ARRAYSIZE(awchBuffer));
                 StringCchPrintf(szMessage,
                                 ARRAYSIZE(szMessage),
-                                awchBuffer,
+                                awchBuffer,  // CodeQL [SM01734] Pulled from a resource file and cannot be a string literal
                                 gpStateInfo->LinkTitle);
                 LoadStringW(ghInstance, IDS_LINKERRCAP, awchBuffer, ARRAYSIZE(awchBuffer));
 

--- a/src/propsheet/console.cpp
+++ b/src/propsheet/console.cpp
@@ -115,7 +115,7 @@ void SaveConsoleSettingsIfNeeded(const HWND hwnd)
                 LoadStringW(ghInstance, IDS_LINKERROR, awchBuffer, ARRAYSIZE(awchBuffer));
                 StringCchPrintf(szMessage,
                                 ARRAYSIZE(szMessage),
-                                awchBuffer,  // CodeQL [SM01734] Pulled from a resource file and cannot be a string literal
+                                awchBuffer, // CodeQL [SM01734] Pulled from a resource file and cannot be a string literal
                                 gpStateInfo->LinkTitle);
                 LoadStringW(ghInstance, IDS_LINKERRCAP, awchBuffer, ARRAYSIZE(awchBuffer));
 


### PR DESCRIPTION
## Summary of the Pull Request
CodeQL is raising errors when building Visual Studio since we have a dependency on Windows Terminal for our integrated terminal. The issue raised by CodeQL refers to a non-constant string format, but in this case the string comes from a resource file and should be considered constant. 

This PR adds an ignore comment for CodeQL

## References and Relevant Issues
CodeQL error: https://liquid.microsoft.com/codeql/issues/95192647-5121-4d27-b873-63e63e825d72?copilot_promptid=E91B0CE9-0C1B-4AC2-8A46-33F49B67E058

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
