### PR TITLE
Remove virtual functions in BaseWindow with CRTP

### DIFF
--- a/src/cascadia/WindowsTerminal/BaseWindow.h
+++ b/src/cascadia/WindowsTerminal/BaseWindow.h
@@ -9,7 +9,6 @@ class BaseWindow
 public:
     static constexpr UINT CM_UPDATE_TITLE = WM_USER + 0;
 
-    virtual ~BaseWindow() = 0;
     static T* GetThisFromHandle(HWND const window) noexcept
     {
         return reinterpret_cast<T*>(GetWindowLongPtr(window, GWLP_USERDATA));
@@ -37,7 +36,7 @@ public:
         return DefWindowProc(window, message, wparam, lparam);
     }
 
-    [[nodiscard]] virtual LRESULT MessageHandler(UINT const message, WPARAM const wparam, LPARAM const lparam) noexcept
+    [[nodiscard]] LRESULT MessageHandler(UINT const message, WPARAM const wparam, LPARAM const lparam) noexcept
     {
         switch (message)
         {
@@ -58,19 +57,19 @@ public:
                 if (_minimized)
                 {
                     _minimized = false;
-                    OnRestore();
+                    static_cast<T*>(this)->OnRestore();
                 }
 
                 // We always need to fire the resize event, even when we're transitioning from minimized.
                 // We might be transitioning directly from minimized to maximized, and we'll need
                 // to trigger any size-related content changes.
-                OnResize(width, height);
+                static_cast<T*>(this)->OnResize(width, height);
                 break;
             case SIZE_MINIMIZED:
                 if (!_minimized)
                 {
                     _minimized = true;
-                    OnMinimize();
+                    static_cast<T*>(this)->OnMinimize();
                 }
                 break;
             default:
@@ -108,10 +107,6 @@ public:
         _inDpiChange = false;
         return 0;
     }
-
-    virtual void OnResize(const UINT width, const UINT height) = 0;
-    virtual void OnMinimize() = 0;
-    virtual void OnRestore() = 0;
 
     RECT GetWindowRect() const noexcept
     {
@@ -204,13 +199,13 @@ protected:
 
     void _setupUserData()
     {
-        SetWindowLongPtr(_window.get(), GWLP_USERDATA, reinterpret_cast<LONG_PTR>(this));
+        SetWindowLongPtr(_window.get(), GWLP_USERDATA, reinterpret_cast<LONG_PTR>(static_cast<T*>(this)));
     }
     // Method Description:
     // - This method is called when the window receives the WM_NCCREATE message.
     // Return Value:
     // - The value returned from the window proc.
-    [[nodiscard]] virtual LRESULT OnNcCreate(WPARAM wParam, LPARAM lParam) noexcept
+    [[nodiscard]] LRESULT OnNcCreate(WPARAM wParam, LPARAM lParam) noexcept
     {
         _setupUserData();
 
@@ -220,8 +215,3 @@ protected:
         return DefWindowProc(_window.get(), WM_NCCREATE, wParam, lParam);
     };
 };
-
-template<typename T>
-inline BaseWindow<T>::~BaseWindow()
-{
-}

--- a/src/cascadia/WindowsTerminal/IslandWindow.h
+++ b/src/cascadia/WindowsTerminal/IslandWindow.h
@@ -19,7 +19,7 @@ public:
     static void ShowCursorMaybe(const UINT message) noexcept;
 
     IslandWindow() noexcept;
-    virtual ~IslandWindow() override;
+    ~IslandWindow();
 
     virtual void MakeWindow() noexcept;
     virtual void Close();
@@ -27,13 +27,13 @@ public:
     virtual void OnSize(const UINT width, const UINT height);
     HWND GetInteropHandle() const;
 
-    [[nodiscard]] virtual LRESULT MessageHandler(UINT const message, WPARAM const wparam, LPARAM const lparam) noexcept override;
+    [[nodiscard]] virtual LRESULT MessageHandler(UINT const message, WPARAM const wparam, LPARAM const lparam) noexcept;
 
-    [[nodiscard]] LRESULT OnNcCreate(WPARAM wParam, LPARAM lParam) noexcept override;
+    [[nodiscard]] LRESULT OnNcCreate(WPARAM wParam, LPARAM lParam) noexcept;
 
-    void OnResize(const UINT width, const UINT height) override;
-    void OnMinimize() override;
-    void OnRestore() override;
+    void OnResize(const UINT width, const UINT height);
+    void OnMinimize();
+    void OnRestore();
     virtual void OnAppInitialized();
     virtual void SetContent(winrt::Windows::UI::Xaml::UIElement content);
     virtual void OnApplicationThemeChanged(const winrt::Windows::UI::Xaml::ElementTheme& requestedTheme);

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.h
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.h
@@ -27,13 +27,13 @@ public:
     static constexpr const int topBorderVisibleHeight = 1;
 
     NonClientIslandWindow(const winrt::Windows::UI::Xaml::ElementTheme& requestedTheme) noexcept;
-    ~NonClientIslandWindow() override;
+    ~NonClientIslandWindow();
 
     virtual void Close() override;
     void MakeWindow() noexcept override;
     virtual void OnSize(const UINT width, const UINT height) override;
 
-    [[nodiscard]] virtual LRESULT MessageHandler(UINT const message, WPARAM const wparam, LPARAM const lparam) noexcept override;
+    [[nodiscard]] virtual LRESULT MessageHandler(UINT const message, WPARAM const wparam, LPARAM const lparam) noexcept;
 
     virtual til::rect GetNonClientFrame(UINT dpi) const noexcept override;
     virtual til::size GetTotalNonClientExclusiveSize(UINT dpi) const noexcept override;


### PR DESCRIPTION
Minor refactors.
Obviously you do not need `virtual` functions when you have CRTP which `BaseWindow<T>` already uses.