### PR TITLE
Fix mutable default argument in `vttests/common.py::sgr_n`

### DIFF
--- a/src/tools/vttests/common.py
+++ b/src/tools/vttests/common.py
@@ -59,7 +59,18 @@ def clear_all():
 def sgr(code=0):
     csi('{}m'.format(code))
 
-def sgr_n(seq=[]):
+def sgr_n(seq=None):
+    """Apply multiple SGR (Select Graphic Rendition) parameters.
+
+    Parameters
+    ----------
+    seq : Iterable of int | None
+        Sequence of numeric SGR codes to emit. If ``None`` (default) an empty
+        sequence is assumed. A mutable default argument must be avoided to
+        prevent unwanted state sharing between calls.
+    """
+    if seq is None:
+        seq = []
     csi('{}m'.format(';'.join(str(code) for code in seq)))
 
 def tbc():


### PR DESCRIPTION
## Overview
[sgr_n](cci:1://file:///d:/Github/terminal/src/tools/vttests/common.py:61:0-73:58) previously used a mutable list (`seq=[]`) as its default parameter.  
In Python, default arguments are instantiated once at function‐definition time and then shared across all calls.  
If any caller mutated that list (e.g., `seq.append(...)`), later invocations would inherit the mutated state, producing unpredictable or corrupted VT-test sequences.

## What’s fixed
* Replaced the default with `seq=None` and create a new list when `None` is passed.  
* Added a clear docstring detailing the function and the rationale for the change.

## Why it matters
* Prevents hidden state leakage between test cases, ensuring reproducible VT escape-sequence output.  
* Guards against subtle bugs that could invalidate rendering tests or complicate debugging.

## Impact
No behavior change for existing callers that pass an explicit sequence.  
All internal tools and CI VT tests now operate with guaranteed clean state on each call to [sgr_n](cci:1://file:///d:/Github/terminal/src/tools/vttests/common.py:61:0-73:58).