### PR TITLE
Improve quality of GDI image scaling

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -215,6 +215,7 @@ codepages
 codepath
 coinit
 colorizing
+COLORONCOLOR
 COLORREFs
 colorschemes
 colorspec

--- a/src/renderer/gdi/state.cpp
+++ b/src/renderer/gdi/state.cpp
@@ -128,6 +128,9 @@ GdiEngine::~GdiEngine()
     // We need the advanced graphics mode in order to set a transform.
     SetGraphicsMode(hdcNewMemoryContext, GM_ADVANCED);
 
+    // We set the bitmap stretching mode to improve the Sixel image quality.
+    SetStretchBltMode(hdcNewMemoryContext, COLORONCOLOR);
+
     // If we had an existing memory context stored, release it before proceeding.
     if (nullptr != _hdcMemoryContext)
     {


### PR DESCRIPTION
## Summary of the Pull Request

When Sixel images are rendered, they're automatically scaled to match
the 10x20 cell size of the original hardware terminals. If this requires
the image to be scaled down, the default GDI stretching mode can produce
ugly visual artefacts, particularly for color images. This PR changes
the stretching mode to `COLORONCOLOR`, which looks considerably better,
but without impacting performance.

## References and Relevant Issues

The initial Sixel implementation was added in PR #17421.

## Validation Steps Performed

I've tested with a number of different images using a small font size to
trigger the downscaling, and I think the results are generally better,
although simple black on white images are still better with the default
mode (i.e. `BLACKONWHITE`), which is understandable.

I've also checked the performance with a variation of the [sixel-bench]
test, and confirmed that the new mode is no worse than the default.

[sixel-bench]: https://github.com/jerch/sixel-bench