### PR TITLE
Tweak spacing on about dialog

### DIFF
--- a/src/cascadia/TerminalApp/AboutDialog.xaml
+++ b/src/cascadia/TerminalApp/AboutDialog.xaml
@@ -29,8 +29,9 @@
 
         <StackPanel Orientation="Vertical">
             <StackPanel Padding="0,16,0,16"
-                        VerticalAlignment="Center" Spacing="8"
+                        VerticalAlignment="Center"
                         Orientation="Horizontal"
+                        Spacing="8"
                         Visibility="{x:Bind CheckingForUpdates, Mode=OneWay}">
                 <mux:ProgressRing Width="16"
                                   Height="16"
@@ -50,17 +51,18 @@
             </StackPanel>
         </StackPanel>
 
-        <StackPanel Margin="-12,0,0,0" Orientation="Vertical">
+        <StackPanel Margin="-12,0,0,0"
+                    Orientation="Vertical">
             <HyperlinkButton x:Uid="AboutDialog_SourceCodeLink"
-                  NavigateUri="https://go.microsoft.com/fwlink/?linkid=2203152" />
+                             NavigateUri="https://go.microsoft.com/fwlink/?linkid=2203152" />
             <HyperlinkButton x:Uid="AboutDialog_DocumentationLink"
-                  NavigateUri="https://go.microsoft.com/fwlink/?linkid=2125416" />
+                             NavigateUri="https://go.microsoft.com/fwlink/?linkid=2125416" />
             <HyperlinkButton x:Uid="AboutDialog_ReleaseNotesLink"
-                  NavigateUri="https://go.microsoft.com/fwlink/?linkid=2125417" />
+                             NavigateUri="https://go.microsoft.com/fwlink/?linkid=2125417" />
             <HyperlinkButton x:Uid="AboutDialog_PrivacyPolicyLink"
-                  NavigateUri="https://go.microsoft.com/fwlink/?linkid=2125418" />
+                             NavigateUri="https://go.microsoft.com/fwlink/?linkid=2125418" />
             <HyperlinkButton x:Uid="AboutDialog_ThirdPartyNoticesLink"
-                  Click="_ThirdPartyNoticesOnClick" />
-        </StackPanel>       
+                             Click="_ThirdPartyNoticesOnClick" />
+        </StackPanel>
     </StackPanel>
 </ContentDialog>


### PR DESCRIPTION
## Summary of the Pull Request
Some minor styling tweaks to the about page.

- Tweaking the spacing of the version-checking / update available text.
- Wrapping the hyperlinkbuttons in a StackPanel so it's easier to set a negative margin so they are visually aligned with the version / title text.

Before:
![image](https://github.com/user-attachments/assets/8ee6ef34-c214-4540-ac3e-94e7d9fcf379)

After:
![image](https://github.com/user-attachments/assets/f952edc8-6338-420e-9775-136f9ef54181)


## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

## PR Checklist
- [x] Closes #18994 
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
