### PR TITLE
Fix color selection off-by-one error and dangling Y-beam

### DIFF
--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -2061,14 +2061,6 @@ void TextBuffer::_ExpandTextRow(til::inclusive_rect& textRow) const
     }
 }
 
-size_t TextBuffer::SpanLength(const til::point coordStart, const til::point coordEnd) const
-{
-    const auto bufferSize = GetSize();
-    // The coords are inclusive, so to get the (inclusive) length we add 1.
-    const auto length = bufferSize.CompareInBounds(coordEnd, coordStart) + 1;
-    return gsl::narrow<size_t>(length);
-}
-
 // Routine Description:
 // - Retrieves the plain text data between the specified coordinates.
 // Arguments:

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -199,8 +199,6 @@ public:
     std::wstring GetCustomIdFromId(uint16_t id) const;
     void CopyHyperlinkMaps(const TextBuffer& OtherBuffer);
 
-    size_t SpanLength(const til::point coordStart, const til::point coordEnd) const;
-
     std::wstring GetPlainText(til::point start, til::point end) const;
 
     struct CopyRequest

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -2868,6 +2868,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                 // coloring other matches, then we need to make sure those get redrawn,
                 // too.
                 _renderer->TriggerRedrawAll();
+                _updateSelectionUI();
             }
         }
     }

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -1571,10 +1571,10 @@ void Terminal::SerializeMainBuffer(const wchar_t* destination) const
 
 void Terminal::ColorSelection(const TextAttribute& attr, winrt::Microsoft::Terminal::Core::MatchMode matchMode)
 {
-    const auto colorSelection = [this](const til::point coordStart, const til::point coordEnd, const TextAttribute& attr) {
+    const auto colorSelection = [this](const til::point coordStartInclusive, const til::point coordEndExclusive, const TextAttribute& attr) {
         auto& textBuffer = _activeBuffer();
-        const auto spanLength = textBuffer.SpanLength(coordStart, coordEnd);
-        textBuffer.Write(OutputCellIterator(attr, spanLength), coordStart);
+        const auto spanLength = textBuffer.GetSize().CompareInBounds(coordEndExclusive, coordStartInclusive, true);
+        textBuffer.Write(OutputCellIterator(attr, spanLength), coordStartInclusive);
     };
 
     for (const auto [start, end] : _GetSelectionSpans())


### PR DESCRIPTION
## Summary of the Pull Request
Fixes a bug where the color selection actions would color one more character than they needed to.
Also fixes a bug where if mark mode was used to create the selection, a dangling y-beam would be left over after executing the action.
 
## References and Relevant Issues
Regressed in #18106

## Detailed Description of the Pull Request / Additional comments
- `TextBuffer::SpanLength` was only used once (in `Terminal::ColorSelection`). All it really did was call `Viewport::CompareInBounds`. So I deduplicated it.
   - Funny enough, the +1 added there was no longer correct because the incoming coordinates were switched from an inclusive range to an exclusive range.
- To fix the dangling y-beam, I added a call to `_updateSelectionUI` in `ControlCore::ColorSelection`. This heuristic is used throughout the file for other selection-related functions.

## Validation Steps Performed
✅ color selection action highlights reference(s) to selected text
✅ color selection action highlights reference(s) to selected text when text is at right boundary
✅ dangling y-beam disappears after executing color selection actions

 Closes #18739
