### PR TITLE
build: run official builds with the R1 network isolation policy

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -86,6 +86,7 @@ autoscrolling
 Autowrap
 AVerify
 awch
+AZCOPY
 azurecr
 AZZ
 backgrounded
@@ -1416,6 +1417,7 @@ propvar
 propvariant
 propvarutil
 psa
+PSCRED
 PSECURITY
 pseudoconsole
 pseudoterminal

--- a/build/pipelines/ob-nightly.yml
+++ b/build/pipelines/ob-nightly.yml
@@ -25,7 +25,7 @@ variables:
 extends:
   template: templates-v2/pipeline-onebranch-full-release-build.yml
   parameters:
-    official: false
+    official: true
     branding: Canary
     buildTerminal: true
     pgoBuildMode: None # BODGY - OneBranch is on VS 17.10, which is known to be the worst

--- a/build/pipelines/ob-nightly.yml
+++ b/build/pipelines/ob-nightly.yml
@@ -25,7 +25,7 @@ variables:
 extends:
   template: templates-v2/pipeline-onebranch-full-release-build.yml
   parameters:
-    official: true
+    official: false
     branding: Canary
     buildTerminal: true
     pgoBuildMode: None # BODGY - OneBranch is on VS 17.10, which is known to be the worst

--- a/build/pipelines/templates-v2/job-deploy-to-azure-storage.yml
+++ b/build/pipelines/templates-v2/job-deploy-to-azure-storage.yml
@@ -75,11 +75,6 @@ jobs:
       }
     displayName: "Wrangle Unpackaged builds into place, rename"
 
-  - powershell: |-
-      Get-PackageProvider -Name NuGet -ForceBootstrap
-      Install-Module -Verbose -AllowClobber -Force Az.Accounts, Az.Storage, Az.Network, Az.Resources, Az.Compute
-    displayName: Install Azure Module Dependencies
-
   - task: AzureFileCopy@6
     displayName: Publish to Storage Account
     inputs:

--- a/build/pipelines/templates-v2/job-deploy-to-azure-storage.yml
+++ b/build/pipelines/templates-v2/job-deploy-to-azure-storage.yml
@@ -75,13 +75,12 @@ jobs:
       }
     displayName: "Wrangle Unpackaged builds into place, rename"
 
-  - task: AzureFileCopy@6
+  - task: AzurePowerShell@5
     displayName: Publish to Storage Account
     inputs:
-      sourcePath: _out/*
-      Destination: AzureBlob
       azureSubscription: ${{ parameters.subscription }}
-      storage: ${{ parameters.storageAccount }}
-      ContainerName: ${{ parameters.storageContainer }}
-      AdditionalArgumentsForBlobCopy: "--content-type application/octet-stream"
-
+      azurePowerShellVersion: LatestVersion
+      pwsh: true
+      ScriptType: InlineScript
+      Inline: |-
+        & AzCopy copy "_out\*" "https://${{ parameters.storageAccount }}.blob.core.windows.net/${{ parameters.storageContainer }}/" --content-type application/octet-stream

--- a/build/pipelines/templates-v2/job-deploy-to-azure-storage.yml
+++ b/build/pipelines/templates-v2/job-deploy-to-azure-storage.yml
@@ -83,4 +83,5 @@ jobs:
       pwsh: true
       ScriptType: InlineScript
       Inline: |-
+        $Env:AZCOPY_AUTO_LOGIN_TYPE="PSCRED"
         & AzCopy copy "_out\*" "https://${{ parameters.storageAccount }}.blob.core.windows.net/${{ parameters.storageContainer }}/" --content-type application/octet-stream

--- a/build/pipelines/templates-v2/job-publish-symbols-using-symbolrequestprod-api.yml
+++ b/build/pipelines/templates-v2/job-publish-symbols-using-symbolrequestprod-api.yml
@@ -52,11 +52,6 @@ jobs:
       itemPattern: '**/*.pdb'
       targetPath: '$(Build.SourcesDirectory)/bin'
 
-  - powershell: |-
-      Get-PackageProvider -Name NuGet -ForceBootstrap
-      Install-Module -Verbose -AllowClobber -Force Az.Accounts, Az.Storage, Az.Network, Az.Resources, Az.Compute
-    displayName: Install Azure Module Dependencies
-
   # Transit the Azure token from the Service Connection into a secret variable for the rest of the pipeline to use.
   - task: AzurePowerShell@5
     displayName: Generate an Azure Token

--- a/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
@@ -79,6 +79,7 @@ extends:
   parameters:
     featureFlags:
       WindowsHostVersion: 1ESWindows2022
+      Network: R1
     platform:
       name: 'windows_undocked'
       product: 'Windows Terminal'

--- a/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
@@ -79,7 +79,7 @@ extends:
   parameters:
     featureFlags:
       WindowsHostVersion:
-        Version: 1ESWindows2022
+        Version: 2022
         Network: R1
     platform:
       name: 'windows_undocked'

--- a/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
@@ -78,8 +78,9 @@ extends:
     template: v2/Microsoft.NonOfficial.yml@templates
   parameters:
     featureFlags:
-      WindowsHostVersion: 2022
-      Network: R1
+      WindowsHostVersion:
+        Version: 1ESWindows2022
+        Network: R1
     platform:
       name: 'windows_undocked'
       product: 'Windows Terminal'

--- a/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
@@ -78,7 +78,7 @@ extends:
     template: v2/Microsoft.NonOfficial.yml@templates
   parameters:
     featureFlags:
-      WindowsHostVersion: 1ESWindows2022
+      WindowsHostVersion: 2022
       Network: R1
     platform:
       name: 'windows_undocked'

--- a/build/pipelines/templates-v2/steps-ensure-nuget-version.yml
+++ b/build/pipelines/templates-v2/steps-ensure-nuget-version.yml
@@ -1,5 +1,12 @@
 steps:
-- task: NuGetToolInstaller@1
-  displayName: Use NuGet 6.6.1
-  inputs:
-    versionSpec: 6.6.1
+- ${{ if eq(variables['System.CollectionId'], 'cb55739e-4afe-46a3-970f-1b49d8ee7564') }}:
+  - pwsh: |-
+      Write-Host "Assuming NuGet is already installed..."
+      & nuget.exe help
+    displayName: Assume NuGet is fine
+
+- ${{ else }}:
+  - task: NuGetToolInstaller@1
+    displayName: Use NuGet 6.6.1
+    inputs:
+      versionSpec: 6.6.1


### PR DESCRIPTION
This required removing connections during the build to `nuget.org` and `powershellgallery.com`.

The NuGet Tool task was downloading nuget from `nuget.org` unconditionally.

The `AzureFileCopy` task was downloading `Az.Accounts` from `powershellgallery.com` unconditionally.

Both of these tasks have better options nowadays.

Tested and passed in OneBranch on 2025-04-01.