### PR TITLE
Bugfix: don't round to nearest cell for mouse movements and VT mouse mode

### DIFF
--- a/src/cascadia/TerminalControl/ControlInteractivity.cpp
+++ b/src/cascadia/TerminalControl/ControlInteractivity.cpp
@@ -340,7 +340,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                                             const Core::Point pixelPosition,
                                             const bool pointerPressedInBounds)
     {
-        const auto terminalPosition = _getTerminalPosition(til::point{ pixelPosition }, true);
+        const auto terminalPosition = _getTerminalPosition(til::point{ pixelPosition }, false);
         // Returning true from this function indicates that the caller should do no further processing of this movement.
         bool handledCompletely = false;
 
@@ -489,7 +489,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                                           const Core::Point pixelPosition,
                                           const Control::MouseButtonState buttonState)
     {
-        const auto terminalPosition = _getTerminalPosition(til::point{ pixelPosition }, true);
+        const auto terminalPosition = _getTerminalPosition(til::point{ pixelPosition }, false);
 
         // Short-circuit isReadOnly check to avoid warning dialog.
         //


### PR DESCRIPTION
## Summary of the Pull Request
Missed a few `_getTerminalPosition()` on the first run. Disabled rounding for pointer movements and mouse wheel events (which are used for hyperlink hover detection and vt mouse mode). The only time we round now is...
- `SetEndSelectionPoint()` --> because we're updating a selection
- `ControlCore->LeftClickOnTerminal()` --> where all paths are used for selection*

*the only path that doesn't is `RepositionCursorWithMouse` being enabled, which also makes sense based on clicking around Notepad with a large font size.

## References and Relevant Issues
Follow-up for #18486 
Closes #18595 

## Validation Steps Performed
In large font size, play around with midnight commander and hover over hyperlink edges.