### PR TITLE
Fix two sources of runtime exceptions

### DIFF
--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -182,8 +182,6 @@ namespace winrt::TerminalApp::implementation
         // this as a MTA, before the app is Create()'d
         WINRT_ASSERT(_loadedInitialSettings);
 
-        _ApplyLanguageSettingChange();
-
         TraceLoggingWrite(
             g_hTerminalAppProvider,
             "AppCreated",
@@ -399,6 +397,9 @@ namespace winrt::TerminalApp::implementation
             _settings.LogSettingChanges(true);
         }
 
+        _ApplyLanguageSettingChange();
+        _ProcessLazySettingsChanges();
+
         if (initialLoad)
         {
             // Register for directory change notification.
@@ -408,9 +409,6 @@ namespace winrt::TerminalApp::implementation
 
         // Here, we successfully reloaded the settings, and created a new
         // TerminalSettings object.
-
-        _ApplyLanguageSettingChange();
-        _ProcessLazySettingsChanges();
 
         auto warnings{ winrt::multi_threaded_vector<SettingsLoadWarnings>() };
         for (auto&& warn : _warnings)

--- a/src/cascadia/TerminalApp/TabPaletteItem.cpp
+++ b/src/cascadia/TerminalApp/TabPaletteItem.cpp
@@ -51,8 +51,10 @@ namespace winrt::TerminalApp::implementation
             _tabStatusChangedRevoker = status.PropertyChanged(winrt::auto_revoke, [weakThis{ get_weak() }](auto& /*sender*/, auto& /*e*/) {
                 // Sometimes nested bindings do not get updated,
                 // thus let's notify property changed on TabStatus when one of its properties changes
-                auto item{ weakThis.get() };
-                item->PropertyChanged.raise(*item, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"TabStatus" });
+                if (auto item{ weakThis.get() })
+                {
+                    item->PropertyChanged.raise(*item, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"TabStatus" });
+                }
             });
         }
     }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1783,16 +1783,22 @@ namespace winrt::TerminalApp::implementation
             auto tab{ weakTab.get() };
             if (page && tab)
             {
-                if (args.PropertyName() == L"Title")
+                const auto propertyName = args.PropertyName();
+                if (propertyName == L"Title")
                 {
                     page->_UpdateTitle(*tab);
                 }
-                else if (args.PropertyName() == L"Content")
+                else if (propertyName == L"Content")
                 {
                     if (*tab == page->_GetFocusedTab())
                     {
-                        page->_tabContent.Children().Clear();
-                        page->_tabContent.Children().Append(tab->Content());
+                        const auto children = page->_tabContent.Children();
+
+                        children.Clear();
+                        if (auto content = tab->Content())
+                        {
+                            page->_tabContent.Children().Append(std::move(content));
+                        }
 
                         tab->Focus(FocusState::Programmatic);
                     }


### PR DESCRIPTION
* `_ApplyLanguageSettingChange` calls `PrimaryLanguageOverride`
  (the WinRT API function) and we would call it every time a new
  window is created. Now it's only called on settings load.
* `_RegisterTabEvents` would listen for "Content" changes which can
  be null. `IVector::Append` throws if a null object is given.
  In our case, it's null if the content got erased with nothing.

Additionally, this fixes a bug where we wouldn't call
`_ProcessLazySettingsChanges` on startup. This is important if the
settings file was changed while Windows Terminal wasn't running.

Lastly, there's a lifetime fix in this PR, which is a one-line change
and I didn't want to make a separate PR for that.