### PR TITLE
Fix crash when closing multiple panes simultaneously

### DIFF
--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -1402,6 +1402,13 @@ void Pane::_CloseChild(const bool closeFirst)
 
         // take the control, profile, id and isDefTermSession of the pane that _wasn't_ closed.
         _setPaneContent(remainingChild->_takePaneContent());
+        if (!_content)
+        {
+            // GH#18071: our content is still null after taking the other pane's content,
+            //           so just notify our parent that we're closed.
+            Closed.raise(nullptr, nullptr);
+            return;
+        }
         _id = remainingChild->Id();
 
         // Revoke the old event handlers. Remove both the handlers for the panes


### PR DESCRIPTION
## Summary of the Pull Request
Fixes a crash when multiple panes were closed simultaneously (i.e. using broadcast input).

The root cause of this crash was that we would get a null pointer exception when trying to access a member/function off of a null `_content`. This is because `Pane::_CloseChild()` would always pass over the content from the non-closed pane and attempt to hook everything up to it.

The fix was to operate similarly to `Pane::Close()` and raise a `Closed` event and return early. Since there's no alternative content to attach to, might as well just close the entire pane. This propagates up the stack of listeners to update the UI appropriately and close the parent pane and eventually the entire tab, if necessary.
 
Closes #18071
Closes #17432

## Validation Steps Performed
1. Open 2 panes
2. Use broadcast input to send "exit" to both panes
3. ✅ Terminal doesn't crash and the tab closes gracefully

