### PR TITLE
Add arm64 build support using the build script

### DIFF
--- a/tools/OpenConsole.psm1
+++ b/tools/OpenConsole.psm1
@@ -83,6 +83,7 @@ function Set-MsbuildDevEnvironment
     switch ($env:PROCESSOR_ARCHITECTURE) {
         "amd64" { $arch = "x64" }
         "x86" { $arch = "x86" }
+        "arm64" { $arch = "arm64" }
         default { throw "Unknown architecture: $switch" }
     }
 


### PR DESCRIPTION
## Summary of the Pull Request
Enable build support for ARM64 in the build script
## References and Relevant Issues
NONE
## Detailed Description of the Pull Request / Additional comments
ARM64 is becoming more prevalent, and terminal should be the first tool we reach for on that platform as well. This pull request lights up build support on ARM64 in the build script. 
## Validation Steps Performed
it built successfully following the documentation on my Snapdragon Surface Laptop :)
## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
