### PR TITLE
Render SGR 1 as bold when used with ITU colors

### DIFF
--- a/src/buffer/out/TextAttribute.cpp
+++ b/src/buffer/out/TextAttribute.cpp
@@ -232,6 +232,11 @@ void TextAttribute::SetRightVerticalDisplayed(const bool isDisplayed) noexcept
     WI_UpdateFlag(_attrs, CharacterAttributes::RightGridline, isDisplayed);
 }
 
+bool TextAttribute::IsBold(const bool intenseIsBold) const noexcept
+{
+    return IsIntense() && (intenseIsBold || !_foreground.CanBeBrightened());
+}
+
 bool TextAttribute::IsIntense() const noexcept
 {
     return WI_IsFlagSet(_attrs, CharacterAttributes::Intense);

--- a/src/buffer/out/TextAttribute.hpp
+++ b/src/buffer/out/TextAttribute.hpp
@@ -115,6 +115,7 @@ public:
         return memcmp(this, &other, sizeof(TextAttribute)) != 0;
     }
 
+    bool IsBold(const bool intenseIsBold) const noexcept;
     bool IsLegacy() const noexcept;
     bool IsIntense() const noexcept;
     bool IsFaint() const noexcept;

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -2278,7 +2278,7 @@ std::string TextBuffer::GenHTML(const CopyRequest& req,
                 fmt::format_to(std::back_inserter(htmlBuilder), FMT_COMPILE("color:{};"), fgHex);
                 fmt::format_to(std::back_inserter(htmlBuilder), FMT_COMPILE("background-color:{};"), bgHex);
 
-                if (isIntenseBold && attr.IsIntense())
+                if (attr.IsBold(isIntenseBold))
                 {
                     htmlBuilder += "font-weight:bold;";
                 }
@@ -2528,7 +2528,7 @@ std::string TextBuffer::GenRTF(const CopyRequest& req,
                 fmt::format_to(std::back_inserter(contentBuilder), FMT_COMPILE("\\cf{}"), fgIdx);
                 fmt::format_to(std::back_inserter(contentBuilder), FMT_COMPILE("\\chshdng0\\chcbpat{}"), bgIdx);
 
-                if (isIntenseBold && attr.IsIntense())
+                if (attr.IsBold(isIntenseBold))
                 {
                     contentBuilder += "\\b";
                 }

--- a/src/renderer/atlas/AtlasEngine.cpp
+++ b/src/renderer/atlas/AtlasEngine.cpp
@@ -651,7 +651,7 @@ try
     if (!isSettingDefaultBrushes)
     {
         auto attributes = FontRelevantAttributes::None;
-        WI_SetFlagIf(attributes, FontRelevantAttributes::Bold, textAttributes.IsIntense() && renderSettings.GetRenderMode(RenderSettings::Mode::IntenseIsBold));
+        WI_SetFlagIf(attributes, FontRelevantAttributes::Bold, textAttributes.IsBold(renderSettings.GetRenderMode(RenderSettings::Mode::IntenseIsBold)));
         WI_SetFlagIf(attributes, FontRelevantAttributes::Italic, textAttributes.IsItalic());
 
         if (_api.attributes != attributes)


### PR DESCRIPTION
## Summary of the Pull Request

The `SGR 1` VT attribute can either be interpreted as a brighter color,
or as a bolder font, depending on the _Intense text style_ setting.
However, the concept of brightness only applies to the eight standard
ANSI colors, so when `SGR 1` is configured as _bright_, it has no effect
on the ITU T.416 colors (RGB and the 256 index colors).

To address that, we now interpret `SGR 1` as a bolder font when applied
to ITU colors, regardless of whether the _Intense text style_ option is
set to bold or not.

Note that this only applies to the Atlas render engine, since the GDI
engine doesn't support bold fonts.

## Validation Steps Performed

I've manually tested `SGR 1` applied to different color formats with the
_Intense text style_ option set to _None_, and confirmed that the text
is now rendered with a bold font for ITU colors, but not for ANSI/AIX
colors.

## PR Checklist
- [x] Closes #18284
