### PR TITLE
Add CAM16 based color scheme "Dimidium"

### DIFF
--- a/.github/actions/spelling/allow/allow.txt
+++ b/.github/actions/spelling/allow/allow.txt
@@ -16,6 +16,7 @@ dcs
 deselection
 dialytika
 diffing
+Dimidium
 dje
 downsides
 dze

--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -82,6 +82,29 @@
         //   - "background"
         //   - "cursorColor"
         {
+            "name": "Dimidium",
+            "background": "#141414",
+            "foreground": "#BAB7B6",
+            "cursorColor": "#37E57B",
+            "selectionBackground": "#FFFFFF",
+            "black": "#000000",
+            "red": "#CF494C",
+            "green": "#60B442",
+            "yellow": "#DB9C11",
+            "blue": "#0575D8",
+            "purple": "#AF5ED2",
+            "cyan": "#1DB6BB",
+            "white": "#BAB7B6",
+            "brightBlack": "#817E7E",
+            "brightRed": "#FF643B",
+            "brightGreen": "#37E57B",
+            "brightYellow": "#FCCD1A",
+            "brightBlue": "#688DFD",
+            "brightPurple": "#ED6FE9",
+            "brightCyan": "#32E0FB",
+            "brightWhite": "#D3D8D9"
+        },
+        {
             "name": "Ottosson",
             "background": "#000000",
             "foreground": "#bebebe",


### PR DESCRIPTION
Okay, here is a challenge for the default color scheme.


## Summary of the Pull Request

This PR adds [Dimidium](https://github.com/dofuuz/dimidium) terminal color scheme.

![palette](https://github.com/user-attachments/assets/51415f5a-dfd0-4971-bc64-783e99aabdd5)


## References and Relevant Issues

#17818
#18502


## Detailed Description of the Pull Request / Additional comments

I adjusted colors using [CAM16](https://en.wikipedia.org/wiki/Color_appearance_model#CAM16). I prioritized lightness so that all colors(especially blue) has appropriate contrast with the background.

[Brief information about the Dimidium color scheme](https://github.com/dofuuz/dimidium/blob/main/README.md)

[Detailed explanation on crafting the color scheme with CAM16](https://dofuuz.github.io/color/2024/03/17/dimidium-terminal-color-scheme.html)

![hue-chroma](https://github.com/user-attachments/assets/7f6317df-3dd9-4a15-91ce-dfec6f4b92d9)

![dimidium](https://github.com/user-attachments/assets/95ede2b3-295e-4ba4-93c8-90e980b966bf)

![preview-terminal](https://github.com/user-attachments/assets/197ebbc8-d2af-482d-8a60-c6966cc85580)
🔍 [More preview](https://htmlpreview.github.io/?https://github.com/dofuuz/dimidium/blob/main/preview/tty-preview-nobold.html)

