### PR TITLE
Fix dispatching of system keys

### DIFF
--- a/src/cascadia/WindowsTerminal/WindowEmperor.h
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.h
@@ -50,7 +50,7 @@ private:
     AppHost* _mostRecentWindow() const noexcept;
     bool _summonWindow(const SummonWindowSelectionArgs& args) const;
     void _summonAllWindows() const;
-    void _dispatchSpecialKey(MSG& msg) const;
+    void _dispatchSpecialKey(const MSG& msg) const;
     void _dispatchCommandline(winrt::TerminalApp::CommandlineArgs args);
     safe_void_coroutine _dispatchCommandlineCurrentDesktop(winrt::TerminalApp::CommandlineArgs args);
     LRESULT _messageHandler(HWND window, UINT message, WPARAM wParam, LPARAM lParam) noexcept;


### PR DESCRIPTION
This fixes the bit check for key down and adds a few comments.

Closes #18331

## Validation Steps Performed
Printing the resulting INPUT_RECORDs shows both key down and up events when pressing F7. Alt-Space now also works again.