### PR TITLE
Delay-load icu so that we don't fail to start up on Windows <1903

### DIFF
--- a/src/cascadia/TerminalControl/dll/TerminalControl.vcxproj
+++ b/src/cascadia/TerminalControl/dll/TerminalControl.vcxproj
@@ -95,7 +95,7 @@
   <ItemDefinitionGroup>
     <Link>
       <AdditionalDependencies>delayimp.lib;Uiautomationcore.lib;onecoreuap.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <DelayLoadDLLs>uiautomationcore.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <DelayLoadDLLs>uiautomationcore.dll;icu.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
       <!--
       ControlLib contains a DllMain that we need to force the use of.
       If you don't have this, then you'll see an error like

--- a/src/host/exe/Host.EXE.vcxproj
+++ b/src/host/exe/Host.EXE.vcxproj
@@ -87,6 +87,7 @@
     <Link>
       <AllowIsolation>true</AllowIsolation>
       <AdditionalDependencies>winmm.lib;imm32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DelayLoadDLLs>icu.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <!-- Careful reordering these. Some default props (contained in these files) are order sensitive. -->


### PR DESCRIPTION
Originally, I intended to switch to icuuc/icuin.dll to make it work on Windows 1703 as well... but it turns out that the 22621 or 26100 SDKs redirect those back to icu.dll. That's a poor decision on their part, as it means that developers can't use the old compatibility names.

VS supports Windows <=1903, so we need to be able to load. Fortunately, the aren't using any of the features that need ICU (search and URL detection). Therefore, we don't need to guard our ICU calls... yet.

ConPTY doesn't use them at all.

When we add support for URL detection and search to HwndTerminal, we'll need to revisit.