### PR TITLE
Ensure items is not null before checking its size so we dont crash

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -3180,7 +3180,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             }
             CATCH_LOG();
 
-            if (items.Size() > 0)
+            if (items && items.Size() > 0)
             {
                 std::vector<std::wstring> fullPaths;
 


### PR DESCRIPTION
## Summary of the Pull Request
Prevents a crash when no storage items are returned from a dropped path.
## References and Relevant Issues
#19015 
## Detailed Description of the Pull Request / Additional comments
Prevents a crash when no storage items are returned from a dropped path.
## Validation Steps Performed
Terminal no longer crashes when a relative path is dropped is dragged and dropped into the tool.
## PR Checklist
- [ #19015 ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
