### PR TITLE
build: try even harder to find a working VC tools version

### DIFF
--- a/build/scripts/Set-LatestVCToolsVersion.ps1
+++ b/build/scripts/Set-LatestVCToolsVersion.ps1
@@ -1,7 +1,23 @@
 $VSInstances = ([xml](& 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -include packages -format xml))
 $VSPackages = $VSInstances.instances.instance.packages.package
-$LatestVCPackage = ($VSInstances.instances.instance.packages.package | ? { $_.id -eq "Microsoft.VisualCpp.Tools.Core" })
+$LatestVCPackage = ($VSPackages | ? { $_.id -eq "Microsoft.VisualCpp.Tools.Core" })
 $LatestVCToolsVersion = $LatestVCPackage.version;
+
+$VSRoot = (& 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property 'resolvedInstallationPath')
+$VCToolsRoot = Join-Path $VSRoot "VC\Tools\MSVC"
+
+$PackageVCToolPath = Join-Path $VCToolsRoot $LatestVCToolsVersion
+If ($Null -Eq (Get-Item $PackageVCToolPath -ErrorAction:Ignore)) {
+    $VCToolsVersions = Get-ChildItem $VCToolsRoot | ForEach-Object {
+        [Version]$_.Name
+    } | Sort -Descending
+    $LatestActualVCToolsVersion = $VCToolsVersions | Select -First 1
+
+    If ([Version]$LatestVCToolsVersion -Ne $LatestActualVCToolsVersion) {
+        Write-Output "VC Tools Mismatch: Directory = $LatestActualVCToolsVersion, Package = $LatestVCToolsVersion"
+        $LatestVCToolsVersion = $LatestActualVCToolsVersion.ToString(3)
+    }
+}
 
 Write-Output "Latest VCToolsVersion: $LatestVCToolsVersion"
 Write-Output "Updating VCToolsVersion environment variable for job"


### PR DESCRIPTION
I can't explain this, but VS 17.14 ships with VisualCpp.Tools.Core version 14.44.35208 but the files say 14.44.35207.