### PR TITLE
Display local time instead of UTC while restoring previous session

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -1831,9 +1831,23 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         }
 
         FILETIME lastWriteTime;
+        FILETIME localFileTime;
         SYSTEMTIME lastWriteSystemTime;
-        if (!GetFileTime(file.get(), nullptr, nullptr, &lastWriteTime) ||
-            !FileTimeToSystemTime(&lastWriteTime, &lastWriteSystemTime))
+
+        // Get the last write time in UTC
+        if (!GetFileTime(file.get(), nullptr, nullptr, &lastWriteTime))
+        {
+            return;
+        }
+
+        // Convert UTC FILETIME to local FILETIME
+        if (!FileTimeToLocalFileTime(&lastWriteTime, &localFileTime))
+        {
+            return;
+        }
+
+        // Convert local FILETIME to SYSTEMTIME
+        if (!FileTimeToSystemTime(&localFileTime, &lastWriteSystemTime))
         {
             return;
         }


### PR DESCRIPTION
## Summary of the Pull Request
* Added logic to convert file time to local time before printing.
![image](https://github.com/user-attachments/assets/6aa42f01-d7ab-45fb-8286-38b2417d6bd9)

## Detailed Description of the Pull Request / Additional comments
* Used FileTimeToLocalFileTime() to convert file time to local time.
* The result is converted to system time again to ensure minimal impact on the method RestoreFromPath().
* Tested with different time zones.

## PR Checklist
- [x] Closes #18727
- [x] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
