### PR TITLE
build: change how we find  the latest VC tools version

### DIFF
--- a/build/scripts/Set-LatestVCToolsVersion.ps1
+++ b/build/scripts/Set-LatestVCToolsVersion.ps1
@@ -1,6 +1,6 @@
 $VSInstances = ([xml](& 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -include packages -format xml))
 $VSPackages = $VSInstances.instances.instance.packages.package
-$LatestVCPackage = ($VSInstances.instances.instance.packages.package | ? { $_.id -eq "Microsoft.VisualCpp.CRT.Source" })
+$LatestVCPackage = ($VSInstances.instances.instance.packages.package | ? { $_.id -eq "Microsoft.VisualCpp.Tools.Core" })
 $LatestVCToolsVersion = $LatestVCPackage.version;
 
 Write-Output "Latest VCToolsVersion: $LatestVCToolsVersion"


### PR DESCRIPTION
Apparently, we were using the package containing the CRT _source code_ to determine the version of the tools.

Also apparently, VS does not guarantee that that package has the same version as the tools package.

We should use the version of the tools package instead.