### PR TITLE
Setting to set pane highlight active, inactive and broadcast color

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2008,6 +2008,24 @@
         }
       }
     },
+    "PaneTheme": {
+      "additionalProperties": false,
+      "description": "A set of properties for customizing the appearance of the panes",
+      "properties": {
+        "activeBorderColor": {
+          "description": "The color of the pane border when the pane is active",
+          "$ref": "#/$defs/ThemeColor"
+        },
+        "inactiveBorderColor": {
+          "description": "The color of the pane border when the pane is inactive",
+          "$ref": "#/$defs/ThemeColor"
+        },
+        "broadcastBorderColor": {
+          "description": "The color of the pane border when broadcasted",
+          "$ref": "#/$defs/ThemeColor"
+        }
+      }
+    },
     "WindowTheme": {
       "additionalProperties": false,
       "description": "A set of properties for customizing the appearance of the window itself",
@@ -2064,6 +2082,9 @@
         },
         "window": {
           "$ref": "#/$defs/WindowTheme"
+        },
+        "pane": {
+          "$ref": "#/$defs/PaneTheme"
         }
       }
     },

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -515,7 +515,9 @@ namespace winrt::TerminalApp::implementation
 
         void _updateThemeColors();
         void _updateAllTabCloseButtons();
-        void _updatePaneResources(const winrt::Windows::UI::Xaml::ElementTheme& requestedTheme);
+        winrt::Windows::UI::Color _colorFromKey(const winrt::Windows::UI::Xaml::ResourceDictionary& resourceDictionary, const winrt::Windows::UI::Xaml::ElementTheme& requestedTheme, const winrt::Windows::Foundation::IInspectable& colorKey);
+        winrt::Windows::UI::Color _parseThemeColorToColor(const winrt::Microsoft::Terminal::Settings::Model::ThemeColor& colorToCopy, const winrt::Windows::UI::Xaml::ResourceDictionary& resourceDictionary, const winrt::Windows::UI::Xaml::ElementTheme& requestedTheme, const winrt::Windows::Foundation::IInspectable& accentKey, const winrt::Windows::UI::Xaml::Media::Brush& backgroundBrush);
+        void _updatePaneResources(const winrt::Windows::UI::Xaml::ElementTheme& requestedTheme, const winrt::Microsoft::Terminal::Settings::Model::PaneTheme& paneTheme, const winrt::Windows::UI::Xaml::Media::Brush& backgroundBrush);
 
         safe_void_coroutine _ControlCompletionsChangedHandler(const winrt::Windows::Foundation::IInspectable sender, const winrt::Microsoft::Terminal::Control::CompletionsChangedEventArgs args);
 

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -147,7 +147,8 @@ Author(s):
     X(winrt::Microsoft::Terminal::Settings::Model::WindowTheme, Window, "window", nullptr)       \
     X(winrt::Microsoft::Terminal::Settings::Model::SettingsTheme, Settings, "settings", nullptr) \
     X(winrt::Microsoft::Terminal::Settings::Model::TabRowTheme, TabRow, "tabRow", nullptr)       \
-    X(winrt::Microsoft::Terminal::Settings::Model::TabTheme, Tab, "tab", nullptr)
+    X(winrt::Microsoft::Terminal::Settings::Model::TabTheme, Tab, "tab", nullptr)                \
+    X(winrt::Microsoft::Terminal::Settings::Model::PaneTheme, Pane, "pane", nullptr)
 
 #define MTSM_THEME_WINDOW_SETTINGS(X)                                                                                              \
     X(winrt::Windows::UI::Xaml::ElementTheme, RequestedTheme, "applicationTheme", winrt::Windows::UI::Xaml::ElementTheme::Default) \
@@ -162,6 +163,11 @@ Author(s):
 #define MTSM_THEME_TABROW_SETTINGS(X)                                                             \
     X(winrt::Microsoft::Terminal::Settings::Model::ThemeColor, Background, "background", nullptr) \
     X(winrt::Microsoft::Terminal::Settings::Model::ThemeColor, UnfocusedBackground, "unfocusedBackground", nullptr)
+
+#define MTSM_THEME_PANE_SETTINGS(X)                                                                                 \
+    X(winrt::Microsoft::Terminal::Settings::Model::ThemeColor, ActiveBorderColor, "activeBorderColor", nullptr)     \
+    X(winrt::Microsoft::Terminal::Settings::Model::ThemeColor, InactiveBorderColor, "inactiveBorderColor", nullptr) \
+    X(winrt::Microsoft::Terminal::Settings::Model::ThemeColor, BroadcastBorderColor, "broadcastBorderColor", nullptr)
 
 #define MTSM_THEME_TAB_SETTINGS(X)                                                                                                                     \
     X(winrt::Microsoft::Terminal::Settings::Model::ThemeColor, Background, "background", nullptr)                                                      \

--- a/src/cascadia/TerminalSettingsModel/Theme.cpp
+++ b/src/cascadia/TerminalSettingsModel/Theme.cpp
@@ -12,6 +12,7 @@
 #include "SettingsTheme.g.h"
 #include "ThemeColor.g.cpp"
 #include "WindowTheme.g.cpp"
+#include "PaneTheme.g.cpp"
 #include "TabRowTheme.g.cpp"
 #include "TabTheme.g.cpp"
 #include "ThemePair.g.cpp"
@@ -60,6 +61,7 @@ THEME_OBJECT(WindowTheme, MTSM_THEME_WINDOW_SETTINGS);
 THEME_OBJECT(SettingsTheme, MTSM_THEME_SETTINGS_SETTINGS);
 THEME_OBJECT(TabRowTheme, MTSM_THEME_TABROW_SETTINGS);
 THEME_OBJECT(TabTheme, MTSM_THEME_TAB_SETTINGS);
+THEME_OBJECT(PaneTheme, MTSM_THEME_PANE_SETTINGS);
 
 #undef THEME_SETTINGS_COPY
 #undef THEME_SETTINGS_TO_JSON
@@ -224,6 +226,7 @@ THEME_OBJECT_CONVERTER(winrt::Microsoft::Terminal::Settings::Model, WindowTheme,
 THEME_OBJECT_CONVERTER(winrt::Microsoft::Terminal::Settings::Model, SettingsTheme, MTSM_THEME_SETTINGS_SETTINGS);
 THEME_OBJECT_CONVERTER(winrt::Microsoft::Terminal::Settings::Model, TabRowTheme, MTSM_THEME_TABROW_SETTINGS);
 THEME_OBJECT_CONVERTER(winrt::Microsoft::Terminal::Settings::Model, TabTheme, MTSM_THEME_TAB_SETTINGS);
+THEME_OBJECT_CONVERTER(winrt::Microsoft::Terminal::Settings::Model, PaneTheme, MTSM_THEME_PANE_SETTINGS);
 
 #undef THEME_SETTINGS_FROM_JSON
 #undef THEME_SETTINGS_TO_JSON
@@ -253,6 +256,10 @@ winrt::com_ptr<Theme> Theme::Copy() const
     if (_Tab)
     {
         theme->_Tab = *winrt::get_self<implementation::TabTheme>(_Tab)->Copy();
+    }
+    if (_Pane)
+    {
+        theme->_Pane = *winrt::get_self<implementation::PaneTheme>(_Pane)->Copy();
     }
     if (_Settings)
     {
@@ -333,6 +340,13 @@ void Theme::LogSettingChanges(std::set<std::string>& changes, const std::string_
         const auto obj = _Tab;
         const auto outerJsonKey = outerTabJsonKey;
         MTSM_THEME_TAB_SETTINGS(LOG_IF_SET)
+    }
+
+    if (isPaneSet)
+    {
+        const auto obj = _Pane;
+        const auto outerJsonKey = outerPaneJsonKey;
+        MTSM_THEME_PANE_SETTINGS(LOG_IF_SET);
     }
 #undef LOG_IF_SET
 #undef GENERATE_SET_CHECK_AND_JSON_KEYS

--- a/src/cascadia/TerminalSettingsModel/Theme.h
+++ b/src/cascadia/TerminalSettingsModel/Theme.h
@@ -23,6 +23,7 @@ Author(s):
 #include "WindowTheme.g.h"
 #include "TabRowTheme.g.h"
 #include "TabTheme.g.h"
+#include "PaneTheme.g.h"
 #include "ThemePair.g.h"
 #include "Theme.g.h"
 
@@ -85,6 +86,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     THEME_OBJECT(SettingsTheme, MTSM_THEME_SETTINGS_SETTINGS);
     THEME_OBJECT(TabRowTheme, MTSM_THEME_TABROW_SETTINGS);
     THEME_OBJECT(TabTheme, MTSM_THEME_TAB_SETTINGS);
+    THEME_OBJECT(PaneTheme, MTSM_THEME_PANE_SETTINGS);
 
     struct Theme : ThemeT<Theme>
     {

--- a/src/cascadia/TerminalSettingsModel/Theme.idl
+++ b/src/cascadia/TerminalSettingsModel/Theme.idl
@@ -71,6 +71,12 @@ namespace Microsoft.Terminal.Settings.Model
         ThemeColor UnfocusedBackground { get; };
     }
 
+    runtimeclass PaneTheme {
+        ThemeColor ActiveBorderColor { get; };
+        ThemeColor InactiveBorderColor { get; };
+        ThemeColor BroadcastBorderColor { get; };
+    }
+
     runtimeclass TabTheme {
         ThemeColor Background { get; };
         ThemeColor UnfocusedBackground { get; };
@@ -92,6 +98,9 @@ namespace Microsoft.Terminal.Settings.Model
             
         // tabRow.* Namespace
         TabRowTheme TabRow { get; };
+
+        // pane.* Namespace
+        PaneTheme Pane { get; };
 
         // tab.* Namespace
         TabTheme Tab { get; };


### PR DESCRIPTION
## Summary of the Pull Request

This commit adds a new setting in which you can configure the active highlight color of panes as well as inactive and broadcast. This will only happen if configured otherwise uses the default as suggested by https://github.com/microsoft/terminal/issues/3061

## References and Relevant Issues

https://github.com/microsoft/terminal/issues/3061

## Detailed Description of the Pull Request / Additional comments

When modifying the settings you can now set pane key to have the following properties:
- "activeBorderColor"
- "inactiveBorderColor"
- "broadcastBorderColor"
This allows for more configuration of the windows terminal

## Validation Steps Performed

Built Locally, Ran Locally and configured a profile with the following theme:
```json
"themes": 
[
    {
        "name": "Under Construction",
        "tab": {
            "background": "#FFFF00FF",
            "iconStyle": "default",
            "showCloseButton": "always",
            "unfocusedBackground": "#88440088"
        },
        "tabRow": {
            "background": "#FF8800FF",
            "unfocusedBackground": "#202020FF"
        },
        "window": {
            "applicationTheme": "light",
            "experimental.rainbowFrame": false,
            "frame": null,
            "unfocusedFrame": null,
            "useMica": true
        },
        "pane": {
            "activeBorderColor": "#13A10E",
            "inactiveBorderColor": "#61D6D6"
        }
    }
]
```

## PR Checklist
- [x] Closes #3061
- [ ] Tests added/passed (None added, can't see how to unit test this but happy to add/dive deeper)
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [x] Schema updated (if necessary) -> I have modified to the best of my knowledge
