### PR TITLE
Fix "Ctrl+Break can leave the WSL shell in an unusable state"

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -483,6 +483,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             {
                 // Ask the hosting application to give us a new connection.
                 RestartTerminalRequested.raise(*this, nullptr);
+                SendInput(L"reset\n");
                 return true;
             }
         }


### PR DESCRIPTION
## Summary of the Pull Request
Runs `reset` in the shell after user kills the shell with `ctrl + break` and presses `enter` to restart the terminal.

## References and Relevant Issues
[18425](https://github.com/microsoft/terminal/issues/18425)

## Detailed Description of the Pull Request / Additional comments
`reset` resets the terminal state, preventing the state of the previous terminal session carrying over into the next one and hence any unintended terminal behavior such as that shown in issue 18425.

## Validation Steps Performed
Reproduce the bug in [18425](https://github.com/microsoft/terminal/issues/18425). It should no longer occur.

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
