### PR TITLE
Reduce log spam on conhost exit

### DIFF
--- a/src/host/srvinit.cpp
+++ b/src/host/srvinit.cpp
@@ -991,7 +991,7 @@ DWORD WINAPI ConsoleIoThread(LPVOID lpParameter)
     {
         if (ReplyMsg != nullptr)
         {
-            LOG_IF_FAILED(ReplyMsg->ReleaseMessageBuffers());
+            ReplyMsg->ReleaseMessageBuffers();
         }
 
         // TODO: 9115192 correct mixed NTSTATUS/HRESULT

--- a/src/server/ApiMessage.cpp
+++ b/src/server/ApiMessage.cpp
@@ -180,12 +180,8 @@ CATCH_RETURN();
 //   (if any) to the message.
 // Arguments:
 // - <none>
-// Return Value:
-// - HRESULT indicating if the payload was successfully written if applicable.
-[[nodiscard]] HRESULT _CONSOLE_API_MSG::ReleaseMessageBuffers()
+void _CONSOLE_API_MSG::ReleaseMessageBuffers()
 {
-    auto hr = S_OK;
-
     if (State.InputBuffer != nullptr)
     {
         _inputBuffer.clear();
@@ -203,15 +199,15 @@ CATCH_RETURN();
             IoOperation.Buffer.Data = State.OutputBuffer;
             IoOperation.Buffer.Size = (ULONG)Complete.IoStatus.Information;
 
-            LOG_IF_FAILED(_pDeviceComm->WriteOutput(&IoOperation));
+            // This call fails when the server pipe is closed on us,
+            // which results in log spam in practice.
+            std::ignore = _pDeviceComm->WriteOutput(&IoOperation);
         }
 
         _outputBuffer.clear();
         State.OutputBuffer = nullptr;
         State.OutputBufferSize = 0;
     }
-
-    return hr;
 }
 
 void _CONSOLE_API_MSG::SetReplyStatus(const NTSTATUS Status)

--- a/src/server/ApiMessage.h
+++ b/src/server/ApiMessage.h
@@ -42,7 +42,7 @@ typedef struct _CONSOLE_API_MSG
     [[nodiscard]] HRESULT GetOutputBuffer(_Outptr_result_bytebuffer_(*pcbSize) void** const ppvBuffer, _Out_ ULONG* const pcbSize);
     [[nodiscard]] HRESULT GetInputBuffer(_Outptr_result_bytebuffer_(*pcbSize) void** const ppvBuffer, _Out_ ULONG* const pcbSize);
 
-    [[nodiscard]] HRESULT ReleaseMessageBuffers();
+    void ReleaseMessageBuffers();
 
     void SetReplyStatus(const NTSTATUS Status);
     void SetReplyInformation(const ULONG_PTR pInformation);

--- a/src/server/ConDrvDeviceComm.cpp
+++ b/src/server/ConDrvDeviceComm.cpp
@@ -137,14 +137,15 @@ ConDrvDeviceComm::~ConDrvDeviceComm() = default;
     // See: https://msdn.microsoft.com/en-us/library/windows/desktop/aa363216(v=vs.85).aspx
     // Written is unused but cannot be nullptr because we aren't using overlapped.
     DWORD cbWritten = 0;
-    RETURN_IF_WIN32_BOOL_FALSE(DeviceIoControl(_Server.get(),
-                                               dwIoControlCode,
-                                               pInBuffer,
-                                               cbInBufferSize,
-                                               pOutBuffer,
-                                               cbOutBufferSize,
-                                               &cbWritten,
-                                               nullptr));
+    RETURN_IF_WIN32_BOOL_FALSE_EXPECTED(DeviceIoControl(
+        _Server.get(),
+        dwIoControlCode,
+        pInBuffer,
+        cbInBufferSize,
+        pOutBuffer,
+        cbOutBufferSize,
+        &cbWritten,
+        nullptr));
 
     return S_OK;
 }

--- a/src/server/WaitBlock.cpp
+++ b/src/server/WaitBlock.cpp
@@ -223,9 +223,11 @@ bool ConsoleWaitBlock::Notify(const WaitTerminationReason TerminationReason)
             a->NumBytes = gsl::narrow<ULONG>(NumBytes);
         }
 
-        LOG_IF_FAILED(_WaitReplyMessage.ReleaseMessageBuffers());
+        _WaitReplyMessage.ReleaseMessageBuffers();
 
-        LOG_IF_FAILED(Microsoft::Console::Interactivity::ServiceLocator::LocateGlobals().pDeviceComm->CompleteIo(&_WaitReplyMessage.Complete));
+        // This call fails when the server pipe is closed on us,
+        // which results in log spam in practice.
+        std::ignore = Microsoft::Console::Interactivity::ServiceLocator::LocateGlobals().pDeviceComm->CompleteIo(&_WaitReplyMessage.Complete);
 
         fRetVal = true;
     }


### PR DESCRIPTION
When the server handle gets closed on conhost (= terminal is gone),
and e.g. PowerShell is used, we would previously log 6 error messages.
This PR reduces it to zero, by removing the 3 biggest offenders.