### PR TITLE
fix(json): remove trailing commas in XamlStyler.json and consolegit2gitgilters.json

### DIFF
--- a/XamlStyler.json
+++ b/XamlStyler.json
@@ -37,5 +37,5 @@
     "ThicknessSeparator": 2,
     "ThicknessAttributes": "Margin, Padding, BorderThickness, ThumbnailClipMargin",
     "FormatOnSave": true,
-    "CommentPadding": 2,
+    "CommentPadding": 2
 }

--- a/consolegit2gitfilters.json
+++ b/consolegit2gitfilters.json
@@ -27,7 +27,7 @@
     "/src/tools/ansi-color/",
     "/src/tools/ColorTool/",
     "/scratch/",
-    "Scratch.sln",
+    "Scratch.sln"
   ],
   "SuffixFilters": [
     ".dbb",


### PR DESCRIPTION
## Summary of the Pull Request

This PR removes trailing commas from `XamlStyler.json` and `consolegit2gitfilters.json`, ensuring they follow valid JSON syntax. Trailing commas are not allowed in JSON and could cause parsing errors.

## Detailed Description of the Pull 

- Removed the trailing commas from:
    - `XamlStyler.json`
    - `consolegit2gitfilters.json`
- Ensured that both files now comply with proper JSON syntax
- Prevents potential issues with JSON parsing in tools or scripts that depend on these files.      

## PR Checklist
- [x] Tests added/passed  
- [ ] Closes #xxx
- [ ] Documentation updated   
- [ ] Schema updated 
