### PR TITLE
Allow users to specify a base settings path, enabling multiple local state and multi-instance scenarios.

### DIFF
--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -1198,9 +1198,15 @@ void AppCommandlineArgs::FullResetState()
     _isHandoffListener = false;
 
     _windowTarget = {};
+    _localState = {};
 }
 
 std::string_view AppCommandlineArgs::GetTargetWindow() const noexcept
 {
     return _windowTarget;
+}
+
+std::string_view AppCommandlineArgs::GetLocalState() const noexcept
+{
+    return _localState;
 }

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.h
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.h
@@ -49,6 +49,7 @@ public:
     void FullResetState();
 
     std::string_view GetTargetWindow() const noexcept;
+    std::string_view GetLocalState() const noexcept;
 
 private:
     static const std::wregex _commandDelimiterRegex;
@@ -139,6 +140,7 @@ private:
 
     int _loadPersistedLayoutIdx{};
     std::string _windowTarget{};
+    std::string _localState{};
     // Are you adding more args or attributes here? If they are not reset in _resetStateToDefault, make sure to reset them in FullResetState
 
     winrt::Microsoft::Terminal::Settings::Model::NewTerminalArgs _getNewTerminalArgs(NewTerminalSubcommand& subcommand);

--- a/src/cascadia/TerminalApp/Remoting.cpp
+++ b/src/cascadia/TerminalApp/Remoting.cpp
@@ -53,6 +53,11 @@ namespace winrt::TerminalApp::implementation
         return winrt::to_hstring(_parsed.GetTargetWindow());
     }
 
+    winrt::hstring CommandlineArgs::LocalState() const
+    {
+        return winrt::to_hstring(_parsed.GetLocalState());
+    }
+
     void CommandlineArgs::Commandline(const winrt::array_view<const winrt::hstring>& value)
     {
         _args = { value.begin(), value.end() };

--- a/src/cascadia/TerminalApp/Remoting.h
+++ b/src/cascadia/TerminalApp/Remoting.h
@@ -24,6 +24,7 @@ namespace winrt::TerminalApp::implementation
         int32_t ExitCode() const noexcept;
         winrt::hstring ExitMessage() const;
         winrt::hstring TargetWindow() const;
+        winrt::hstring LocalState() const;
 
         void Commandline(const winrt::array_view<const winrt::hstring>& value);
         winrt::com_array<winrt::hstring> Commandline();

--- a/src/cascadia/TerminalApp/Remoting.idl
+++ b/src/cascadia/TerminalApp/Remoting.idl
@@ -11,6 +11,7 @@ namespace TerminalApp
         Int32 ExitCode { get; };
         String ExitMessage { get; };
         String TargetWindow { get; };
+        String LocalState { get; };
 
         String[] Commandline;
         String CurrentDirectory { get; };

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -422,6 +422,9 @@
   <data name="CmdSavedLayoutArgDesc" xml:space="preserve">
     <value>This parameter is an internal implementation detail and should not be used.</value>
   </data>
+  <data name="CmdLocalStateArgDesc" xml:space="preserve">
+    <value>Local State folder path.</value>
+  </data>
   <data name="CmdWindowTargetArgDesc" xml:space="preserve">
     <value>Specify a terminal window to run the given commandline in. "0" always refers to the current window. </value>
   </data>

--- a/src/cascadia/TerminalSettingsModel/FileUtils.cpp
+++ b/src/cascadia/TerminalSettingsModel/FileUtils.cpp
@@ -8,6 +8,8 @@
 #include <shlobj.h>
 #include <WtExeUtils.h>
 
+#define ENV_WT_BASE_SETTINGS_PATH L"WT_BASE_SETTINGS_PATH"
+
 static constexpr std::wstring_view UnpackagedSettingsFolderName{ L"Microsoft\\Windows Terminal\\" };
 static constexpr std::wstring_view ReleaseSettingsFolder{ L"Packages\\Microsoft.WindowsTerminal_8wekyb3d8bbwe\\LocalState\\" };
 static constexpr std::wstring_view PortableModeMarkerFile{ L".portable" };
@@ -30,6 +32,14 @@ namespace winrt::Microsoft::Terminal::Settings::Model
     std::filesystem::path GetBaseSettingsPath()
     {
         static auto baseSettingsPath = []() {
+            try
+            {
+                std::filesystem::path envSettingsPath{ wil::GetEnvironmentVariableW<std::wstring>(ENV_WT_BASE_SETTINGS_PATH) };
+                std::filesystem::create_directories(envSettingsPath);
+                return envSettingsPath;
+            }
+            CATCH_LOG()
+
             if (!IsPackaged() && IsPortableMode())
             {
                 std::filesystem::path modulePath{ wil::GetModuleFileNameW<std::wstring>(wil::GetModuleInstanceHandle()) };
@@ -64,6 +74,14 @@ namespace winrt::Microsoft::Terminal::Settings::Model
     std::filesystem::path GetReleaseSettingsPath()
     {
         static std::filesystem::path baseSettingsPath = []() {
+            try
+            {
+                std::filesystem::path envSettingsPath{ wil::GetEnvironmentVariableW<std::wstring>(ENV_WT_BASE_SETTINGS_PATH) };
+                std::filesystem::create_directories(envSettingsPath);
+                return envSettingsPath;
+            }
+            CATCH_LOG()
+
             wil::unique_cotaskmem_string localAppDataFolder;
             // We're using KF_FLAG_NO_PACKAGE_REDIRECTION to ensure that we always get the
             // user's actual local AppData directory.

--- a/src/cascadia/TerminalSettingsModel/FileUtils.cpp
+++ b/src/cascadia/TerminalSettingsModel/FileUtils.cpp
@@ -34,9 +34,12 @@ namespace winrt::Microsoft::Terminal::Settings::Model
         static auto baseSettingsPath = []() {
             try
             {
-                std::filesystem::path envSettingsPath{ wil::GetEnvironmentVariableW<std::wstring>(ENV_WT_BASE_SETTINGS_PATH) };
-                std::filesystem::create_directories(envSettingsPath);
-                return envSettingsPath;
+                std::filesystem::path envSettingsPath{ wil::TryGetEnvironmentVariableW<std::wstring>(ENV_WT_BASE_SETTINGS_PATH) };
+                if (!envSettingsPath.empty())
+                {
+                    std::filesystem::create_directories(envSettingsPath);
+                    return envSettingsPath;
+                }
             }
             CATCH_LOG()
 
@@ -76,9 +79,12 @@ namespace winrt::Microsoft::Terminal::Settings::Model
         static std::filesystem::path baseSettingsPath = []() {
             try
             {
-                std::filesystem::path envSettingsPath{ wil::GetEnvironmentVariableW<std::wstring>(ENV_WT_BASE_SETTINGS_PATH) };
-                std::filesystem::create_directories(envSettingsPath);
-                return envSettingsPath;
+                std::filesystem::path envSettingsPath{ wil::TryGetEnvironmentVariableW<std::wstring>(ENV_WT_BASE_SETTINGS_PATH) };
+                if (!envSettingsPath.empty())
+                {
+                    std::filesystem::create_directories(envSettingsPath);
+                    return envSettingsPath;
+                }
             }
             CATCH_LOG()
 

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -24,6 +24,8 @@ using namespace ::Microsoft::Console;
 using namespace std::chrono_literals;
 using VirtualKeyModifiers = winrt::Windows::System::VirtualKeyModifiers;
 
+#define ENV_WT_BASE_SETTINGS_PATH L"WT_BASE_SETTINGS_PATH"
+
 #ifdef _WIN64
 static constexpr ULONG_PTR TERMINAL_HANDOFF_MAGIC = 0x4c414e494d524554; // 'TERMINAL'
 #else
@@ -296,6 +298,18 @@ void WindowEmperor::HandleCommandlineArgs(int nCmdShow)
         fmt::format_to(std::back_inserter(windowClassName), FMT_COMPILE(L" {:08x}"), hash);
 #endif
     }
+
+    try
+    {
+        const auto settingsPath = wil::GetEnvironmentVariableW<std::wstring>(ENV_WT_BASE_SETTINGS_PATH);
+        const auto settingsHash = til::hash(settingsPath);
+#ifdef _WIN64
+        fmt::format_to(std::back_inserter(windowClassName), FMT_COMPILE(L" {:016x}"), settingsHash);
+#else
+        fmt::format_to(std::back_inserter(windowClassName), FMT_COMPILE(L" {:08x}"), settingsHash);
+#endif
+    }
+    CATCH_LOG()
 
     // Windows Terminal is a single-instance application. Either acquire ownership
     // over the mutex, or hand off the command line to the existing instance.


### PR DESCRIPTION
### Description of the new feature

Multi local state and settings and multi instance with `--localstate` command-line argument

## Summary

Introduce a new command-line option `-L` or `--localstate` to allow users to specify a custom local state directory for Windows Terminal, enabling multiple local states, settings and multi-instance scenarios.

Enhancements:

- Modify command-line argument parsing to support the new local state option
- Update environment variable handling to use the new local state path

### Proposed technical implementation details

## Reviewer Guide

Introducing the ability to run multiple instances of Windows Terminal with separate settings and state by using the `--localstate` command-line  argument. Modify parsing to support the new local state option. The changes modify the settings path retrieval logic and window class name generation to incorporate the environment variable, allowing for isolated settings for each instance.

This pull request adds support for a new command-line argument `-L` or `--localstate` to allow users to specify a custom local state directory for Windows Terminal. The implementation involves modifying command-line argument parsing, updating environment variable handling, and updating file utilities to use the new local state path.

#### Sequence diagram for handling the new localstate argument

```mermaid
sequenceDiagram
    participant User
    participant Command Line
    participant AppCommandlineArgs
    participant WindowEmperor
    participant FileUtils

    User->>Command Line: wt --localstate <path>
    Command Line->>AppCommandlineArgs: Parse arguments
    AppCommandlineArgs->>AppCommandlineArgs: Store local state path
    AppCommandlineArgs->>WindowEmperor: Launch Terminal
    WindowEmperor->>WindowEmperor: Handle Commandline Args
    WindowEmperor->>AppCommandlineArgs: Get Local State
    WindowEmperor->>FileUtils: Set ENV_WT_BASE_SETTINGS_PATH to local state path
    FileUtils->>FileUtils: Create directories at local state path
```

#### Updated class diagram for AppCommandlineArgs

```mermaid
classDiagram
  class AppCommandlineArgs {
    -std::wregex _commandDelimiterRegex
    -std::vector<std::wstring> _args
    -bool _hasParseError
    -bool _shouldExitEarly
    -bool _isHandoffListener
    -int _loadPersistedLayoutIdx
    -std::string _windowTarget
    -std::string _localState
    +FullResetState()
    +GetTargetWindow() string_view
    +GetLocalState() string_view
    -_getNewTerminalArgs(NewTerminalSubcommand& subcommand) NewTerminalArgs
  }
```

### File-Level Changes

| Change | Details | Files |
| ------ | ------- | ----- |
| Introduced a new command-line argument `-L` or `--localstate` to allow users to specify a custom local state directory for Windows Terminal. | <ul><li>Added `_localState` field to `AppCommandlineArgs` class to store the local state path.</li><li>Added `-L,--localstate` option to the command-line argument parser.</li><li>Implemented `GetLocalState()` method in `AppCommandlineArgs` to retrieve the local state path.</li><li>Added `LocalState()` property to the `CommandlineArgs` class in `Remoting.idl` and implemented it in `Remoting.cpp`.</li><li>Modified `WindowEmperor::HandleCommandlineArgs` to retrieve the settings path from the command line arguments.</li><li>Updated `FileUtils::GetBaseSettingsPath` to retrieve the settings path from the environment variables.</li></ul> | `src/cascadia/WindowsTerminal/WindowEmperor.cpp`<br/>`src/cascadia/TerminalSettingsModel/FileUtils.cpp`<br/>`src/cascadia/TerminalApp/AppCommandlineArgs.cpp`<br/>`src/cascadia/TerminalApp/Remoting.cpp`<br/>`src/cascadia/TerminalApp/AppCommandlineArgs.h`<br/>`src/cascadia/TerminalApp/Remoting.h`<br/>`src/cascadia/CascadiaPackage/Package-Dev.appxmanifest`<br/>`src/cascadia/TerminalApp/Remoting.idl`<br/>`src/cascadia/TerminalApp/Resources/en-US/Resources.resw` |

---


## PR Checklist
- [x] Closes #18696
- [x] New feature

## Motivation
I created Windows Terminal Layout Manager application. Which is an advanced yet user-friendly application designed to simplify and streamline the management of your Windows Terminal sessions. Effortlessly save, restore, and dynamically manage multiple terminal layouts and settings, ensuring a smooth and consistent workflow.
[WTLayoutManager](https://github.com/dmitrykok/WTLayoutManager)

![Image](https://github.com/user-attachments/assets/944ca59c-75be-4b5e-8df9-af04b4a23ced)

![Image](https://github.com/user-attachments/assets/94b9b7ca-49a8-4dc4-83d8-0d28ce0f775b)