### PR TITLE
Bugfix: only round to the nearest cell for selection

### DIFF
--- a/src/cascadia/TerminalControl/ControlInteractivity.cpp
+++ b/src/cascadia/TerminalControl/ControlInteractivity.cpp
@@ -241,7 +241,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                                               const ::Microsoft::Terminal::Core::ControlKeyStates modifiers,
                                               const Core::Point pixelPosition)
     {
-        const auto terminalPosition = _getTerminalPosition(til::point{ pixelPosition }, true);
+        // Follow-up from GH#18106:
+        //  We DO NOT want to round to the nearest cell _unless_ we're selecting text.
+        const auto terminalPosition = _getTerminalPosition(til::point{ pixelPosition }, false);
 
         const auto altEnabled = modifiers.IsAltPressed();
         const auto shiftEnabled = modifiers.IsShiftPressed();
@@ -285,7 +287,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             }
             const auto isOnOriginalPosition = _lastMouseClickPosNoSelection == pixelPosition;
 
-            _core->LeftClickOnTerminal(terminalPosition,
+            // Follow-up from GH#18106:
+            //  We DO NOT want to round to the nearest cell _unless_ we're selecting text.
+            _core->LeftClickOnTerminal(_getTerminalPosition(til::point{ pixelPosition }, true),
                                        multiClickMapper,
                                        altEnabled,
                                        shiftEnabled,

--- a/src/cascadia/TerminalControl/ControlInteractivity.cpp
+++ b/src/cascadia/TerminalControl/ControlInteractivity.cpp
@@ -241,8 +241,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                                               const ::Microsoft::Terminal::Core::ControlKeyStates modifiers,
                                               const Core::Point pixelPosition)
     {
-        // Follow-up from GH#18106:
-        //  We DO NOT want to round to the nearest cell _unless_ we're selecting text.
+        // Un-rounded coordinates; we only round when selecting text
         const auto terminalPosition = _getTerminalPosition(til::point{ pixelPosition }, false);
 
         const auto altEnabled = modifiers.IsAltPressed();
@@ -287,8 +286,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             }
             const auto isOnOriginalPosition = _lastMouseClickPosNoSelection == pixelPosition;
 
-            // Follow-up from GH#18106:
-            //  We DO NOT want to round to the nearest cell _unless_ we're selecting text.
+            // Rounded coordinates for text selection
             _core->LeftClickOnTerminal(_getTerminalPosition(til::point{ pixelPosition }, true),
                                        multiClickMapper,
                                        altEnabled,


### PR DESCRIPTION
## Summary of the Pull Request
Fixes a bug where VT mouse mode would round to the nearest cell when clicking the mouse button. 
The fix is to round to the nearest cell only when we're selecting text. The other scenarios affected are:
- clicking on a hyperlink
- vt mouse mode
- where the context menu is anchored

Really the most notable ones were the first two. So now, we use the position of the cell we clicked on. We only round for selection.

## References and Relevant Issues
Follow-up to #18106

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed
Opened Midnight Commander in Ubuntu and clicked between the two panes.
- Before: threshold was too early to switch between panes
- After: threshold is clearly separated between the outline of the two panes

