### PR TITLE
Add CP_UTF8 support to GetConsoleLangId

### DIFF
--- a/src/host/srvinit.cpp
+++ b/src/host/srvinit.cpp
@@ -695,6 +695,7 @@ PWSTR TranslateConsoleTitle(_In_ PCWSTR pwszConsoleTitle, const BOOL fUnexpand, 
 {
     auto Status = STATUS_NOT_SUPPORTED;
 
+    // Notes (miniksa):
     // -- WARNING -- LOAD BEARING CODE --
     // Only attempt to return the Lang ID if the Windows ACP on console launch was an East Asian Code Page.
     // -
@@ -719,6 +720,19 @@ PWSTR TranslateConsoleTitle(_In_ PCWSTR pwszConsoleTitle, const BOOL fUnexpand, 
     // I would also highly advise against expanding the LANGIDs returned here or modifying them in any way until the cascading impacts
     // discovered in MSFT: 9808579 are vetted against any changes.
     // -- END WARNING --
+
+    // Notes (lhecker):
+    // To summarize, this hidden console function gets called by the OS when a new process is created.
+    // The returned language, if any, is then used as the default locale for all new threads.
+    // The problem with is that it has worked like this virtually unchanged since at least Windows 2000,
+    // including the bug where it returns STATUS_SUCCESS when pLangId is null.
+    //
+    // In 2025 I added handling of the CP_UTF8 codepage, because while this special treatment doesn't
+    // make much sense to me in the first place [^1], it almost certainly makes no sense for CP_UTF8
+    // to return an US English locale to override a valid user locale.
+    //
+    // [^1]: Why was this ever added? Couldn't we just patch it up now? Maybe YOU will do it? :)
+
     if (IsAvailableEastAsianCodePage(ServiceLocator::LocateGlobals().uiWindowsCP))
     {
         if (pLangId != nullptr)
@@ -737,6 +751,8 @@ PWSTR TranslateConsoleTitle(_In_ PCWSTR pwszConsoleTitle, const BOOL fUnexpand, 
             case CP_CHINESE_TRADITIONAL:
                 *pLangId = MAKELANGID(LANG_CHINESE, SUBLANG_CHINESE_TRADITIONAL);
                 break;
+            case CP_UTF8:
+                return STATUS_NOT_SUPPORTED;
             default:
                 *pLangId = MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US);
                 break;


### PR DESCRIPTION
The reasons why the console code page has an effect on the default
thread locale on Windows is not noted anywhere. If I had to take a
guess, I'd say it's related to the history of the han unification.

In any case, CP_UTF8 is not a "code page" and so it should not have
an effect on the thread locale either. This issue goes all the way
back to the introduction of CP_UTF8 in XP, over 20 years ago.

Closes MSFT-56188683

## Validation Steps Performed
* Switch OS display language to Japanese
* Switch user default codepage to Japanese (932)
* Run the modded OpenConsole
* `chcp 65001`
* `netsh interface ipv4 show interface`
  has Japanese table headers ❌