### PR TITLE
Fix leaking the contents of the first tab in the first window

### DIFF
--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -95,6 +95,7 @@ void IslandWindow::Close()
 
     if (_source)
     {
+        // BODGY
         // WinUI will strongly hold onto the first DesktopWindowXamlSource that is created.
         // If we don't manually set the Content() to null first, closing that first window
         // will leak all of its contents permanently.

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -95,6 +95,11 @@ void IslandWindow::Close()
 
     if (_source)
     {
+        // WinUI will strongly hold onto the first DesktopWindowXamlSource that is created.
+        // If we don't manually set the Content() to null first, closing that first window
+        // will leak all of its contents permanently.
+        _source.Content(nullptr);
+
         _source.Close();
         _source = nullptr;
     }


### PR DESCRIPTION
Found this one completely randomly.

## Validation Steps Performed
* Open 2 windows with 1 tab each
* Click the X button on the tab in the 1st window
* OpenConsole/etc. is cleaned up ✅