### PR TITLE
Fix a ConPTY startup hang with 0-param DA1 responses

### DIFF
--- a/src/terminal/parser/InputStateMachineEngine.hpp
+++ b/src/terminal/parser/InputStateMachineEngine.hpp
@@ -51,6 +51,10 @@ namespace Microsoft::Console::VirtualTerminal
 
     enum class DeviceAttribute : uint64_t
     {
+        // Special value to indicate that InputStateMachineEngine::_deviceAttributes has been set.
+        // 0 in this case means 1<<0 == 1, which in turn means that _deviceAttributes is non-zero.
+        __some__ = 0,
+
         Columns132 = 1,
         PrinterPort = 2,
         Sixel = 4,


### PR DESCRIPTION
Since `WaitForDA1` would wait until `_deviceAttributes` is non-zero,
we must ensure it's actually non-zero at the end of this handler,
even if there are no parameters.

## Validation Steps Performed
* Mod the Terminal DA1 to be `\x1b[?6c`. No hang ✅
* Mod the Terminal DA1 to be `\x1b[?61c`. No hang ✅