### PR TITLE
Manually focus panes after swapping them

### DIFF
--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -697,12 +697,24 @@ bool Pane::SwapPanes(std::shared_ptr<Pane> first, std::shared_ptr<Pane> second)
         // Refocus the last pane if there was a pane focused
         if (const auto focus = first->GetActivePane())
         {
-            focus->_Focus();
+            // GH#18184: manually focus the pane and content.
+            //           _Focus() results in no-op because the pane was _lastActive
+            focus->GotFocus.raise(focus, FocusState::Programmatic);
+            if (const auto& lastContent{ focus->GetLastFocusedContent() })
+            {
+                lastContent.Focus(FocusState::Programmatic);
+            }
         }
 
         if (const auto focus = second->GetActivePane())
         {
-            focus->_Focus();
+            // GH#18184: manually focus the pane and content.
+            //           _Focus() results in no-op because the pane was _lastActive
+            focus->GotFocus.raise(focus, FocusState::Programmatic);
+            if (const auto& lastContent{ focus->GetLastFocusedContent() })
+            {
+                lastContent.Focus(FocusState::Programmatic);
+            }
         }
 
         return true;


### PR DESCRIPTION
## Summary of the Pull Request
Fixes a bug where the swap panes action would result in no content being focused!

The root cause of this bug was that in `Pane::SwapPanes()`, we would do the following:
```
if (const auto focus = first->GetActivePane())
   focus->_Focus();
```
However, `_Focus` would exit early if the pane was `_lastActive`, which was always the case because `GetActivePane()` would retrieve the `_lastActive` pane!

To fix this, we just manually focus the pane and its content.

Closes #18184

## Validation Steps Performed
1. Split pane (type content in them to more easily differentiate them)
2. Swap panes
3. ✅ Focus is on the same pane content as before (which should now be in a different position)