### PR TITLE
OutputDebugString Added

### DIFF
--- a/scratch/ScratchIslandApp/SampleApp/init.cpp
+++ b/scratch/ScratchIslandApp/SampleApp/init.cpp
@@ -2,12 +2,29 @@
 // Licensed under the MIT license.
 
 #include "pch.h"
-#include <LibraryResources.h>
-#include <WilErrorReporting.h>
 
-BOOL WINAPI DllMain(HINSTANCE /*hInstDll*/, DWORD /*reason*/, LPVOID /*reserved*/)
+#include <LibraryResources.h>
+#include <WilErrorReporting.h> // Needed for OutputDebugString
+
+BOOL WINAPI DllMain(HINSTANCE hInstDll, DWORD reason, LPVOID reserved)
 {
+    switch (reason)
+    {
+        case DLL_PROCESS_ATTACH:
+            OutputDebugString(L"DLL loaded (PROCESS_ATTACH)\n");
+            break;
+        case DLL_PROCESS_DETACH:
+            OutputDebugString(L"DLL unloaded (PROCESS_DETACH)\n");
+            break;
+        case DLL_THREAD_ATTACH:
+            OutputDebugString(L"Thread created (THREAD_ATTACH)\n");
+            break;
+        case DLL_THREAD_DETACH:
+            OutputDebugString(L"Thread destroyed (THREAD_DETACH)\n");
+            break;
+    }
     return TRUE;
 }
+
 
 UTILS_DEFINE_LIBRARY_RESOURCE_SCOPE(L"SampleApp/Resources")


### PR DESCRIPTION
## Summary of the Pull Request
OutputDebugString is added in init.cpp
## References and Relevant Issues
In the file Since, DllMain returns TRUE unconditionally and ignores the reason, initialization failures may go undetected. 
## Detailed Description of the Pull Request / Additional comments
Added logging or conditionally handle reason for checking all the possible Reason and minimizing the risk of failures.
## Validation Steps Performed
This switch block doesn't validate input values explicitly, but it validates program execution flow by tracking which DllMain event occurs.


Validation Goal                                        ||                How This Code Helps

Confirm DLL is loaded correctly               |                  "DLL loaded (PROCESS_ATTACH)" is logged
Confirm DLL is unloaded correctly           |             "DLL unloaded (PROCESS_DETACH)" is logged
Debug thread-level loading/unloading   |               Thread attach/detach messages will appear
Validate lifecycle flow of DLL                   |                 You see the exact sequence of OS interactions

## PR Checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [x] Schema updated (if necessary)




