### PR TITLE
Add Badge to highlight new Extensions Page

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
+++ b/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
@@ -1267,4 +1267,24 @@
             </Setter.Value>
         </Setter>
     </Style>
+
+    <Style x:Key="NewInfoBadge"
+           TargetType="muxc:InfoBadge">
+        <Setter Property="Padding" Value="5,1,5,2" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="muxc:InfoBadge">
+                    <Border x:Name="RootGrid"
+                            Padding="{TemplateBinding Padding}"
+                            Background="{TemplateBinding Background}"
+                            CornerRadius="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.InfoBadgeCornerRadius}">
+                        <TextBlock x:Uid="NewInfoBadgeTextBlock"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"
+                                   FontSize="10" />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 </ResourceDictionary>

--- a/src/cascadia/TerminalSettingsEditor/Extensions.h
+++ b/src/cascadia/TerminalSettingsEditor/Extensions.h
@@ -44,6 +44,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         bool NoProfilesModified() const noexcept { return _profilesModifiedView.Size() == 0; }
         bool NoProfilesAdded() const noexcept { return _profilesAddedView.Size() == 0; }
         bool NoSchemesAdded() const noexcept { return _colorSchemesAddedView.Size() == 0; }
+        bool DisplayBadge() const noexcept;
 
         // Views
         Windows::Foundation::Collections::IObservableVector<Editor::ExtensionPackageViewModel> ExtensionPackages() const noexcept { return _extensionPackages; }
@@ -55,6 +56,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void UpdateSettings(const Model::CascadiaSettings& settings, const Editor::ColorSchemesPageViewModel& colorSchemesPageVM);
         void NavigateToProfile(const guid profileGuid);
         void NavigateToColorScheme(const Editor::ColorSchemeViewModel& schemeVM);
+        void MarkAsVisited();
 
         static bool GetExtensionState(hstring extensionSource, const Model::CascadiaSettings& settings);
         static void SetExtensionState(hstring extensionSource, const Model::CascadiaSettings& settings, bool enableExt);

--- a/src/cascadia/TerminalSettingsEditor/Extensions.idl
+++ b/src/cascadia/TerminalSettingsEditor/Extensions.idl
@@ -21,6 +21,7 @@ namespace Microsoft.Terminal.Settings.Editor
         Boolean NoProfilesModified { get; };
         Boolean NoProfilesAdded { get; };
         Boolean NoSchemesAdded { get; };
+        Boolean DisplayBadge { get; };
 
         // Views
         IVector<ExtensionPackageViewModel> ExtensionPackages { get; };

--- a/src/cascadia/TerminalSettingsEditor/MainPage.h
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.h
@@ -45,6 +45,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         winrt::Windows::UI::Xaml::Media::Brush BackgroundBrush();
 
         Windows::Foundation::Collections::IObservableVector<IInspectable> Breadcrumbs() noexcept;
+        Editor::ExtensionsViewModel ExtensionsVM() const noexcept { return _extensionsVM; }
 
         til::typed_event<Windows::Foundation::IInspectable, Model::SettingsTarget> OpenJson;
 

--- a/src/cascadia/TerminalSettingsEditor/MainPage.idl
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.idl
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import "Extensions.idl";
+
 namespace Microsoft.Terminal.Settings.Editor
 {
     // Due to a XAML Compiler bug, it is hard for us to propagate an HWND into a XAML-using runtimeclass.
@@ -43,6 +45,7 @@ namespace Microsoft.Terminal.Settings.Editor
         void SetHostingWindow(UInt64 window);
 
         Windows.Foundation.Collections.IObservableVector<IInspectable> Breadcrumbs { get; };
+        ExtensionsViewModel ExtensionsVM { get; };
 
         Windows.UI.Xaml.Media.Brush BackgroundBrush { get; };
     }

--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -162,8 +162,8 @@
                     <FontIcon Glyph="&#xEA86;" />
                 </muxc:NavigationViewItem.Icon>
                 <muxc:NavigationViewItem.InfoBadge>
-                    <muxc:InfoBadge Visibility="{x:Bind ExtensionsVM.DisplayBadge, Mode=OneWay}"
-                                    Value="1" />
+                    <muxc:InfoBadge Style="{StaticResource NewInfoBadge}"
+                                    Visibility="{x:Bind ExtensionsVM.DisplayBadge, Mode=OneWay}" />
                 </muxc:NavigationViewItem.InfoBadge>
             </muxc:NavigationViewItem>
 

--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -161,6 +161,10 @@
                 <muxc:NavigationViewItem.Icon>
                     <FontIcon Glyph="&#xEA86;" />
                 </muxc:NavigationViewItem.Icon>
+                <muxc:NavigationViewItem.InfoBadge>
+                    <muxc:InfoBadge Visibility="{x:Bind ExtensionsVM.DisplayBadge, Mode=OneWay}"
+                                    Value="1" />
+                </muxc:NavigationViewItem.InfoBadge>
             </muxc:NavigationViewItem>
 
             <muxc:NavigationViewItemHeader x:Uid="Nav_Profiles" />

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -2403,4 +2403,8 @@
     <value>Disabled</value>
     <comment>Text displayed when an extension is disabled</comment>
   </data>
+  <data name="NewInfoBadgeTextBlock.Text" xml:space="preserve">
+    <value>NEW</value>
+    <comment>Text is used on an info badge for new navigation items. Must be all caps.</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/ApplicationState.cpp
+++ b/src/cascadia/TerminalSettingsModel/ApplicationState.cpp
@@ -318,11 +318,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             {
                 state->DismissedBadges = std::unordered_set<hstring>{};
             }
-            if (!state->DismissedBadges->contains(badgeId))
-            {
-                state->DismissedBadges->insert(badgeId);
-                inserted = true;
-            }
+            inserted = state->DismissedBadges->insert(badgeId).second;
         }
         _throttler();
         return inserted;

--- a/src/cascadia/TerminalSettingsModel/ApplicationState.cpp
+++ b/src/cascadia/TerminalSettingsModel/ApplicationState.cpp
@@ -309,6 +309,35 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         _throttler();
     }
 
+    bool ApplicationState::DismissBadge(const hstring& badgeId)
+    {
+        bool inserted{ false };
+        {
+            const auto state = _state.lock();
+            if (!state->DismissedBadges)
+            {
+                state->DismissedBadges = std::unordered_set<hstring>{};
+            }
+            if (!state->DismissedBadges->contains(badgeId))
+            {
+                state->DismissedBadges->insert(badgeId);
+                inserted = true;
+            }
+        }
+        _throttler();
+        return inserted;
+    }
+
+    bool ApplicationState::BadgeDismissed(const hstring& badgeId) const
+    {
+        const auto state = _state.lock_shared();
+        if (state->DismissedBadges)
+        {
+            return state->DismissedBadges->contains(badgeId);
+        }
+        return false;
+    }
+
     // Generate all getter/setters
 #define MTSM_APPLICATION_STATE_GEN(source, type, name, key, ...) \
     type ApplicationState::name() const noexcept                 \

--- a/src/cascadia/TerminalSettingsModel/ApplicationState.h
+++ b/src/cascadia/TerminalSettingsModel/ApplicationState.h
@@ -40,7 +40,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     X(FileSource::Local, Windows::Foundation::Collections::IVector<Model::WindowLayout>, PersistedWindowLayouts, "persistedWindowLayouts")                                \
     X(FileSource::Shared, Windows::Foundation::Collections::IVector<hstring>, RecentCommands, "recentCommands")                                                           \
     X(FileSource::Shared, Windows::Foundation::Collections::IVector<winrt::Microsoft::Terminal::Settings::Model::InfoBarMessage>, DismissedMessages, "dismissedMessages") \
-    X(FileSource::Local, Windows::Foundation::Collections::IVector<hstring>, AllowedCommandlines, "allowedCommandlines")
+    X(FileSource::Local, Windows::Foundation::Collections::IVector<hstring>, AllowedCommandlines, "allowedCommandlines")                                                  \
+    X(FileSource::Local, std::unordered_set<hstring>, DismissedBadges, "dismissedBadges")
 
     struct WindowLayout : WindowLayoutT<WindowLayout>
     {
@@ -70,6 +71,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         Json::Value ToJson(FileSource parseSource) const noexcept;
 
         void AppendPersistedWindowLayout(Model::WindowLayout layout);
+        bool DismissBadge(const hstring& badgeId);
+        bool BadgeDismissed(const hstring& badgeId) const;
 
         // State getters/setters
 #define MTSM_APPLICATION_STATE_GEN(source, type, name, key, ...) \

--- a/src/cascadia/TerminalSettingsModel/ApplicationState.idl
+++ b/src/cascadia/TerminalSettingsModel/ApplicationState.idl
@@ -33,6 +33,8 @@ namespace Microsoft.Terminal.Settings.Model
         void Reset();
 
         void AppendPersistedWindowLayout(WindowLayout layout);
+        Boolean DismissBadge(String badgeId);
+        Boolean BadgeDismissed(String badgeId);
 
         String SettingsHash;
         Windows.Foundation.Collections.IVector<WindowLayout> PersistedWindowLayouts;


### PR DESCRIPTION
## Summary of the Pull Request
Adds a badge to the Extensions Page in the SUI's navigation pane to highlight that it's new!

## References and Relevant Issues
Targets #18633

## Detailed Description of the Pull Request / Additional comments
- Settings Model changes:
   - Leveraged the `ApplicationState` class to track which badges have been dismissed and prevent them from appearing again
   - Used a `std::unordered_set`, but exposed a `get` and `append` function via the IDL
- Settings UI changes:
   - Added a `NewInfoBadge` style that is just an InfoBadge with "NEW" in it instead of a number or an icon. Based on https://github.com/microsoft/PowerToys/pull/36939
   - The visibility is bound to a `get` call to the `ApplicationState` conducted via the `ExtensionsPageViewModel`. The VM is also responsible for updating the state.

Long-term, we can reuse this system and make the following minor changes:
- `SettingContainer`: display the badge. and add logic to read/write `ApplicationState` appropriately (similarly to above)
- `XPageViewModel`:
   - count all the badges that will be displayed and expose/bind that to InfoBadge.Value
   - If a whole page is new, we can just style the badge using the `NewInfoBadge` style

## Validation Steps Performed
✅ Extensions page nav item displays a badge if page hasn't been visited
✅ The badge is dismissed when the user visits the page