### PR TITLE
ServicingPipeline: make a bunch of quality of life improvements

### DIFF
--- a/tools/ReleaseEngineering/ServicingPipeline.ps1
+++ b/tools/ReleaseEngineering/ServicingPipeline.ps1
@@ -315,7 +315,7 @@ If ($incompleteCards.Length -Gt 0) {
     Write-Host ""
 }
 
-$considerCards = $cards | Where-Object { [String]::IsNullOrEmpty($_.Commit) -And $_.Status -Eq ([ServicingStatus]::ToConsider) }
+$considerCards = $cards | Where-Object Status -Eq ([ServicingStatus]::ToConsider)
 If ($considerCards.Length -Gt 0) {
     Write-Host "`e[7m CONSIDERATION QUEUE `e[27m"
     $considerCards | ForEach-Object {

--- a/tools/ReleaseEngineering/ServicingPipeline.ps1
+++ b/tools/ReleaseEngineering/ServicingPipeline.ps1
@@ -246,11 +246,11 @@ Class ServicingCard {
             ([ServicingItemType]::Redacted)    { "`u{25ec}" } # triangle with dot
             Default                            { "`u{2b24}" }
         }
-        $numberWithLink = ""
+        $localTitle = $this.Title
         If ($this.Number -Gt 0) {
-            $numberWithLink = " (`e]8;;https://github.com/microsoft/terminal/issues/$($this.Number)`e\#$($this.Number)`e]8;;`e\)"
+            $localTitle = "[`e]8;;https://github.com/microsoft/terminal/issues/{1}`e\Link`e]8;;`e\] {0} (#{1})" -f ($this.Title, $this.Number)
         }
-        Return "{0}{1}`e[m ({2}) {3}{4}" -f ($color, $symbol, $this.Status, $this.Title, $numberWithLink)
+        Return "{0}{1}`e[m ({2}) {3}" -f ($color, $symbol, $this.Status, $localTitle)
     }
 }
 


### PR DESCRIPTION
We used to cherry-pick every commit that had even one card in "To Cherry Pick", even if it was also referenced by a card in "Rejected" or even "To Consider".

Now we will warn and skip those commits.

I took this opportunity to add a bit of an object model for servicing cards as well as prettify the output.

That allowed us to add a list of cards that were ignored due to having no commits, and display little icons for each type of card.
