### PR TITLE
[1.22] Fix teardown when 'allowHeadless' is enabled

### DIFF
--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -1320,7 +1320,7 @@ void AppHost::_WindowMoved()
 void AppHost::_CloseRequested(const winrt::Windows::Foundation::IInspectable& /*sender*/,
                               const winrt::Windows::Foundation::IInspectable& /*args*/)
 {
-    if (_windowManager.GetNumberOfPeasants() <= 1)
+    if (_windowManager.GetNumberOfPeasants() <= 1 && !_appLogic.AllowHeadless())
     {
         _quit();
         return;


### PR DESCRIPTION
## Summary of the Pull Request
Fixes a bug where `Monarch::_peasants` would not be updated when the last window was closed and `compatibility.allowHeadless` was enabled.

## Detailed Description of the Pull Request / Additional comments
The bug was originally caused by `Monarch::_peasants` still holding on to a reference to itself in the list. Normally, a `Peasant` was removed from the list via the `WindowManager::SignalClose()` (aka `Monarch::SignalClose()`) function. However, `AppHost::_CloseRequested()` would omit that call when the last window was closing.

Normally, that makes sense. It's the last window, so let's call `AppHost::_quit()` --> `WindowManager::QuitAll()` --> `Monarch::QuitAll()`, where we just call `Peasant::Quit()` on all the peasants and the monarch and we call it a day. Everything should be cleaned up and if we need a new session, we'll create a new `Monarch` anyways.

Problem is, when `compatibility.allowHeadless` is enabled, the `WindowEmperor` doesn't actually close! We want the `WindowEmperor` to stick around because that's the "headless" part we're allowing. See `WindowEmperor::_decrementWindowCount()`: https://github.com/microsoft/terminal/blob/bbd6427b0831a16dc65506b386f63e6c3b3567ad/src/cascadia/WindowsTerminal/WindowEmperor.cpp#L296-L308

The fix here was to avoid the `QuitAll()` code path mentioned above if `compatibility.allowHeadless` is enabled. Just treat this as a normal teardown otherwise so that the `WindowEmperor` creates a new `Monarch` when we need it.

## Validation Steps Performed
✅ The scenario from the bug works:
- enable `compatibility.allowHeadless`
- set `windowingBehavior` to `useExisting`
- Open Terminal
- Close the only open window
- Attempting to open Terminal again should open a new window
✅ when all windows are closed, we still have the background process

Closes #18827