### PR TITLE
Enable Copy As Path/Paste with Path Translation in *nix profiles

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -1443,11 +1443,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         using namespace ::Microsoft::Console::Utils;
 
         auto filtered = FilterStringForPaste(hstr, CarriageReturnNewline | ControlCodes);
-        std::filesystem::path path{ filtered };
-
-        if (!path.empty() && _settings->PathTranslationStyle() != PathTranslationStyle::None)
+        if (!filtered.empty() && _settings->PathTranslationStyle() != PathTranslationStyle::None)
         {
-            filtered = path.wstring();
             // Explorer puts paths wrapped in double quotes on the clipboard. The translation routine expects it to be without quotes.
             if (!filtered.empty() && filtered.front() == '\"')
             {

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -20,6 +20,8 @@
 #include "../../renderer/uia/UiaRenderer.hpp"
 #include "../../types/inc/CodepointWidthDetector.hpp"
 
+#include "TermControl.h"
+
 #include "ControlCore.g.cpp"
 #include "SelectionColor.g.cpp"
 
@@ -1441,6 +1443,24 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         using namespace ::Microsoft::Console::Utils;
 
         auto filtered = FilterStringForPaste(hstr, CarriageReturnNewline | ControlCodes);
+        std::filesystem::path path{ filtered };
+
+        if (!path.empty() && _settings->PathTranslationStyle() != PathTranslationStyle::None)
+        {
+            filtered = path.wstring();
+            // Explorer puts paths wrapped in double quotes on the clipboard. The translation routine expects it to be without quotes.
+            if (!filtered.empty() && filtered.front() == '\"')
+            {
+                filtered.erase(0, 1);
+            }
+            if (!filtered.empty() && filtered.back() == '\"')
+            {
+                filtered.pop_back();
+            }
+
+            TermControl::_translatePathInPlace(filtered, _settings->PathTranslationStyle());
+        }
+
         if (BracketedPasteEnabled())
         {
             filtered.insert(0, L"\x1b[200~");

--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -449,6 +449,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         friend class ControlUnitTests::ControlCoreTests;
         friend class ControlUnitTests::ControlInteractivityTests;
+
         bool _inUnitTests{ false };
     };
 }

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -90,7 +90,7 @@ static Microsoft::Console::TSF::Handle& GetTSFHandle()
 
 namespace winrt::Microsoft::Terminal::Control::implementation
 {
-    static void _translatePathInPlace(std::wstring& fullPath, PathTranslationStyle translationStyle)
+    void TermControl::_translatePathInPlace(std::wstring& fullPath, PathTranslationStyle translationStyle)
     {
         static constexpr wil::zwstring_view s_pathPrefixes[] = {
             {},

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -59,6 +59,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         uint64_t ContentId() const;
 
         hstring GetProfileName() const;
+        static void _translatePathInPlace(std::wstring& fullPath, PathTranslationStyle translationStyle);
 
         bool CopySelectionToClipboard(bool dismissSelection, bool singleLine, bool withControlSequences, const Windows::Foundation::IReference<CopyFormat>& formats);
         void PasteTextFromClipboard();


### PR DESCRIPTION
## Summary of the Pull Request
Copy as Path / Paste with PathTranslation for *nix profiles in Terminal.
## References and Relevant Issues
#18544 
## Detailed Description of the Pull Request / Additional comments
Path translation for drag and drop is already a thing. This pull request takes it one step further and enables Copy As Path on a file/directory and then pasting in terminal. If the profile has a PathTranslationStyle configured the path will be translated before paste.

## Validation Steps Performed
This was validated to work on my machine.
## PR Checklist
- [#18544 ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
