### PR TITLE
Use RenderSettings for DECSET 2026 - Synchronized Output

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -143,7 +143,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // the UIA Engine to the renderer. This prevents us from signaling changes to the cursor or buffer.
         {
             // Now create the renderer and initialize the render thread.
-            const auto& renderSettings = _terminal->GetRenderSettings();
+            auto& renderSettings = _terminal->GetRenderSettings();
             _renderer = std::make_unique<::Microsoft::Console::Render::Renderer>(renderSettings, _terminal.get());
 
             _renderer->SetBackgroundColorChangedCallback([this]() { _rendererBackgroundColorChanged(); });

--- a/src/renderer/base/RenderSettings.cpp
+++ b/src/renderer/base/RenderSettings.cpp
@@ -46,9 +46,9 @@ void RenderSettings::RestoreDefaultSettings() noexcept
 {
     _colorTable = _defaultColorTable;
     _colorAliasIndices = _defaultColorAliasIndices;
-    // For now, DECSCNM is the only render mode we need to reset. The others are
-    // all user preferences that can't be changed programmatically.
-    _renderMode.reset(Mode::ScreenReversed);
+    // DECSCNM and Synchronized Output are the only render mode we need to reset.
+    // The others are all user preferences that can't be changed programmatically.
+    _renderMode.reset(Mode::ScreenReversed, Mode::SynchronizedOutput);
 }
 
 // Routine Description:

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -28,15 +28,14 @@ namespace Microsoft::Console::Render
     class Renderer
     {
     public:
-        Renderer(const RenderSettings& renderSettings, IRenderData* pData);
+        Renderer(RenderSettings& renderSettings, IRenderData* pData);
 
         IRenderData* GetRenderData() const noexcept;
 
         [[nodiscard]] HRESULT PaintFrame();
 
         void NotifyPaintFrame() noexcept;
-        void SynchronizedOutputBegin() noexcept;
-        void SynchronizedOutputEnd() noexcept;
+        void SynchronizedOutputChanged() noexcept;
         void TriggerSystemRedraw(const til::rect* const prcDirtyClient);
         void TriggerRedraw(const Microsoft::Console::Types::Viewport& region);
         void TriggerRedraw(const til::point* const pcoord);
@@ -113,7 +112,7 @@ namespace Microsoft::Console::Render
         void _prepareNewComposition();
         [[nodiscard]] HRESULT _PrepareRenderInfo(_In_ IRenderEngine* const pEngine);
 
-        const RenderSettings& _renderSettings;
+        RenderSettings& _renderSettings;
         std::array<IRenderEngine*, 2> _engines{};
         IRenderData* _pData = nullptr; // Non-ownership pointer
         static constexpr size_t _firstSoftFontChar = 0xEF20;

--- a/src/renderer/inc/RenderSettings.hpp
+++ b/src/renderer/inc/RenderSettings.hpp
@@ -25,7 +25,8 @@ namespace Microsoft::Console::Render
             AlwaysDistinguishableColors,
             IntenseIsBold,
             IntenseIsBright,
-            ScreenReversed
+            ScreenReversed,
+            SynchronizedOutput,
         };
 
         RenderSettings() noexcept;

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1915,16 +1915,10 @@ void AdaptDispatch::_ModeParamsHelper(const DispatchTypes::ModeParams param, con
         _api.SetSystemMode(ITerminalApi::Mode::BracketedPaste, enable);
         break;
     case DispatchTypes::ModeParams::SO_SynchronizedOutput:
+        _renderSettings.SetRenderMode(RenderSettings::Mode::SynchronizedOutput, enable);
         if (_renderer)
         {
-            if (enable)
-            {
-                _renderer->SynchronizedOutputBegin();
-            }
-            else
-            {
-                _renderer->SynchronizedOutputEnd();
-            }
+            _renderer->SynchronizedOutputChanged();
         }
         break;
     case DispatchTypes::ModeParams::GCM_GraphemeClusterMode:
@@ -2064,6 +2058,9 @@ void AdaptDispatch::RequestMode(const DispatchTypes::ModeParams param)
         break;
     case DispatchTypes::ModeParams::XTERM_BracketedPasteMode:
         state = mapTemp(_api.GetSystemMode(ITerminalApi::Mode::BracketedPaste));
+        break;
+    case DispatchTypes::ModeParams::SO_SynchronizedOutput:
+        state = mapTemp(_renderSettings.GetRenderMode(RenderSettings::Mode::SynchronizedOutput));
         break;
     case DispatchTypes::ModeParams::GCM_GraphemeClusterMode:
         state = mapPerm(CodepointWidthDetector::Singleton().GetMode() == TextMeasurementMode::Graphemes);

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -3047,6 +3047,7 @@ void AdaptDispatch::HardReset()
     if (_renderer)
     {
         _renderer->TriggerRedrawAll(true, true);
+        _renderer->SynchronizedOutputChanged();
     }
 
     // Cursor to 1,1 - the Soft Reset guarantees this is absolute


### PR DESCRIPTION
`RenderSettings` already stores `DECSCNM` (reversed screen),
so it only makes sense to also store DECSET 2026 there.

## Validation Steps Performed
* Same as in #18826 ✅