### PR TITLE
Back Button in Settings

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/MainPage.h
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.h
@@ -33,6 +33,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void SettingsNav_Loaded(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
         void SettingsNav_ItemInvoked(const Microsoft::UI::Xaml::Controls::NavigationView& sender, const Microsoft::UI::Xaml::Controls::NavigationViewItemInvokedEventArgs& args);
         void SaveButton_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
+        void BackButton_Click(winrt::Microsoft::UI::Xaml::Controls::NavigationView const& args, winrt::Microsoft::UI::Xaml::Controls::NavigationViewBackRequestedEventArgs const& sender);
         void ResetButton_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
         void BreadcrumbBar_ItemClicked(const Microsoft::UI::Xaml::Controls::BreadcrumbBar& sender, const Microsoft::UI::Xaml::Controls::BreadcrumbBarItemClickedEventArgs& args);
 
@@ -72,6 +73,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void _Navigate(const Editor::ExtensionPackageViewModel& extPkgVM, BreadcrumbSubPage subPage);
         void _NavigateToProfileHandler(const IInspectable& sender, winrt::guid profileGuid);
         void _NavigateToColorSchemeHandler(const IInspectable& sender, const IInspectable& args);
+        void _NavigatePreviousPageForBreadcrumb(const winrt::impl::com_ref<Breadcrumb>& breadcrumb);
+        void _OnNavigated(const IInspectable& sender, const Windows::UI::Xaml::Navigation::INavigationEventArgs& args);
 
         void _UpdateBackgroundForMica();
         void _MoveXamlParsedNavItemsIntoItemSource();

--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -66,7 +66,8 @@
 
     <muxc:NavigationView x:Name="SettingsNav"
                          Background="{ThemeResource SettingsPageBackground}"
-                         IsBackButtonVisible="Collapsed"
+                         BackRequested="BackButton_Click"
+                         IsBackButtonVisible="Visible"
                          IsSettingsVisible="False"
                          ItemInvoked="SettingsNav_ItemInvoked"
                          Loaded="SettingsNav_Loaded"


### PR DESCRIPTION
## Summary of the Pull Request

This PR makes it so that if you are in a 'nested' context e.g. Advanced Settings, a back button will appear, this is consistent with Windows UI (see Settings and go to a nested page and see in the top left a back button will appear).

## References and Relevant Issues

https://github.com/microsoft/terminal/issues/18658

## Detailed Description of the Pull Request / Additional comments

This is done by enabling the native back button in the navigation list IFF the breadcrumbs length is >1 (i.e nested context).

## Validation Steps Performed

- Built Locally & Tested Locally on nested pages

## PR Checklist
- [x] Closes #18658
- [ ] Tests added/passed (Need guidance as to if and where I need to add tests for this)
- [ ] Documentation updated (N/A?)
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary) (N/A?)
