### PR TITLE
Add reset cache and settings buttons to SUI

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Compatibility.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.cpp
@@ -12,8 +12,8 @@ using namespace winrt::Microsoft::Terminal::Settings::Model;
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
-    CompatibilityViewModel::CompatibilityViewModel(Model::GlobalAppSettings globalSettings) :
-        _GlobalSettings{ globalSettings }
+    CompatibilityViewModel::CompatibilityViewModel(Model::CascadiaSettings settings) :
+        _settings{ settings }
     {
         INITIALIZE_BINDABLE_ENUM_SETTING(TextMeasurement, TextMeasurement, winrt::Microsoft::Terminal::Control::TextMeasurement, L"Globals_TextMeasurement_", L"Text");
     }
@@ -21,6 +21,16 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     bool CompatibilityViewModel::DebugFeaturesAvailable() const noexcept
     {
         return Feature_DebugModeUI::IsEnabled();
+    }
+
+    void CompatibilityViewModel::ResetApplicationState()
+    {
+        _settings.ResetApplicationState();
+    }
+
+    void CompatibilityViewModel::ResetToDefaultSettings()
+    {
+        _settings.ResetToDefaultSettings();
     }
 
     Compatibility::Compatibility()
@@ -31,5 +41,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     void Compatibility::OnNavigatedTo(const NavigationEventArgs& e)
     {
         _ViewModel = e.Parameter().as<Editor::CompatibilityViewModel>();
+    }
+
+    void Compatibility::ResetApplicationStateButton_Click(const Windows::Foundation::IInspectable& /*sender*/, const Windows::UI::Xaml::RoutedEventArgs& /*e*/)
+    {
+        _ViewModel.ResetApplicationState();
+        ResetCacheFlyout().Hide();
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.h
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.h
@@ -13,19 +13,22 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     struct CompatibilityViewModel : CompatibilityViewModelT<CompatibilityViewModel>, ViewModelHelper<CompatibilityViewModel>
     {
     public:
-        CompatibilityViewModel(Model::GlobalAppSettings globalSettings);
+        CompatibilityViewModel(Model::CascadiaSettings settings);
 
         bool DebugFeaturesAvailable() const noexcept;
 
         // DON'T YOU DARE ADD A `WINRT_CALLBACK(PropertyChanged` TO A CLASS DERIVED FROM ViewModelHelper. Do this instead:
         using ViewModelHelper<CompatibilityViewModel>::PropertyChanged;
 
-        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, AllowHeadless);
-        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, DebugFeaturesEnabled);
-        GETSET_BINDABLE_ENUM_SETTING(TextMeasurement, winrt::Microsoft::Terminal::Control::TextMeasurement, _GlobalSettings.TextMeasurement);
+        void ResetApplicationState();
+        void ResetToDefaultSettings();
+
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_settings.GlobalSettings(), AllowHeadless);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_settings.GlobalSettings(), DebugFeaturesEnabled);
+        GETSET_BINDABLE_ENUM_SETTING(TextMeasurement, winrt::Microsoft::Terminal::Control::TextMeasurement, _settings.GlobalSettings().TextMeasurement);
 
     private:
-        Model::GlobalAppSettings _GlobalSettings;
+        Model::CascadiaSettings _settings;
     };
 
     struct Compatibility : public HasScrollViewer<Compatibility>, CompatibilityT<Compatibility>
@@ -33,6 +36,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         Compatibility();
 
         void OnNavigatedTo(const winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs& e);
+        void ResetApplicationStateButton_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& e);
 
         til::property_changed_event PropertyChanged;
         WINRT_OBSERVABLE_PROPERTY(Editor::CompatibilityViewModel, ViewModel, PropertyChanged.raise, nullptr);

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.idl
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.idl
@@ -9,9 +9,11 @@ namespace Microsoft.Terminal.Settings.Editor
 {
     runtimeclass CompatibilityViewModel : Windows.UI.Xaml.Data.INotifyPropertyChanged
     {
-        CompatibilityViewModel(Microsoft.Terminal.Settings.Model.GlobalAppSettings globalSettings);
+        CompatibilityViewModel(Microsoft.Terminal.Settings.Model.CascadiaSettings settings);
 
         Boolean DebugFeaturesAvailable { get; };
+        void ResetApplicationState();
+        void ResetToDefaultSettings();
 
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, AllowHeadless);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, DebugFeaturesEnabled);

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.xaml
@@ -46,5 +46,47 @@
             <ToggleSwitch IsOn="{x:Bind ViewModel.DebugFeaturesEnabled, Mode=TwoWay}"
                           Style="{StaticResource ToggleSwitchInExpanderStyle}" />
         </local:SettingContainer>
+
+        <!--  Reset Application State  -->
+        <local:SettingContainer x:Uid="Settings_ResetApplicationState">
+            <Button x:Uid="Settings_ResetApplicationStateButton"
+                    Style="{StaticResource DeleteButtonStyle}">
+                <Button.Flyout>
+                    <Flyout x:Name="ResetCacheFlyout"
+                            FlyoutPresenterStyle="{StaticResource CustomFlyoutPresenterStyle}">
+                        <StackPanel>
+                            <TextBlock x:Uid="Settings_ResetApplicationStateConfirmationMessageHeader"
+                                       Style="{StaticResource CustomFlyoutTextStyle}" />
+                            <TextBlock x:Uid="Settings_ResetApplicationStateConfirmationMessageBody"
+                                       FontWeight="Normal"
+                                       Style="{StaticResource CustomFlyoutTextStyle}" />
+                            <Button x:Uid="Settings_ResetApplicationStateConfirmationButton"
+                                    Click="ResetApplicationStateButton_Click" />
+                        </StackPanel>
+                    </Flyout>
+                </Button.Flyout>
+            </Button>
+        </local:SettingContainer>
+
+        <!--  Reset to Default Settings  -->
+        <local:SettingContainer x:Uid="Settings_ResetToDefaultSettings">
+            <Button x:Uid="Settings_ResetToDefaultSettingsButton"
+                    Style="{StaticResource DeleteButtonStyle}">
+                <Button.Flyout>
+                    <Flyout FlyoutPresenterStyle="{StaticResource CustomFlyoutPresenterStyle}">
+                        <StackPanel>
+                            <TextBlock x:Uid="Settings_ResetToDefaultSettingsConfirmationMessageHeader"
+                                       Style="{StaticResource CustomFlyoutTextStyle}" />
+                            <TextBlock x:Uid="Settings_ResetToDefaultSettingsConfirmationMessageBody"
+                                       FontWeight="Normal"
+                                       Style="{StaticResource CustomFlyoutTextStyle}" />
+                            <Button x:Uid="Settings_ResetToDefaultSettingsConfirmationButton"
+                                    Click="{x:Bind ViewModel.ResetToDefaultSettings}" />
+                        </StackPanel>
+                    </Flyout>
+                </Button.Flyout>
+            </Button>
+        </local:SettingContainer>
+
     </StackPanel>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -431,7 +431,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
         else if (clickedItemTag == compatibilityTag)
         {
-            contentFrame().Navigate(xaml_typename<Editor::Compatibility>(), winrt::make<CompatibilityViewModel>(_settingsClone.GlobalSettings()));
+            contentFrame().Navigate(xaml_typename<Editor::Compatibility>(), winrt::make<CompatibilityViewModel>(_settingsClone));
             const auto crumb = winrt::make<Breadcrumb>(box_value(clickedItemTag), RS_(L"Nav_Compatibility/Content"), BreadcrumbSubPage::None);
             _breadcrumbs.Append(crumb);
         }

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -2352,4 +2352,37 @@
     <value>None</value>
     <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
+  <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
+    <value>Reset to default settings</value>
+  </data>
+  <data name="Settings_ResetApplicationState.Header" xml:space="preserve">
+    <value>Clear cache</value>
+  </data>
+  <data name="Settings_ResetApplicationState.HelpText" xml:space="preserve">
+    <value>The cache stores data related to persisting sessions and automatic profile generation.</value>
+  </data>
+  <data name="Settings_ResetToDefaultSettingsButton.Content" xml:space="preserve">
+    <value>Reset</value>
+  </data>
+  <data name="Settings_ResetApplicationStateButton.Content" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="Settings_ResetToDefaultSettingsConfirmationMessageBody.Text" xml:space="preserve">
+    <value>This action is applied immediately and cannot be undone.</value>
+  </data>
+  <data name="Settings_ResetApplicationStateConfirmationMessageBody.Text" xml:space="preserve">
+    <value>This action is applied immediately and cannot be undone.</value>
+  </data>
+  <data name="Settings_ResetToDefaultSettingsConfirmationMessageHeader.Text" xml:space="preserve">
+    <value>Are you sure you want to reset your settings?</value>
+  </data>
+  <data name="Settings_ResetApplicationStateConfirmationMessageHeader.Text" xml:space="preserve">
+    <value>Are you sure you want to clear your cache?</value>
+  </data>
+  <data name="Settings_ResetToDefaultSettingsConfirmationButton.Content" xml:space="preserve">
+    <value>Yes, reset my settings</value>
+  </data>
+  <data name="Settings_ResetApplicationStateConfirmationButton.Content" xml:space="preserve">
+    <value>Yes, clear the cache</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
@@ -127,6 +127,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         winrt::Windows::Foundation::Collections::IObservableVector<Model::Profile> AllProfiles() const noexcept;
         winrt::Windows::Foundation::Collections::IObservableVector<Model::Profile> ActiveProfiles() const noexcept;
         Model::ActionMap ActionMap() const noexcept;
+        void ResetApplicationState() const;
+        void ResetToDefaultSettings();
         void WriteSettingsToDisk();
         Json::Value ToJson() const;
         Model::Profile ProfileDefaults() const;
@@ -162,6 +164,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         winrt::com_ptr<implementation::Profile> _createNewProfile(const std::wstring_view& name) const;
         Model::Profile _getProfileForCommandLine(const winrt::hstring& commandLine) const;
         void _refreshDefaultTerminals();
+        void _writeSettingsToDisk(std::string_view contents);
 
         void _resolveDefaultProfile() const;
         void _resolveNewTabMenuProfiles() const;

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.idl
@@ -23,6 +23,8 @@ namespace Microsoft.Terminal.Settings.Model
         CascadiaSettings(String userJSON, String inboxJSON);
 
         CascadiaSettings Copy();
+        void ResetApplicationState();
+        void ResetToDefaultSettings();
         void WriteSettingsToDisk();
         void LogSettingChanges(Boolean isJsonLoad);
 


### PR DESCRIPTION
## Summary of the Pull Request
Adds the ability to reset the settings.json file and application state via the Settings UI. Since these are destructive operations, the destructive styling is applied, as well as a confirmation prompt notifying the user that this occurs immediately.

## Validation Steps Performed
✅ "reset settings" results in the correct contents for settings.json and state.json
✅ "reset cache" results in the correct contents for state.json

Closes #947