### PR TITLE
[SUI] Improve accessibility to open json

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -38,6 +38,7 @@ using namespace winrt::Windows::System;
 using namespace winrt::Windows::UI::Xaml::Controls;
 using namespace winrt::Windows::Foundation::Collections;
 
+static const std::wstring_view openJsonTag{ L"OpenJson_Nav" };
 static const std::wstring_view launchTag{ L"Launch_Nav" };
 static const std::wstring_view interactionTag{ L"Interaction_Nav" };
 static const std::wstring_view renderingTag{ L"Rendering_Nav" };
@@ -324,6 +325,17 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
             if (const auto navString = clickedItemContainer.Tag().try_as<hstring>())
             {
+                if (*navString == openJsonTag)
+                {
+                    const auto window = CoreWindow::GetForCurrentThread();
+                    const auto rAltState = window.GetKeyState(VirtualKey::RightMenu);
+                    const auto lAltState = window.GetKeyState(VirtualKey::LeftMenu);
+                    const auto altPressed = WI_IsFlagSet(lAltState, CoreVirtualKeyStates::Down) ||
+                                            WI_IsFlagSet(rAltState, CoreVirtualKeyStates::Down);
+                    const auto target = altPressed ? SettingsTarget::DefaultsFile : SettingsTarget::SettingsFile;
+                    OpenJson.raise(nullptr, target);
+                    return;
+                }
                 _Navigate(*navString, BreadcrumbSubPage::None);
             }
             else if (const auto profile = clickedItemContainer.Tag().try_as<Editor::ProfileViewModel>())
@@ -572,27 +584,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 // If we couldn't find a reasonable match, just go back to the root
                 _newTabMenuPageVM.CurrentFolder(nullptr);
             }
-        }
-    }
-
-    void MainPage::OpenJsonTapped(const IInspectable& /*sender*/, const Windows::UI::Xaml::Input::TappedRoutedEventArgs& /*args*/)
-    {
-        const auto window = CoreWindow::GetForCurrentThread();
-        const auto rAltState = window.GetKeyState(VirtualKey::RightMenu);
-        const auto lAltState = window.GetKeyState(VirtualKey::LeftMenu);
-        const auto altPressed = WI_IsFlagSet(lAltState, CoreVirtualKeyStates::Down) ||
-                                WI_IsFlagSet(rAltState, CoreVirtualKeyStates::Down);
-
-        const auto target = altPressed ? SettingsTarget::DefaultsFile : SettingsTarget::SettingsFile;
-        OpenJson.raise(nullptr, target);
-    }
-
-    void MainPage::OpenJsonKeyDown(const IInspectable& /*sender*/, const Windows::UI::Xaml::Input::KeyRoutedEventArgs& args)
-    {
-        if (args.Key() == VirtualKey::Enter || args.Key() == VirtualKey::Space)
-        {
-            const auto target = args.KeyStatus().IsMenuKeyDown ? SettingsTarget::DefaultsFile : SettingsTarget::SettingsFile;
-            OpenJson.raise(nullptr, target);
         }
     }
 

--- a/src/cascadia/TerminalSettingsEditor/MainPage.h
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.h
@@ -30,8 +30,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         void UpdateSettings(const Model::CascadiaSettings& settings);
 
-        void OpenJsonKeyDown(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Input::KeyRoutedEventArgs& args);
-        void OpenJsonTapped(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Input::TappedRoutedEventArgs& args);
         void SettingsNav_Loaded(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
         void SettingsNav_ItemInvoked(const Microsoft::UI::Xaml::Controls::NavigationView& sender, const Microsoft::UI::Xaml::Controls::NavigationViewItemInvokedEventArgs& args);
         void SaveButton_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);

--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -171,8 +171,8 @@
             <!--  The OpenJson item needs both Tapped and KeyDown handler  -->
             <muxc:NavigationViewItem x:Name="OpenJsonNavItem"
                                      x:Uid="Nav_OpenJSON"
-                                     KeyDown="OpenJsonKeyDown"
-                                     Tapped="OpenJsonTapped">
+                                     SelectsOnInvoked="False"
+                                     Tag="OpenJson_Nav">
                 <muxc:NavigationViewItem.Icon>
                     <FontIcon Glyph="&#xE713;" />
                 </muxc:NavigationViewItem.Icon>


### PR DESCRIPTION
## Summary of the Pull Request
The "open JSON" button in the settings UI wasn't working when invoked via accessibility tools (specifically Narrator in scan mode and Voice Access). For some reason, in those scenarios, neither the `Tapped` or `KeyDown` event were hit!

This PR adds the logic to open the json file via the `ItemInvoked` event instead. The `Tapped` and `KeyDown` handlers were removed to prevent a redundant `OpenJson` event being raised.

Additionally, `SelectsOnInvoked` was set to `False` on the "open JSON" nav item. This prevents the selection pill from moving to the nav item, which feels more correct.

## Validation Steps Performed
The following scenarios are confirmed to open the JSON
✅ Mouse click
✅ Keyboard (Spacebar and Enter)
✅ Voice Access
✅ Narrator in scan mode

For all of these (except Voice Access), I've confirmed that holding the Alt button while invoking the JSON button opens defaults.json.

## PR Checklist
Closes #18770
Closes #12003