### PR TITLE
Implement DECSET 2026 - Synchronized Output

### DIFF
--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -4,10 +4,6 @@
 #include "precomp.h"
 #include "renderer.hpp"
 
-#include <til/atomic.h>
-
-#pragma hdrstop
-
 using namespace Microsoft::Console::Render;
 using namespace Microsoft::Console::Types;
 

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -94,7 +94,6 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT _PaintFrame() noexcept;
         [[nodiscard]] HRESULT _PaintFrameForEngine(_In_ IRenderEngine* const pEngine) noexcept;
         void _synchronizeWithOutput() noexcept;
-        void _synchronizeWithOutputSlow(uint64_t deadline) noexcept;
         bool _CheckViewportAndScroll();
         [[nodiscard]] HRESULT _PaintBackground(_In_ IRenderEngine* const pEngine);
         void _PaintBufferOutput(_In_ IRenderEngine* const pEngine);
@@ -128,7 +127,7 @@ namespace Microsoft::Console::Render
         std::function<void()> _pfnBackgroundColorChanged;
         std::function<void()> _pfnFrameColorChanged;
         std::function<void()> _pfnRendererEnteredErrorState;
-        std::atomic<uint64_t> _synchronizedOutputDeadline{ 0 };
+        bool _isSynchronizingOutput = false;
         bool _forceUpdateViewport = false;
 
         til::point_span _lastSelectionPaintSpan{};

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -35,6 +35,8 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT PaintFrame();
 
         void NotifyPaintFrame() noexcept;
+        void SynchronizedOutputBegin() noexcept;
+        void SynchronizedOutputEnd() noexcept;
         void TriggerSystemRedraw(const til::rect* const prcDirtyClient);
         void TriggerRedraw(const Microsoft::Console::Types::Viewport& region);
         void TriggerRedraw(const til::point* const pcoord);
@@ -91,6 +93,8 @@ namespace Microsoft::Console::Render
 
         [[nodiscard]] HRESULT _PaintFrame() noexcept;
         [[nodiscard]] HRESULT _PaintFrameForEngine(_In_ IRenderEngine* const pEngine) noexcept;
+        void _synchronizeWithOutput() noexcept;
+        void _synchronizeWithOutputSlow(uint64_t deadline) noexcept;
         bool _CheckViewportAndScroll();
         [[nodiscard]] HRESULT _PaintBackground(_In_ IRenderEngine* const pEngine);
         void _PaintBufferOutput(_In_ IRenderEngine* const pEngine);
@@ -124,6 +128,7 @@ namespace Microsoft::Console::Render
         std::function<void()> _pfnBackgroundColorChanged;
         std::function<void()> _pfnFrameColorChanged;
         std::function<void()> _pfnRendererEnteredErrorState;
+        std::atomic<uint64_t> _synchronizedOutputDeadline{ 0 };
         bool _forceUpdateViewport = false;
 
         til::point_span _lastSelectionPaintSpan{};

--- a/src/renderer/base/thread.cpp
+++ b/src/renderer/base/thread.cpp
@@ -34,7 +34,7 @@ DWORD WINAPI RenderThread::_ThreadProc()
 
         // Between waiting on _hEvent and calling PaintFrame() there should be a minimal delay,
         // so that a key press progresses to a drawing operation as quickly as possible.
-        // As such, we wait for the renderer to complete _before_ waiting on _hEvent.
+        // As such, we wait for the renderer to complete _before_ waiting on `_redraw`.
         renderer->WaitUntilCanRender();
 
         _redraw.wait();
@@ -78,6 +78,8 @@ void RenderThread::EnablePainting() noexcept
     }
 }
 
+// This function is meant to only be called by `Renderer`. You should use `TriggerTeardown()` instead,
+// even if you plan to call `EnablePainting()` later, because that ensures proper synchronization.
 void RenderThread::DisablePainting() noexcept
 {
     _enable.ResetEvent();

--- a/src/terminal/adapter/DispatchTypes.hpp
+++ b/src/terminal/adapter/DispatchTypes.hpp
@@ -544,6 +544,7 @@ namespace Microsoft::Console::VirtualTerminal::DispatchTypes
         ALTERNATE_SCROLL = DECPrivateMode(1007),
         ASB_AlternateScreenBuffer = DECPrivateMode(1049),
         XTERM_BracketedPasteMode = DECPrivateMode(2004),
+        SO_SynchronizedOutput = DECPrivateMode(2026),
         GCM_GraphemeClusterMode = DECPrivateMode(2027),
         W32IM_Win32InputMode = DECPrivateMode(9001),
     };

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1914,6 +1914,19 @@ void AdaptDispatch::_ModeParamsHelper(const DispatchTypes::ModeParams param, con
     case DispatchTypes::ModeParams::XTERM_BracketedPasteMode:
         _api.SetSystemMode(ITerminalApi::Mode::BracketedPaste, enable);
         break;
+    case DispatchTypes::ModeParams::SO_SynchronizedOutput:
+        if (_renderer)
+        {
+            if (enable)
+            {
+                _renderer->SynchronizedOutputBegin();
+            }
+            else
+            {
+                _renderer->SynchronizedOutputEnd();
+            }
+        }
+        break;
     case DispatchTypes::ModeParams::GCM_GraphemeClusterMode:
         break;
     case DispatchTypes::ModeParams::W32IM_Win32InputMode:


### PR DESCRIPTION
Now that we have passthrough mode (#17510), as well as the render thread
rewrite (#18632), adding support for DECSET 2026 is a piece of cake.

Closes #8331

## Validation Steps Performed
* Run `btop` via ssh in a huge window
  * Open the Options menu
  * No flicker ✅
* Run the following in PowerShell 7+:
  ```pwsh
  1..10000 | % { Write-Host -NoNewline ("`e[?2026h" + "foobar`r`e[K$_" * 10000 + "`e[?2026l") }
  ```
  * "foobar" is not visible ❌
  * The number count goes up smoothly ❌