### PR TITLE
Add support for language override to unpackaged/portable builds

### DIFF
--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -331,8 +331,16 @@ namespace winrt::TerminalApp::implementation
     void AppLogic::_ApplyLanguageSettingChange() noexcept
     try
     {
+        const auto language = _settings.GlobalSettings().Language();
+
         if (!IsPackaged())
         {
+            if (!language.empty())
+            {
+                // We cannot use the packaged app API, PrimaryLanguageOverride, but we *can* tell the resource loader
+                // to set the Language for all loaded resources to the user's preferred language.
+                winrt::Windows::ApplicationModel::Resources::Core::ResourceContext::SetGlobalQualifierValue(L"Language", language);
+            }
             return;
         }
 
@@ -340,8 +348,6 @@ namespace winrt::TerminalApp::implementation
 
         // NOTE: PrimaryLanguageOverride throws if this instance is unpackaged.
         const auto primaryLanguageOverride = ApplicationLanguages::PrimaryLanguageOverride();
-        const auto language = _settings.GlobalSettings().Language();
-
         if (primaryLanguageOverride != language)
         {
             ApplicationLanguages::PrimaryLanguageOverride(language);

--- a/src/cascadia/TerminalApp/pch.h
+++ b/src/cascadia/TerminalApp/pch.h
@@ -27,6 +27,7 @@
 
 #include <winrt/Windows.ApplicationModel.h>
 #include <winrt/Windows.ApplicationModel.DataTransfer.h>
+#include <winrt/Windows.ApplicationModel.Resources.Core.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Foundation.Metadata.h>

--- a/src/cascadia/TerminalSettingsEditor/Launch.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Launch.xaml
@@ -140,8 +140,7 @@
             </local:SettingContainer>
 
             <!--  Language  -->
-            <local:SettingContainer x:Uid="Globals_Language"
-                                    Visibility="{x:Bind ViewModel.LanguageSelectorAvailable}">
+            <local:SettingContainer x:Uid="Globals_Language">
                 <ComboBox ItemsSource="{x:Bind ViewModel.LanguageList}"
                           SelectedItem="{x:Bind ViewModel.CurrentLanguage, Mode=TwoWay}"
                           Style="{StaticResource ComboBoxSettingStyle}">

--- a/src/cascadia/TerminalSettingsEditor/LaunchViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/LaunchViewModel.h
@@ -20,7 +20,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // "Deutsch (Deutschland)". This works independently of the user's locale.
         static winrt::hstring LanguageDisplayConverter(const winrt::hstring& tag);
 
-        bool LanguageSelectorAvailable();
         winrt::Windows::Foundation::Collections::IObservableVector<winrt::hstring> LanguageList();
         winrt::Windows::Foundation::IInspectable CurrentLanguage();
         void CurrentLanguage(const winrt::Windows::Foundation::IInspectable& tag);

--- a/src/cascadia/TerminalSettingsEditor/LaunchViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/LaunchViewModel.idl
@@ -10,7 +10,6 @@ namespace Microsoft.Terminal.Settings.Editor
     runtimeclass LaunchViewModel : Windows.UI.Xaml.Data.INotifyPropertyChanged
     {
         static String LanguageDisplayConverter(String tag);
-        Boolean LanguageSelectorAvailable { get; };
         Windows.Foundation.Collections.IObservableVector<String> LanguageList { get; };
         IInspectable CurrentLanguage;
 


### PR DESCRIPTION
It turns out that we *can* support language overrides--fairly easily, in fact!--by simply changing the default Language qualifier.

I elected not to change how packaged language override works until we are certain this works properly everywhere. Consider it a healthy distrust of the Windows App Platform.

Closes #18419
Closes #18336
Closes #17619