### PR TITLE
Remove outdated arg comment for `_ClosePseudoConsoleMembers`

### DIFF
--- a/src/winconpty/winconpty.cpp
+++ b/src/winconpty/winconpty.cpp
@@ -359,7 +359,6 @@ HRESULT _ReparentPseudoConsole(_In_ const PseudoConsole* const pPty, _In_ const 
 //      HPCON via the API).
 // Arguments:
 // - pPty: A pointer to a PseudoConsole struct.
-// - wait: If true, waits for conhost/OpenConsole to exit first.
 // Return Value:
 // - <none>
 void _ClosePseudoConsoleMembers(_In_ PseudoConsole* pPty)


### PR DESCRIPTION
Since the argument no longer exists.

## Summary of the Pull Request

Removes argument documentation of "wait" which no longer exists.

