### PR TITLE
Add reflection to the ActionArgs in the settings model

### DIFF
--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -102,189 +102,208 @@ protected:                                                                  \
 // false, if we don't really care if the parameter is required or not.
 
 ////////////////////////////////////////////////////////////////////////////////
-#define COPY_TEXT_ARGS(X)                                               \
-    X(bool, DismissSelection, "dismissSelection", false, true)          \
-    X(bool, SingleLine, "singleLine", false, false)                     \
-    X(bool, WithControlSequences, "withControlSequences", false, false) \
-    X(Windows::Foundation::IReference<Control::CopyFormat>, CopyFormatting, "copyFormatting", false, nullptr)
+#define COPY_TEXT_ARGS(X)                                                             \
+    X(bool, DismissSelection, "dismissSelection", false, ArgTag::None, true)          \
+    X(bool, SingleLine, "singleLine", false, ArgTag::None, false)                     \
+    X(bool, WithControlSequences, "withControlSequences", false, ArgTag::None, false) \
+    X(Windows::Foundation::IReference<Control::CopyFormat>, CopyFormatting, "copyFormatting", false, ArgTag::None, nullptr)
 
 ////////////////////////////////////////////////////////////////////////////////
-#define MOVE_PANE_ARGS(X)                    \
-    X(uint32_t, TabIndex, "index", false, 0) \
-    X(winrt::hstring, Window, "window", false, L"")
+#define MOVE_PANE_ARGS(X)                                  \
+    X(uint32_t, TabIndex, "index", false, ArgTag::None, 0) \
+    X(winrt::hstring, Window, "window", false, ArgTag::None, L"")
 
 ////////////////////////////////////////////////////////////////////////////////
 #define SWITCH_TO_TAB_ARGS(X) \
-    X(uint32_t, TabIndex, "index", false, 0)
+    X(uint32_t, TabIndex, "index", false, ArgTag::None, 0)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define RESIZE_PANE_ARGS(X) \
-    X(Model::ResizeDirection, ResizeDirection, "direction", args->ResizeDirection() == ResizeDirection::None, Model::ResizeDirection::None)
+    X(Model::ResizeDirection, ResizeDirection, "direction", args->ResizeDirection() == ResizeDirection::None, ArgTag::None, Model::ResizeDirection::None)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define MOVE_FOCUS_ARGS(X) \
-    X(Model::FocusDirection, FocusDirection, "direction", args->FocusDirection() == Model::FocusDirection::None, Model::FocusDirection::None)
+    X(Model::FocusDirection, FocusDirection, "direction", args->FocusDirection() == Model::FocusDirection::None, ArgTag::None, Model::FocusDirection::None)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define SWAP_PANE_ARGS(X) \
-    X(Model::FocusDirection, Direction, "direction", args->Direction() == Model::FocusDirection::None, Model::FocusDirection::None)
+    X(Model::FocusDirection, Direction, "direction", args->Direction() == Model::FocusDirection::None, ArgTag::None, Model::FocusDirection::None)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define ADJUST_FONT_SIZE_ARGS(X) \
-    X(float, Delta, "delta", false, 0)
+    X(float, Delta, "delta", false, ArgTag::None, 0)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define SEND_INPUT_ARGS(X) \
-    X(winrt::hstring, Input, "input", args->Input().empty(), L"")
+    X(winrt::hstring, Input, "input", args->Input().empty(), ArgTag::None, L"")
 
 ////////////////////////////////////////////////////////////////////////////////
 #define OPEN_SETTINGS_ARGS(X) \
-    X(SettingsTarget, Target, "target", false, SettingsTarget::SettingsFile)
+    X(SettingsTarget, Target, "target", false, ArgTag::None, SettingsTarget::SettingsFile)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define SET_FOCUS_MODE_ARGS(X) \
-    X(bool, IsFocusMode, "isFocusMode", false, false)
+    X(bool, IsFocusMode, "isFocusMode", false, ArgTag::None, false)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define SET_MAXIMIZED_ARGS(X) \
-    X(bool, IsMaximized, "isMaximized", false, false)
+    X(bool, IsMaximized, "isMaximized", false, ArgTag::None, false)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define SET_FULL_SCREEN_ARGS(X) \
-    X(bool, IsFullScreen, "isFullScreen", false, false)
+    X(bool, IsFullScreen, "isFullScreen", false, ArgTag::None, false)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define SET_MAXIMIZED_ARGS(X) \
-    X(bool, IsMaximized, "isMaximized", false, false)
+    X(bool, IsMaximized, "isMaximized", false, ArgTag::None, false)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define SET_COLOR_SCHEME_ARGS(X) \
-    X(winrt::hstring, SchemeName, "colorScheme", args->SchemeName().empty(), L"")
+    X(winrt::hstring, SchemeName, "colorScheme", args->SchemeName().empty(), ArgTag::ColorScheme, L"")
 
 ////////////////////////////////////////////////////////////////////////////////
 #define SET_TAB_COLOR_ARGS(X) \
-    X(Windows::Foundation::IReference<Windows::UI::Color>, TabColor, "color", false, nullptr)
+    X(Windows::Foundation::IReference<Windows::UI::Color>, TabColor, "color", false, ArgTag::None, nullptr)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define RENAME_TAB_ARGS(X) \
-    X(winrt::hstring, Title, "title", false, L"")
+    X(winrt::hstring, Title, "title", false, ArgTag::None, L"")
 
 ////////////////////////////////////////////////////////////////////////////////
 #define EXECUTE_COMMANDLINE_ARGS(X) \
-    X(winrt::hstring, Commandline, "commandline", args->Commandline().empty(), L"")
+    X(winrt::hstring, Commandline, "commandline", args->Commandline().empty(), ArgTag::None, L"")
 
 ////////////////////////////////////////////////////////////////////////////////
 #define CLOSE_OTHER_TABS_ARGS(X) \
-    X(Windows::Foundation::IReference<uint32_t>, Index, "index", false, nullptr)
+    X(Windows::Foundation::IReference<uint32_t>, Index, "index", false, ArgTag::None, nullptr)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define CLOSE_TABS_AFTER_ARGS(X) \
-    X(Windows::Foundation::IReference<uint32_t>, Index, "index", false, nullptr)
+    X(Windows::Foundation::IReference<uint32_t>, Index, "index", false, ArgTag::None, nullptr)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define CLOSE_TAB_ARGS(X) \
-    X(Windows::Foundation::IReference<uint32_t>, Index, "index", false, nullptr)
+    X(Windows::Foundation::IReference<uint32_t>, Index, "index", false, ArgTag::None, nullptr)
 
 ////////////////////////////////////////////////////////////////////////////////
 // Interestingly, the order MATTERS here. Window has to be BEFORE Direction,
 // because otherwise we won't have parsed the Window yet when we validate the
 // Direction.
-#define MOVE_TAB_ARGS(X)                            \
-    X(winrt::hstring, Window, "window", false, L"") \
-    X(MoveTabDirection, Direction, "direction", (args->Direction() == MoveTabDirection::None) && (args->Window().empty()), MoveTabDirection::None)
+#define MOVE_TAB_ARGS(X)                                          \
+    X(winrt::hstring, Window, "window", false, ArgTag::None, L"") \
+    X(MoveTabDirection, Direction, "direction", (args->Direction() == MoveTabDirection::None) && (args->Window().empty()), ArgTag::None, MoveTabDirection::None)
 
 // Other ideas:
 //  X(uint32_t, TabIndex, "index", false, 0) \ // target? source?
 
 ////////////////////////////////////////////////////////////////////////////////
 #define SCROLL_UP_ARGS(X) \
-    X(Windows::Foundation::IReference<uint32_t>, RowsToScroll, "rowsToScroll", false, nullptr)
+    X(Windows::Foundation::IReference<uint32_t>, RowsToScroll, "rowsToScroll", false, ArgTag::None, nullptr)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define SCROLL_DOWN_ARGS(X) \
-    X(Windows::Foundation::IReference<uint32_t>, RowsToScroll, "rowsToScroll", false, nullptr)
+    X(Windows::Foundation::IReference<uint32_t>, RowsToScroll, "rowsToScroll", false, ArgTag::None, nullptr)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define SCROLL_TO_MARK_ARGS(X) \
-    X(Microsoft::Terminal::Control::ScrollToMarkDirection, Direction, "direction", false, Microsoft::Terminal::Control::ScrollToMarkDirection::Previous)
+    X(Microsoft::Terminal::Control::ScrollToMarkDirection, Direction, "direction", false, ArgTag::None, Microsoft::Terminal::Control::ScrollToMarkDirection::Previous)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define ADD_MARK_ARGS(X) \
-    X(Windows::Foundation::IReference<Microsoft::Terminal::Core::Color>, Color, "color", false, nullptr)
+    X(Windows::Foundation::IReference<Microsoft::Terminal::Core::Color>, Color, "color", false, ArgTag::None, nullptr)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define TOGGLE_COMMAND_PALETTE_ARGS(X) \
-    X(CommandPaletteLaunchMode, LaunchMode, "launchMode", false, CommandPaletteLaunchMode::Action)
+    X(CommandPaletteLaunchMode, LaunchMode, "launchMode", false, ArgTag::None, CommandPaletteLaunchMode::Action)
 
 ////////////////////////////////////////////////////////////////////////////////
-#define SAVE_TASK_ARGS(X)                                                           \
-    X(winrt::hstring, Name, "name", false, L"")                                     \
-    X(winrt::hstring, Commandline, "commandline", args->Commandline().empty(), L"") \
-    X(winrt::hstring, KeyChord, "keyChord", false, L"")
+#define SAVE_TASK_ARGS(X)                                                                         \
+    X(winrt::hstring, Name, "name", false, ArgTag::None, L"")                                     \
+    X(winrt::hstring, Commandline, "commandline", args->Commandline().empty(), ArgTag::None, L"") \
+    X(winrt::hstring, KeyChord, "keyChord", false, ArgTag::None, L"")
 
 ////////////////////////////////////////////////////////////////////////////////
-#define SUGGESTIONS_ARGS(X)                                                 \
-    X(SuggestionsSource, Source, "source", false, SuggestionsSource::Tasks) \
-    X(bool, UseCommandline, "useCommandline", false, false)
+#define SUGGESTIONS_ARGS(X)                                                               \
+    X(SuggestionsSource, Source, "source", false, ArgTag::None, SuggestionsSource::Tasks) \
+    X(bool, UseCommandline, "useCommandline", false, ArgTag::None, false)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define FIND_MATCH_ARGS(X) \
-    X(FindMatchDirection, Direction, "direction", args->Direction() == FindMatchDirection::None, FindMatchDirection::None)
+    X(FindMatchDirection, Direction, "direction", args->Direction() == FindMatchDirection::None, ArgTag::None, FindMatchDirection::None)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define PREV_TAB_ARGS(X) \
-    X(Windows::Foundation::IReference<TabSwitcherMode>, SwitcherMode, "tabSwitcherMode", false, nullptr)
+    X(Windows::Foundation::IReference<TabSwitcherMode>, SwitcherMode, "tabSwitcherMode", false, ArgTag::None, nullptr)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define NEXT_TAB_ARGS(X) \
-    X(Windows::Foundation::IReference<TabSwitcherMode>, SwitcherMode, "tabSwitcherMode", false, nullptr)
+    X(Windows::Foundation::IReference<TabSwitcherMode>, SwitcherMode, "tabSwitcherMode", false, ArgTag::None, nullptr)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define RENAME_WINDOW_ARGS(X) \
-    X(winrt::hstring, Name, "name", false, L"")
+    X(winrt::hstring, Name, "name", false, ArgTag::None, L"")
 
 ////////////////////////////////////////////////////////////////////////////////
 #define SEARCH_FOR_TEXT_ARGS(X) \
-    X(winrt::hstring, QueryUrl, "queryUrl", false, L"")
+    X(winrt::hstring, QueryUrl, "queryUrl", false, ArgTag::None, L"")
 
 ////////////////////////////////////////////////////////////////////////////////
-#define GLOBAL_SUMMON_ARGS(X)                                                               \
-    X(winrt::hstring, Name, "name", false, L"")                                             \
-    X(Model::DesktopBehavior, Desktop, "desktop", false, Model::DesktopBehavior::ToCurrent) \
-    X(Model::MonitorBehavior, Monitor, "monitor", false, Model::MonitorBehavior::ToMouse)   \
-    X(bool, ToggleVisibility, "toggleVisibility", false, true)                              \
-    X(uint32_t, DropdownDuration, "dropdownDuration", false, 0)
+#define GLOBAL_SUMMON_ARGS(X)                                                                             \
+    X(winrt::hstring, Name, "name", false, ArgTag::None, L"")                                             \
+    X(Model::DesktopBehavior, Desktop, "desktop", false, ArgTag::None, Model::DesktopBehavior::ToCurrent) \
+    X(Model::MonitorBehavior, Monitor, "monitor", false, ArgTag::None, Model::MonitorBehavior::ToMouse)   \
+    X(bool, ToggleVisibility, "toggleVisibility", false, ArgTag::None, true)                              \
+    X(uint32_t, DropdownDuration, "dropdownDuration", false, ArgTag::None, 0)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define FOCUS_PANE_ARGS(X) \
-    X(uint32_t, Id, "id", false, 0u)
+    X(uint32_t, Id, "id", false, ArgTag::None, 0u)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define EXPORT_BUFFER_ARGS(X) \
-    X(winrt::hstring, Path, "path", false, L"")
+    X(winrt::hstring, Path, "path", false, ArgTag::FilePath, L"")
 
 ////////////////////////////////////////////////////////////////////////////////
 #define CLEAR_BUFFER_ARGS(X) \
-    X(winrt::Microsoft::Terminal::Control::ClearBufferType, Clear, "clear", false, winrt::Microsoft::Terminal::Control::ClearBufferType::All)
+    X(winrt::Microsoft::Terminal::Control::ClearBufferType, Clear, "clear", false, ArgTag::None, winrt::Microsoft::Terminal::Control::ClearBufferType::All)
 
 ////////////////////////////////////////////////////////////////////////////////
-#define ADJUST_OPACITY_ARGS(X)               \
-    X(int32_t, Opacity, "opacity", false, 0) \
-    X(bool, Relative, "relative", false, true)
+#define ADJUST_OPACITY_ARGS(X)                             \
+    X(int32_t, Opacity, "opacity", false, ArgTag::None, 0) \
+    X(bool, Relative, "relative", false, ArgTag::None, true)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define SELECT_COMMAND_ARGS(X) \
-    X(SelectOutputDirection, Direction, "direction", false, SelectOutputDirection::Previous)
+    X(SelectOutputDirection, Direction, "direction", false, ArgTag::None, SelectOutputDirection::Previous)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define SELECT_OUTPUT_ARGS(X) \
-    X(SelectOutputDirection, Direction, "direction", false, SelectOutputDirection::Previous)
+    X(SelectOutputDirection, Direction, "direction", false, ArgTag::None, SelectOutputDirection::Previous)
 
 ////////////////////////////////////////////////////////////////////////////////
-#define COLOR_SELECTION_ARGS(X)                                                                      \
-    X(winrt::Microsoft::Terminal::Control::SelectionColor, Foreground, "foreground", false, nullptr) \
-    X(winrt::Microsoft::Terminal::Control::SelectionColor, Background, "background", false, nullptr) \
-    X(winrt::Microsoft::Terminal::Core::MatchMode, MatchMode, "matchMode", false, winrt::Microsoft::Terminal::Core::MatchMode::None)
+#define COLOR_SELECTION_ARGS(X)                                                                                    \
+    X(winrt::Microsoft::Terminal::Control::SelectionColor, Foreground, "foreground", false, ArgTag::None, nullptr) \
+    X(winrt::Microsoft::Terminal::Control::SelectionColor, Background, "background", false, ArgTag::None, nullptr) \
+    X(winrt::Microsoft::Terminal::Core::MatchMode, MatchMode, "matchMode", false, ArgTag::None, winrt::Microsoft::Terminal::Core::MatchMode::None)
+
+////////////////////////////////////////////////////////////////////////////////
+#define NEW_TERMINAL_ARGS(X)                                                                                                                \
+    X(winrt::hstring, Commandline, "commandline", false, ArgTag::None, L"")                                                                 \
+    X(winrt::hstring, StartingDirectory, "startingDirectory", false, ArgTag::None, L"")                                                     \
+    X(winrt::hstring, TabTitle, "tabTitle", false, ArgTag::None, L"")                                                                       \
+    X(Windows::Foundation::IReference<Windows::UI::Color>, TabColor, "tabColor", false, ArgTag::None, nullptr)                              \
+    X(Windows::Foundation::IReference<int32_t>, ProfileIndex, "index", false, ArgTag::None, nullptr)                                        \
+    X(winrt::hstring, Profile, "profile", false, ArgTag::None, L"")                                                                         \
+    X(Windows::Foundation::IReference<bool>, SuppressApplicationTitle, "suppressApplicationTitle", false, ArgTag::None, nullptr)            \
+    X(winrt::hstring, ColorScheme, "colorScheme", args->SchemeName().empty(), ArgTag::ColorScheme, L"")                                     \
+    X(Windows::Foundation::IReference<bool>, Elevate, "elevate", false, ArgTag::None, nullptr)                                              \
+    X(Windows::Foundation::IReference<bool>, ReloadEnvironmentVariables, "reloadEnvironmentVariables", false, ArgTag::None, nullptr)
+
+////////////////////////////////////////////////////////////////////////////////
+#define SPLIT_PANE_ARGS(X)                                                                             \
+    X(Model::SplitDirection, SplitDirection, "split", false, ArgTag::None, SplitDirection::Automatic)  \
+    X(SplitType, SplitMode, "splitMode", false, ArgTag::None, SplitType::Manual)                       \
+    X(float, SplitSize, "size", false, ArgTag::None, 0.5f)
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -358,41 +377,21 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     // assumptions made in the macro.
     struct NewTerminalArgs : public NewTerminalArgsT<NewTerminalArgs>
     {
-        NewTerminalArgs() = default;
-        NewTerminalArgs(int32_t& profileIndex) :
-            _ProfileIndex{ profileIndex } {};
-
+        PARTIAL_ACTION_ARG_BODY(NewTerminalArgs, NEW_TERMINAL_ARGS);
         ACTION_ARG(winrt::hstring, Type, L"");
-
-        ACTION_ARG(winrt::hstring, Commandline, L"");
-        ACTION_ARG(winrt::hstring, StartingDirectory, L"");
-        ACTION_ARG(winrt::hstring, TabTitle, L"");
-        ACTION_ARG(Windows::Foundation::IReference<Windows::UI::Color>, TabColor, nullptr);
-        ACTION_ARG(Windows::Foundation::IReference<int32_t>, ProfileIndex, nullptr);
-        ACTION_ARG(winrt::hstring, Profile, L"");
         ACTION_ARG(winrt::guid, SessionId, winrt::guid{});
         ACTION_ARG(bool, AppendCommandLine, false);
-        ACTION_ARG(Windows::Foundation::IReference<bool>, SuppressApplicationTitle, nullptr);
-        ACTION_ARG(winrt::hstring, ColorScheme);
-        ACTION_ARG(Windows::Foundation::IReference<bool>, Elevate, nullptr);
-        ACTION_ARG(Windows::Foundation::IReference<bool>, ReloadEnvironmentVariables, nullptr);
         ACTION_ARG(uint64_t, ContentId);
 
-        static constexpr std::string_view CommandlineKey{ "commandline" };
-        static constexpr std::string_view StartingDirectoryKey{ "startingDirectory" };
-        static constexpr std::string_view TabTitleKey{ "tabTitle" };
-        static constexpr std::string_view TabColorKey{ "tabColor" };
-        static constexpr std::string_view ProfileIndexKey{ "index" };
-        static constexpr std::string_view ProfileKey{ "profile" };
         static constexpr std::string_view SessionIdKey{ "sessionId" };
         static constexpr std::string_view AppendCommandLineKey{ "appendCommandLine" };
-        static constexpr std::string_view SuppressApplicationTitleKey{ "suppressApplicationTitle" };
-        static constexpr std::string_view ColorSchemeKey{ "colorScheme" };
-        static constexpr std::string_view ElevateKey{ "elevate" };
-        static constexpr std::string_view ReloadEnvironmentVariablesKey{ "reloadEnvironmentVariables" };
         static constexpr std::string_view ContentKey{ "__content" };
 
     public:
+        NewTerminalArgs(int32_t& profileIndex) :
+            _ProfileIndex{ profileIndex } {
+            NEW_TERMINAL_ARGS(APPEND_ARG_DESCRIPTION);
+        };
         hstring GenerateName() const;
         hstring ToCommandline() const;
 
@@ -471,6 +470,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             copy->_Elevate = _Elevate;
             copy->_ReloadEnvironmentVariables = _ReloadEnvironmentVariables;
             copy->_ContentId = _ContentId;
+            copy->_argDescriptions = _argDescriptions;
             return *copy;
         }
         size_t Hash() const
@@ -589,7 +589,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         NewTabArgs() = default;
         NewTabArgs(const Model::INewContentArgs& terminalArgs) :
             _ContentArgs{ terminalArgs } {};
-        WINRT_PROPERTY(Model::INewContentArgs, ContentArgs, nullptr);
+        WINRT_PROPERTY(Model::INewContentArgs, ContentArgs, Model::NewTerminalArgs{});
 
     public:
         hstring GenerateName() const;
@@ -632,34 +632,54 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             h.write(ContentArgs());
             return h.finalize();
         }
+        uint32_t GetArgCount() const
+        {
+            return _ContentArgs.as<NewTerminalArgs>()->GetArgCount();
+        }
+        Model::ArgDescription GetArgDescriptionAt(uint32_t index) const
+        {
+            return _ContentArgs.as<NewTerminalArgs>()->GetArgDescriptionAt(index);
+        }
+        IInspectable GetArgAt(uint32_t index) const
+        {
+            return _ContentArgs.as<NewTerminalArgs>()->GetArgAt(index);
+        }
+        void SetArgAt(uint32_t index, IInspectable value)
+        {
+            _ContentArgs.as<NewTerminalArgs>()->SetArgAt(index, value);
+        }
     };
 
     struct SplitPaneArgs : public SplitPaneArgsT<SplitPaneArgs>
     {
-        SplitPaneArgs() = default;
+        SplitPaneArgs() {
+            SPLIT_PANE_ARGS(APPEND_ARG_DESCRIPTION)
+        };
         SplitPaneArgs(SplitType splitMode, SplitDirection direction, float size, const Model::INewContentArgs& terminalArgs) :
             _SplitMode{ splitMode },
             _SplitDirection{ direction },
             _SplitSize{ size },
-            _ContentArgs{ terminalArgs } {};
+            _ContentArgs{ terminalArgs } {
+            SPLIT_PANE_ARGS(APPEND_ARG_DESCRIPTION)
+        };
         SplitPaneArgs(SplitDirection direction, float size, const Model::INewContentArgs& terminalArgs) :
             _SplitDirection{ direction },
             _SplitSize{ size },
-            _ContentArgs{ terminalArgs } {};
+            _ContentArgs{ terminalArgs } {
+            SPLIT_PANE_ARGS(APPEND_ARG_DESCRIPTION)
+        };
         SplitPaneArgs(SplitDirection direction, const Model::INewContentArgs& terminalArgs) :
             _SplitDirection{ direction },
-            _ContentArgs{ terminalArgs } {};
+            _ContentArgs{ terminalArgs } {
+            SPLIT_PANE_ARGS(APPEND_ARG_DESCRIPTION)
+        };
         SplitPaneArgs(SplitType splitMode) :
-            _SplitMode{ splitMode } {};
+            _SplitMode{ splitMode } {
+            SPLIT_PANE_ARGS(APPEND_ARG_DESCRIPTION)
+        };
 
-        ACTION_ARG(Model::SplitDirection, SplitDirection, SplitDirection::Automatic);
-        WINRT_PROPERTY(Model::INewContentArgs, ContentArgs, nullptr);
-        ACTION_ARG(SplitType, SplitMode, SplitType::Manual);
-        ACTION_ARG(float, SplitSize, 0.5f);
-
-        static constexpr std::string_view SplitKey{ "split" };
-        static constexpr std::string_view SplitModeKey{ "splitMode" };
-        static constexpr std::string_view SplitSizeKey{ "size" };
+        SPLIT_PANE_ARGS(DECLARE_ARGS);
+        WINRT_PROPERTY(Model::INewContentArgs, ContentArgs, Model::NewTerminalArgs{});
 
     public:
         hstring GenerateName() const;
@@ -681,7 +701,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         {
             // LOAD BEARING: Not using make_self here _will_ break you in the future!
             auto args = winrt::make_self<SplitPaneArgs>();
-            JsonUtils::GetValueForKey(json, SplitKey, args->_SplitDirection);
+            JsonUtils::GetValueForKey(json, SplitDirectionKey, args->_SplitDirection);
             JsonUtils::GetValueForKey(json, SplitModeKey, args->_SplitMode);
             JsonUtils::GetValueForKey(json, SplitSizeKey, args->_SplitSize);
             if (args->SplitSize() >= 1 || args->SplitSize() <= 0)
@@ -701,7 +721,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             }
             const auto args{ get_self<SplitPaneArgs>(val) };
             auto json{ ContentArgsToJson(args->_ContentArgs) };
-            JsonUtils::SetValueForKey(json, SplitKey, args->_SplitDirection);
+            JsonUtils::SetValueForKey(json, SplitDirectionKey, args->_SplitDirection);
             JsonUtils::SetValueForKey(json, SplitModeKey, args->_SplitMode);
             JsonUtils::SetValueForKey(json, SplitSizeKey, args->_SplitSize);
             return json;
@@ -713,6 +733,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             copy->_ContentArgs = _ContentArgs.Copy();
             copy->_SplitMode = _SplitMode;
             copy->_SplitSize = _SplitSize;
+            copy->_argDescriptions = _argDescriptions;
             return *copy;
         }
         size_t Hash() const
@@ -724,6 +745,59 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             h.write(SplitSize());
             return h.finalize();
         }
+        uint32_t GetArgCount() const
+        {
+            if (const auto newTermArgs = _ContentArgs.try_as<NewTerminalArgs>())
+            {
+                return newTermArgs->GetArgCount() + gsl::narrow<uint32_t>(_argDescriptions.size());
+            }
+            else
+            {
+                return gsl::narrow<uint32_t>(_argDescriptions.size());
+            }
+        }
+        Model::ArgDescription GetArgDescriptionAt(uint32_t index) const
+        {
+            const auto additionalArgCount = gsl::narrow<uint32_t>(_argDescriptions.size());
+            if (index < additionalArgCount)
+            {
+                return _argDescriptions.at(index);
+            }
+            else
+            {
+                return _ContentArgs.as<NewTerminalArgs>()->GetArgDescriptionAt(index - additionalArgCount);
+            }
+        }
+        IInspectable GetArgAt(uint32_t index) const
+        {
+            const auto additionalArgCount = gsl::narrow<uint32_t>(_argDescriptions.size());
+            if (index < additionalArgCount)
+            {
+                uint32_t curIndex{ 0 };
+                SPLIT_PANE_ARGS(GET_ARG_BY_INDEX);
+            }
+            else
+            {
+                return _ContentArgs.as<NewTerminalArgs>()->GetArgAt(index - additionalArgCount);
+            }
+            return nullptr;
+        }
+        void SetArgAt(uint32_t index, IInspectable value)
+        {
+            const auto additionalArgCount = gsl::narrow<uint32_t>(_argDescriptions.size());
+            if (index < additionalArgCount)
+            {
+                uint32_t curIndex{ 0 };
+                SPLIT_PANE_ARGS(SET_ARG_BY_INDEX);
+            }
+            else
+            {
+                _ContentArgs.as<NewTerminalArgs>()->SetArgAt(index - additionalArgCount, value);
+            }
+        }
+
+    private:
+        std::vector<ArgDescription> _argDescriptions;
     };
 
     struct NewWindowArgs : public NewWindowArgsT<NewWindowArgs>
@@ -731,7 +805,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         NewWindowArgs() = default;
         NewWindowArgs(const Model::INewContentArgs& terminalArgs) :
             _ContentArgs{ terminalArgs } {};
-        WINRT_PROPERTY(Model::INewContentArgs, ContentArgs, nullptr);
+        WINRT_PROPERTY(Model::INewContentArgs, ContentArgs, Model::NewTerminalArgs{});
 
     public:
         hstring GenerateName() const;
@@ -773,6 +847,22 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             til::hasher h;
             h.write(ContentArgs());
             return h.finalize();
+        }
+        uint32_t GetArgCount() const
+        {
+            return _ContentArgs.as<NewTerminalArgs>()->GetArgCount();
+        }
+        Model::ArgDescription GetArgDescriptionAt(uint32_t index) const
+        {
+            return _ContentArgs.as<NewTerminalArgs>()->GetArgDescriptionAt(index);
+        }
+        IInspectable GetArgAt(uint32_t index) const
+        {
+            return _ContentArgs.as<NewTerminalArgs>()->GetArgAt(index);
+        }
+        void SetArgAt(uint32_t index, IInspectable value)
+        {
+            _ContentArgs.as<NewTerminalArgs>()->SetArgAt(index, value);
         }
     };
 
@@ -912,6 +1002,22 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             til::hasher h;
             h.write(winrt::get_abi(_Actions));
             return h.finalize();
+        }
+        uint32_t GetArgCount() const
+        {
+            return _Actions.Size();
+        }
+        Model::ArgDescription GetArgDescriptionAt(uint32_t /*index*/) const
+        {
+            return {};
+        }
+        IInspectable GetArgAt(uint32_t /*index*/) const
+        {
+            return nullptr;
+        }
+        void SetArgAt(uint32_t /*index*/, IInspectable /*value*/)
+        {
+            throw winrt::hresult_not_implemented();
         }
     };
 

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -5,12 +5,32 @@ import "Command.idl";
 
 namespace Microsoft.Terminal.Settings.Model
 {
+    enum ArgTag
+    {
+        None = 0,
+        FilePath,
+        ColorScheme
+    };
+
+    struct ArgDescription
+    {
+        String Name;
+        String Type;
+        Boolean Required;
+        ArgTag Tag;
+    };
+
     interface IActionArgs
     {
         Boolean Equals(IActionArgs other);
         String GenerateName();
         IActionArgs Copy();
         UInt64 Hash();
+
+        UInt32 GetArgCount();
+        ArgDescription GetArgDescriptionAt(UInt32 index);
+        IInspectable GetArgAt(UInt32 index);
+        void SetArgAt(UInt32 index, Object value);
     };
 
     interface IActionEventArgs
@@ -168,6 +188,11 @@ namespace Microsoft.Terminal.Settings.Model
         UInt64 ContentId{ get; set; };
 
         String ToCommandline();
+
+        UInt32 GetArgCount();
+        ArgDescription GetArgDescriptionAt(UInt32 index);
+        IInspectable GetArgAt(UInt32 index);
+        void SetArgAt(UInt32 index, Object value);
     };
 
     [default_interface] runtimeclass ActionEventArgs : IActionEventArgs
@@ -230,7 +255,7 @@ namespace Microsoft.Terminal.Settings.Model
     {
         SendInputArgs(String input);
 
-        String Input { get; };
+        String Input;
     };
 
     [default_interface] runtimeclass SplitPaneArgs : IActionArgs
@@ -309,7 +334,7 @@ namespace Microsoft.Terminal.Settings.Model
     [default_interface] runtimeclass CloseTabArgs : IActionArgs
     {
         CloseTabArgs(UInt32 tabIndex);
-        Windows.Foundation.IReference<UInt32> Index { get; };
+        Windows.Foundation.IReference<UInt32> Index;
     };
 
     [default_interface] runtimeclass MoveTabArgs : IActionArgs

--- a/src/cascadia/TerminalSettingsModel/ActionArgsMagic.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgsMagic.h
@@ -54,23 +54,54 @@ struct InitListPlaceholder
 // expanded. Pretty critical for tracking down extraneous commas, etc.
 
 // Property definitions, and JSON keys
-#define DECLARE_ARGS(type, name, jsonKey, required, ...)    \
+#define DECLARE_ARGS(type, name, jsonKey, required, tag, ...)    \
     static constexpr std::string_view name##Key{ jsonKey }; \
     ACTION_ARG(type, name, ##__VA_ARGS__);
 
 // Parameters to the non-default ctor
-#define CTOR_PARAMS(type, name, jsonKey, required, ...) \
+#define CTOR_PARAMS(type, name, jsonKey, required, tag, ...) \
     const type &name##Param,
 
 // initializers in the ctor
-#define CTOR_INIT(type, name, jsonKey, required, ...) \
+#define CTOR_INIT(type, name, jsonKey, required, tag, ...) \
     _##name{ name##Param },
+
+// append this argument's description to the internal vector
+#define APPEND_ARG_DESCRIPTION(type, name, jsonKey, required, tag, ...)                                      \
+    _argDescriptions.push_back({ L## #name, L## #type, std::wstring_view(L## #required) != L"false", tag });
 
 // check each property in the Equals() method. You'll note there's a stray
 // `true` in the definition of Equals() below, that's to deal with trailing
 // commas
-#define EQUALS_ARGS(type, name, jsonKey, required, ...) \
+#define EQUALS_ARGS(type, name, jsonKey, required, tag, ...) \
     &&(otherAsUs->_##name == _##name)
+
+// getter and setter for each property by index
+#define GET_ARG_BY_INDEX(type, name, jsonKey, required, tag, ...)         \
+    if (index == curIndex++)                                              \
+    {                                                                     \
+        if (_##name.has_value())                                          \
+        {                                                                 \
+            return winrt::box_value(_##name.value());                     \
+        }                                                                 \
+        else                                                              \
+        {                                                                 \
+            return winrt::box_value(static_cast<type>(__VA_ARGS__));      \
+        }                                                                 \
+    }
+
+#define SET_ARG_BY_INDEX(type, name, jsonKey, required, tag, ...) \
+    if (index == curIndex++)                                      \
+    {                                                             \
+        if (value)                                                \
+        {                                                         \
+            _##name = winrt::unbox_value<type>(value);            \
+        }                                                         \
+        else                                                      \
+        {                                                         \
+            _##name = std::nullopt;                               \
+        }                                                         \
+    }
 
 // JSON deserialization. If the parameter is required to pass any validation,
 // add that as the `required` parameter here, as the body of a conditional
@@ -79,25 +110,25 @@ struct InitListPlaceholder
 // the bit
 //    args->ResizeDirection() == ResizeDirection::None
 // is used as the conditional for the validation here.
-#define FROM_JSON_ARGS(type, name, jsonKey, required, ...)                      \
-    JsonUtils::GetValueForKey(json, jsonKey, args->_##name);                    \
-    if (required)                                                               \
-    {                                                                           \
-        return { nullptr, { SettingsLoadWarnings::MissingRequiredParameter } }; \
+#define FROM_JSON_ARGS(type, name, jsonKey, required, tag, ...)                                                \
+    JsonUtils::GetValueForKey(json, jsonKey, args->_##name);                                                   \
+    if (required)                                                                                              \
+    {                                                                                                          \
+        return { nullptr, { SettingsLoadWarnings::MissingRequiredParameter } };                                \
     }
 
 // JSON serialization
-#define TO_JSON_ARGS(type, name, jsonKey, required, ...) \
+#define TO_JSON_ARGS(type, name, jsonKey, required, tag, ...) \
     JsonUtils::SetValueForKey(json, jsonKey, args->_##name);
 
 // Copy each property in the Copy() method
-#define COPY_ARGS(type, name, jsonKey, required, ...) \
+#define COPY_ARGS(type, name, jsonKey, required, tag, ...) \
     copy->_##name = _##name;
 
 // hash each property in Hash(). You'll note there's a stray `0` in the
 // definition of Hash() below, that's to deal with trailing commas (or in this
 // case, leading.)
-#define HASH_ARGS(type, name, jsonKey, required, ...) \
+#define HASH_ARGS(type, name, jsonKey, required, tag, ...) \
     h.write(name());
 
 // Use ACTION_ARGS_STRUCT when you've got no other customizing to do.
@@ -111,53 +142,110 @@ struct InitListPlaceholder
 //   * NewTerminalArgs has a ToCommandline method it needs to additionally declare.
 //   * GlobalSummonArgs has the QuakeModeFromJson helper
 
-#define ACTION_ARG_BODY(className, argsMacro)               \
-    className() = default;                                  \
-    className(                                              \
-        argsMacro(CTOR_PARAMS) InitListPlaceholder = {}) :  \
-        argsMacro(CTOR_INIT) _placeholder{} {};             \
-    argsMacro(DECLARE_ARGS);                                \
-                                                            \
-private:                                                    \
-    InitListPlaceholder _placeholder;                       \
-                                                            \
-public:                                                     \
-    hstring GenerateName() const;                           \
-    bool Equals(const IActionArgs& other)                   \
-    {                                                       \
-        auto otherAsUs = other.try_as<className>();         \
-        if (otherAsUs)                                      \
-        {                                                   \
-            return true argsMacro(EQUALS_ARGS);             \
-        }                                                   \
-        return false;                                       \
-    };                                                      \
-    static FromJsonResult FromJson(const Json::Value& json) \
-    {                                                       \
-        auto args = winrt::make_self<className>();          \
-        argsMacro(FROM_JSON_ARGS);                          \
-        return { *args, {} };                               \
-    }                                                       \
-    static Json::Value ToJson(const IActionArgs& val)       \
-    {                                                       \
-        if (!val)                                           \
-        {                                                   \
-            return {};                                      \
-        }                                                   \
-        Json::Value json{ Json::ValueType::objectValue };   \
-        const auto args{ get_self<className>(val) };        \
-        argsMacro(TO_JSON_ARGS);                            \
-        return json;                                        \
-    }                                                       \
-    IActionArgs Copy() const                                \
-    {                                                       \
-        auto copy{ winrt::make_self<className>() };         \
-        argsMacro(COPY_ARGS);                               \
-        return *copy;                                       \
-    }                                                       \
-    size_t Hash() const                                     \
-    {                                                       \
-        til::hasher h;                                      \
-        argsMacro(HASH_ARGS);                               \
-        return h.finalize();                                \
+#define ACTION_ARG_BODY(className, argsMacro)                    \
+    className() { argsMacro(APPEND_ARG_DESCRIPTION) };           \
+    className(                                                   \
+        argsMacro(CTOR_PARAMS) InitListPlaceholder = {}) :       \
+        argsMacro(CTOR_INIT) _placeholder{} {                    \
+            argsMacro(APPEND_ARG_DESCRIPTION)                    \
+        };                                                       \
+    argsMacro(DECLARE_ARGS);                                     \
+                                                                 \
+private:                                                         \
+    InitListPlaceholder _placeholder;                            \
+    std::vector<ArgDescription> _argDescriptions;                \
+                                                                 \
+public:                                                          \
+    hstring GenerateName() const;                                \
+    bool Equals(const IActionArgs& other)                        \
+    {                                                            \
+        auto otherAsUs = other.try_as<className>();              \
+        if (otherAsUs)                                           \
+        {                                                        \
+            return true argsMacro(EQUALS_ARGS);                  \
+        }                                                        \
+        return false;                                            \
+    };                                                           \
+    static FromJsonResult FromJson(const Json::Value& json)      \
+    {                                                            \
+        auto args = winrt::make_self<className>();               \
+        argsMacro(FROM_JSON_ARGS);                               \
+        return { *args, {} };                                    \
+    }                                                            \
+    static Json::Value ToJson(const IActionArgs& val)            \
+    {                                                            \
+        if (!val)                                                \
+        {                                                        \
+            return {};                                           \
+        }                                                        \
+        Json::Value json{ Json::ValueType::objectValue };        \
+        const auto args{ get_self<className>(val) };             \
+        argsMacro(TO_JSON_ARGS);                                 \
+        return json;                                             \
+    }                                                            \
+    IActionArgs Copy() const                                     \
+    {                                                            \
+        auto copy{ winrt::make_self<className>() };              \
+        argsMacro(COPY_ARGS);                                    \
+        copy->_argDescriptions = _argDescriptions;               \
+        return *copy;                                            \
+    }                                                            \
+    size_t Hash() const                                          \
+    {                                                            \
+        til::hasher h;                                           \
+        argsMacro(HASH_ARGS);                                    \
+        return h.finalize();                                     \
+    }                                                            \
+    uint32_t GetArgCount() const                                 \
+    {                                                            \
+        return gsl::narrow<uint32_t>(_argDescriptions.size());   \
+    }                                                            \
+    ArgDescription GetArgDescriptionAt(uint32_t index) const     \
+    {                                                            \
+        return _argDescriptions.at(index);                       \
+    }                                                            \
+    IInspectable GetArgAt(uint32_t index) const                  \
+    {                                                            \
+        uint32_t curIndex{ 0 };                                  \
+        argsMacro(GET_ARG_BY_INDEX)                              \
+        return nullptr;                                          \
+    }                                                            \
+    void SetArgAt(uint32_t index, IInspectable value)            \
+    {                                                            \
+        uint32_t curIndex{ 0 };                                  \
+        argsMacro(SET_ARG_BY_INDEX)                              \
+    }
+
+#define PARTIAL_ACTION_ARG_BODY(className, argsMacro)          \
+    className(){ argsMacro(APPEND_ARG_DESCRIPTION) };          \
+    className(                                                 \
+        argsMacro(CTOR_PARAMS) InitListPlaceholder = {}) :     \
+        argsMacro(CTOR_INIT) _placeholder{} {                  \
+            argsMacro(APPEND_ARG_DESCRIPTION)                  \
+        };                                                     \
+    argsMacro(DECLARE_ARGS);                                   \
+                                                               \
+private:                                                       \
+    InitListPlaceholder _placeholder;                          \
+    std::vector<ArgDescription> _argDescriptions;              \
+                                                               \
+public:                                                        \
+    uint32_t GetArgCount() const                               \
+    {                                                          \
+        return gsl::narrow<uint32_t>(_argDescriptions.size()); \
+    }                                                          \
+    ArgDescription GetArgDescriptionAt(uint32_t index) const   \
+    {                                                          \
+        return _argDescriptions.at(index);                     \
+    }                                                          \
+    IInspectable GetArgAt(uint32_t index) const                \
+    {                                                          \
+        uint32_t curIndex{ 0 };                                \
+        argsMacro(GET_ARG_BY_INDEX)                            \
+        return nullptr;                                        \
+    }                                                          \
+    void SetArgAt(uint32_t index, IInspectable value)          \
+    {                                                          \
+        uint32_t curIndex{ 0 };                                \
+        argsMacro(SET_ARG_BY_INDEX)                            \
     }

--- a/src/cascadia/TerminalSettingsModel/ActionMap.h
+++ b/src/cascadia/TerminalSettingsModel/ActionMap.h
@@ -56,6 +56,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         Windows::Foundation::Collections::IMapView<hstring, Model::Command> NameMap();
         Windows::Foundation::Collections::IMapView<Control::KeyChord, Model::Command> GlobalHotkeys();
         Windows::Foundation::Collections::IMapView<Control::KeyChord, Model::Command> KeyBindings();
+        Windows::Foundation::Collections::IVectorView<Model::Command> AllCommands();
         com_ptr<ActionMap> Copy() const;
 
         // queries
@@ -63,6 +64,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         Model::Command GetActionByID(const winrt::hstring& cmdID) const;
         bool IsKeyChordExplicitlyUnbound(const Control::KeyChord& keys) const;
         Control::KeyChord GetKeyBindingForAction(const winrt::hstring& cmdID);
+        Windows::Foundation::Collections::IVector<Control::KeyChord> AllKeyBindingsForAction(const winrt::hstring& cmdID);
 
         // population
         void AddAction(const Model::Command& cmd, const Control::KeyChord& keys);
@@ -78,7 +80,9 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         // modification
         bool RebindKeys(const Control::KeyChord& oldKeys, const Control::KeyChord& newKeys);
         void DeleteKeyBinding(const Control::KeyChord& keys);
+        void AddKeyBinding(Control::KeyChord keys, const winrt::hstring& cmdID);
         void RegisterKeyBinding(Control::KeyChord keys, Model::ActionAndArgs action);
+        void DeleteUserCommand(const winrt::hstring& cmdID);
         void AddSendInputAction(winrt::hstring name, winrt::hstring input, const Control::KeyChord keys);
 
         Windows::Foundation::Collections::IVector<Model::Command> ExpandedCommands();
@@ -104,6 +108,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         void _TryUpdateKeyChord(const Model::Command& cmd, const Control::KeyChord& keys);
 
         static std::unordered_map<hstring, Model::Command> _loadLocalSnippets(const std::filesystem::path& currentWorkingDirectory);
+
+        void _CommandIDChangedHandler(const Model::Command& senderCmd, const winrt::hstring& oldID);
 
         Windows::Foundation::Collections::IMap<hstring, Model::ActionAndArgs> _AvailableActionsCache{ nullptr };
         Windows::Foundation::Collections::IMap<hstring, Model::Command> _NameMapCache{ nullptr };
@@ -136,6 +142,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         // This is effectively a combination of _CumulativeKeyMapCache and _CumulativeActionMapCache and its purpose is so that
         // we can give the SUI a view of the key chords and the commands they map to
         Windows::Foundation::Collections::IMap<Control::KeyChord, Model::Command> _ResolvedKeyToActionMapCache{ nullptr };
+        Windows::Foundation::Collections::IVector<Model::Command> _AllCommandsCache{ nullptr };
 
         til::shared_mutex<std::unordered_map<std::filesystem::path, std::unordered_map<hstring, Model::Command>>> _cwdLocalSnippetsCache{};
 

--- a/src/cascadia/TerminalSettingsModel/ActionMap.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionMap.idl
@@ -13,12 +13,14 @@ namespace Microsoft.Terminal.Settings.Model
         Command GetActionByKeyChord(Microsoft.Terminal.Control.KeyChord keys);
         Command GetActionByID(String cmdID);
         Microsoft.Terminal.Control.KeyChord GetKeyBindingForAction(String cmdID);
+        IVector<Microsoft.Terminal.Control.KeyChord> AllKeyBindingsForAction(String cmdID);
 
         Windows.Foundation.Collections.IMapView<String, ActionAndArgs> AvailableActions { get; };
 
         Windows.Foundation.Collections.IMapView<String, Command> NameMap { get; };
         Windows.Foundation.Collections.IMapView<Microsoft.Terminal.Control.KeyChord, Command> KeyBindings { get; };
         Windows.Foundation.Collections.IMapView<Microsoft.Terminal.Control.KeyChord, Command> GlobalHotkeys { get; };
+        Windows.Foundation.Collections.IVectorView<Command> AllCommands { get; };
 
         IVector<Command> ExpandedCommands { get; };
 
@@ -27,9 +29,11 @@ namespace Microsoft.Terminal.Settings.Model
 
     [default_interface] runtimeclass ActionMap : IActionMapView
     {
+        void AddAction(Command cmd, Microsoft.Terminal.Control.KeyChord keys);
         void RebindKeys(Microsoft.Terminal.Control.KeyChord oldKeys, Microsoft.Terminal.Control.KeyChord newKeys);
         void DeleteKeyBinding(Microsoft.Terminal.Control.KeyChord keys);
-
+        void DeleteUserCommand(String cmdID);
+        void AddKeyBinding(Microsoft.Terminal.Control.KeyChord keys, String cmdID);
         void RegisterKeyBinding(Microsoft.Terminal.Control.KeyChord keys, ActionAndArgs action);
         void AddSendInputAction(String name, String input, Microsoft.Terminal.Control.KeyChord keys);
     }

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -9,6 +9,8 @@
 #include "DefaultTerminal.h"
 #include "FileUtils.h"
 
+#include "AllShortcutActions.h"
+
 #include <LibraryResources.h>
 #include <VersionHelpers.h>
 #include <WtExeUtils.h>
@@ -1015,6 +1017,109 @@ winrt::hstring CascadiaSettings::ApplicationVersion()
     CATCH_LOG();
 
     return RS_(L"ApplicationVersionUnknown");
+}
+
+winrt::Windows::Foundation::Collections::IMap<Model::ShortcutAction, winrt::hstring> CascadiaSettings::AvailableShortcutActionsAndNames()
+{
+    std::map<ShortcutAction, winrt::hstring> availableShortcutActionsAndNames;
+
+#define ON_ALL_ACTIONS(action) availableShortcutActionsAndNames.emplace(ShortcutAction::action, RS_(L## #action));
+    ALL_SHORTCUT_ACTIONS
+    // Don't include internal actions here
+#undef ON_ALL_ACTIONS
+
+    return single_threaded_map(std::move(availableShortcutActionsAndNames));
+}
+
+Model::IActionArgs CascadiaSettings::GetEmptyArgsForAction(Model::ShortcutAction shortcutAction)
+{
+    switch (shortcutAction)
+    {
+    case Model::ShortcutAction::CopyText:
+        return winrt::make<CopyTextArgs>();
+    case Model::ShortcutAction::MovePane:
+        return winrt::make<MovePaneArgs>();
+    case Model::ShortcutAction::SwitchToTab:
+        return winrt::make<SwitchToTabArgs>();
+    case Model::ShortcutAction::ResizePane:
+        return winrt::make<ResizePaneArgs>();
+    case Model::ShortcutAction::MoveFocus:
+        return winrt::make<MoveFocusArgs>();
+    case Model::ShortcutAction::SwapPane:
+        return winrt::make<SwapPaneArgs>();
+    case Model::ShortcutAction::AdjustFontSize:
+        return winrt::make<AdjustFontSizeArgs>();
+    case Model::ShortcutAction::SendInput:
+        return winrt::make<SendInputArgs>();
+    case Model::ShortcutAction::OpenSettings:
+        return winrt::make<OpenSettingsArgs>();
+    case Model::ShortcutAction::SetFocusMode:
+        return winrt::make<SetFocusModeArgs>();
+    case Model::ShortcutAction::SetFullScreen:
+        return winrt::make<SetFullScreenArgs>();
+    case Model::ShortcutAction::SetMaximized:
+        return winrt::make<SetMaximizedArgs>();
+    case Model::ShortcutAction::SetColorScheme:
+        return winrt::make<SetColorSchemeArgs>();
+    case Model::ShortcutAction::RenameTab:
+        return winrt::make<RenameTabArgs>();
+    case Model::ShortcutAction::ExecuteCommandline:
+        return winrt::make<ExecuteCommandlineArgs>();
+    case Model::ShortcutAction::CloseOtherTabs:
+        return winrt::make<CloseOtherTabsArgs>();
+    case Model::ShortcutAction::CloseTabsAfter:
+        return winrt::make<CloseTabsAfterArgs>();
+    case Model::ShortcutAction::CloseTab:
+        return winrt::make<CloseTabArgs>();
+    case Model::ShortcutAction::MoveTab:
+        return winrt::make<MoveTabArgs>();
+    case Model::ShortcutAction::ScrollUp:
+        return winrt::make<ScrollUpArgs>();
+    case Model::ShortcutAction::ScrollDown:
+        return winrt::make<ScrollDownArgs>();
+    case Model::ShortcutAction::ScrollToMark:
+        return winrt::make<ScrollToMarkArgs>();
+    case Model::ShortcutAction::ToggleCommandPalette:
+        return winrt::make<ToggleCommandPaletteArgs>();
+    case Model::ShortcutAction::Suggestions:
+        return winrt::make<SuggestionsArgs>();
+    case Model::ShortcutAction::FindMatch:
+        return winrt::make<FindMatchArgs>();
+    case Model::ShortcutAction::RenameWindow:
+        return winrt::make<RenameWindowArgs>();
+    case Model::ShortcutAction::SearchForText:
+        return winrt::make<SearchForTextArgs>();
+    case Model::ShortcutAction::GlobalSummon:
+        return winrt::make<GlobalSummonArgs>();
+    case Model::ShortcutAction::FocusPane:
+        return winrt::make<FocusPaneArgs>();
+    case Model::ShortcutAction::ExportBuffer:
+        return winrt::make<ExportBufferArgs>();
+    case Model::ShortcutAction::ClearBuffer:
+        return winrt::make<ClearBufferArgs>();
+    case Model::ShortcutAction::AdjustOpacity:
+        return winrt::make<AdjustOpacityArgs>();
+    case Model::ShortcutAction::SelectCommand:
+        return winrt::make<SelectCommandArgs>();
+    case Model::ShortcutAction::SelectOutput:
+        return winrt::make<SelectOutputArgs>();
+    case Model::ShortcutAction::AddMark:
+        return winrt::make<AddMarkArgs>();
+    case Model::ShortcutAction::SetTabColor:
+        return winrt::make<SetTabColorArgs>();
+    case Model::ShortcutAction::PrevTab:
+        return winrt::make<PrevTabArgs>();
+    case Model::ShortcutAction::NextTab:
+        return winrt::make<NextTabArgs>();
+    case Model::ShortcutAction::NewTab:
+        return winrt::make<NewTabArgs>();
+    case Model::ShortcutAction::NewWindow:
+        return winrt::make<NewWindowArgs>();
+    case Model::ShortcutAction::SplitPane:
+        return winrt::make<SplitPaneArgs>();
+    default:
+        return nullptr;
+    }
 }
 
 // Method Description:

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
@@ -115,6 +115,9 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         static winrt::hstring ApplicationVersion();
         static bool IsPortableMode();
 
+        static Windows::Foundation::Collections::IMap<Model::ShortcutAction, winrt::hstring> AvailableShortcutActionsAndNames();
+        static Model::IActionArgs GetEmptyArgsForAction(Model::ShortcutAction shortcutAction);
+
         CascadiaSettings() noexcept = default;
         CascadiaSettings(const winrt::hstring& userJSON, const winrt::hstring& inboxJSON);
         CascadiaSettings(const std::string_view& userJSON, const std::string_view& inboxJSON = {});

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.idl
@@ -5,6 +5,7 @@ import "GlobalAppSettings.idl";
 import "Profile.idl";
 import "TerminalWarnings.idl";
 import "DefaultTerminal.idl";
+import "ActionArgs.idl";
 
 namespace Microsoft.Terminal.Settings.Model
 {
@@ -19,6 +20,9 @@ namespace Microsoft.Terminal.Settings.Model
 
         static String ApplicationDisplayName { get; };
         static String ApplicationVersion { get; };
+
+        static Windows.Foundation.Collections.IMap<Microsoft.Terminal.Settings.Model.ShortcutAction, String> AvailableShortcutActionsAndNames { get; };
+        static IActionArgs GetEmptyArgsForAction(Microsoft.Terminal.Settings.Model.ShortcutAction shortcutAction);
 
         CascadiaSettings(String userJSON, String inboxJSON);
 

--- a/src/cascadia/TerminalSettingsModel/Command.cpp
+++ b/src/cascadia/TerminalSettingsModel/Command.cpp
@@ -28,6 +28,21 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 {
     Command::Command() = default;
 
+    Model::Command Command::NewUserCommand()
+    {
+        auto newCmd{ winrt::make_self<Command>() };
+        newCmd->_Origin = OriginTag::User;
+        return *newCmd;
+    }
+
+    Model::Command Command::CopyAsUserCommand(Model::Command originalCmd)
+    {
+        auto command{ winrt::get_self<Command>(originalCmd) };
+        auto copy{ command->Copy() };
+        copy->_Origin = OriginTag::User;
+        return *copy;
+    }
+
     com_ptr<Command> Command::Copy() const
     {
         auto command{ winrt::make_self<Command>() };
@@ -113,6 +128,13 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         return hstring{ _ID };
     }
 
+    void Command::ID(const hstring& ID) noexcept
+    {
+        const auto oldID = _ID;
+        _ID = ID;
+        IDChanged.raise(*this, oldID);
+    }
+
     void Command::GenerateID()
     {
         if (_ActionAndArgs)
@@ -120,8 +142,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             auto actionAndArgsImpl{ winrt::get_self<implementation::ActionAndArgs>(_ActionAndArgs) };
             if (const auto generatedID = actionAndArgsImpl->GenerateID(); !generatedID.empty())
             {
-                _ID = generatedID;
                 _IDWasGenerated = true;
+                ID(generatedID);
             }
         }
     }
@@ -129,6 +151,16 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     bool Command::IDWasGenerated()
     {
         return _IDWasGenerated;
+    }
+
+    Model::ActionAndArgs Command::ActionAndArgs() const noexcept
+    {
+        return _ActionAndArgs;
+    }
+
+    void Command::ActionAndArgs(const Model::ActionAndArgs& value) noexcept
+    {
+        _ActionAndArgs = value;
     }
 
     void Command::Name(const hstring& value)

--- a/src/cascadia/TerminalSettingsModel/Command.h
+++ b/src/cascadia/TerminalSettingsModel/Command.h
@@ -45,6 +45,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     struct Command : CommandT<Command>
     {
         Command();
+        static Model::Command NewUserCommand();
+        static Model::Command CopyAsUserCommand(Model::Command originalCmd);
         com_ptr<Command> Copy() const;
 
         static winrt::com_ptr<Command> FromJson(const Json::Value& json,
@@ -73,8 +75,13 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         void Name(const hstring& name);
 
         hstring ID() const noexcept;
+        void ID(const hstring& ID) noexcept;
         void GenerateID();
         bool IDWasGenerated();
+
+        // we cannot use the WINRT_PROPERTY macro for ActionAndArgs because the setter has some additional logic regarding the ID
+        Model::ActionAndArgs ActionAndArgs() const noexcept;
+        void ActionAndArgs(const Model::ActionAndArgs& value) noexcept;
 
         hstring IconPath() const noexcept;
         void IconPath(const hstring& val);
@@ -86,12 +93,15 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                                                                                            hstring iconPath);
 
         WINRT_PROPERTY(ExpandCommandType, IterateOn, ExpandCommandType::None);
-        WINRT_PROPERTY(Model::ActionAndArgs, ActionAndArgs);
         WINRT_PROPERTY(OriginTag, Origin);
         WINRT_PROPERTY(winrt::hstring, Description, L"");
 
+    public:
+        til::typed_event<Model::Command, winrt::hstring> IDChanged;
+
     private:
         Json::Value _originalJson;
+        Model::ActionAndArgs _ActionAndArgs{};
         Windows::Foundation::Collections::IMap<winrt::hstring, Model::Command> _subcommands{ nullptr };
         std::optional<std::wstring> _name;
         std::wstring _ID;

--- a/src/cascadia/TerminalSettingsModel/Command.idl
+++ b/src/cascadia/TerminalSettingsModel/Command.idl
@@ -35,13 +35,17 @@ namespace Microsoft.Terminal.Settings.Model
     [default_interface] runtimeclass Command : ISettingsModelObject
     {
         Command();
+        static Command NewUserCommand();
+        static Command CopyAsUserCommand(Command originalCmd);
 
-        String Name { get; };
-        String ID { get; };
+        String Name;
+        Boolean HasName();
+        String ID;
+        void GenerateID();
 
         String Description { get; };
 
-        ActionAndArgs ActionAndArgs { get; };
+        ActionAndArgs ActionAndArgs;
 
         String IconPath;
 
@@ -51,5 +55,6 @@ namespace Microsoft.Terminal.Settings.Model
         static IVector<Command> ParsePowerShellMenuComplete(String json, Int32 replaceLength);
         static IVector<Command> HistoryToCommands(IVector<String> commandHistory, String commandline, Boolean directories, String iconPath);
 
+        event Windows.Foundation.TypedEventHandler<Command, String> IDChanged;
     }
 }

--- a/src/cascadia/TerminalSettingsModel/EnumMappings.cpp
+++ b/src/cascadia/TerminalSettingsModel/EnumMappings.cpp
@@ -53,6 +53,22 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     DEFINE_ENUM_MAP(Microsoft::Terminal::Core::AdjustTextMode, AdjustIndistinguishableColors);
     DEFINE_ENUM_MAP(Microsoft::Terminal::Control::PathTranslationStyle, PathTranslationStyle);
 
+    // Actions
+    DEFINE_ENUM_MAP(Microsoft::Terminal::Settings::Model::ResizeDirection, ResizeDirection);
+    DEFINE_ENUM_MAP(Microsoft::Terminal::Settings::Model::FocusDirection, FocusDirection);
+    DEFINE_ENUM_MAP(Microsoft::Terminal::Settings::Model::SplitDirection, SplitDirection);
+    DEFINE_ENUM_MAP(Microsoft::Terminal::Settings::Model::SplitType, SplitType);
+    DEFINE_ENUM_MAP(Microsoft::Terminal::Settings::Model::SettingsTarget, SettingsTarget);
+    DEFINE_ENUM_MAP(Microsoft::Terminal::Settings::Model::MoveTabDirection, MoveTabDirection);
+    DEFINE_ENUM_MAP(Microsoft::Terminal::Control::ScrollToMarkDirection, ScrollToMarkDirection);
+    DEFINE_ENUM_MAP(Microsoft::Terminal::Settings::Model::CommandPaletteLaunchMode, CommandPaletteLaunchMode);
+    DEFINE_ENUM_MAP(Microsoft::Terminal::Settings::Model::SuggestionsSource, SuggestionsSource);
+    DEFINE_ENUM_MAP(Microsoft::Terminal::Settings::Model::FindMatchDirection, FindMatchDirection);
+    DEFINE_ENUM_MAP(Microsoft::Terminal::Settings::Model::DesktopBehavior, DesktopBehavior);
+    DEFINE_ENUM_MAP(Microsoft::Terminal::Settings::Model::MonitorBehavior, MonitorBehavior);
+    DEFINE_ENUM_MAP(Microsoft::Terminal::Control::ClearBufferType, ClearBufferType);
+    DEFINE_ENUM_MAP(Microsoft::Terminal::Settings::Model::SelectOutputDirection, SelectOutputDirection);
+
     // FontWeight is special because the JsonUtils::ConversionTrait for it
     // creates a FontWeight object, but we need to use the uint16_t value.
     winrt::Windows::Foundation::Collections::IMap<winrt::hstring, uint16_t> EnumMappings::FontWeight()

--- a/src/cascadia/TerminalSettingsModel/EnumMappings.h
+++ b/src/cascadia/TerminalSettingsModel/EnumMappings.h
@@ -49,6 +49,22 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::Microsoft::Terminal::Settings::Model::IntenseStyle> IntenseTextStyle();
         static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::Microsoft::Terminal::Core::AdjustTextMode> AdjustIndistinguishableColors();
         static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::Microsoft::Terminal::Control::PathTranslationStyle> PathTranslationStyle();
+
+        // Actions
+        static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::Microsoft::Terminal::Settings::Model::ResizeDirection> ResizeDirection();
+        static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::Microsoft::Terminal::Settings::Model::FocusDirection> FocusDirection();
+        static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::Microsoft::Terminal::Settings::Model::SplitDirection> SplitDirection();
+        static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::Microsoft::Terminal::Settings::Model::SplitType> SplitType();
+        static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::Microsoft::Terminal::Settings::Model::SettingsTarget> SettingsTarget();
+        static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::Microsoft::Terminal::Settings::Model::MoveTabDirection> MoveTabDirection();
+        static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::Microsoft::Terminal::Control::ScrollToMarkDirection> ScrollToMarkDirection();
+        static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::Microsoft::Terminal::Settings::Model::CommandPaletteLaunchMode> CommandPaletteLaunchMode();
+        static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::Microsoft::Terminal::Settings::Model::SuggestionsSource> SuggestionsSource();
+        static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::Microsoft::Terminal::Settings::Model::FindMatchDirection> FindMatchDirection();
+        static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::Microsoft::Terminal::Settings::Model::DesktopBehavior> DesktopBehavior();
+        static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::Microsoft::Terminal::Settings::Model::MonitorBehavior> MonitorBehavior();
+        static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::Microsoft::Terminal::Control::ClearBufferType> ClearBufferType();
+        static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::Microsoft::Terminal::Settings::Model::SelectOutputDirection> SelectOutputDirection();
     };
 }
 

--- a/src/cascadia/TerminalSettingsModel/EnumMappings.idl
+++ b/src/cascadia/TerminalSettingsModel/EnumMappings.idl
@@ -31,5 +31,21 @@ namespace Microsoft.Terminal.Settings.Model
         static Windows.Foundation.Collections.IMap<String, UInt16> FontWeight { get; };
         static Windows.Foundation.Collections.IMap<String, Microsoft.Terminal.Settings.Model.IntenseStyle> IntenseTextStyle { get; };
         static Windows.Foundation.Collections.IMap<String, Microsoft.Terminal.Control.PathTranslationStyle> PathTranslationStyle { get; };
+
+        // Actions
+        static Windows.Foundation.Collections.IMap<String, Microsoft.Terminal.Settings.Model.ResizeDirection> ResizeDirection { get; };
+        static Windows.Foundation.Collections.IMap<String, Microsoft.Terminal.Settings.Model.FocusDirection> FocusDirection { get; };
+        static Windows.Foundation.Collections.IMap<String, Microsoft.Terminal.Settings.Model.SplitDirection> SplitDirection { get; };
+        static Windows.Foundation.Collections.IMap<String, Microsoft.Terminal.Settings.Model.SplitType> SplitType { get; };
+        static Windows.Foundation.Collections.IMap<String, Microsoft.Terminal.Settings.Model.SettingsTarget> SettingsTarget { get; };
+        static Windows.Foundation.Collections.IMap<String, Microsoft.Terminal.Settings.Model.MoveTabDirection> MoveTabDirection { get; };
+        static Windows.Foundation.Collections.IMap<String, Microsoft.Terminal.Control.ScrollToMarkDirection> ScrollToMarkDirection { get; };
+        static Windows.Foundation.Collections.IMap<String, Microsoft.Terminal.Settings.Model.CommandPaletteLaunchMode> CommandPaletteLaunchMode { get; };
+        static Windows.Foundation.Collections.IMap<String, Microsoft.Terminal.Settings.Model.SuggestionsSource> SuggestionsSource { get; };
+        static Windows.Foundation.Collections.IMap<String, Microsoft.Terminal.Settings.Model.FindMatchDirection> FindMatchDirection { get; };
+        static Windows.Foundation.Collections.IMap<String, Microsoft.Terminal.Settings.Model.DesktopBehavior> DesktopBehavior { get; };
+        static Windows.Foundation.Collections.IMap<String, Microsoft.Terminal.Settings.Model.MonitorBehavior> MonitorBehavior { get; };
+        static Windows.Foundation.Collections.IMap<String, Microsoft.Terminal.Control.ClearBufferType> ClearBufferType { get; };
+        static Windows.Foundation.Collections.IMap<String, Microsoft.Terminal.Settings.Model.SelectOutputDirection> SelectOutputDirection { get; };
     }
 }

--- a/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
@@ -740,4 +740,274 @@
   <data name="OpenCWDCommandKey" xml:space="preserve">
     <value>Open current working directory</value>
   </data>
+  <data name="CopyText" xml:space="preserve">
+    <value>Copy Text</value>
+  </data>
+  <data name="PasteText" xml:space="preserve">
+    <value>Paste Text</value>
+  </data>
+  <data name="OpenNewTabDropdown" xml:space="preserve">
+    <value>Open New Tab Dropdown</value>
+  </data>
+  <data name="DuplicateTab" xml:space="preserve">
+    <value>Duplicate Tab</value>
+  </data>
+  <data name="NewTab" xml:space="preserve">
+    <value>New Tab</value>
+  </data>
+  <data name="CloseWindow" xml:space="preserve">
+    <value>Close Window</value>
+  </data>
+  <data name="CloseTab" xml:space="preserve">
+    <value>Close Tab</value>
+  </data>
+  <data name="ClosePane" xml:space="preserve">
+    <value>Close Pane</value>
+  </data>
+  <data name="NextTab" xml:space="preserve">
+    <value>Next Tab</value>
+  </data>
+  <data name="PrevTab" xml:space="preserve">
+    <value>Previous Tab</value>
+  </data>
+  <data name="SendInput" xml:space="preserve">
+    <value>Send Input</value>
+  </data>
+  <data name="SplitPane" xml:space="preserve">
+    <value>Split Pane</value>
+  </data>
+  <data name="ToggleSplitOrientation" xml:space="preserve">
+    <value>Toggle Split Orientation</value>
+  </data>
+  <data name="TogglePaneZoom" xml:space="preserve">
+    <value>Toggle Pane Zoom</value>
+  </data>
+  <data name="SwitchToTab" xml:space="preserve">
+    <value>Switch To Tab</value>
+  </data>
+  <data name="AdjustFontSize" xml:space="preserve">
+    <value>Adjust Font Size</value>
+  </data>
+  <data name="ResetFontSize" xml:space="preserve">
+    <value>Reset Font Size</value>
+  </data>
+  <data name="ScrollUp" xml:space="preserve">
+    <value>Scroll Up</value>
+  </data>
+  <data name="ScrollDown" xml:space="preserve">
+    <value>Scroll Down</value>
+  </data>
+  <data name="ScrollUpPage" xml:space="preserve">
+    <value>Scroll Up Page</value>
+  </data>
+  <data name="ScrollDownPage" xml:space="preserve">
+    <value>Scroll Down Page</value>
+  </data>
+  <data name="ScrollToTop" xml:space="preserve">
+    <value>Scroll To Top</value>
+  </data>
+  <data name="ScrollToBottom" xml:space="preserve">
+    <value>Scroll To Bottom</value>
+  </data>
+  <data name="ScrollToMark" xml:space="preserve">
+    <value>Scroll To Mark</value>
+  </data>
+  <data name="AddMark" xml:space="preserve">
+    <value>Add Mark</value>
+  </data>
+  <data name="ClearMark" xml:space="preserve">
+    <value>Clear Mark</value>
+  </data>
+  <data name="ClearAllMarks" xml:space="preserve">
+    <value>Clear All Marks</value>
+  </data>
+  <data name="ResizePane" xml:space="preserve">
+    <value>Resize Pane</value>
+  </data>
+  <data name="MoveFocus" xml:space="preserve">
+    <value>Move Focus</value>
+  </data>
+  <data name="MovePane" xml:space="preserve">
+    <value>Move Pane</value>
+  </data>
+  <data name="SwapPane" xml:space="preserve">
+    <value>Swap Pane</value>
+  </data>
+  <data name="Find" xml:space="preserve">
+    <value>Find</value>
+  </data>
+  <data name="ToggleShaderEffects" xml:space="preserve">
+    <value>Toggle Shader Effects</value>
+  </data>
+  <data name="ToggleFocusMode" xml:space="preserve">
+    <value>Toggle Focus Mode</value>
+  </data>
+  <data name="ToggleFullscreen" xml:space="preserve">
+    <value>Toggle Fullscreen</value>
+  </data>
+  <data name="ToggleAlwaysOnTop" xml:space="preserve">
+    <value>Toggle Always On Top</value>
+  </data>
+  <data name="OpenSettings" xml:space="preserve">
+    <value>Open Settings</value>
+  </data>
+  <data name="SetFocusMode" xml:space="preserve">
+    <value>Set Focus Mode</value>
+  </data>
+  <data name="SetFullScreen" xml:space="preserve">
+    <value>Set Full Screen</value>
+  </data>
+  <data name="SetMaximized" xml:space="preserve">
+    <value>Set Maximized</value>
+  </data>
+  <data name="SetColorScheme" xml:space="preserve">
+    <value>Set Color Scheme</value>
+  </data>
+  <data name="SetTabColor" xml:space="preserve">
+    <value>Set Tab Color</value>
+  </data>
+  <data name="OpenTabColorPicker" xml:space="preserve">
+    <value>Open Tab Color Picker</value>
+  </data>
+  <data name="RenameTab" xml:space="preserve">
+    <value>Rename Tab</value>
+  </data>
+  <data name="OpenTabRenamer" xml:space="preserve">
+    <value>Open Tab Renamer</value>
+  </data>
+  <data name="ExecuteCommandline" xml:space="preserve">
+    <value>Execute Command Line</value>
+  </data>
+  <data name="ToggleCommandPalette" xml:space="preserve">
+    <value>Toggle Command Palette</value>
+  </data>
+  <data name="CloseOtherTabs" xml:space="preserve">
+    <value>Close Other Tabs</value>
+  </data>
+  <data name="CloseTabsAfter" xml:space="preserve">
+    <value>Close Tabs After</value>
+  </data>
+  <data name="TabSearch" xml:space="preserve">
+    <value>Tab Search</value>
+  </data>
+  <data name="MoveTab" xml:space="preserve">
+    <value>Move Tab</value>
+  </data>
+  <data name="BreakIntoDebugger" xml:space="preserve">
+    <value>Break Into Debugger</value>
+  </data>
+  <data name="TogglePaneReadOnly" xml:space="preserve">
+    <value>Toggle Pane Read-Only</value>
+  </data>
+  <data name="EnablePaneReadOnly" xml:space="preserve">
+    <value>Enable Pane Read-Only</value>
+  </data>
+  <data name="DisablePaneReadOnly" xml:space="preserve">
+    <value>Disable Pane Read-Only</value>
+  </data>
+  <data name="FindMatch" xml:space="preserve">
+    <value>Find Match</value>
+  </data>
+  <data name="NewWindow" xml:space="preserve">
+    <value>New Window</value>
+  </data>
+  <data name="IdentifyWindow" xml:space="preserve">
+    <value>Identify Window</value>
+  </data>
+  <data name="IdentifyWindows" xml:space="preserve">
+    <value>Identify Windows</value>
+  </data>
+  <data name="RenameWindow" xml:space="preserve">
+    <value>Rename Window</value>
+  </data>
+  <data name="OpenWindowRenamer" xml:space="preserve">
+    <value>Open Window Renamer</value>
+  </data>
+  <data name="DisplayWorkingDirectory" xml:space="preserve">
+    <value>Display Working Directory</value>
+  </data>
+  <data name="SearchForText" xml:space="preserve">
+    <value>Search For Text</value>
+  </data>
+  <data name="GlobalSummon" xml:space="preserve">
+    <value>Global Summon</value>
+  </data>
+  <data name="QuakeMode" xml:space="preserve">
+    <value>Quake Mode</value>
+  </data>
+  <data name="FocusPane" xml:space="preserve">
+    <value>Focus Pane</value>
+  </data>
+  <data name="OpenSystemMenu" xml:space="preserve">
+    <value>Open System Menu</value>
+  </data>
+  <data name="ExportBuffer" xml:space="preserve">
+    <value>Export Buffer</value>
+  </data>
+  <data name="ClearBuffer" xml:space="preserve">
+    <value>Clear Buffer</value>
+  </data>
+  <data name="MultipleActions" xml:space="preserve">
+    <value>Multiple Actions</value>
+  </data>
+  <data name="Quit" xml:space="preserve">
+    <value>Quit</value>
+  </data>
+  <data name="AdjustOpacity" xml:space="preserve">
+    <value>Adjust Opacity</value>
+  </data>
+  <data name="RestoreLastClosed" xml:space="preserve">
+    <value>Restore Last Closed</value>
+  </data>
+  <data name="SelectAll" xml:space="preserve">
+    <value>Select All</value>
+  </data>
+  <data name="SelectCommand" xml:space="preserve">
+    <value>Select Command</value>
+  </data>
+  <data name="SelectOutput" xml:space="preserve">
+    <value>Select Output</value>
+  </data>
+  <data name="MarkMode" xml:space="preserve">
+    <value>Mark Mode</value>
+  </data>
+  <data name="ToggleBlockSelection" xml:space="preserve">
+    <value>Toggle Block Selection</value>
+  </data>
+  <data name="SwitchSelectionEndpoint" xml:space="preserve">
+    <value>Switch Selection Endpoint</value>
+  </data>
+  <data name="Suggestions" xml:space="preserve">
+    <value>Suggestions</value>
+  </data>
+  <data name="ColorSelection" xml:space="preserve">
+    <value>Color Selection</value>
+  </data>
+  <data name="ShowContextMenu" xml:space="preserve">
+    <value>Show Context Menu</value>
+  </data>
+  <data name="ExpandSelectionToWord" xml:space="preserve">
+    <value>Expand Selection To Word</value>
+  </data>
+  <data name="CloseOtherPanes" xml:space="preserve">
+    <value>Close Other Panes</value>
+  </data>
+  <data name="RestartConnection" xml:space="preserve">
+    <value>Restart Connection</value>
+  </data>
+  <data name="ToggleBroadcastInput" xml:space="preserve">
+    <value>Toggle Broadcast Input</value>
+  </data>
+  <data name="OpenScratchpad" xml:space="preserve">
+    <value>Open Scratchpad</value>
+  </data>
+  <data name="OpenAbout" xml:space="preserve">
+    <value>Open About</value>
+  </data>
+  <data name="QuickFix" xml:space="preserve">
+    <value>Quick Fix</value>
+  </data>
+  <data name="OpenCWD" xml:space="preserve">
+    <value>Open Current Working Directory</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary of the Pull Request
Implements reflection to the various ActionArg types in the settings model, which allows these structs to provide information about themselves (i.e. what args they contain and what types they are). This is necessary as a pre-requisite for the Settings Editor to display and modify these arg values.

## Detailed Description of the Pull Request / Additional comments
* The `IActionArgs` interface now has additional methods:
	* Get the number of args
	* Get/Set an arg at a specific index
	* Get the arg description of an arg at a specific index; the arg description contains:
		* name of the arg
		* type of the arg
		* whether the arg is required
		* a tag, this is to cover special cases (for example the ColorScheme argument is technically of type "string", but only allows specific values)
* All the macros in `ActionArgsMagic` have been updated to support the new interface
* `ActionMap` has been updated to support adding/editing/deleting actions and keybindings from outside the SettingsModel
	* It now also tracks for ID changes to commands and updates accordingly
* `Command` has been updated to allow setting its values from outside the SettingsModel
* EnumMappings have been added to various ActionArg enums that weren't there before

## Validation Steps Performed


## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
