### PR TITLE
Fixed size comparisons that could lead to infinite loops

### DIFF
--- a/src/buffer/out/Row.cpp
+++ b/src/buffer/out/Row.cpp
@@ -433,7 +433,9 @@ OutputCellIterator ROW::WriteCells(OutputCellIterator it, const til::CoordType c
     auto colorStarts = gsl::narrow_cast<uint16_t>(columnBegin);
     auto currentIndex = colorStarts;
 
-    while (it && currentIndex <= finalColumnInRow)
+    // finalColumnInRow is 32-bit and currentIndex is 16-bit. If finalColumnInRow is higher
+    // than the 16-bit integer limit, we will loop indefinitely.
+    while (it && currentIndex <= saturated_cast<uint16_t>(finalColumnInRow))
     {
         // Fill the color if the behavior isn't set to keeping the current color.
         if (it->TextAttrBehavior() != TextAttributeBehavior::Current)

--- a/src/terminal/adapter/SixelParser.cpp
+++ b/src/terminal/adapter/SixelParser.cpp
@@ -610,7 +610,9 @@ void SixelParser::_updateTextColors()
     // the text output as well.
     if (_conformanceLevel <= 3 && _maxColors > 2 && _colorTableChanged) [[unlikely]]
     {
-        for (IndexType tableIndex = 0; tableIndex < _maxColors; tableIndex++)
+        // _maxColors is 64-bit and tableIndex is 8-bit. If _maxColors is higher
+        // than the 8-bit integer limit, we will loop indefinitely.
+        for (IndexType tableIndex = 0; tableIndex < (saturated_cast<uint8_t>(_maxColors)); tableIndex++)
         {
             _dispatcher.SetColorTableEntry(tableIndex, _colorFromIndex(tableIndex));
         }

--- a/src/terminal/adapter/charsets.hpp
+++ b/src/terminal/adapter/charsets.hpp
@@ -19,7 +19,7 @@ namespace Microsoft::Console::VirtualTerminal
     public:
         constexpr CharSet(const std::initializer_list<std::pair<wchar_t, wchar_t>> replacements)
         {
-            for (auto i = L'\0'; i < _translationTable.size(); i++)
+            for (size_t i = L'\0'; i < _translationTable.size(); i++)
                 _translationTable.at(i) = BaseChar + i;
             for (auto replacement : replacements)
                 _translationTable.at(replacement.first - BaseChar) = replacement.second;


### PR DESCRIPTION
## Summary of the Pull Request
After taking in 1.22, our CodeQL process caught a few locations where we were performing integer comparisons of different sizes which could lead to an infinite loop if the larger integer goes out of range of the smaller integer.

For example, comparing `uint8_t` < `size_t` works until `size_t` goes above 256, where no matter how much we change `uin8_t` we will never reach 256

## References and Relevant Issues
CodeQL issues:
https://liquid.microsoft.com/codeql/issues/5f2b05d5-9e87-4df4-b493-f00e710d38df?copilot_promptid=E91B0CE9-0C1B-4AC2-8A46-33F49B67E058
https://liquid.microsoft.com/codeql/issues/76268284-2d4b-4b10-8aff-a947ecc1a576?copilot_promptid=E91B0CE9-0C1B-4AC2-8A46-33F49B67E058
https://liquid.microsoft.com/codeql/issues/452f966b-5b99-420e-96c0-153caea2a0b4?copilot_promptid=E91B0CE9-0C1B-4AC2-8A46-33F49B67E058

## Detailed Description of the Pull Request / Additional comments
I used `saturated_cast<>` for these changes to make overflow values equal to the max value of the smallest integer.

## Validation Steps Performed

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
