### PR TITLE
Fix persistence of empty windows

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1988,6 +1988,12 @@ namespace winrt::TerminalApp::implementation
             actions.insert(actions.end(), std::make_move_iterator(tabActions.begin()), std::make_move_iterator(tabActions.end()));
         }
 
+        // Avoid persisting a window with zero tabs, because `BuildStartupActions` happened to return an empty vector.
+        if (actions.empty())
+        {
+            return;
+        }
+
         // if the focused tab was not the last tab, restore that
         auto idx = _GetFocusedTabIndex();
         if (idx && idx != tabCount - 1)


### PR DESCRIPTION
This is a theoretical fix for #18584 as I cannot reproduce the issue
anymore. It did happen briefly on one of my devices though, and at the
time I observed that it would persist a window with no startup actions.
