### PR TITLE
Add WinGet configuration file for building terminal

### DIFF
--- a/.config/configuration.vsEnterprise.winget
+++ b/.config/configuration.vsEnterprise.winget
@@ -29,6 +29,7 @@ properties:
       directives:
         description: Install required VS workloads from project .vsconfig file
         allowPrerelease: true
+        securityContext: elevated
       settings:
         productId: Microsoft.VisualStudio.Product.Enterprise
         channelId: VisualStudio.17.Release

--- a/.config/configuration.vsEnterprise.winget
+++ b/.config/configuration.vsEnterprise.winget
@@ -13,6 +13,7 @@ properties:
       id: powershell
       directives:
         description: Install PowerShell 7
+        securityContext: elevated
       settings:
         id: Microsoft.PowerShell
         source: winget
@@ -20,6 +21,7 @@ properties:
       id: vsPackage
       directives:
         description: Install Visual Studio 2022 Enterprise (any edition is OK)
+        securityContext: elevated
       settings:
         id: Microsoft.VisualStudio.2022.Enterprise
         source: winget

--- a/.config/configuration.vsEnterprise.winget
+++ b/.config/configuration.vsEnterprise.winget
@@ -6,6 +6,7 @@ properties:
       directives:
         description: Enable Developer Mode
         allowPrerelease: true
+        # Requires elevation for the set operation
         securityContext: elevated
       settings:
         Ensure: Present
@@ -13,6 +14,7 @@ properties:
       id: powershell
       directives:
         description: Install PowerShell 7
+        # Requires elevation for the set operation (i.e., installation)
         securityContext: elevated
       settings:
         id: Microsoft.PowerShell
@@ -21,6 +23,7 @@ properties:
       id: vsPackage
       directives:
         description: Install Visual Studio 2022 Enterprise (any edition is OK)
+        # Requires elevation for the set operation (i.e., installation)
         securityContext: elevated
       settings:
         id: Microsoft.VisualStudio.2022.Enterprise
@@ -31,6 +34,7 @@ properties:
       directives:
         description: Install required VS workloads from project .vsconfig file
         allowPrerelease: true
+        # Requires elevation for the get and set operations
         securityContext: elevated
       settings:
         productId: Microsoft.VisualStudio.Product.Enterprise

--- a/.config/configuration.vsEnterprise.winget
+++ b/.config/configuration.vsEnterprise.winget
@@ -19,9 +19,9 @@ properties:
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: vsPackage
       directives:
-        description: Install Visual Studio 2022 Community (any edition is OK)
+        description: Install Visual Studio 2022 Enterprise (any edition is OK)
       settings:
-        id: Microsoft.VisualStudio.2022.Community
+        id: Microsoft.VisualStudio.2022.Enterprise
         source: winget
     - resource: Microsoft.VisualStudio.DSC/VSComponents
       dependsOn:
@@ -30,7 +30,7 @@ properties:
         description: Install required VS workloads from project .vsconfig file
         allowPrerelease: true
       settings:
-        productId: Microsoft.VisualStudio.Product.Community
+        productId: Microsoft.VisualStudio.Product.Enterprise
         channelId: VisualStudio.17.Release
         vsConfigFile: '${WinGetConfigRoot}\..\.vsconfig'
   configurationVersion: 0.2.0

--- a/.config/configuration.vsProfessional.winget
+++ b/.config/configuration.vsProfessional.winget
@@ -19,9 +19,9 @@ properties:
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: vsPackage
       directives:
-        description: Install Visual Studio 2022 Community (any edition is OK)
+        description: Install Visual Studio 2022 Professional (any edition is OK)
       settings:
-        id: Microsoft.VisualStudio.2022.Community
+        id: Microsoft.VisualStudio.2022.Professional
         source: winget
     - resource: Microsoft.VisualStudio.DSC/VSComponents
       dependsOn:
@@ -30,7 +30,7 @@ properties:
         description: Install required VS workloads from project .vsconfig file
         allowPrerelease: true
       settings:
-        productId: Microsoft.VisualStudio.Product.Community
+        productId: Microsoft.VisualStudio.Product.Professional
         channelId: VisualStudio.17.Release
         vsConfigFile: '${WinGetConfigRoot}\..\.vsconfig'
   configurationVersion: 0.2.0

--- a/.config/configuration.vsProfessional.winget
+++ b/.config/configuration.vsProfessional.winget
@@ -6,6 +6,7 @@ properties:
       directives:
         description: Enable Developer Mode
         allowPrerelease: true
+        # Requires elevation for the set operation
         securityContext: elevated
       settings:
         Ensure: Present
@@ -13,6 +14,7 @@ properties:
       id: powershell
       directives:
         description: Install PowerShell 7
+        # Requires elevation for the set operation (i.e., installation)
         securityContext: elevated
       settings:
         id: Microsoft.PowerShell
@@ -21,6 +23,7 @@ properties:
       id: vsPackage
       directives:
         description: Install Visual Studio 2022 Professional (any edition is OK)
+        # Requires elevation for the set operation (i.e., installation)
         securityContext: elevated
       settings:
         id: Microsoft.VisualStudio.2022.Professional
@@ -31,6 +34,7 @@ properties:
       directives:
         description: Install required VS workloads from project .vsconfig file
         allowPrerelease: true
+        # Requires elevation for the get and set operations
         securityContext: elevated
       settings:
         productId: Microsoft.VisualStudio.Product.Professional

--- a/.config/configuration.vsProfessional.winget
+++ b/.config/configuration.vsProfessional.winget
@@ -13,6 +13,7 @@ properties:
       id: powershell
       directives:
         description: Install PowerShell 7
+        securityContext: elevated
       settings:
         id: Microsoft.PowerShell
         source: winget
@@ -20,6 +21,7 @@ properties:
       id: vsPackage
       directives:
         description: Install Visual Studio 2022 Professional (any edition is OK)
+        securityContext: elevated
       settings:
         id: Microsoft.VisualStudio.2022.Professional
         source: winget

--- a/.config/configuration.vsProfessional.winget
+++ b/.config/configuration.vsProfessional.winget
@@ -29,6 +29,7 @@ properties:
       directives:
         description: Install required VS workloads from project .vsconfig file
         allowPrerelease: true
+        securityContext: elevated
       settings:
         productId: Microsoft.VisualStudio.Product.Professional
         channelId: VisualStudio.17.Release

--- a/.config/configuration.winget
+++ b/.config/configuration.winget
@@ -29,6 +29,7 @@ properties:
       directives:
         description: Install required VS workloads from project .vsconfig file
         allowPrerelease: true
+        securityContext: elevated
       settings:
         productId: Microsoft.VisualStudio.Product.Community
         channelId: VisualStudio.17.Release

--- a/.config/configuration.winget
+++ b/.config/configuration.winget
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+# Reference: https://github.com/microsoft/terminal/blob/main/README.md#developer-guidance
+properties:
+  resources:
+    - resource: Microsoft.Windows.Developer/DeveloperMode
+      directives:
+        description: Enable Developer Mode
+        allowPrerelease: true
+      settings:
+        Ensure: Present
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: powershell
+      directives:
+        description: Install PowerShell 7
+      settings:
+        id: Microsoft.PowerShell
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: vsPackage
+      directives:
+        description: Install Visual Studio 2022 (any edition is OK)
+      settings:
+        id: Microsoft.VisualStudio.2022.Community
+        source: winget
+    - resource: Microsoft.VisualStudio.DSC/VSComponents
+      dependsOn:
+        - vsPackage
+      directives:
+        description: Install required VS workloads from project .vsconfig file
+        allowPrerelease: true
+      settings:
+        productId: Microsoft.VisualStudio.Product.Community
+        channelId: VisualStudio.17.Release
+        vsConfigFile: '${WinGetConfigRoot}\..\.vsconfig'
+  configurationVersion: 0.2.0

--- a/.config/configuration.winget
+++ b/.config/configuration.winget
@@ -13,6 +13,7 @@ properties:
       id: powershell
       directives:
         description: Install PowerShell 7
+        securityContext: elevated
       settings:
         id: Microsoft.PowerShell
         source: winget
@@ -20,6 +21,7 @@ properties:
       id: vsPackage
       directives:
         description: Install Visual Studio 2022 Community (any edition is OK)
+        securityContext: elevated
       settings:
         id: Microsoft.VisualStudio.2022.Community
         source: winget

--- a/.config/configuration.winget
+++ b/.config/configuration.winget
@@ -6,6 +6,7 @@ properties:
       directives:
         description: Enable Developer Mode
         allowPrerelease: true
+        securityContext: elevated
       settings:
         Ensure: Present
     - resource: Microsoft.WinGet.DSC/WinGetPackage

--- a/.config/configuration.winget
+++ b/.config/configuration.winget
@@ -6,6 +6,7 @@ properties:
       directives:
         description: Enable Developer Mode
         allowPrerelease: true
+        # Requires elevation for the set operation
         securityContext: elevated
       settings:
         Ensure: Present
@@ -13,6 +14,7 @@ properties:
       id: powershell
       directives:
         description: Install PowerShell 7
+        # Requires elevation for the set operation (i.e., installation)
         securityContext: elevated
       settings:
         id: Microsoft.PowerShell
@@ -21,6 +23,7 @@ properties:
       id: vsPackage
       directives:
         description: Install Visual Studio 2022 Community (any edition is OK)
+        # Requires elevation for the set operation (i.e., installation)
         securityContext: elevated
       settings:
         id: Microsoft.VisualStudio.2022.Community
@@ -31,6 +34,7 @@ properties:
       directives:
         description: Install required VS workloads from project .vsconfig file
         allowPrerelease: true
+        # Requires elevation for the get and set operations
         securityContext: elevated
       settings:
         productId: Microsoft.VisualStudio.Product.Community

--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -1945,6 +1945,7 @@ VPACKMANIFESTDIRECTORY
 VPR
 VREDRAW
 vsc
+vsconfig
 vscprintf
 VSCROLL
 vsdevshell

--- a/README.md
+++ b/README.md
@@ -340,6 +340,19 @@ If you would like to ask a question that you feel doesn't warrant an issue
 
 ## Prerequisites
 
+You can configure your environment to build Terminal in one of two ways:
+
+### Using WinGet configuration file
+
+After cloning the repository, you can use the [configuration file](.config/configuration.winget)
+to set up your environment. To run the configuration file, you can either double-click the file from file explorer or run the following command:
+
+```powershell
+winget configure .config\configuration.winget
+```
+
+### Manual configuration
+
 * You must be running Windows 10 2004 (build >= 10.0.19041.0) or later to run
   Windows Terminal
 * You must [enable Developer Mode in the Windows Settings

--- a/README.md
+++ b/README.md
@@ -344,8 +344,8 @@ You can configure your environment to build Terminal in one of two ways:
 
 ### Using WinGet configuration file
 
-After cloning the repository, you can use the [configuration file](.config/configuration.winget)
-to set up your environment. To run the configuration file, you can either double-click the file from file explorer or run the following command:
+After cloning the repository, you can use a [WinGet configuration file](https://learn.microsoft.com/en-us/windows/package-manager/configuration/#use-a-winget-configuration-file-to-configure-your-machine)
+to set up your environment. The [default configuration file](.config/configuration.winget) installs Visual Studio 2022 Community & rest of the required tools. There are two other variants of the configuration file available in the [.config](.config) directory for Enterprise & Professional editions of Visual Studio 2022. To run the default configuration file, you can either double-click the file from explorer or run the following command:
 
 ```powershell
 winget configure .config\configuration.winget


### PR DESCRIPTION
## Summary of the Pull Request
PR adds a WinGet configuration file to install the necessary dependencies in order to build terminal locally. The configuration file enables developer mode, installs PowerShell 7, Visual Studio 2022 & all the required workloads from the project's [.vsconfig](https://github.com/microsoft/terminal/blob/main/.vsconfig) file (in accordance with the [dependencies listed](https://github.com/microsoft/terminal?tab=readme-ov-file#prerequisites) in the project's README).

## Validation Steps Performed
Tested the configuration file by spinning up a clean Win11 Pro VM in azure and then doing the following:

1. Install latest WinGet on the VM using [WinGet sandbox script](https://learn.microsoft.com/en-us/windows/package-manager/winget/#install-winget-on-windows-sandbox). Install git and clone the repo
2. Run `winget configure .config/configuration.winget` (this should work by just double-clicking the file in explorer too)
3. After the configuration is completed, open the solution in the now installed Visual Studio and build. The build is successful and I could start terminal with <kbd>F5</kbd>