### PR TITLE
fix: wrong term in zh-TW

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
@@ -335,7 +335,7 @@
     <comment>This text is shown next to a list of choices.</comment>
   </data>
   <data name="Globals_GraphicsAPI.HelpText" xml:space="preserve">
-    <value>Direct3D 11 提供更具效能且功能更豐富的體驗，而 Direct2D 則較穩定。默認選項 [自動] 會挑選最適合您圖形硬體的 API。如果您遇到重大問題，請考慮使用 Direct2D。</value>
+    <value>Direct3D 11 提供更具效能且功能更豐富的體驗，而 Direct2D 則較穩定。預設選項 [自動] 會挑選最適合您圖形硬體的 API。如果您遇到重大問題，請考慮使用 Direct2D。</value>
   </data>
   <data name="Globals_GraphicsAPI_Automatic.Text" xml:space="preserve">
     <value>自動</value>
@@ -1010,7 +1010,7 @@
     <comment>A description for what the "line height" setting does. Presented near "Profile_LineHeight".</comment>
   </data>
   <data name="Profile_CellWidth.HelpText" xml:space="preserve">
-    <value>覆寫終端機的單元格寬度。以字型大小的倍數表示。默認值取決於您的字型，通常大約是0.6。</value>
+    <value>覆寫終端機的單元格寬度。以字型大小的倍數表示。預設值取決於您的字型，通常大約是0.6。</value>
     <comment>A description for what the "cell width" setting does. Presented near "Profile_CellWidth".</comment>
   </data>
   <data name="Profile_LineHeightBox.PlaceholderText" xml:space="preserve">


### PR DESCRIPTION
## Summary of the Pull Request

Fix wrong term in zh-TW.

## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments

The "default" should be translated as "預設" in zh-TW, "默認" is in zh-CN.

## Validation Steps Performed

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)

------

I check the CONTRIBUTING.md and README.md, there seems no part about the localization improvement so I open a PR and edit file directly. If there are a better way, please tell me and close this PR. Thanks!
