### PR TITLE
Use Microsoft.Windows.Settings module for enabling developer mode

### DIFF
--- a/.config/configuration.vsEnterprise.winget
+++ b/.config/configuration.vsEnterprise.winget
@@ -2,14 +2,14 @@
 # Reference: https://github.com/microsoft/terminal/blob/main/README.md#developer-guidance
 properties:
   resources:
-    - resource: Microsoft.Windows.Developer/DeveloperMode
+    - resource: Microsoft.Windows.Settings/WindowsSettings
       directives:
         description: Enable Developer Mode
         allowPrerelease: true
         # Requires elevation for the set operation
         securityContext: elevated
       settings:
-        Ensure: Present
+        DeveloperMode: true
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: powershell
       directives:

--- a/.config/configuration.vsProfessional.winget
+++ b/.config/configuration.vsProfessional.winget
@@ -2,14 +2,14 @@
 # Reference: https://github.com/microsoft/terminal/blob/main/README.md#developer-guidance
 properties:
   resources:
-    - resource: Microsoft.Windows.Developer/DeveloperMode
+    - resource: Microsoft.Windows.Settings/WindowsSettings
       directives:
         description: Enable Developer Mode
         allowPrerelease: true
         # Requires elevation for the set operation
         securityContext: elevated
       settings:
-        Ensure: Present
+        DeveloperMode: true
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: powershell
       directives:

--- a/.config/configuration.winget
+++ b/.config/configuration.winget
@@ -2,14 +2,14 @@
 # Reference: https://github.com/microsoft/terminal/blob/main/README.md#developer-guidance
 properties:
   resources:
-    - resource: Microsoft.Windows.Developer/DeveloperMode
+    - resource: Microsoft.Windows.Settings/WindowsSettings
       directives:
         description: Enable Developer Mode
         allowPrerelease: true
         # Requires elevation for the set operation
         securityContext: elevated
       settings:
-        Ensure: Present
+        DeveloperMode: true
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: powershell
       directives:


### PR DESCRIPTION
## Summary of the Pull Request

Using the [Microsoft.Windows.Settings](https://www.powershellgallery.com/packages/Microsoft.Windows.Settings/) module is the now the recommended way of configuring Windows Settings, including developer mode.

## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

Verified that setting developer mode with the new resource works as intended

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
