### PR TITLE
Center text of default launch terminal

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Launch.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Launch.xaml
@@ -117,7 +117,8 @@
                                            Grid.Column="1"
                                            Grid.ColumnSpan="2"
                                            AutomationProperties.AccessibilityView="Raw"
-                                           Text="{x:Bind Name}" />
+                                           Text="{x:Bind Name}"
+                                           VerticalAlignment="Center" />
 
                                 <TextBlock Grid.Row="1"
                                            Grid.Column="1"


### PR DESCRIPTION
## Summary of the Pull Request
A small ui fix to center the default terminal application ComboBox.

## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments
Original:
![fb13746cc0928fc0b792551ea2873d1d](https://github.com/user-attachments/assets/a910f834-527f-4b31-b77b-86f5c562e52d)

After:
![121692bfa2792098075a15b5d33bb59a](https://github.com/user-attachments/assets/ab08f799-5169-4fdc-a7f1-75cc8e5f9d78)


**The red border are just for reference**

## Validation Steps Performed

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
