### PR TITLE
ConPTY: Fix shutdown if killed during startup

### DIFF
--- a/src/host/VtIo.cpp
+++ b/src/host/VtIo.cpp
@@ -215,7 +215,7 @@ bool VtIo::IsUsingVt() const
     if (_state != State::Starting)
     {
         // Here's where we _could_ call CloseConsoleProcessState(), but this function
-        // only gets get called once when the first client connects and CONSOLE_INITIALIZED
+        // only gets called once when the first client connects and CONSOLE_INITIALIZED
         // is not set yet. The process list may already contain that first client,
         // but since it hasn't finished connecting yet, it won't react to a CTRL_CLOSE_EVENT.
         // Instead, we return an error here which will abort the connection setup.

--- a/src/host/srvinit.cpp
+++ b/src/host/srvinit.cpp
@@ -381,7 +381,6 @@ HRESULT ConsoleCreateIoThread(_In_ HANDLE Server,
     //      can start, so they're started below, in ConsoleAllocateConsole
     auto& gci = g.getConsoleInformation();
     RETURN_IF_FAILED(gci.GetVtIo()->Initialize(args));
-    RETURN_IF_FAILED(gci.GetVtIo()->CreateAndStartSignalThread());
 
     return S_OK;
 }
@@ -945,27 +944,11 @@ PWSTR TranslateConsoleTitle(_In_ PCWSTR pwszConsoleTitle, const BOOL fUnexpand, 
     // We'll need the size of the screen buffer in the vt i/o initialization
     if (SUCCEEDED_NTSTATUS(Status))
     {
-        auto hr = gci.GetVtIo()->CreateIoHandlers();
-        if (hr == S_FALSE)
-        {
-            // We're not in VT I/O mode, this is fine.
-        }
-        else if (SUCCEEDED(hr))
-        {
-            // Actually start the VT I/O threads
-            hr = gci.GetVtIo()->StartIfNeeded();
-            // Don't convert S_FALSE to an NTSTATUS - the equivalent NTSTATUS
-            //      is treated as an error
-            if (hr != S_FALSE)
-            {
-                Status = NTSTATUS_FROM_HRESULT(hr);
-            }
-            else
-            {
-                Status = ERROR_SUCCESS;
-            }
-        }
-        else
+        // Actually start the VT I/O threads
+        auto hr = gci.GetVtIo()->StartIfNeeded();
+        // Don't convert S_FALSE to an NTSTATUS - the equivalent NTSTATUS
+        //      is treated as an error
+        if (FAILED(hr))
         {
             Status = NTSTATUS_FROM_HRESULT(hr);
         }


### PR DESCRIPTION
During startup we relinquish ownership of the console lock to wait for the DA1 response of the hosting terminal. The problem occurs if the hosting terminal disconnects during that time. The broken pipe will cause `VtIo` to send out `CTRL_CLOSE_EVENT` messages, but those won't achieve anything, because the first and only client hasn't even finished connecting yet. What we need to do instead is to return an error code.

In order to not use a bunch of booleans to control this behavior, I gave `VtIo` a state enum. This however required restructuring the calling code in order to not have a dozen states.

## Validation Steps Performed
* Launch cmd.exe with ConPTY
* ...but leave the stdin pipe unbound (which will hang the DA1 request)
* Immediately kill the ConPTY session
* cmd.exe exits after clicking away the error message ✅