### PR TITLE
vcpkg: add an overlay port for fmt 11.1.4; enable /W3

### DIFF
--- a/dep/vcpkg-overlay-ports/fmt/fix-write-batch.patch
+++ b/dep/vcpkg-overlay-ports/fmt/fix-write-batch.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 88c12148..967b53dd 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -260,7 +260,7 @@ if (FMT_MASTER_PROJECT AND CMAKE_GENERATOR MATCHES "Visual Studio")
+   join(netfxpath
+        "C:\\Program Files\\Reference Assemblies\\Microsoft\\Framework\\"
+        ".NETFramework\\v4.0")
+-  file(WRITE run-msbuild.bat "
++  file(WRITE "${CMAKE_BINARY_DIR}/run-msbuild.bat" "
+     ${MSBUILD_SETUP}
+     ${CMAKE_MAKE_PROGRAM} -p:FrameworkPathOverride=\"${netfxpath}\" %*")
+ endif ()

--- a/dep/vcpkg-overlay-ports/fmt/portfile.cmake
+++ b/dep/vcpkg-overlay-ports/fmt/portfile.cmake
@@ -1,0 +1,37 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO fmtlib/fmt
+    REF "${VERSION}"
+    SHA512 573b7de1bd224b7b1b60d44808a843db35d4bc4634f72a9edcb52cf68e99ca66c744fd5d5c97b4336ba70b94abdabac5fc253b245d0d5cd8bbe2a096bf941e39
+    HEAD_REF master
+    PATCHES
+        fix-write-batch.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DFMT_CMAKE_DIR=share/fmt
+        -DFMT_TEST=OFF
+        -DFMT_DOC=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/fmt/base.h"
+        "defined(FMT_SHARED)"
+        "1"
+    )
+endif()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/dep/vcpkg-overlay-ports/fmt/portfile.cmake
+++ b/dep/vcpkg-overlay-ports/fmt/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_cmake_configure(
         -DFMT_CMAKE_DIR=share/fmt
         -DFMT_TEST=OFF
         -DFMT_DOC=OFF
+        -DFMT_PEDANTIC=ON
 )
 
 vcpkg_cmake_install()

--- a/dep/vcpkg-overlay-ports/fmt/usage
+++ b/dep/vcpkg-overlay-ports/fmt/usage
@@ -1,0 +1,8 @@
+The package fmt provides CMake targets:
+
+    find_package(fmt CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE fmt::fmt)
+
+    # Or use the header-only version
+    find_package(fmt CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE fmt::fmt-header-only)

--- a/dep/vcpkg-overlay-ports/fmt/vcpkg.json
+++ b/dep/vcpkg-overlay-ports/fmt/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "fmt",
+  "version": "11.1.4",
+  "description": "{fmt} is an open-source formatting library providing a fast and safe alternative to C stdio and C++ iostreams.",
+  "homepage": "https://github.com/fmtlib/fmt",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -17,7 +17,7 @@
   "overrides": [
     {
       "name": "fmt",
-      "version": "11.0.2"
+      "version": "11.1.4"
     },
     {
       "name": "ms-gsl",
@@ -36,5 +36,8 @@
       "version": "0.30.3"
     }
   ],
-  "builtin-baseline": "fe1cde61e971d53c9687cf9a46308f8f55da19fa"
+  "builtin-baseline": "fe1cde61e971d53c9687cf9a46308f8f55da19fa",
+  "vcpkg-configuration": {
+    "overlay-ports": [ "./dep/vcpkg-overlay-ports" ]
+  }
 }


### PR DESCRIPTION
This pull request brings us up to fmt 11.1.4 and enables `FMT_PEDANTIC`.

`FMT_PEDANTIC` turns on `/W3`, which is required by our local feudal lords who will automatically file bugs on us if we don't build with enough warnings enabled.