### PR TITLE
Apply localization and documentation fixes for regex code

### DIFF
--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -945,6 +945,6 @@
     <value>Move right</value>
   </data>
   <data name="InvalidRegex" xml:space="preserve">
-    <value>An invalid regex was found.</value>
+    <value>An invalid regular expression was found.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -2105,7 +2105,7 @@
     <comment>Header for a control that adds any remaining profiles to the new tab menu.</comment>
   </data>
   <data name="NewTabMenu_AddMatchProfiles.HelpText" xml:space="preserve">
-    <value>Add a group of profiles that match at least one of the defined regex properties</value>
+    <value>Add a group of profiles that match at least one of the defined regular expression properties</value>
     <comment>Additional information for a control that adds a terminal profile matcher to the new tab menu. Presented near "NewTabMenu_AddMatchProfiles".</comment>
   </data>
   <data name="NewTabMenu_AddRemainingProfiles.HelpText" xml:space="preserve">
@@ -2121,15 +2121,15 @@
     <comment>Header for a control that adds a folder to the new tab menu.</comment>
   </data>
   <data name="NewTabMenu_AddMatchProfiles_Name.Header" xml:space="preserve">
-    <value>Profile name (Regex)</value>
+    <value>Profile name (regular expression)</value>
     <comment>Header for a text box used to define a regex for the names of profiles to add.</comment>
   </data>
   <data name="NewTabMenu_AddMatchProfiles_Source.Header" xml:space="preserve">
-    <value>Profile source (Regex)</value>
+    <value>Profile source (regular expression)</value>
     <comment>Header for a text box used to define a regex for the sources of profiles to add.</comment>
   </data>
   <data name="NewTabMenu_AddMatchProfiles_Commandline.Header" xml:space="preserve">
-    <value>Commandline (Regex)</value>
+    <value>Commandline (regular expression)</value>
     <comment>Header for a text box used to define a regex for the commandlines of profiles to add.</comment>
   </data>
   <data name="NewTabMenu_AddMatchProfilesTextBlock.Text" xml:space="preserve">
@@ -2362,7 +2362,7 @@
     <value>Clear cache</value>
   </data>
   <data name="Settings_ResetApplicationState.HelpText" xml:space="preserve">
-    <value>The cache stores data related to persisting sessions and automatic profile generation.</value>
+    <value>The cache stores data related to saved sessions and automatically generated profiles.</value>
   </data>
   <data name="Settings_ResetToDefaultSettingsButton.Content" xml:space="preserve">
     <value>Reset</value>

--- a/src/cascadia/TerminalSettingsModel/MatchProfilesEntry.cpp
+++ b/src/cascadia/TerminalSettingsModel/MatchProfilesEntry.cpp
@@ -36,13 +36,13 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         auto entry = winrt::make_self<MatchProfilesEntry>();
 
         JsonUtils::GetValueForKey(json, NameKey, entry->_Name);
-        entry->_validateName();
+        entry->_validateAndPopulateNameRegex();
 
         JsonUtils::GetValueForKey(json, CommandlineKey, entry->_Commandline);
-        entry->_validateCommandline();
+        entry->_validateAndPopulateCommandlineRegex();
 
         JsonUtils::GetValueForKey(json, SourceKey, entry->_Source);
-        entry->_validateSource();
+        entry->_validateAndPopulateSourceRegex();
 
         return entry;
     }
@@ -53,22 +53,22 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         return !(_invalidName || _invalidCommandline || _invalidSource);
     }
 
-#define DEFINE_VALIDATE_FUNCTION(name)                               \
-    void MatchProfilesEntry::_validate##name() noexcept              \
-    {                                                                \
-        _invalid##name = false;                                      \
-        if (_##name.empty())                                         \
-        {                                                            \
-            /* empty field is valid*/                                \
-            return;                                                  \
-        }                                                            \
-        UErrorCode status = U_ZERO_ERROR;                            \
-        _##name##Regex = til::ICU::CreateRegex(_##name, 0, &status); \
-        if (U_FAILURE(status))                                       \
-        {                                                            \
-            _invalid##name = true;                                   \
-            _##name##Regex.reset();                                  \
-        }                                                            \
+#define DEFINE_VALIDATE_FUNCTION(name)                                    \
+    void MatchProfilesEntry::_validateAndPopulate##name##Regex() noexcept \
+    {                                                                     \
+        _invalid##name = false;                                           \
+        if (_##name.empty())                                              \
+        {                                                                 \
+            /* empty field is valid*/                                     \
+            return;                                                       \
+        }                                                                 \
+        UErrorCode status = U_ZERO_ERROR;                                 \
+        _##name##Regex = til::ICU::CreateRegex(_##name, 0, &status);      \
+        if (U_FAILURE(status))                                            \
+        {                                                                 \
+            _invalid##name = true;                                        \
+            _##name##Regex.reset();                                       \
+        }                                                                 \
     }
 
     DEFINE_VALIDATE_FUNCTION(Name);

--- a/src/cascadia/TerminalSettingsModel/MatchProfilesEntry.h
+++ b/src/cascadia/TerminalSettingsModel/MatchProfilesEntry.h
@@ -23,23 +23,23 @@ Author(s):
 // The setter tries to instantiate the regex immediately and caches
 // it if successful. If it fails, it sets a boolean flag to track that
 // it failed.
-#define DEFINE_MATCH_PROFILE_REGEX_PROPERTY(name) \
-public:                                           \
-    hstring name() const noexcept                 \
-    {                                             \
-        return _##name;                           \
-    }                                             \
-    void name(const hstring& value) noexcept      \
-    {                                             \
-        _##name = value;                          \
-        _validate##name();                        \
-    }                                             \
-                                                  \
-private:                                          \
-    void _validate##name() noexcept;              \
-                                                  \
-    hstring _##name;                              \
-    til::ICU::unique_uregex _##name##Regex;       \
+#define DEFINE_MATCH_PROFILE_REGEX_PROPERTY(name)      \
+public:                                                \
+    hstring name() const noexcept                      \
+    {                                                  \
+        return _##name;                                \
+    }                                                  \
+    void name(const hstring& value) noexcept           \
+    {                                                  \
+        _##name = value;                               \
+        _validateAndPopulate##name##Regex();           \
+    }                                                  \
+                                                       \
+private:                                               \
+    void _validateAndPopulate##name##Regex() noexcept; \
+                                                       \
+    hstring _##name;                                   \
+    til::ICU::unique_uregex _##name##Regex;            \
     bool _invalid##name{ false };
 
 namespace winrt::Microsoft::Terminal::Settings::Model::implementation


### PR DESCRIPTION
Applies some localization fixes for the regex strings and Settings_ResetApplicationState.HelpText.
Also renames the `_validateX()` functions to `_validateAndPopulateXRegex()` for clarity.