### PR TITLE
Fix SGR mouse movement reports

### DIFF
--- a/src/terminal/adapter/ut_adapter/MouseInputTest.cpp
+++ b/src/terminal/adapter/ut_adapter/MouseInputTest.cpp
@@ -99,7 +99,7 @@ public:
 
         TerminalInput::StringType str;
         str.append(std::wstring_view{ buffer });
-        str[str.size() - 1] = IsButtonDown(uiButton) ? L'M' : L'm';
+        str[str.size() - 1] = IsButtonUp(uiButton) ? L'm' : L'M';
         return str;
     }
 
@@ -182,23 +182,18 @@ public:
         return result;
     }
 
-    bool IsButtonDown(unsigned int uiButton)
+    bool IsButtonUp(unsigned int uiButton)
     {
-        auto fIsDown = false;
         switch (uiButton)
         {
-        case WM_LBUTTONDBLCLK:
-        case WM_LBUTTONDOWN:
-        case WM_RBUTTONDOWN:
-        case WM_RBUTTONDBLCLK:
-        case WM_MBUTTONDOWN:
-        case WM_MBUTTONDBLCLK:
-        case WM_MOUSEWHEEL:
-        case WM_MOUSEHWHEEL:
-            fIsDown = true;
-            break;
+        case WM_LBUTTONUP:
+        case WM_RBUTTONUP:
+        case WM_MBUTTONUP:
+        case WM_XBUTTONUP:
+            return true;
+        default:
+            return false;
         }
-        return fIsDown;
     }
 
     /* From winuser.h - Needed to manually specify the test properties

--- a/src/terminal/input/terminalInput.hpp
+++ b/src/terminal/input/terminalInput.hpp
@@ -109,7 +109,7 @@ namespace Microsoft::Console::VirtualTerminal
 #pragma region MouseInput
         [[nodiscard]] OutputType _GenerateDefaultSequence(til::point position, unsigned int button, bool isHover, short modifierKeyState, short delta);
         [[nodiscard]] OutputType _GenerateUtf8Sequence(til::point position, unsigned int button, bool isHover, short modifierKeyState, short delta);
-        [[nodiscard]] OutputType _GenerateSGRSequence(til::point position, unsigned int button, bool isDown, bool isHover, short modifierKeyState, short delta);
+        [[nodiscard]] OutputType _GenerateSGRSequence(til::point position, unsigned int button, bool isRelease, bool isHover, short modifierKeyState, short delta);
 
         [[nodiscard]] OutputType _makeAlternateScrollOutput(short delta) const;
 


### PR DESCRIPTION
According to the documentation, the final character of an SGR mouse
report is meant to be `M` for a button press and `m` for a button
release. However it isn't clear what the final character should be for
motion events, and we were using an `m` if there weren't any buttons
held down at the time, while all other terminals used an `M`, regardless
of the button state.

This PR updates our implementation to match what everyone else is doing,
since our interpretation of the spec was causing problems for some apps.

## Validation Steps Performed

I've manually tested the new behavior in Vttest, and confirmed that our
mouse reports now match Xterm more closely, and I've tested with v0.42.0
of Zellij, which was previous glitching badly in Windows Terminal, but
now works correctly.

I've also updated our unit tests for the SGR mouse mode to reflect the
correct report format.

Closes #18712
