### PR TITLE
Fix cwd not applying on launch

### DIFF
--- a/src/cascadia/TerminalApp/Remoting.cpp
+++ b/src/cascadia/TerminalApp/Remoting.cpp
@@ -17,7 +17,7 @@ namespace winrt::TerminalApp::implementation
 {
     CommandlineArgs::CommandlineArgs(winrt::array_view<const winrt::hstring> args, winrt::hstring currentDirectory, uint32_t showWindowCommand, winrt::hstring envString) :
         _args{ args.begin(), args.end() },
-        _cwd{ std::move(currentDirectory) },
+        CurrentDirectory{ std::move(currentDirectory) },
         ShowWindowCommand{ showWindowCommand },
         CurrentEnvironment{ std::move(envString) }
     {

--- a/src/cascadia/TerminalApp/Remoting.h
+++ b/src/cascadia/TerminalApp/Remoting.h
@@ -36,7 +36,6 @@ namespace winrt::TerminalApp::implementation
         ::TerminalApp::AppCommandlineArgs _parsed;
         int32_t _parseResult = 0;
         winrt::com_array<winrt::hstring> _args;
-        winrt::hstring _cwd;
     };
 
     struct RequestReceiveContentArgs : RequestReceiveContentArgsT<RequestReceiveContentArgs>

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -563,8 +563,11 @@ namespace winrt::TerminalApp::implementation
                 _WindowProperties.VirtualEnvVars(originalVirtualEnv);
             }
         });
-        _WindowProperties.VirtualWorkingDirectory(cwd);
-        _WindowProperties.VirtualEnvVars(env);
+        if (!cwd.empty())
+        {
+            _WindowProperties.VirtualWorkingDirectory(cwd);
+            _WindowProperties.VirtualEnvVars(env);
+        }
 
         for (size_t i = 0; i < actions.size(); ++i)
         {


### PR DESCRIPTION
This fixes two issues:
* An unused `_cwd` property that should've been `CurrentDirectory`
* A cwd override that was applied even if there wasn't an override

Closes #18637

## Validation Steps Performed
* Launch WT, then run `wtd -d ..`
* Launches in the expected relative path ✅