### PR TITLE
Small enhancements for VS profile generation

### DIFF
--- a/src/cascadia/TerminalSettingsModel/VsDevCmdGenerator.cpp
+++ b/src/cascadia/TerminalSettingsModel/VsDevCmdGenerator.cpp
@@ -46,14 +46,14 @@ std::wstring VsDevCmdGenerator::GetProfileCommandLine(const VsSetupConfiguration
     // setting the shell path so the path in the profile will be used instead.
 #if defined(_M_ARM64)
     commandLine.append(LR"(" -startdir=none -arch=arm64 -host_arch=)");
-	if (instance.VersionInRange(L"[17.4,"))
-	{
+    if (instance.VersionInRange(L"[17.4,"))
+    {
         commandLine.append(LR"(arm64)");
-	}
-	else
-	{
+    }
+    else
+    {
         commandLine.append(LR"(x64)");
-	}
+    }
 #elif defined(_M_AMD64)
     commandLine.append(LR"(" -startdir=none -arch=x64 -host_arch=x64)");
 #else

--- a/src/cascadia/TerminalSettingsModel/VsDevShellGenerator.cpp
+++ b/src/cascadia/TerminalSettingsModel/VsDevShellGenerator.cpp
@@ -57,7 +57,6 @@ std::wstring VsDevShellGenerator::GetProfileCommandLine(const VsSetupConfigurati
         commandLine.append(L"powershell.exe");
     }
 
-
     // The triple-quotes are a PowerShell path escape sequence that can safely be stored in a JSON object.
     // The "SkipAutomaticLocation" parameter will prevent "Enter-VsDevShell" from automatically setting the shell path
     // so the path in the profile will be used instead


### PR DESCRIPTION
## Summary of the Pull Request

* Make PowerShell profile generation try to find `pwsh.exe` before falling back to legacy powershell
* Make profiles generated on an `arm64` host work properly

## Validation Steps Performed

* Local build ran
* Verified the new `arm64` profile works
* Verified `pwsh.exe` is used if present
* Verified `powershell.exe` is used if `pwsh` is not present in path
* Verified we don't attempt to create `arm64` host cmd/pwsh profiles if VS is not >= 17.4 (thanks @DHowett)
