### PR TITLE
CodeQL: Prevent cast of BOOL to HRESULT

### DIFF
--- a/src/renderer/gdi/paint.cpp
+++ b/src/renderer/gdi/paint.cpp
@@ -574,7 +574,8 @@ try
         }
 
         const auto cpt = gsl::narrow_cast<DWORD>(points.size());
-        return PolyBezier(_hdcMemoryContext, points.data(), cpt);
+        RETURN_HR_IF(E_FAIL, !PolyBezier(_hdcMemoryContext, points.data(), cpt));
+        return S_OK;
     };
 
     if (lines.test(GridLines::Left))


### PR DESCRIPTION
## Summary of the Pull Request
CodeQL for paint.cpp

## References and Relevant Issues
Some CodeQL for converting BOOL to HRESULT.

## Detailed Description of the Pull Request / Additional comments
PolyBezier returns a BOOL instead of an HRESULT, so just refactoring how the pertaining function returns.

## Validation Steps Performed
Built, ran all tests.

## PR Checklist
- [ ] Closes #xxx
- [x] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
