### PR TITLE
Add support for OSC 104, 110, 111, 112 and 117 (resets)

### DIFF
--- a/src/renderer/base/RenderSettings.cpp
+++ b/src/renderer/base/RenderSettings.cpp
@@ -166,6 +166,11 @@ size_t RenderSettings::GetColorAliasIndex(const ColorAlias alias) const noexcept
     return gsl::at(_colorAliasIndices, static_cast<size_t>(alias));
 }
 
+void RenderSettings::RestoreDefaultColorAliasIndex(const ColorAlias alias) noexcept
+{
+    gsl::at(_colorAliasIndices, static_cast<size_t>(alias)) = gsl::at(_defaultColorAliasIndices, static_cast<size_t>(alias));
+}
+
 // Routine Description:
 // - Calculates the RGB colors of a given text attribute, using the current
 //   color table configuration and active render settings.

--- a/src/renderer/base/RenderSettings.cpp
+++ b/src/renderer/base/RenderSettings.cpp
@@ -113,6 +113,13 @@ COLORREF RenderSettings::GetColorTableEntry(const size_t tableIndex) const
 }
 
 // Routine Description:
+// - Returns one color table entry to the value saved in SaveDefaultSettings.
+void RenderSettings::RestoreDefaultColorTableEntry(const size_t tableIndex)
+{
+    _colorTable.at(tableIndex) = _defaultColorTable.at(tableIndex);
+}
+
+// Routine Description:
 // - Sets the position in the color table for the given color alias and updates the color.
 // Arguments:
 // - alias - The color alias to update.

--- a/src/renderer/base/RenderSettings.cpp
+++ b/src/renderer/base/RenderSettings.cpp
@@ -114,9 +114,9 @@ COLORREF RenderSettings::GetColorTableEntry(const size_t tableIndex) const
 
 // Routine Description:
 // - Returns one color table entry to the value saved in SaveDefaultSettings.
-void RenderSettings::RestoreDefaultColorTableEntry(const size_t tableIndex)
+void RenderSettings::RestoreDefaultColorTableEntries(const size_t startIndex, const size_t count)
 {
-    _colorTable.at(tableIndex) = _defaultColorTable.at(tableIndex);
+    std::copy_n(&_defaultColorTable.at(startIndex), count, &_colorTable.at(startIndex));
 }
 
 // Routine Description:

--- a/src/renderer/base/RenderSettings.cpp
+++ b/src/renderer/base/RenderSettings.cpp
@@ -113,7 +113,7 @@ COLORREF RenderSettings::GetColorTableEntry(const size_t tableIndex) const
 }
 
 // Routine Description:
-// - Returns one color table entry to the value saved in SaveDefaultSettings.
+// - Restores a range of color table entries to the values saved in SaveDefaultSettings.
 void RenderSettings::RestoreDefaultColorTableEntries(const size_t startIndex, const size_t count)
 {
     std::copy_n(&_defaultColorTable.at(startIndex), count, &_colorTable.at(startIndex));

--- a/src/renderer/base/RenderSettings.cpp
+++ b/src/renderer/base/RenderSettings.cpp
@@ -113,10 +113,17 @@ COLORREF RenderSettings::GetColorTableEntry(const size_t tableIndex) const
 }
 
 // Routine Description:
-// - Restores a range of color table entries to the values saved in SaveDefaultSettings.
-void RenderSettings::RestoreDefaultColorTableEntries(const size_t startIndex, const size_t count)
+// - Restores all of the xterm-addressable colors to the ones saved in SaveDefaultSettings.
+void RenderSettings::RestoreDefaultIndexed256ColorTable()
 {
-    std::copy_n(&_defaultColorTable.at(startIndex), count, &_colorTable.at(startIndex));
+    std::copy_n(_defaultColorTable.begin(), 256, _colorTable.begin());
+}
+
+// Routine Description:
+// - Restores a color table entry to the value saved in SaveDefaultSettings.
+void RenderSettings::RestoreDefaultColorTableEntry(const size_t tableIndex)
+{
+    _colorTable.at(tableIndex) = _defaultColorTable.at(tableIndex);
 }
 
 // Routine Description:

--- a/src/renderer/inc/RenderSettings.hpp
+++ b/src/renderer/inc/RenderSettings.hpp
@@ -42,6 +42,7 @@ namespace Microsoft::Console::Render
         COLORREF GetColorAlias(const ColorAlias alias) const;
         void SetColorAliasIndex(const ColorAlias alias, const size_t tableIndex) noexcept;
         size_t GetColorAliasIndex(const ColorAlias alias) const noexcept;
+        void RestoreDefaultColorAliasIndex(const ColorAlias alias) noexcept;
         std::pair<COLORREF, COLORREF> GetAttributeColors(const TextAttribute& attr) const noexcept;
         std::pair<COLORREF, COLORREF> GetAttributeColorsWithAlpha(const TextAttribute& attr) const noexcept;
         COLORREF GetAttributeUnderlineColor(const TextAttribute& attr) const noexcept;

--- a/src/renderer/inc/RenderSettings.hpp
+++ b/src/renderer/inc/RenderSettings.hpp
@@ -37,6 +37,7 @@ namespace Microsoft::Console::Render
         void ResetColorTable() noexcept;
         void SetColorTableEntry(const size_t tableIndex, const COLORREF color);
         COLORREF GetColorTableEntry(const size_t tableIndex) const;
+        void RestoreDefaultColorTableEntry(const size_t tableIndex);
         void SetColorAlias(const ColorAlias alias, const size_t tableIndex, const COLORREF color);
         COLORREF GetColorAlias(const ColorAlias alias) const;
         void SetColorAliasIndex(const ColorAlias alias, const size_t tableIndex) noexcept;

--- a/src/renderer/inc/RenderSettings.hpp
+++ b/src/renderer/inc/RenderSettings.hpp
@@ -37,7 +37,7 @@ namespace Microsoft::Console::Render
         void ResetColorTable() noexcept;
         void SetColorTableEntry(const size_t tableIndex, const COLORREF color);
         COLORREF GetColorTableEntry(const size_t tableIndex) const;
-        void RestoreDefaultColorTableEntry(const size_t tableIndex);
+        void RestoreDefaultColorTableEntries(const size_t startIndex, const size_t count);
         void SetColorAlias(const ColorAlias alias, const size_t tableIndex, const COLORREF color);
         COLORREF GetColorAlias(const ColorAlias alias) const;
         void SetColorAliasIndex(const ColorAlias alias, const size_t tableIndex) noexcept;

--- a/src/renderer/inc/RenderSettings.hpp
+++ b/src/renderer/inc/RenderSettings.hpp
@@ -37,7 +37,8 @@ namespace Microsoft::Console::Render
         void ResetColorTable() noexcept;
         void SetColorTableEntry(const size_t tableIndex, const COLORREF color);
         COLORREF GetColorTableEntry(const size_t tableIndex) const;
-        void RestoreDefaultColorTableEntries(const size_t startIndex, const size_t count);
+        void RestoreDefaultIndexed256ColorTable();
+        void RestoreDefaultColorTableEntry(const size_t tableIndex);
         void SetColorAlias(const ColorAlias alias, const size_t tableIndex, const COLORREF color);
         COLORREF GetColorAlias(const ColorAlias alias) const;
         void SetColorAliasIndex(const ColorAlias alias, const size_t tableIndex) noexcept;

--- a/src/terminal/adapter/ITermDispatch.hpp
+++ b/src/terminal/adapter/ITermDispatch.hpp
@@ -78,8 +78,9 @@ public:
     virtual void TabSet(const VTParameter setType) = 0; // DECST8C
     virtual void SetColorTableEntry(const size_t tableIndex, const DWORD color) = 0; // OSCSetColorTable
     virtual void RequestColorTableEntry(const size_t tableIndex) = 0; // OSCGetColorTable
-    virtual void SetXtermColorResource(const size_t resource, const DWORD color) = 0; // OSCSetDefaultForeground, OSCSetDefaultBackground, OSCSetCursorColor, OSCResetCursorColor
+    virtual void SetXtermColorResource(const size_t resource, const DWORD color) = 0; // OSCSetDefaultForeground, OSCSetDefaultBackground, OSCSetCursorColor
     virtual void RequestXtermColorResource(const size_t resource) = 0; // OSCGetDefaultForeground, OSCGetDefaultBackground, OSCGetCursorColor
+    virtual void ResetXtermColorResource(const size_t resource) = 0; // OSCResetForegroundColor, OSCResetBackgroundColor, OSCResetCursorColor, OSCResetHighlightColor
     virtual void AssignColor(const DispatchTypes::ColorItem item, const VTInt fgIndex, const VTInt bgIndex) = 0; // DECAC
 
     virtual void EraseInDisplay(const DispatchTypes::EraseType eraseType) = 0; // ED

--- a/src/terminal/adapter/ITermDispatch.hpp
+++ b/src/terminal/adapter/ITermDispatch.hpp
@@ -78,6 +78,7 @@ public:
     virtual void TabSet(const VTParameter setType) = 0; // DECST8C
     virtual void SetColorTableEntry(const size_t tableIndex, const DWORD color) = 0; // OSCSetColorTable
     virtual void RequestColorTableEntry(const size_t tableIndex) = 0; // OSCGetColorTable
+    virtual void ResetColorTable() = 0; // OSCResetColorTable
     virtual void ResetColorTableEntry(const size_t tableIndex) = 0; // OSCResetColorTable
     virtual void SetXtermColorResource(const size_t resource, const DWORD color) = 0; // OSCSetDefaultForeground, OSCSetDefaultBackground, OSCSetCursorColor
     virtual void RequestXtermColorResource(const size_t resource) = 0; // OSCGetDefaultForeground, OSCGetDefaultBackground, OSCGetCursorColor

--- a/src/terminal/adapter/ITermDispatch.hpp
+++ b/src/terminal/adapter/ITermDispatch.hpp
@@ -78,6 +78,7 @@ public:
     virtual void TabSet(const VTParameter setType) = 0; // DECST8C
     virtual void SetColorTableEntry(const size_t tableIndex, const DWORD color) = 0; // OSCSetColorTable
     virtual void RequestColorTableEntry(const size_t tableIndex) = 0; // OSCGetColorTable
+    virtual void ResetColorTableEntry(const size_t tableIndex) = 0; // OSCResetColorTable
     virtual void SetXtermColorResource(const size_t resource, const DWORD color) = 0; // OSCSetDefaultForeground, OSCSetDefaultBackground, OSCSetCursorColor
     virtual void RequestXtermColorResource(const size_t resource) = 0; // OSCGetDefaultForeground, OSCGetDefaultBackground, OSCGetCursorColor
     virtual void ResetXtermColorResource(const size_t resource) = 0; // OSCResetForegroundColor, OSCResetBackgroundColor, OSCResetCursorColor, OSCResetHighlightColor

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -3292,13 +3292,24 @@ void AdaptDispatch::RequestColorTableEntry(const size_t tableIndex)
     }
 }
 
+void AdaptDispatch::ResetColorTable()
+{
+    _renderSettings.RestoreDefaultColorTableEntries(0, 256);
+    if (_renderer)
+    {
+        // This is a pessimization, because it's unlikely that the frame or background changed,
+        // but let's tell the renderer that both changed anyway.
+        _renderer->TriggerRedrawAll(true, true);
+    }
+}
+
 // Method Description:
 // - Restores a single color table entry to its default user-specified value
 // Arguments:
 // - tableIndex: The VT color table index
 void AdaptDispatch::ResetColorTableEntry(const size_t tableIndex)
 {
-    _renderSettings.RestoreDefaultColorTableEntry(tableIndex);
+    _renderSettings.RestoreDefaultColorTableEntries(tableIndex, 1);
 
     if (_renderer)
     {

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -3294,7 +3294,7 @@ void AdaptDispatch::RequestColorTableEntry(const size_t tableIndex)
 
 void AdaptDispatch::ResetColorTable()
 {
-    _renderSettings.RestoreDefaultColorTableEntries(0, 256);
+    _renderSettings.RestoreDefaultIndexed256ColorTable();
     if (_renderer)
     {
         // This is pessimistic because it's unlikely that the frame or background changed,
@@ -3309,7 +3309,7 @@ void AdaptDispatch::ResetColorTable()
 // - tableIndex: The VT color table index
 void AdaptDispatch::ResetColorTableEntry(const size_t tableIndex)
 {
-    _renderSettings.RestoreDefaultColorTableEntries(tableIndex, 1);
+    _renderSettings.RestoreDefaultColorTableEntry(tableIndex);
 
     if (_renderer)
     {

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -3297,7 +3297,7 @@ void AdaptDispatch::ResetColorTable()
     _renderSettings.RestoreDefaultColorTableEntries(0, 256);
     if (_renderer)
     {
-        // This is a pessimization, because it's unlikely that the frame or background changed,
+        // This is pessimistic because it's unlikely that the frame or background changed,
         // but let's tell the renderer that both changed anyway.
         _renderer->TriggerRedrawAll(true, true);
     }

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -3293,6 +3293,29 @@ void AdaptDispatch::RequestColorTableEntry(const size_t tableIndex)
 }
 
 // Method Description:
+// - Restores a single color table entry to its default user-specified value
+// Arguments:
+// - tableIndex: The VT color table index
+void AdaptDispatch::ResetColorTableEntry(const size_t tableIndex)
+{
+    _renderSettings.RestoreDefaultColorTableEntry(tableIndex);
+
+    if (_renderer)
+    {
+        // If we're updating the background color, we need to let the renderer
+        // know, since it may want to repaint the window background to match.
+        const auto backgroundIndex = _renderSettings.GetColorAliasIndex(ColorAlias::DefaultBackground);
+        const auto backgroundChanged = (tableIndex == backgroundIndex);
+
+        // Similarly for the frame color, the tab may need to be repainted.
+        const auto frameIndex = _renderSettings.GetColorAliasIndex(ColorAlias::FrameBackground);
+        const auto frameChanged = (tableIndex == frameIndex);
+
+        _renderer->TriggerRedrawAll(backgroundChanged, frameChanged);
+    }
+}
+
+// Method Description:
 // - Sets one Xterm Color Resource such as Default Foreground, Background, Cursor
 void AdaptDispatch::SetXtermColorResource(const size_t resource, const DWORD color)
 {
@@ -3335,6 +3358,25 @@ void AdaptDispatch::RequestXtermColorResource(const size_t resource)
             // Scale values up to match xterm's 16-bit color report format.
             _ReturnOscResponse(fmt::format(FMT_COMPILE(L"{};rgb:{:04x}/{:04x}/{:04x}"), resource, c.r * 0x0101, c.g * 0x0101, c.b * 0x0101));
         }
+    }
+}
+
+// Method Description:
+// - Restores to the original user-provided value one Xterm Color Resource such as Default Foreground, Background, Cursor
+void AdaptDispatch::ResetXtermColorResource(const size_t resource)
+{
+    assert(resource >= 10);
+    const auto mappingIndex = resource - 10;
+    const auto& oscMapping = XtermResourceColorTableMappings.at(mappingIndex);
+    if (oscMapping.ColorTableIndex > 0)
+    {
+        if (oscMapping.AliasIndex >= 0) [[unlikely]]
+        {
+            // If this color reset applies to an aliased color, point the alias back at the original color
+            _renderSettings.SetColorAliasIndex(static_cast<ColorAlias>(oscMapping.AliasIndex), oscMapping.ColorTableIndex);
+        }
+
+        ResetColorTableEntry(oscMapping.ColorTableIndex);
     }
 }
 

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -3370,10 +3370,10 @@ void AdaptDispatch::ResetXtermColorResource(const size_t resource)
     const auto& oscMapping = XtermResourceColorTableMappings.at(mappingIndex);
     if (oscMapping.ColorTableIndex > 0)
     {
-        if (oscMapping.AliasIndex >= 0) [[unlikely]]
+        if (oscMapping.AliasIndex >= 0)
         {
             // If this color reset applies to an aliased color, point the alias back at the original color
-            _renderSettings.SetColorAliasIndex(static_cast<ColorAlias>(oscMapping.AliasIndex), oscMapping.ColorTableIndex);
+            _renderSettings.RestoreDefaultColorAliasIndex(static_cast<ColorAlias>(oscMapping.AliasIndex));
         }
 
         ResetColorTableEntry(oscMapping.ColorTableIndex);

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -133,8 +133,10 @@ namespace Microsoft::Console::VirtualTerminal
         void SetColorTableEntry(const size_t tableIndex,
                                 const DWORD color) override; // OSCSetColorTable
         void RequestColorTableEntry(const size_t tableIndex) override; // OSCGetColorTable
-        void SetXtermColorResource(const size_t resource, const DWORD color) override; // OSCSetDefaultForeground, OSCSetDefaultBackground, OSCSetCursorColor, OSCResetCursorColor
+        void ResetColorTableEntry(const size_t tableIndex) /*override*/; // OSCResetColorTable
+        void SetXtermColorResource(const size_t resource, const DWORD color) override; // OSCSetDefaultForeground, OSCSetDefaultBackground, OSCSetCursorColor
         void RequestXtermColorResource(const size_t resource) override; // OSCGetDefaultForeground, OSCGetDefaultBackground, OSCGetCursorColor
+        void ResetXtermColorResource(const size_t resource) override; // OSCResetForegroundColor, OSCResetBackgroundColor, OSCResetCursorColor, OSCResetHighlightColor
         void AssignColor(const DispatchTypes::ColorItem item, const VTInt fgIndex, const VTInt bgIndex) override; // DECAC
 
         void WindowManipulation(const DispatchTypes::WindowManipulationType function,

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -133,7 +133,7 @@ namespace Microsoft::Console::VirtualTerminal
         void SetColorTableEntry(const size_t tableIndex,
                                 const DWORD color) override; // OSCSetColorTable
         void RequestColorTableEntry(const size_t tableIndex) override; // OSCGetColorTable
-        void ResetColorTableEntry(const size_t tableIndex) /*override*/; // OSCResetColorTable
+        void ResetColorTableEntry(const size_t tableIndex) override; // OSCResetColorTable
         void SetXtermColorResource(const size_t resource, const DWORD color) override; // OSCSetDefaultForeground, OSCSetDefaultBackground, OSCSetCursorColor
         void RequestXtermColorResource(const size_t resource) override; // OSCGetDefaultForeground, OSCGetDefaultBackground, OSCGetCursorColor
         void ResetXtermColorResource(const size_t resource) override; // OSCResetForegroundColor, OSCResetBackgroundColor, OSCResetCursorColor, OSCResetHighlightColor

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -133,6 +133,7 @@ namespace Microsoft::Console::VirtualTerminal
         void SetColorTableEntry(const size_t tableIndex,
                                 const DWORD color) override; // OSCSetColorTable
         void RequestColorTableEntry(const size_t tableIndex) override; // OSCGetColorTable
+        void ResetColorTable() override; // OSCResetColorTable
         void ResetColorTableEntry(const size_t tableIndex) override; // OSCResetColorTable
         void SetXtermColorResource(const size_t resource, const DWORD color) override; // OSCSetDefaultForeground, OSCSetDefaultBackground, OSCSetCursorColor
         void RequestXtermColorResource(const size_t resource) override; // OSCGetDefaultForeground, OSCGetDefaultBackground, OSCGetCursorColor

--- a/src/terminal/adapter/termDispatch.hpp
+++ b/src/terminal/adapter/termDispatch.hpp
@@ -71,10 +71,11 @@ public:
     void TabSet(const VTParameter /*setType*/) override {} // DECST8C
     void SetColorTableEntry(const size_t /*tableIndex*/, const DWORD /*color*/) override {} // OSCSetColorTable
     void RequestColorTableEntry(const size_t /*tableIndex*/) override {} // OSCGetColorTable
+    void ResetColorTable() override {} // OSCResetColorTable
     void ResetColorTableEntry(const size_t /*tableIndex*/) override {} // OSCResetColorTable
     void SetXtermColorResource(const size_t /*resource*/, const DWORD /*color*/) override {} // OSCSetDefaultForeground, OSCSetDefaultBackground, OSCSetCursorColor
     void RequestXtermColorResource(const size_t /*resource*/) override {} // OSCGetDefaultForeground, OSCGetDefaultBackground, OSCGetCursorColor
-    void ResetXtermColorResource(const size_t /*resource*/) override {}; // OSCResetForegroundColor, OSCResetBackgroundColor, OSCResetCursorColor, OSCResetHighlightColor
+    void ResetXtermColorResource(const size_t /*resource*/) override {} // OSCResetForegroundColor, OSCResetBackgroundColor, OSCResetCursorColor, OSCResetHighlightColor
     void AssignColor(const DispatchTypes::ColorItem /*item*/, const VTInt /*fgIndex*/, const VTInt /*bgIndex*/) override {} // DECAC
 
     void EraseInDisplay(const DispatchTypes::EraseType /* eraseType*/) override {} // ED

--- a/src/terminal/adapter/termDispatch.hpp
+++ b/src/terminal/adapter/termDispatch.hpp
@@ -71,8 +71,9 @@ public:
     void TabSet(const VTParameter /*setType*/) override {} // DECST8C
     void SetColorTableEntry(const size_t /*tableIndex*/, const DWORD /*color*/) override {} // OSCSetColorTable
     void RequestColorTableEntry(const size_t /*tableIndex*/) override {} // OSCGetColorTable
-    void SetXtermColorResource(const size_t /*resource*/, const DWORD /*color*/) override {} // OSCSetDefaultForeground, OSCSetDefaultBackground, OSCSetCursorColor, OSCResetCursorColor
+    void SetXtermColorResource(const size_t /*resource*/, const DWORD /*color*/) override {} // OSCSetDefaultForeground, OSCSetDefaultBackground, OSCSetCursorColor
     void RequestXtermColorResource(const size_t /*resource*/) override {} // OSCGetDefaultForeground, OSCGetDefaultBackground, OSCGetCursorColor
+    void ResetXtermColorResource(const size_t /*resource*/) override {}; // OSCResetForegroundColor, OSCResetBackgroundColor, OSCResetCursorColor, OSCResetHighlightColor
     void AssignColor(const DispatchTypes::ColorItem /*item*/, const VTInt /*fgIndex*/, const VTInt /*bgIndex*/) override {} // DECAC
 
     void EraseInDisplay(const DispatchTypes::EraseType /* eraseType*/) override {} // ED

--- a/src/terminal/adapter/termDispatch.hpp
+++ b/src/terminal/adapter/termDispatch.hpp
@@ -71,6 +71,7 @@ public:
     void TabSet(const VTParameter /*setType*/) override {} // DECST8C
     void SetColorTableEntry(const size_t /*tableIndex*/, const DWORD /*color*/) override {} // OSCSetColorTable
     void RequestColorTableEntry(const size_t /*tableIndex*/) override {} // OSCGetColorTable
+    void ResetColorTableEntry(const size_t /*tableIndex*/) override {} // OSCResetColorTable
     void SetXtermColorResource(const size_t /*resource*/, const DWORD /*color*/) override {} // OSCSetDefaultForeground, OSCSetDefaultBackground, OSCSetCursorColor
     void RequestXtermColorResource(const size_t /*resource*/) override {} // OSCGetDefaultForeground, OSCGetDefaultBackground, OSCGetCursorColor
     void ResetXtermColorResource(const size_t /*resource*/) override {}; // OSCResetForegroundColor, OSCResetBackgroundColor, OSCResetCursorColor, OSCResetHighlightColor

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -826,9 +826,7 @@ bool OutputStateMachineEngine::ActionOscDispatch(const size_t parameter, const s
                 }
                 else
                 {
-                    // NOTE: xterm stops at the first unparseable index
-                    // whereas libvte keeps going. What should we
-                    // do?
+                    // NOTE: xterm stops at the first unparseable index whereas VTE keeps going.
                     break;
                 }
             }
@@ -840,8 +838,7 @@ bool OutputStateMachineEngine::ActionOscDispatch(const size_t parameter, const s
     case OscActionCodes::ResetCursorColor:
     case OscActionCodes::ResetHighlightColor:
     {
-        // NOTE: xterm ignores the request if there's any parameters
-        // whereas libvte resets the first one
+        // NOTE: xterm ignores the request if there's any parameters whereas VTE resets the provided index and ignores the rest
         if (string.empty())
         {
             // The reset codes for xterm dynamic resources are the set codes + 100

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -827,7 +827,7 @@ bool OutputStateMachineEngine::ActionOscDispatch(const size_t parameter, const s
                 else
                 {
                     // NOTE: xterm stops at the first unparseable index
-                    // whereas gnome-terminal keeps going. What should we
+                    // whereas libvte keeps going. What should we
                     // do?
                     break;
                 }
@@ -840,8 +840,8 @@ bool OutputStateMachineEngine::ActionOscDispatch(const size_t parameter, const s
     case OscActionCodes::ResetCursorColor:
     case OscActionCodes::ResetHighlightColor:
     {
-        // NOTE: xterm does not allow 110;111;112 in a single request,
-        // whereas gnome-terminal does. What should we do here?
+        // NOTE: xterm ignores the request if there's any parameters
+        // whereas libvte resets the first one
         if (string.empty())
         {
             // The reset codes for xterm dynamic resources are the set codes + 100

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -826,7 +826,7 @@ bool OutputStateMachineEngine::ActionOscDispatch(const size_t parameter, const s
                 }
                 else
                 {
-                    // ERRATA: xterm stops at the first unparseable index
+                    // NOTE: xterm stops at the first unparseable index
                     // whereas gnome-terminal keeps going. What should we
                     // do?
                     break;
@@ -840,7 +840,7 @@ bool OutputStateMachineEngine::ActionOscDispatch(const size_t parameter, const s
     case OscActionCodes::ResetCursorColor:
     case OscActionCodes::ResetHighlightColor:
     {
-        // ERRATA: xterm does not allow 110;111;112 in a single request,
+        // NOTE: xterm does not allow 110;111;112 in a single request,
         // whereas gnome-terminal does. What should we do here?
         if (string.empty())
         {

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -810,10 +810,18 @@ bool OutputStateMachineEngine::ActionOscDispatch(const size_t parameter, const s
         }
         break;
     }
+    case OscActionCodes::ResetForegroundColor:
+    case OscActionCodes::ResetBackgroundColor:
     case OscActionCodes::ResetCursorColor:
+    case OscActionCodes::ResetHighlightColor:
+    // **CANNOT BE CHAINED** in xterm; ignored if chained (!)
+    // xterm allows chaining 104 (reset color index); if chained, only reset the colors within
+    // if not chained, reset all colors
+    // gets weird in conhost - we use aliases to set the dfault bg/fg in default config
+    // so overwriting the aliases makes the background **white** instead
     {
         // The reset codes for xterm dynamic resources are the set codes + 100
-        _dispatch->SetXtermColorResource(parameter - 100u, INVALID_COLOR);
+        _dispatch->ResetXtermColorResource(parameter - 100u);
         break;
     }
     case OscActionCodes::Hyperlink:

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -812,11 +812,9 @@ bool OutputStateMachineEngine::ActionOscDispatch(const size_t parameter, const s
     }
     case OscActionCodes::ResetColor:
     {
-        // xterm allows parameters for 104 (reset color index); if there are 1..n parameters, reset color[param_1]...color[param_n]
-        // if there are no parameters, reset all colors
         if (string.empty())
         {
-            // reset all colors (TODO)
+            _dispatch->ResetColorTable();
         }
         else
         {
@@ -828,8 +826,9 @@ bool OutputStateMachineEngine::ActionOscDispatch(const size_t parameter, const s
                 }
                 else
                 {
-                    // xterm bails out if it encounters an unparseable color index
-                    // gnome-terminal does not; it keeps going
+                    // ERRATA: xterm stops at the first unparseable index
+                    // whereas gnome-terminal keeps going. What should we
+                    // do?
                     break;
                 }
             }
@@ -841,8 +840,8 @@ bool OutputStateMachineEngine::ActionOscDispatch(const size_t parameter, const s
     case OscActionCodes::ResetCursorColor:
     case OscActionCodes::ResetHighlightColor:
     {
-        // **CANNOT BE CHAINED** like osc 10;11;12 in xterm; ignored if multiple params (!)
-        // **CAN** be chained in gnome-terminal (who should we follow?)
+        // ERRATA: xterm does not allow 110;111;112 in a single request,
+        // whereas gnome-terminal does. What should we do here?
         if (string.empty())
         {
             // The reset codes for xterm dynamic resources are the set codes + 100

--- a/src/terminal/parser/OutputStateMachineEngine.hpp
+++ b/src/terminal/parser/OutputStateMachineEngine.hpp
@@ -214,6 +214,7 @@ namespace Microsoft::Console::VirtualTerminal
             SetHighlightColor = 17,
             DECSWT_SetWindowTitle = 21,
             SetClipboard = 52,
+            ResetColor = 104,
             ResetForegroundColor = 110,
             ResetBackgroundColor = 111,
             ResetCursorColor = 112,

--- a/src/terminal/parser/OutputStateMachineEngine.hpp
+++ b/src/terminal/parser/OutputStateMachineEngine.hpp
@@ -214,9 +214,10 @@ namespace Microsoft::Console::VirtualTerminal
             SetHighlightColor = 17,
             DECSWT_SetWindowTitle = 21,
             SetClipboard = 52,
-            ResetForegroundColor = 110, // Not implemented
-            ResetBackgroundColor = 111, // Not implemented
+            ResetForegroundColor = 110,
+            ResetBackgroundColor = 111,
             ResetCursorColor = 112,
+            ResetHighlightColor = 117,
             FinalTermAction = 133,
             VsCodeAction = 633,
             ITerm2Action = 1337,

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -1163,7 +1163,8 @@ public:
         _hyperlinkMode{ false },
         _options{ s_cMaxOptions, static_cast<DispatchTypes::GraphicsOptions>(s_uiGraphicsCleared) }, // fill with cleared option
         _colorTable{},
-        _setColorTableEntry{ false }
+        _setColorTableEntry{ false },
+        _resetAllColors{ false }
     {
     }
 
@@ -1390,6 +1391,11 @@ public:
         _colorTableEntriesRequested.push_back(tableIndex);
     }
 
+    void ResetColorTable() noexcept override
+    {
+        _resetAllColors = true;
+    }
+
     void ResetColorTableEntry(const size_t tableIndex) noexcept override
     {
         _colorTableEntriesReset.push_back(tableIndex);
@@ -1489,6 +1495,7 @@ public:
     std::vector<size_t> _xtermResourcesReset;
     bool _setColorTableEntry;
     std::vector<size_t> _colorTableEntriesRequested;
+    bool _resetAllColors;
     std::vector<size_t> _colorTableEntriesReset;
     bool _hyperlinkMode;
     std::wstring _copyContent;
@@ -3243,8 +3250,61 @@ class StateMachineExternalTest final
         mach.ProcessString(L"\033]110\033\\");
         VERIFY_ARE_EQUAL(0u, pDispatch->_xtermResourcesChanged.size());
         VERIFY_ARE_EQUAL(0u, pDispatch->_xtermResourcesRequested.size());
-        VERIFY_ARE_EQUAL(0u, pDispatch->_xtermResourcesReset.size());
+        VERIFY_ARE_EQUAL(1u, pDispatch->_xtermResourcesReset.size());
         VERIFY_ARE_EQUAL(10u, pDispatch->_xtermResourcesReset[0]);
+        pDispatch->ClearState();
+
+        mach.ProcessString(L"\033]111;110\033\\");
+        // ERRATA: this is xterm behavior - ignore the sequence if any params exist
+        VERIFY_ARE_EQUAL(0u, pDispatch->_xtermResourcesChanged.size());
+        VERIFY_ARE_EQUAL(0u, pDispatch->_xtermResourcesRequested.size());
+        VERIFY_ARE_EQUAL(0u, pDispatch->_xtermResourcesReset.size());
+        pDispatch->ClearState();
+    }
+
+    TEST_METHOD(TestOscColorTableReset)
+    {
+        auto dispatch = std::make_unique<StatefulDispatch>();
+        auto pDispatch = dispatch.get();
+        auto engine = std::make_unique<OutputStateMachineEngine>(std::move(dispatch));
+        StateMachine mach(std::move(engine));
+
+        mach.ProcessString(L"\033]104\033\\");
+        VERIFY_IS_TRUE(pDispatch->_resetAllColors);
+        VERIFY_ARE_EQUAL(0u, pDispatch->_colorTableEntriesReset.size());
+        VERIFY_ARE_EQUAL(0u, pDispatch->_colorTableEntriesRequested.size());
+        VERIFY_ARE_EQUAL(0u, pDispatch->_xtermResourcesReset.size());
+        //VERIFY_ARE_EQUAL(10u, pDispatch->_xtermResourcesReset[0]);
+        pDispatch->ClearState();
+
+        mach.ProcessString(L"\033]104;1;3;5;7;9\033\\");
+        VERIFY_IS_FALSE(pDispatch->_resetAllColors);
+        VERIFY_ARE_EQUAL(5u, pDispatch->_colorTableEntriesReset.size());
+        VERIFY_ARE_EQUAL(0u, pDispatch->_colorTableEntriesRequested.size());
+        VERIFY_ARE_EQUAL(0u, pDispatch->_xtermResourcesReset.size());
+        VERIFY_ARE_EQUAL(1u, pDispatch->_colorTableEntriesReset[0]);
+        VERIFY_ARE_EQUAL(3u, pDispatch->_colorTableEntriesReset[1]);
+        VERIFY_ARE_EQUAL(5u, pDispatch->_colorTableEntriesReset[2]);
+        VERIFY_ARE_EQUAL(7u, pDispatch->_colorTableEntriesReset[3]);
+        VERIFY_ARE_EQUAL(9u, pDispatch->_colorTableEntriesReset[4]);
+        pDispatch->ClearState();
+
+        // ERRATA: xterm behavior - stop after first failed parse
+        mach.ProcessString(L"\033]104;1;a;3\033\\");
+        VERIFY_IS_FALSE(pDispatch->_resetAllColors);
+        VERIFY_IS_FALSE(pDispatch->_setColorTableEntry);
+        VERIFY_ARE_EQUAL(1u, pDispatch->_colorTableEntriesReset.size());
+        VERIFY_ARE_EQUAL(0u, pDispatch->_colorTableEntriesRequested.size());
+        VERIFY_ARE_EQUAL(0u, pDispatch->_xtermResourcesReset.size());
+        VERIFY_ARE_EQUAL(1u, pDispatch->_colorTableEntriesReset[0]);
+        pDispatch->ClearState();
+
+        mach.ProcessString(L"\033]104;;;\033\\");
+        VERIFY_IS_FALSE(pDispatch->_setColorTableEntry);
+        VERIFY_ARE_EQUAL(0u, pDispatch->_colorTableEntriesReset.size());
+        VERIFY_ARE_EQUAL(0u, pDispatch->_colorTableEntriesRequested.size());
+        VERIFY_ARE_EQUAL(0u, pDispatch->_xtermResourcesReset.size());
+        //VERIFY_ARE_EQUAL(10u, pDispatch->_xtermResourcesReset[0]);
         pDispatch->ClearState();
     }
 

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -1401,6 +1401,11 @@ public:
         _xtermResourcesRequested.push_back(resource);
     }
 
+    void ResetXtermColorResource(const size_t resource) override
+    {
+        _xtermResourcesReset.push_back(resource);
+    }
+
     void SetClipboard(wil::zwstring_view content) noexcept override
     {
         _copyContent = content;
@@ -1476,6 +1481,7 @@ public:
     std::vector<size_t> _xtermResourcesChanged;
     std::vector<DWORD> _xtermResourceValues;
     std::vector<size_t> _xtermResourcesRequested;
+    std::vector<size_t> _xtermResourcesReset;
     bool _setColorTableEntry;
     std::vector<size_t> _colorTableEntriesRequested;
     bool _hyperlinkMode;
@@ -3218,6 +3224,21 @@ class StateMachineExternalTest final
         VERIFY_ARE_EQUAL(0u, pDispatch->_xtermResourcesChanged.size());
         VERIFY_ARE_EQUAL(1u, pDispatch->_xtermResourcesRequested.size());
         VERIFY_ARE_EQUAL(11u, pDispatch->_xtermResourcesRequested[0]);
+        pDispatch->ClearState();
+    }
+
+    TEST_METHOD(TestOscXtermResourceReset)
+    {
+        auto dispatch = std::make_unique<StatefulDispatch>();
+        auto pDispatch = dispatch.get();
+        auto engine = std::make_unique<OutputStateMachineEngine>(std::move(dispatch));
+        StateMachine mach(std::move(engine));
+
+        mach.ProcessString(L"\033]110\033\\");
+        VERIFY_ARE_EQUAL(0u, pDispatch->_xtermResourcesChanged.size());
+        VERIFY_ARE_EQUAL(0u, pDispatch->_xtermResourcesRequested.size());
+        VERIFY_ARE_EQUAL(0u, pDispatch->_xtermResourcesReset.size());
+        VERIFY_ARE_EQUAL(10u, pDispatch->_xtermResourcesReset[0]);
         pDispatch->ClearState();
     }
 

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -3254,8 +3254,15 @@ class StateMachineExternalTest final
         VERIFY_ARE_EQUAL(10u, pDispatch->_xtermResourcesReset[0]);
         pDispatch->ClearState();
 
+        mach.ProcessString(L"\033]111;\033\\"); // dangling ;
+        VERIFY_ARE_EQUAL(0u, pDispatch->_xtermResourcesChanged.size());
+        VERIFY_ARE_EQUAL(0u, pDispatch->_xtermResourcesRequested.size());
+        VERIFY_ARE_EQUAL(1u, pDispatch->_xtermResourcesReset.size());
+        VERIFY_ARE_EQUAL(11u, pDispatch->_xtermResourcesReset[0]);
+        pDispatch->ClearState();
+
         mach.ProcessString(L"\033]111;110\033\\");
-        // NOTE: this is xterm behavior - ignore the sequence if any params exist
+        // NOTE: this is xterm behavior - ignore the entire sequence if any params exist
         VERIFY_ARE_EQUAL(0u, pDispatch->_xtermResourcesChanged.size());
         VERIFY_ARE_EQUAL(0u, pDispatch->_xtermResourcesRequested.size());
         VERIFY_ARE_EQUAL(0u, pDispatch->_xtermResourcesReset.size());

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -3310,7 +3310,6 @@ class StateMachineExternalTest final
         VERIFY_ARE_EQUAL(0u, pDispatch->_colorTableEntriesReset.size());
         VERIFY_ARE_EQUAL(0u, pDispatch->_colorTableEntriesRequested.size());
         VERIFY_ARE_EQUAL(0u, pDispatch->_xtermResourcesReset.size());
-        //VERIFY_ARE_EQUAL(10u, pDispatch->_xtermResourcesReset[0]);
         pDispatch->ClearState();
     }
 

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -1390,6 +1390,11 @@ public:
         _colorTableEntriesRequested.push_back(tableIndex);
     }
 
+    void ResetColorTableEntry(const size_t tableIndex) noexcept override
+    {
+        _colorTableEntriesReset.push_back(tableIndex);
+    }
+
     void SetXtermColorResource(const size_t resource, const DWORD color) override
     {
         _xtermResourcesChanged.push_back(resource);
@@ -1484,6 +1489,7 @@ public:
     std::vector<size_t> _xtermResourcesReset;
     bool _setColorTableEntry;
     std::vector<size_t> _colorTableEntriesRequested;
+    std::vector<size_t> _colorTableEntriesReset;
     bool _hyperlinkMode;
     std::wstring _copyContent;
     std::wstring _uri;

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -3255,7 +3255,7 @@ class StateMachineExternalTest final
         pDispatch->ClearState();
 
         mach.ProcessString(L"\033]111;110\033\\");
-        // ERRATA: this is xterm behavior - ignore the sequence if any params exist
+        // NOTE: this is xterm behavior - ignore the sequence if any params exist
         VERIFY_ARE_EQUAL(0u, pDispatch->_xtermResourcesChanged.size());
         VERIFY_ARE_EQUAL(0u, pDispatch->_xtermResourcesRequested.size());
         VERIFY_ARE_EQUAL(0u, pDispatch->_xtermResourcesReset.size());
@@ -3274,7 +3274,6 @@ class StateMachineExternalTest final
         VERIFY_ARE_EQUAL(0u, pDispatch->_colorTableEntriesReset.size());
         VERIFY_ARE_EQUAL(0u, pDispatch->_colorTableEntriesRequested.size());
         VERIFY_ARE_EQUAL(0u, pDispatch->_xtermResourcesReset.size());
-        //VERIFY_ARE_EQUAL(10u, pDispatch->_xtermResourcesReset[0]);
         pDispatch->ClearState();
 
         mach.ProcessString(L"\033]104;1;3;5;7;9\033\\");
@@ -3289,7 +3288,7 @@ class StateMachineExternalTest final
         VERIFY_ARE_EQUAL(9u, pDispatch->_colorTableEntriesReset[4]);
         pDispatch->ClearState();
 
-        // ERRATA: xterm behavior - stop after first failed parse
+        // NOTE: xterm behavior - stop after first failed parse
         mach.ProcessString(L"\033]104;1;a;3\033\\");
         VERIFY_IS_FALSE(pDispatch->_resetAllColors);
         VERIFY_IS_FALSE(pDispatch->_setColorTableEntry);


### PR DESCRIPTION
This pull request adds support for resetting the various color table entries and xterm resource values back to their defaults.

Building on the default color table James introduced in #17879, it was relatively straightforward to add support for resetting specific entries.

This implementation cleaves tightly to observed behavior in xterm(379) rather than observed behavior in libvte(0.70.6). They differ in the following ways:

- xterm rejects any OSC [110..119] with any number of parameters; libvte accepts it but only resets the first color.
- When passed a list of color indices to reset in 104, xterm resets any colors up until the first one which fails to parse as an integer and does _not_ reset the rest; libvte resets all parseable color indices.

I was unable to verify how these reset commands interact with colors set via `DECAC Assign Color` so I went with the implementation that made the most sense:

- Resetting the background color with `110` also restores the background color alias entry to its pre-`DECAC` value; this results in the perceived background color returning to e.g. index 0 in conhost and the `background` color in Terminal.
- _ibid._ for the foreground color

Refs #18695
Refs #17879
Closes #3719