### PR TITLE
Add 2 additional error messages

### DIFF
--- a/.github/actions/spelling/allow/allow.txt
+++ b/.github/actions/spelling/allow/allow.txt
@@ -11,6 +11,7 @@ colorbrewer
 commandlines
 consvc
 copyable
+CText
 dalet
 dcs
 deselection

--- a/src/cascadia/TerminalConnection/ConptyConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConptyConnection.cpp
@@ -443,7 +443,6 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
             TerminalOutput.raise(fileNotFoundText);
         }
 
-
         _transitionToState(ConnectionState::Failed);
 
         // Tear down any state we may have accumulated.

--- a/src/cascadia/TerminalConnection/ConptyConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConptyConnection.cpp
@@ -428,6 +428,28 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
             TerminalOutput.raise(L"\r\n");
             TerminalOutput.raise(badPathText);
         }
+        // If the requested action requires elevation, display appropriate message
+        else if (hr == HRESULT_FROM_WIN32(ERROR_ELEVATION_REQUIRED))
+        {
+            const auto elevationText = RS_(L"ElevationRequired");
+            TerminalOutput.raise(L"\r\n");
+            TerminalOutput.raise(elevationText);
+        }
+        // If a stop signal (ctrl+c) is detected, display appropriate message
+        else if (hr == HRESULT_FROM_NT(STATUS_CONTROL_C_EXIT))
+        {
+            const auto ctrlCText = RS_(L"CtrlCToClose");
+            TerminalOutput.raise(L"\r\n");
+            TerminalOutput.raise(ctrlCText);
+        }
+        // If the command or file is invalid, display appropriate message
+        else if (hr == HRESULT_FROM_WIN32(ERROR_BAD_COMMAND) || hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
+        {
+            const auto badCommandText = RS_fmt(L"BadCommandOrFile", _commandline);
+            TerminalOutput.raise(L"\r\n");
+            TerminalOutput.raise(badCommandText);
+        }
+
 
         _transitionToState(ConnectionState::Failed);
 

--- a/src/cascadia/TerminalConnection/ConptyConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConptyConnection.cpp
@@ -435,13 +435,6 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
             TerminalOutput.raise(L"\r\n");
             TerminalOutput.raise(elevationText);
         }
-        // If a stop signal (ctrl+c) is detected, display appropriate message
-        else if (hr == HRESULT_FROM_NT(STATUS_CONTROL_C_EXIT))
-        {
-            const auto ctrlCText = RS_(L"CtrlCToClose");
-            TerminalOutput.raise(L"\r\n");
-            TerminalOutput.raise(ctrlCText);
-        }
         // If the requested executable was not found, display appropriate message
         else if (hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
         {

--- a/src/cascadia/TerminalConnection/ConptyConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConptyConnection.cpp
@@ -442,12 +442,12 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
             TerminalOutput.raise(L"\r\n");
             TerminalOutput.raise(ctrlCText);
         }
-        // If the command or file is invalid, display appropriate message
-        else if (hr == HRESULT_FROM_WIN32(ERROR_BAD_COMMAND) || hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
+        // If the requested executable was not found, display appropriate message
+        else if (hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
         {
-            const auto badCommandText = RS_fmt(L"BadCommandOrFile", _commandline);
+            const auto fileNotFoundText = RS_(L"FileNotFound");
             TerminalOutput.raise(L"\r\n");
-            TerminalOutput.raise(badCommandText);
+            TerminalOutput.raise(fileNotFoundText);
         }
 
 

--- a/src/cascadia/TerminalConnection/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalConnection/Resources/en-US/Resources.resw
@@ -209,7 +209,7 @@
   </data>
   <data name="CtrlDToClose" xml:space="preserve">
     <value>You can now close this terminal with Ctrl+D, or press Enter to restart.</value>
-	  <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
+    <comment>"Ctrl+D" and "Enter" represent keys the user will press (control+D and Enter).</comment>
   </data>
   <data name="ProcessFailedToLaunch" xml:space="preserve">
     <value>[error {0} when launching `{1}']</value>
@@ -219,5 +219,15 @@
   <data name="BadPathText" xml:space="preserve">
     <value>Could not access starting directory "{0}"</value>
     <comment>The first argument {0} is a path to a directory on the filesystem, as provided by the user.</comment>
+  </data>
+  <data name="ElevationRequired" xml:space="preserve">
+    <value>The requested operation requires elevation.</value>
+  </data>
+  <data name="CtrlCToClose" xml:space="preserve">
+    <value>{Application Exit by CTRL+C} The application terminated as a result of a CTRL+C.</value>
+  </data>
+  <data name="BadCommandOrFile" xml:space="preserve">
+    <value>{0} is not recognized as an internal or external command, operable program or batch file.</value>
+    <comment>The first argument {0} is the command or file, as provided by the user</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalConnection/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalConnection/Resources/en-US/Resources.resw
@@ -223,9 +223,6 @@
   <data name="ElevationRequired" xml:space="preserve">
     <value>The requested operation requires elevation.</value>
   </data>
-  <data name="CtrlCToClose" xml:space="preserve">
-    <value>The application terminated as a result of a CTRL+C.</value>
-  </data>
   <data name="FileNotFound" xml:space="preserve">
     <value>The system cannot find the file specified.</value>
   </data>

--- a/src/cascadia/TerminalConnection/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalConnection/Resources/en-US/Resources.resw
@@ -224,10 +224,9 @@
     <value>The requested operation requires elevation.</value>
   </data>
   <data name="CtrlCToClose" xml:space="preserve">
-    <value>{Application Exit by CTRL+C} The application terminated as a result of a CTRL+C.</value>
+    <value>The application terminated as a result of a CTRL+C.</value>
   </data>
-  <data name="BadCommandOrFile" xml:space="preserve">
-    <value>{0} is not recognized as an internal or external command, operable program or batch file.</value>
-    <comment>The first argument {0} is the command or file, as provided by the user</comment>
+  <data name="FileNotFound" xml:space="preserve">
+    <value>The system cannot find the file specified.</value>
   </data>
 </root>


### PR DESCRIPTION
Add additional information to 2 error scenarios when launching a different profile in the `ConptyConnection.cpp` file.
  - Requires Elevation
  - File Not Found

Created a profile that required elevation and verified the error message. Created profile that passed a made up command and verified the error message. Unable to test CTRL+C case, but included due to issue conversation. 

Closes #7186