### PR TITLE
Let folks disable OSC 52

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2373,11 +2373,6 @@
           "description": "When set to true, Windows Terminal will run in the background. This allows globalSummon and quakeMode actions to work even when no windows are open.",
           "type": "boolean"
         },
-        "compatibility.allowDECRQCRA": {
-          "default": false,
-          "description": "When set to true, the terminal will support the DECRQCRA (Request Checksum of Rectangular Area) escape sequence.",
-          "type": "boolean"
-        },
         "compatibility.textMeasurement": {
           "default": "graphemes",
           "description": "This changes the way incoming text is grouped into cells. The \"graphemes\" option is the most modern and Unicode-correct way to do so, while \"wcswidth\" is a common approach on UNIX, and \"console\" replicates the way it used to work on Windows.",
@@ -2724,6 +2719,16 @@
         "compatibility.reloadEnvironmentVariables": {
           "default": true,
           "description": "When set to true, when opening a new tab or pane it will get reloaded environment variables.",
+          "type": "boolean"
+        },
+        "compatibility.allowDECRQCRA": {
+          "default": false,
+          "description": "When set to true, the terminal will support the DECRQCRA (Request Checksum of Rectangular Area) escape sequence.",
+          "type": "boolean"
+        },
+        "compatibility.allowOSC52": {
+          "default": true,
+          "description": "When set to true, VT applications will be allowed to set the contents of the local clipboard using OSC 52 (Manipulate Selection Data).",
           "type": "boolean"
         },
         "unfocusedAppearance": {

--- a/src/cascadia/TerminalCore/ICoreSettings.idl
+++ b/src/cascadia/TerminalCore/ICoreSettings.idl
@@ -22,6 +22,7 @@ namespace Microsoft.Terminal.Core
 
         Boolean ForceVTInput;
         Boolean AllowVtChecksumReport;
+        Boolean AllowVtClipboardWrite;
         Boolean TrimBlockSelection;
         Boolean DetectURLs;
 

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -89,6 +89,7 @@ void Terminal::UpdateSettings(ICoreSettings settings)
     _trimBlockSelection = settings.TrimBlockSelection();
     _autoMarkPrompts = settings.AutoMarkPrompts();
     _rainbowSuggestions = settings.RainbowSuggestions();
+    _clipboardOperationsAllowed = settings.AllowVtClipboardWrite();
 
     if (_stateMachine)
     {

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -413,6 +413,7 @@ private:
     Microsoft::Console::Types::Viewport _mutableViewport;
     til::CoordType _scrollbackLines = 0;
     bool _detectURLs = false;
+    bool _clipboardOperationsAllowed = true;
 
     til::size _altBufferSize;
     std::optional<til::size> _deferredResize;

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -140,7 +140,10 @@ unsigned int Terminal::GetInputCodePage() const noexcept
 
 void Terminal::CopyToClipboard(wil::zwstring_view content)
 {
-    _pfnCopyToClipboard(content);
+    if (_clipboardOperationsAllowed)
+    {
+        _pfnCopyToClipboard(content);
+    }
 }
 
 // Method Description:

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
@@ -153,6 +153,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         OBSERVABLE_PROJECTED_SETTING(_profile, RepositionCursorWithMouse);
         OBSERVABLE_PROJECTED_SETTING(_profile, ForceVTInput);
         OBSERVABLE_PROJECTED_SETTING(_profile, AllowVtChecksumReport);
+        OBSERVABLE_PROJECTED_SETTING(_profile, AllowVtClipboardWrite);
         OBSERVABLE_PROJECTED_SETTING(_profile, AnswerbackMessage);
         OBSERVABLE_PROJECTED_SETTING(_profile, RainbowSuggestions);
         OBSERVABLE_PROJECTED_SETTING(_profile, PathTranslationStyle);

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
@@ -155,5 +155,6 @@ namespace Microsoft.Terminal.Settings.Editor
         OBSERVABLE_PROJECTED_PROFILE_SETTING(String, AnswerbackMessage);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, RainbowSuggestions);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Microsoft.Terminal.Control.PathTranslationStyle, PathTranslationStyle);
+        OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, AllowVtClipboardWrite);
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Terminal.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Terminal.xaml
@@ -70,6 +70,15 @@
                 <TextBox Style="{StaticResource TextBoxSettingStyle}"
                          Text="{x:Bind Profile.AnswerbackMessage, Mode=TwoWay}" />
             </local:SettingContainer>
+
+            <!--  Allow VT Clipboard Writing  -->
+            <local:SettingContainer x:Uid="Profile_AllowVtClipboardWrite"
+                                    ClearSettingValue="{x:Bind Profile.ClearAllowVtClipboardWrite}"
+                                    HasSettingValue="{x:Bind Profile.HasAllowVtClipboardWrite, Mode=OneWay}"
+                                    SettingOverrideSource="{x:Bind Profile.AllowVtClipboardWriteOverrideSource, Mode=OneWay}">
+                <ToggleSwitch IsOn="{x:Bind Profile.AllowVtClipboardWrite, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
         </StackPanel>
     </Grid>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Terminal.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Terminal.xaml
@@ -60,6 +60,15 @@
                               Style="{StaticResource ToggleSwitchInExpanderStyle}" />
             </local:SettingContainer>
 
+            <!--  Allow VT Clipboard Writing  -->
+            <local:SettingContainer x:Uid="Profile_AllowVtClipboardWrite"
+                                    ClearSettingValue="{x:Bind Profile.ClearAllowVtClipboardWrite}"
+                                    HasSettingValue="{x:Bind Profile.HasAllowVtClipboardWrite, Mode=OneWay}"
+                                    SettingOverrideSource="{x:Bind Profile.AllowVtClipboardWriteOverrideSource, Mode=OneWay}">
+                <ToggleSwitch IsOn="{x:Bind Profile.AllowVtClipboardWrite, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
+
             <!--  Answerback Message  -->
             <local:SettingContainer x:Uid="Profile_AnswerbackMessage"
                                     ClearSettingValue="{x:Bind Profile.ClearAnswerbackMessage}"
@@ -69,15 +78,6 @@
                                     Style="{StaticResource ExpanderSettingContainerStyle}">
                 <TextBox Style="{StaticResource TextBoxSettingStyle}"
                          Text="{x:Bind Profile.AnswerbackMessage, Mode=TwoWay}" />
-            </local:SettingContainer>
-
-            <!--  Allow VT Clipboard Writing  -->
-            <local:SettingContainer x:Uid="Profile_AllowVtClipboardWrite"
-                                    ClearSettingValue="{x:Bind Profile.ClearAllowVtClipboardWrite}"
-                                    HasSettingValue="{x:Bind Profile.HasAllowVtClipboardWrite, Mode=OneWay}"
-                                    SettingOverrideSource="{x:Bind Profile.AllowVtClipboardWriteOverrideSource, Mode=OneWay}">
-                <ToggleSwitch IsOn="{x:Bind Profile.AllowVtClipboardWrite, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
             </local:SettingContainer>
         </StackPanel>
     </Grid>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -568,6 +568,10 @@
     <value>Allow DECRQCRA (Request Checksum of Rectangular Area)</value>
     <comment>{Locked="DECRQCRA"}{Locked="Request Checksum of Rectangular Area"}Header for a control to toggle support for the DECRQCRA control sequence.</comment>
   </data>
+  <data name="Profile_AllowVtClipboardWrite.Header" xml:space="preserve">
+    <value>Allow OSC 52 (Manipulate Selection Data) to write to the clipboard</value>
+    <comment>{Locked="OSC 52"}{Locked="Manipulate Selection Data"}Header for a control to toggle support for applications to change the contents of the Windows system clipboard.</comment>
+  </data>
   <data name="Globals_AllowHeadless.Header" xml:space="preserve">
     <value>Allow Windows Terminal to run in the background</value>
     <comment>Header for a control to toggle support for Windows Terminal to run in the background.</comment>

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -101,6 +101,7 @@ Author(s):
     X(bool, RainbowSuggestions, "experimental.rainbowSuggestions", false)                                                                                      \
     X(bool, ForceVTInput, "compatibility.input.forceVT", false)                                                                                                \
     X(bool, AllowVtChecksumReport, "compatibility.allowDECRQCRA", false)                                                                                       \
+    X(bool, AllowVtClipboardWrite, "compatibility.allowOSC52", true)                                                                                           \
     X(bool, AllowKeypadMode, "compatibility.allowDECNKM", false)                                                                                               \
     X(Microsoft::Terminal::Control::PathTranslationStyle, PathTranslationStyle, "pathTranslationStyle", Microsoft::Terminal::Control::PathTranslationStyle::None)
 

--- a/src/cascadia/TerminalSettingsModel/Profile.idl
+++ b/src/cascadia/TerminalSettingsModel/Profile.idl
@@ -94,6 +94,7 @@ namespace Microsoft.Terminal.Settings.Model
         INHERITABLE_PROFILE_SETTING(Boolean, ForceVTInput);
         INHERITABLE_PROFILE_SETTING(Boolean, AllowVtChecksumReport);
         INHERITABLE_PROFILE_SETTING(Boolean, AllowKeypadMode);
+        INHERITABLE_PROFILE_SETTING(Boolean, AllowVtClipboardWrite);
 
         INHERITABLE_PROFILE_SETTING(Microsoft.Terminal.Control.PathTranslationStyle, PathTranslationStyle);
     }

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
@@ -348,6 +348,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         _RainbowSuggestions = profile.RainbowSuggestions();
         _ForceVTInput = profile.ForceVTInput();
         _AllowVtChecksumReport = profile.AllowVtChecksumReport();
+        _AllowVtClipboardWrite = profile.AllowVtClipboardWrite();
         _PathTranslationStyle = profile.PathTranslationStyle();
     }
 

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.h
@@ -97,7 +97,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         INHERITABLE_SETTING(Model::TerminalSettings, bool, AllowVtChecksumReport, false);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, TrimBlockSelection, true);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, DetectURLs, true);
-        INHERITABLE_SETTING(Model::TerminalSettings, bool, AllowVtClipboardWrite, false);
+        INHERITABLE_SETTING(Model::TerminalSettings, bool, AllowVtClipboardWrite, true);
 
         INHERITABLE_SETTING(Model::TerminalSettings, Windows::Foundation::IReference<Microsoft::Terminal::Core::Color>, TabColor, nullptr);
 

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.h
@@ -97,6 +97,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         INHERITABLE_SETTING(Model::TerminalSettings, bool, AllowVtChecksumReport, false);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, TrimBlockSelection, true);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, DetectURLs, true);
+        INHERITABLE_SETTING(Model::TerminalSettings, bool, AllowVtClipboardWrite, false);
 
         INHERITABLE_SETTING(Model::TerminalSettings, Windows::Foundation::IReference<Microsoft::Terminal::Core::Color>, TabColor, nullptr);
 

--- a/src/cascadia/inc/ControlProperties.h
+++ b/src/cascadia/inc/ControlProperties.h
@@ -52,7 +52,8 @@
     X(bool, AutoMarkPrompts)                                                                                      \
     X(bool, RepositionCursorWithMouse, false)                                                                     \
     X(bool, RainbowSuggestions)                                                                                   \
-    X(bool, AllowVtChecksumReport)
+    X(bool, AllowVtChecksumReport)                                                                                \
+    X(bool, AllowVtClipboardWrite)
 
 // --------------------------- Control Settings ---------------------------
 //  All of these settings are defined in IControlSettings.


### PR DESCRIPTION
This pull request introduces a new profile setting, `compatibility.allowOSC52`, which defaults to `true`. When disabled, it will not allow applications to write to the clipboard.

Security-minded folks may choose to disable it.