### PR TITLE
Enable terminal chat message copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -286,3 +286,4 @@ profiles.json
 
 # MSBuildCache
 /MSBuildCacheLogs/
+enc_temp_folder/

--- a/src/cascadia/QueryExtension/ExtensionPalette.cpp
+++ b/src/cascadia/QueryExtension/ExtensionPalette.cpp
@@ -460,9 +460,7 @@ namespace winrt::Microsoft::Terminal::Query::Extension::implementation
         _richBlock = Microsoft::Terminal::UI::Markdown::Builder::Convert(_messageContent, L"");
         _richBlock.IsTextSelectionEnabled(true);
         _richBlock.ContextMenuOpening([this](const Windows::Foundation::IInspectable& /*sender*/, const Windows::UI::Xaml::Controls::ContextMenuEventArgs& e) {
-            // If the context menu is opening, we want to show the copy option
-            // and select all option if the message is not a query.
-
+            // If the context menu is opening we want to show our custom copy option
             MenuFlyout menuFlyout;
             Windows::UI::Xaml::Controls::FontIcon copyIcon;
             copyIcon.Glyph(L"\uE8C8"); // Copy icon

--- a/src/cascadia/QueryExtension/ExtensionPalette.cpp
+++ b/src/cascadia/QueryExtension/ExtensionPalette.cpp
@@ -35,7 +35,7 @@ namespace winrt::Microsoft::Terminal::Query::Extension::implementation
     ExtensionPalette::ExtensionPalette()
     {
         InitializeComponent();
-        
+
         _clearAndInitializeMessages(nullptr, nullptr);
         ControlName(RS_(L"ControlName"));
         QueryBoxPlaceholderText(RS_(L"CurrentShell"));
@@ -301,7 +301,6 @@ namespace winrt::Microsoft::Terminal::Query::Extension::implementation
         }
     }
 
-
     // Method Description:
     // - This event is triggered when someone clicks anywhere in the bounds of
     //   the window that's _not_ the query palette UI. When that happens,
@@ -313,7 +312,6 @@ namespace winrt::Microsoft::Terminal::Query::Extension::implementation
     void ExtensionPalette::_rootPointerPressed(const Windows::Foundation::IInspectable& /*sender*/,
                                                const Windows::UI::Xaml::Input::PointerRoutedEventArgs& /*e*/)
     {
-        
         if (Visibility() != Visibility::Collapsed)
         {
             _close();
@@ -343,9 +341,8 @@ namespace winrt::Microsoft::Terminal::Query::Extension::implementation
     void ExtensionPalette::_lostFocusHandler(const Windows::Foundation::IInspectable& /*sender*/,
                                              const Windows::UI::Xaml::RoutedEventArgs& /*args*/)
     {
-
         const auto focusedElement = Input::FocusManager::GetFocusedElement(this->XamlRoot());
-        if(focusedElement && (focusedElement.try_as<RichTextBlock>() || focusedElement.try_as<MenuFlyoutPresenter>() || focusedElement.try_as<Popup>()))
+        if (focusedElement && (focusedElement.try_as<RichTextBlock>() || focusedElement.try_as<MenuFlyoutPresenter>() || focusedElement.try_as<Popup>()))
         {
             // The context menu for the message don't seem to be found when the the VisualTreeHelper walks the visual tree. So we check here
             // if one of the focused elements is a message or a context menu of one of those messages and return early to support
@@ -460,7 +457,7 @@ namespace winrt::Microsoft::Terminal::Query::Extension::implementation
     {
         _richBlock = Microsoft::Terminal::UI::Markdown::Builder::Convert(_messageContent, L"");
         _richBlock.IsTextSelectionEnabled(true);
-        _richBlock.ContextRequested({this, &ChatMessage::_chatMessageCopyRequested});
+        _richBlock.ContextRequested({ this, &ChatMessage::_chatMessageCopyRequested });
         _richBlock.AllowFocusWhenDisabled(true);
         _richBlock.AllowFocusOnInteraction(true);
         const auto resources = Application::Current().Resources();
@@ -502,7 +499,6 @@ namespace winrt::Microsoft::Terminal::Query::Extension::implementation
         }
     }
 
-
     // Method Description:
     // - Handle the ContextFlyoutRequested Event
     //   * Should be handled according to the documentation
@@ -511,7 +507,7 @@ namespace winrt::Microsoft::Terminal::Query::Extension::implementation
     // Return Value:
     // - <none>
     void ChatMessage::_chatMessageCopyRequested(const Windows::Foundation::IInspectable& /*sender*/,
-                                                     const Windows::UI::Xaml::Input::ContextRequestedEventArgs& e)
+                                                const Windows::UI::Xaml::Input::ContextRequestedEventArgs& e)
     {
         e.Handled(true);
     }

--- a/src/cascadia/QueryExtension/ExtensionPalette.cpp
+++ b/src/cascadia/QueryExtension/ExtensionPalette.cpp
@@ -346,7 +346,7 @@ namespace winrt::Microsoft::Terminal::Query::Extension::implementation
         const auto focusedElement = Input::FocusManager::GetFocusedElement(this->XamlRoot());
         if (focusedElement && (focusedElement.try_as<RichTextBlock>() || focusedElement.try_as<MenuFlyoutPresenter>() || focusedElement.try_as<Popup>()))
         {
-            // The context menu for the message don't seem to be found when the VisualTreeHelper walks the visual tree. So we check here
+            // The context menu for the message doesn't seem to be found when the VisualTreeHelper walks the visual tree. So we check here
             // if one of the focused elements is a message or a context menu of one of those messages and return early to support
             // copy and select all using a mouse
             return;
@@ -422,7 +422,10 @@ namespace winrt::Microsoft::Terminal::Query::Extension::implementation
                 const auto textBlock = focusedElement.as<RichTextBlock>();
                 textBlock.CopySelectionToClipboard();
             }
-            _queryBox().CopySelectionToClipboard();
+            else
+            {
+                _queryBox().CopySelectionToClipboard();
+            }
             e.Handled(true);
         }
         else if (key == VirtualKey::V && ctrlDown)
@@ -458,37 +461,6 @@ namespace winrt::Microsoft::Terminal::Query::Extension::implementation
         _richBlock{ nullptr }
     {
         _richBlock = Microsoft::Terminal::UI::Markdown::Builder::Convert(_messageContent, L"");
-        _richBlock.IsTextSelectionEnabled(true);
-        _richBlock.ContextMenuOpening([this](const Windows::Foundation::IInspectable& /*sender*/, const Windows::UI::Xaml::Controls::ContextMenuEventArgs& e) {
-            // If the context menu is opening we want to show our custom copy option
-            MenuFlyout menuFlyout;
-            Windows::UI::Xaml::Controls::FontIcon copyIcon;
-            copyIcon.Glyph(L"\uE8C8"); // Copy icon
-
-            auto copyItem = MenuFlyoutItem();
-            copyItem.Text(RS_(L"CopyMessage"));
-            copyItem.Icon(copyIcon);
-            copyItem.Click([this](auto&, auto&) {
-                const auto messageContent = this->MessageContent();
-
-                if (!messageContent.empty())
-                {
-                    // Create a DataPackage and set the content to the message content
-                    Windows::ApplicationModel::DataTransfer::DataPackage package{};
-                    package.SetText(messageContent);
-                    Windows::ApplicationModel::DataTransfer::Clipboard::SetContent(package);
-                }
-            });
-            menuFlyout.Items().Append(copyItem);
-
-            menuFlyout.ShouldConstrainToRootBounds(true);
-            menuFlyout.Placement(Windows::UI::Xaml::Controls::Primitives::FlyoutPlacementMode::BottomEdgeAlignedRight);
-            menuFlyout.ShowAt(_richBlock);
-            e.Handled(true);
-        });
-        _richBlock.AllowFocusWhenDisabled(true);
-        _richBlock.AllowFocusOnInteraction(true);
-
         const auto resources = Application::Current().Resources();
         const auto textBrushObj = _isQuery ? resources.Lookup(box_value(L"TextOnAccentFillColorPrimaryBrush")) : resources.Lookup(box_value(L"TextFillColorPrimaryBrush"));
         if (const auto textBrush = textBrushObj.try_as<Windows::UI::Xaml::Media::SolidColorBrush>())

--- a/src/cascadia/QueryExtension/ExtensionPalette.cpp
+++ b/src/cascadia/QueryExtension/ExtensionPalette.cpp
@@ -344,9 +344,9 @@ namespace winrt::Microsoft::Terminal::Query::Extension::implementation
         const auto focusedElement = Input::FocusManager::GetFocusedElement(this->XamlRoot());
         if (focusedElement && (focusedElement.try_as<RichTextBlock>() || focusedElement.try_as<MenuFlyoutPresenter>() || focusedElement.try_as<Popup>()))
         {
-            // The context menu for the message don't seem to be found when the the VisualTreeHelper walks the visual tree. So we check here
+            // The context menu for the message don't seem to be found when the VisualTreeHelper walks the visual tree. So we check here
             // if one of the focused elements is a message or a context menu of one of those messages and return early to support
-            // copy/select all using a mouse
+            // copy and select all using a mouse
             return;
         }
         const auto flyout = _queryBox().ContextFlyout();

--- a/src/cascadia/QueryExtension/ExtensionPalette.h
+++ b/src/cascadia/QueryExtension/ExtensionPalette.h
@@ -69,7 +69,6 @@ namespace winrt::Microsoft::Terminal::Query::Extension::implementation
         void _chatMessageCopyRequested(const Windows::Foundation::IInspectable& /*sender*/,
                                        const Windows::UI::Xaml::Input::ContextRequestedEventArgs& e);
 
-
         TYPED_EVENT(RunCommandClicked, winrt::Microsoft::Terminal::Query::Extension::ChatMessage, winrt::hstring);
 
     private:

--- a/src/cascadia/QueryExtension/ExtensionPalette.h
+++ b/src/cascadia/QueryExtension/ExtensionPalette.h
@@ -56,7 +56,6 @@ namespace winrt::Microsoft::Terminal::Query::Extension::implementation
         void _previewKeyDownHandler(const Windows::Foundation::IInspectable& sender,
                                     const Windows::UI::Xaml::Input::KeyRoutedEventArgs& e);
         void _setUpAIProviderInSettings(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
-
         void _close();
     };
 
@@ -67,6 +66,9 @@ namespace winrt::Microsoft::Terminal::Query::Extension::implementation
         bool IsQuery() const { return _isQuery; };
         winrt::hstring MessageContent() const { return _messageContent; };
         winrt::Windows::UI::Xaml::Controls::RichTextBlock RichBlock() const { return _richBlock; };
+        void _chatMessageCopyRequested(const Windows::Foundation::IInspectable& /*sender*/,
+                                       const Windows::UI::Xaml::Input::ContextRequestedEventArgs& e);
+
 
         TYPED_EVENT(RunCommandClicked, winrt::Microsoft::Terminal::Query::Extension::ChatMessage, winrt::hstring);
 

--- a/src/cascadia/QueryExtension/ExtensionPalette.h
+++ b/src/cascadia/QueryExtension/ExtensionPalette.h
@@ -66,9 +66,6 @@ namespace winrt::Microsoft::Terminal::Query::Extension::implementation
         bool IsQuery() const { return _isQuery; };
         winrt::hstring MessageContent() const { return _messageContent; };
         winrt::Windows::UI::Xaml::Controls::RichTextBlock RichBlock() const { return _richBlock; };
-        void _chatMessageCopyRequested(const Windows::Foundation::IInspectable& /*sender*/,
-                                       const Windows::UI::Xaml::Input::ContextRequestedEventArgs& e);
-
         TYPED_EVENT(RunCommandClicked, winrt::Microsoft::Terminal::Query::Extension::ChatMessage, winrt::hstring);
 
     private:

--- a/src/cascadia/QueryExtension/ExtensionPalette.xaml
+++ b/src/cascadia/QueryExtension/ExtensionPalette.xaml
@@ -320,7 +320,7 @@
                                 <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                                 <Setter Property="ContextFlyout">
                                     <Setter.Value>
-                                        <mtu:TextMenuFlyout x:Name="test" />
+                                        <mtu:TextMenuFlyout  />
                                     </Setter.Value>
                                 </Setter>
                             </Style>

--- a/src/cascadia/QueryExtension/ExtensionPalette.xaml
+++ b/src/cascadia/QueryExtension/ExtensionPalette.xaml
@@ -318,6 +318,11 @@
                         <ListView.ItemContainerStyle>
                             <Style TargetType="ListViewItem">
                                 <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                                <Setter Property="ContextFlyout">
+                                    <Setter.Value>
+                                        <mtu:TextMenuFlyout x:Name="test" />
+                                    </Setter.Value>
+                                </Setter>
                             </Style>
                         </ListView.ItemContainerStyle>
                     </ListView>

--- a/src/cascadia/QueryExtension/ExtensionPalette.xaml
+++ b/src/cascadia/QueryExtension/ExtensionPalette.xaml
@@ -320,7 +320,7 @@
                                 <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                                 <Setter Property="ContextFlyout">
                                     <Setter.Value>
-                                        <mtu:TextMenuFlyout  />
+                                        <mtu:TextMenuFlyout />
                                     </Setter.Value>
                                 </Setter>
                             </Style>

--- a/src/cascadia/QueryExtension/Resources/en-US/Resources.resw
+++ b/src/cascadia/QueryExtension/Resources/en-US/Resources.resw
@@ -197,8 +197,4 @@
     <value>GitHub Copilot</value>
     <comment>The metadata string to display whenever a response is received from the GitHub Copilot service provider</comment>
   </data>
-  <data name="CopyMessage" xml:space="preserve">
-    <value>Copy Message</value>
-    <comment>Copy terminal chat message</comment>
-  </data>
 </root>

--- a/src/cascadia/QueryExtension/Resources/en-US/Resources.resw
+++ b/src/cascadia/QueryExtension/Resources/en-US/Resources.resw
@@ -197,4 +197,8 @@
     <value>GitHub Copilot</value>
     <comment>The metadata string to display whenever a response is received from the GitHub Copilot service provider</comment>
   </data>
+  <data name="CopyMessage" xml:space="preserve">
+    <value>Copy Message</value>
+    <comment>Copy terminal chat message</comment>
+  </data>
 </root>


### PR DESCRIPTION
## Summary of the Pull Request
This pull request enables copying terminal chat messages from AI Suggesstions.
## References and Relevant Issues
#17941 
## Detailed Description of the Pull Request / Additional comments
Enables both keyboard copy with ctrl+c and mouse copy with a context menu.
## Validation Steps Performed
This was tested locally on my machine. Both functions verified to work.
## PR Checklist
- [ ] Closes #17941 
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
