### PR TITLE
Fix remaining settings container previews in SUI

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Appearances.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.cpp
@@ -219,7 +219,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 // into the path TextBox, we properly update the checkbox and stored
                 // _lastBgImagePath. Without this, then we'll permanently hide the text
                 // box, prevent it from ever being changed again.
-                _NotifyChanges(L"UseDesktopBGImage", L"BackgroundImageSettingsVisible");
+                _NotifyChanges(L"UseDesktopBGImage", L"BackgroundImageSettingsVisible", L"CurrentBackgroundImagePath");
             }
             else if (viewModelProperty == L"BackgroundImageAlignment")
             {
@@ -954,7 +954,21 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         return GetLibraryResourceString(alignmentResourceKey);
     }
 
-    bool AppearanceViewModel::UseDesktopBGImage()
+    hstring AppearanceViewModel::CurrentBackgroundImagePath() const
+    {
+        const auto bgImagePath = BackgroundImagePath();
+        if (bgImagePath.empty())
+        {
+            return RS_(L"Appearance_BackgroundImageNone");
+        }
+        else if (bgImagePath == L"desktopWallpaper")
+        {
+            return RS_(L"Profile_UseDesktopImage/Content");
+        }
+        return bgImagePath;
+    }
+
+    bool AppearanceViewModel::UseDesktopBGImage() const
     {
         return BackgroundImagePath() == L"desktopWallpaper";
     }
@@ -983,7 +997,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
     }
 
-    bool AppearanceViewModel::BackgroundImageSettingsVisible()
+    bool AppearanceViewModel::BackgroundImageSettingsVisible() const
     {
         return !BackgroundImagePath().empty();
     }

--- a/src/cascadia/TerminalSettingsEditor/Appearances.h
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.h
@@ -120,9 +120,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void UpdateFontSetting(const FontKeyValuePair* kv);
 
         // background image
-        bool UseDesktopBGImage();
+        hstring CurrentBackgroundImagePath() const;
+        bool UseDesktopBGImage() const;
         void UseDesktopBGImage(const bool useDesktop);
-        bool BackgroundImageSettingsVisible();
+        bool BackgroundImageSettingsVisible() const;
         void SetBackgroundImageOpacityFromPercentageValue(double percentageValue);
         void SetBackgroundImagePath(winrt::hstring path);
         hstring BackgroundImageAlignmentCurrentValue() const;

--- a/src/cascadia/TerminalSettingsEditor/Appearances.idl
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.idl
@@ -38,6 +38,7 @@ namespace Microsoft.Terminal.Settings.Editor
         void SetBackgroundImageOpacityFromPercentageValue(Double percentageValue);
         void SetBackgroundImagePath(String path);
 
+        String CurrentBackgroundImagePath { get; };
         Boolean UseDesktopBGImage;
         Boolean BackgroundImageSettingsVisible { get; };
         String BackgroundImageAlignmentCurrentValue { get; };

--- a/src/cascadia/TerminalSettingsEditor/Appearances.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.xaml
@@ -533,13 +533,13 @@
             <local:SettingContainer x:Name="BackgroundImageContainer"
                                     x:Uid="Profile_BackgroundImage"
                                     ClearSettingValue="{x:Bind Appearance.ClearBackgroundImagePath}"
-                                    CurrentValue="{x:Bind Appearance.BackgroundImagePath, Mode=OneWay}"
+                                    CurrentValue="{x:Bind Appearance.CurrentBackgroundImagePath, Mode=OneWay}"
                                     HasSettingValue="{x:Bind Appearance.HasBackgroundImagePath, Mode=OneWay}"
                                     SettingOverrideSource="{x:Bind Appearance.BackgroundImagePathOverrideSource, Mode=OneWay}"
                                     Style="{StaticResource ExpanderSettingContainerStyle}">
                 <StackPanel Orientation="Vertical">
                     <TextBox x:Uid="Profile_BackgroundImageBox"
-                             IsEnabled="{x:Bind mtu:Converters.StringsAreNotEqual('desktopWallpaper', Appearance.BackgroundImagePath), Mode=OneWay}"
+                             IsEnabled="{x:Bind mtu:Converters.InvertBoolean(Appearance.UseDesktopBGImage), Mode=OneWay}"
                              IsSpellCheckEnabled="False"
                              Style="{StaticResource TextBoxSettingStyle}"
                              Text="{x:Bind mtu:Converters.StringOrEmptyIfPlaceholder('desktopWallpaper', Appearance.BackgroundImagePath), Mode=TwoWay, BindBack=Appearance.SetBackgroundImagePath}" />
@@ -547,7 +547,7 @@
                         <Button x:Uid="Profile_BackgroundImageBrowse"
                                 Margin="0,10,10,0"
                                 Click="BackgroundImage_Click"
-                                IsEnabled="{x:Bind mtu:Converters.StringsAreNotEqual('desktopWallpaper', Appearance.BackgroundImagePath), Mode=OneWay}"
+                                IsEnabled="{x:Bind mtu:Converters.InvertBoolean(Appearance.UseDesktopBGImage), Mode=OneWay}"
                                 Style="{StaticResource BrowseButtonStyle}" />
                         <CheckBox x:Name="UseDesktopImageCheckBox"
                                   x:Uid="Profile_UseDesktopImage"

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
@@ -143,6 +143,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             {
                 _NotifyChanges(L"TabTitlePreview");
             }
+            else if (viewModelProperty == L"AnswerbackMessage")
+            {
+                _NotifyChanges(L"AnswerbackMessagePreview");
+            }
         });
 
         // Do the same for the starting directory
@@ -415,6 +419,15 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             return tabTitle;
         }
         return RS_(L"Profile_TabTitleNone");
+    }
+
+    hstring ProfileViewModel::AnswerbackMessagePreview() const
+    {
+        if (const auto answerbackMessage{ AnswerbackMessage() }; !answerbackMessage.empty())
+        {
+            return answerbackMessage;
+        }
+        return RS_(L"Profile_AnswerbackMessageNone");
     }
 
     Editor::AppearanceViewModel ProfileViewModel::DefaultAppearance()

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
@@ -83,7 +83,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             }
             else if (viewModelProperty == L"BellStyle")
             {
-                _NotifyChanges(L"IsBellStyleFlagSet");
+                _NotifyChanges(L"IsBellStyleFlagSet", L"BellStylePreview");
             }
             else if (viewModelProperty == L"ScrollState")
             {
@@ -628,6 +628,52 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     bool ProfileViewModel::UsingImageIcon() const
     {
         return _currentIconType == _IconTypes.GetAt(3);
+    }
+
+    hstring ProfileViewModel::BellStylePreview() const
+    {
+        const auto bellStyle = BellStyle();
+        const bool isAudibleSet = WI_IsFlagSet(bellStyle, BellStyle::Audible);
+        const bool isWindowSet = WI_IsFlagSet(bellStyle, BellStyle::Window);
+        const bool isTaskbarSet = WI_IsFlagSet(bellStyle, BellStyle::Taskbar);
+        if (bellStyle == Model::BellStyle::All || (isAudibleSet && isWindowSet && isTaskbarSet))
+        {
+            return RS_(L"Profile_BellStyleAll/Content");
+        }
+        else if (bellStyle == static_cast<Model::BellStyle>(0))
+        {
+            return RS_(L"Profile_BellStyleNone/Content");
+        }
+
+        std::vector<hstring> resultList;
+        resultList.reserve(3);
+        if (isAudibleSet)
+        {
+            resultList.emplace_back(RS_(L"Profile_BellStyleAudible/Content"));
+        }
+        if (isWindowSet)
+        {
+            resultList.emplace_back(RS_(L"Profile_BellStyleWindow/Content"));
+        }
+        if (isTaskbarSet)
+        {
+            resultList.emplace_back(RS_(L"Profile_BellStyleTaskbar/Content"));
+        }
+
+        // add in the commas
+        hstring result{};
+        for (auto&& entry : resultList)
+        {
+            if (entry == resultList.front())
+            {
+                result = entry;
+            }
+            else
+            {
+                result = result + L", " + entry;
+            }
+        }
+        return result;
     }
 
     bool ProfileViewModel::IsBellStyleFlagSet(const uint32_t flag)

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
@@ -633,10 +633,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     hstring ProfileViewModel::BellStylePreview() const
     {
         const auto bellStyle = BellStyle();
-        const bool isAudibleSet = WI_IsFlagSet(bellStyle, BellStyle::Audible);
-        const bool isWindowSet = WI_IsFlagSet(bellStyle, BellStyle::Window);
-        const bool isTaskbarSet = WI_IsFlagSet(bellStyle, BellStyle::Taskbar);
-        if (bellStyle == Model::BellStyle::All || (isAudibleSet && isWindowSet && isTaskbarSet))
+        if (WI_AreAllFlagsSet(bellStyle, BellStyle::Audible | BellStyle::Window | BellStyle::Taskbar))
         {
             return RS_(L"Profile_BellStyleAll/Content");
         }
@@ -647,15 +644,15 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         std::vector<hstring> resultList;
         resultList.reserve(3);
-        if (isAudibleSet)
+        if (WI_IsFlagSet(bellStyle, BellStyle::Audible))
         {
             resultList.emplace_back(RS_(L"Profile_BellStyleAudible/Content"));
         }
-        if (isWindowSet)
+        if (WI_IsFlagSet(bellStyle, BellStyle::Window))
         {
             resultList.emplace_back(RS_(L"Profile_BellStyleWindow/Content"));
         }
-        if (isTaskbarSet)
+        if (WI_IsFlagSet(bellStyle, BellStyle::Taskbar))
         {
             resultList.emplace_back(RS_(L"Profile_BellStyleTaskbar/Content"));
         }
@@ -664,7 +661,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         hstring result{};
         for (auto&& entry : resultList)
         {
-            if (entry == resultList.front())
+            if (result.empty())
             {
                 result = entry;
             }

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
@@ -71,7 +71,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             {
                 // notify listener that all starting directory related values might have changed
                 // NOTE: this is similar to what is done with BackgroundImagePath above
-                _NotifyChanges(L"UseParentProcessDirectory", L"UseCustomStartingDirectory");
+                _NotifyChanges(L"UseParentProcessDirectory", L"CurrentStartingDirectoryPreview");
             }
             else if (viewModelProperty == L"AntialiasingMode")
             {
@@ -470,18 +470,18 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         return Feature_ScrollbarMarks::IsEnabled();
     }
 
-    bool ProfileViewModel::UseParentProcessDirectory()
+    hstring ProfileViewModel::CurrentStartingDirectoryPreview() const
     {
-        return StartingDirectory().empty();
+        if (UseParentProcessDirectory())
+        {
+            return RS_(L"Profile_StartingDirectoryUseParentCheckbox/Content");
+        }
+        return StartingDirectory();
     }
 
-    // This function simply returns the opposite of UseParentProcessDirectory.
-    // We bind the 'IsEnabled' parameters of the textbox and browse button
-    // to this because it needs to be the reverse of UseParentProcessDirectory
-    // but we don't want to create a whole new converter for inverting a boolean
-    bool ProfileViewModel::UseCustomStartingDirectory()
+    bool ProfileViewModel::UseParentProcessDirectory() const
     {
-        return !UseParentProcessDirectory();
+        return StartingDirectory().empty();
     }
 
     void ProfileViewModel::UseParentProcessDirectory(const bool useParent)

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
@@ -139,6 +139,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 _parsedPadding = StringToXamlThickness(_profile.Padding());
                 _NotifyChanges(L"LeftPadding", L"TopPadding", L"RightPadding", L"BottomPadding");
             }
+            else if (viewModelProperty == L"TabTitle")
+            {
+                _NotifyChanges(L"TabTitlePreview");
+            }
         });
 
         // Do the same for the starting directory

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
@@ -116,6 +116,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         bool Orphaned() const;
         hstring TabTitlePreview() const;
+        hstring AnswerbackMessagePreview() const;
 
         til::typed_event<Editor::ProfileViewModel, Editor::DeleteProfileEventArgs> DeleteProfileRequested;
 

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
@@ -55,6 +55,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void SetupAppearances(Windows::Foundation::Collections::IObservableVector<Editor::ColorSchemeViewModel> schemesList);
 
         // bell style bits
+        hstring BellStylePreview() const;
         bool IsBellStyleFlagSet(const uint32_t flag);
         void SetBellStyleAudible(winrt::Windows::Foundation::IReference<bool> on);
         void SetBellStyleWindow(winrt::Windows::Foundation::IReference<bool> on);

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
@@ -95,9 +95,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         bool UsingImageIcon() const;
 
         // starting directory
-        bool UseParentProcessDirectory();
+        hstring CurrentStartingDirectoryPreview() const;
+        bool UseParentProcessDirectory() const;
         void UseParentProcessDirectory(const bool useParent);
-        bool UseCustomStartingDirectory();
 
         // general profile knowledge
         winrt::guid OriginalProfileGuid() const noexcept;

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
@@ -87,12 +87,13 @@ namespace Microsoft.Terminal.Settings.Editor
         IInspectable CurrentPathTranslationStyle;
         Windows.Foundation.Collections.IObservableVector<Microsoft.Terminal.Settings.Editor.EnumEntry> PathTranslationStyleList { get; };
 
+        String CurrentStartingDirectoryPreview { get; };
+        Boolean UseParentProcessDirectory;
+
         Boolean CanDeleteProfile { get; };
         Boolean FocusDeleteButton;
         Boolean IsBaseLayer;
         ProfileSubPage CurrentPage;
-        Boolean UseParentProcessDirectory;
-        Boolean UseCustomStartingDirectory { get; };
         AppearanceViewModel DefaultAppearance { get; };
         Guid OriginalProfileGuid { get; };
         Boolean HasUnfocusedAppearance { get; };

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
@@ -120,6 +120,7 @@ namespace Microsoft.Terminal.Settings.Editor
         Windows.Foundation.Collections.IVector<IInspectable> BuiltInIcons { get; };
 
         String TabTitlePreview { get; };
+        String AnswerbackMessagePreview { get; };
 
         void CreateUnfocusedAppearance();
         void DeleteUnfocusedAppearance();

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
@@ -60,6 +60,7 @@ namespace Microsoft.Terminal.Settings.Editor
 
         void SetAcrylicOpacityPercentageValue(Double value);
 
+        String BellStylePreview { get; };
         Boolean IsBellStyleFlagSet(UInt32 flag);
         void SetBellStyleAudible(Windows.Foundation.IReference<Boolean> on);
         void SetBellStyleWindow(Windows.Foundation.IReference<Boolean> on);

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.xaml
@@ -96,6 +96,7 @@
             <!--  Bell Style  -->
             <local:SettingContainer x:Uid="Profile_BellStyle"
                                     ClearSettingValue="{x:Bind Profile.ClearBellStyle}"
+                                    CurrentValue="{x:Bind Profile.BellStylePreview, Mode=OneWay}"
                                     HasSettingValue="{x:Bind Profile.HasBellStyle, Mode=OneWay}"
                                     SettingOverrideSource="{x:Bind Profile.BellStyleOverrideSource, Mode=OneWay}"
                                     Style="{StaticResource ExpanderSettingContainerStyle}">

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
@@ -74,13 +74,13 @@
             <local:SettingContainer x:Name="StartingDirectoryContainer"
                                     x:Uid="Profile_StartingDirectory"
                                     ClearSettingValue="{x:Bind Profile.ClearStartingDirectory}"
-                                    CurrentValue="{x:Bind Profile.StartingDirectory, Mode=OneWay}"
+                                    CurrentValue="{x:Bind Profile.CurrentStartingDirectoryPreview, Mode=OneWay}"
                                     HasSettingValue="{x:Bind Profile.HasStartingDirectory, Mode=OneWay}"
                                     SettingOverrideSource="{x:Bind Profile.StartingDirectoryOverrideSource, Mode=OneWay}"
                                     Style="{StaticResource ExpanderSettingContainerStyle}">
                 <StackPanel Orientation="Vertical">
                     <TextBox x:Uid="Profile_StartingDirectoryBox"
-                             IsEnabled="{x:Bind Profile.UseCustomStartingDirectory, Mode=OneWay}"
+                             IsEnabled="{x:Bind mtu:Converters.InvertBoolean(Profile.UseParentProcessDirectory), Mode=OneWay}"
                              IsSpellCheckEnabled="False"
                              Style="{StaticResource TextBoxSettingStyle}"
                              Text="{x:Bind Profile.StartingDirectory, Mode=TwoWay}" />
@@ -89,7 +89,7 @@
                                 x:Uid="Profile_StartingDirectoryBrowse"
                                 Margin="0,10,10,0"
                                 Click="StartingDirectory_Click"
-                                IsEnabled="{x:Bind Profile.UseCustomStartingDirectory, Mode=OneWay}"
+                                IsEnabled="{x:Bind mtu:Converters.InvertBoolean(Profile.UseParentProcessDirectory), Mode=OneWay}"
                                 Style="{StaticResource BrowseButtonStyle}" />
                         <CheckBox x:Name="StartingDirectoryUseParentCheckbox"
                                   x:Uid="Profile_StartingDirectoryUseParentCheckbox"

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Terminal.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Terminal.xaml
@@ -72,7 +72,7 @@
             <!--  Answerback Message  -->
             <local:SettingContainer x:Uid="Profile_AnswerbackMessage"
                                     ClearSettingValue="{x:Bind Profile.ClearAnswerbackMessage}"
-                                    CurrentValue="{x:Bind Profile.AnswerbackMessage, Mode=OneWay}"
+                                    CurrentValue="{x:Bind Profile.AnswerbackMessagePreview, Mode=OneWay}"
                                     HasSettingValue="{x:Bind Profile.HasAnswerbackMessage, Mode=OneWay}"
                                     SettingOverrideSource="{x:Bind Profile.AnswerbackMessageOverrideSource, Mode=OneWay}"
                                     Style="{StaticResource ExpanderSettingContainerStyle}">

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -2344,4 +2344,8 @@
     <value>This option is managed by enterprise policy and cannot be changed here.</value>
     <comment>This is displayed in concordance with Globals_StartOnUserLogin if the enterprise administrator has taken control of this setting.</comment>
   </data>
+  <data name="Appearance_BackgroundImageNone" xml:space="preserve">
+    <value>None</value>
+    <comment>Text displayed when the background image path is not defined.</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -2348,4 +2348,8 @@
     <value>None</value>
     <comment>Text displayed when the background image path is not defined.</comment>
   </data>
+  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
+    <value>None</value>
+    <comment>Text displayed when the answerback message is not defined.</comment>
+  </data>
 </root>


### PR DESCRIPTION
Went through the settings UI and checked which other setting containers were missing a preview. Here's the list:
- starting directory
- tab title
- background image
- answerback message
- bell style

Adding them was fairly straightforward. Tried to reuse existing resources when possible. The general pattern was to add a "Current<Setting>" or "<Setting>Preview" getter that just created the human-readable format of the setting.

## Validation Steps Performed
✅ value is shown (including special values!)
✅ each of these work with a screen reader

Closes #18576