### PR TITLE
Added right margin to description textblock of action suggestion

### DIFF
--- a/src/cascadia/TerminalApp/SuggestionsControl.xaml
+++ b/src/cascadia/TerminalApp/SuggestionsControl.xaml
@@ -230,6 +230,7 @@
                               VerticalScrollMode="Enabled"
                               Visibility="Visible">
                     <TextBlock x:Name="_descriptionComment"
+                               Margin="0,0,15,0"
                                IsTextSelectionEnabled="True"
                                TextWrapping="WrapWholeWords" />
                 </ScrollViewer>

--- a/src/cascadia/TerminalApp/SuggestionsControl.xaml
+++ b/src/cascadia/TerminalApp/SuggestionsControl.xaml
@@ -230,7 +230,7 @@
                               VerticalScrollMode="Enabled"
                               Visibility="Visible">
                     <TextBlock x:Name="_descriptionComment"
-                               Margin="0,0,15,0"
+                               Margin="0,0,20,0"
                                IsTextSelectionEnabled="True"
                                TextWrapping="WrapWholeWords" />
                 </ScrollViewer>


### PR DESCRIPTION
## Summary of the Pull Request
* Added a right margin to _descriptionComment  TextBlock of SuggestionsControl.xaml.
* This ensures that the vertical scrollbar will not cover the description text.
* Without margin
![image](https://github.com/user-attachments/assets/135e9ba7-30f5-4e2a-b4a4-a86e49aa9984)
* With margin
![image](https://github.com/user-attachments/assets/75d7e462-2c20-4e07-8032-51d280e7f85d)

## PR Checklist
- [x] Closes #18545 
- [ ] Tests added/passed
