### PR TITLE
Dark and Light Profile Icons

### DIFF
--- a/src/cascadia/TerminalApp/IPaneContent.idl
+++ b/src/cascadia/TerminalApp/IPaneContent.idl
@@ -36,6 +36,7 @@ namespace TerminalApp
 
         void Focus(Windows.UI.Xaml.FocusState reason);
 
+        void IconRefresh();
         void Close();
 
         event Windows.Foundation.TypedEventHandler<IPaneContent, Object> CloseRequested;

--- a/src/cascadia/TerminalApp/MarkdownPaneContent.cpp
+++ b/src/cascadia/TerminalApp/MarkdownPaneContent.cpp
@@ -183,6 +183,11 @@ namespace winrt::TerminalApp::implementation
         return *this;
     }
 
+    // Does nothing as Icon doesn't need to be refreshed for MarkdownPaneContent
+    void MarkdownPaneContent::IconRefresh() noexcept
+    {
+    }
+
     void MarkdownPaneContent::Close()
     {
         CloseRequested.raise(*this, nullptr);

--- a/src/cascadia/TerminalApp/MarkdownPaneContent.h
+++ b/src/cascadia/TerminalApp/MarkdownPaneContent.h
@@ -37,6 +37,7 @@ namespace winrt::TerminalApp::implementation
         uint64_t TaskbarProgress() { return 0; }
         bool ReadOnly() { return false; }
         winrt::hstring Icon() const;
+        void IconRefresh() noexcept;
         Windows::Foundation::IReference<winrt::Windows::UI::Color> TabColor() const noexcept { return nullptr; }
         winrt::Windows::UI::Xaml::Media::Brush BackgroundBrush() { return Background(); }
 

--- a/src/cascadia/TerminalApp/ScratchpadContent.cpp
+++ b/src/cascadia/TerminalApp/ScratchpadContent.cpp
@@ -53,6 +53,11 @@ namespace winrt::TerminalApp::implementation
         return BaseContentArgs(L"scratchpad");
     }
 
+    // No refresh has to occur for ScratchpadContent so no implementation
+    void ScratchpadContent::IconRefresh() noexcept
+    {
+    }
+
     winrt::hstring ScratchpadContent::Icon() const
     {
         static constexpr std::wstring_view glyph{ L"\xe70b" }; // QuickNote

--- a/src/cascadia/TerminalApp/ScratchpadContent.h
+++ b/src/cascadia/TerminalApp/ScratchpadContent.h
@@ -27,6 +27,7 @@ namespace winrt::TerminalApp::implementation
         uint64_t TaskbarProgress() { return 0; }
         bool ReadOnly() { return false; }
         winrt::hstring Icon() const;
+        void IconRefresh() noexcept;
         Windows::Foundation::IReference<winrt::Windows::UI::Color> TabColor() const noexcept { return nullptr; }
         winrt::Windows::UI::Xaml::Media::Brush BackgroundBrush();
 

--- a/src/cascadia/TerminalApp/SettingsPaneContent.cpp
+++ b/src/cascadia/TerminalApp/SettingsPaneContent.cpp
@@ -61,6 +61,11 @@ namespace winrt::TerminalApp::implementation
         return winrt::hstring{ glyph };
     }
 
+    // No need to perform an icon refresh here
+    void SettingsPaneContent::IconRefresh() noexcept
+    {
+    }
+
     Windows::Foundation::IReference<winrt::Windows::UI::Color> SettingsPaneContent::TabColor() const noexcept
     {
         return nullptr;

--- a/src/cascadia/TerminalApp/SettingsPaneContent.h
+++ b/src/cascadia/TerminalApp/SettingsPaneContent.h
@@ -28,6 +28,7 @@ namespace winrt::TerminalApp::implementation
         uint64_t TaskbarProgress() { return 0; }
         bool ReadOnly() { return false; }
         winrt::hstring Icon() const;
+        void IconRefresh() noexcept;
         Windows::Foundation::IReference<winrt::Windows::UI::Color> TabColor() const noexcept;
         winrt::Windows::UI::Xaml::Media::Brush BackgroundBrush();
 

--- a/src/cascadia/TerminalApp/SnippetsPaneContent.cpp
+++ b/src/cascadia/TerminalApp/SnippetsPaneContent.cpp
@@ -108,6 +108,11 @@ namespace winrt::TerminalApp::implementation
         return winrt::hstring{ glyph };
     }
 
+    // No need to perform an icon refresh
+    void SnippetsPaneContent::IconRefresh() noexcept
+    {
+    }
+
     winrt::WUX::Media::Brush SnippetsPaneContent::BackgroundBrush()
     {
         static const auto key = winrt::box_value(L"SettingsUiTabBrush");

--- a/src/cascadia/TerminalApp/SnippetsPaneContent.h
+++ b/src/cascadia/TerminalApp/SnippetsPaneContent.h
@@ -29,6 +29,7 @@ namespace winrt::TerminalApp::implementation
         uint64_t TaskbarProgress() { return 0; }
         bool ReadOnly() { return false; }
         winrt::hstring Icon() const;
+        void IconRefresh() noexcept;
         Windows::Foundation::IReference<winrt::Windows::UI::Color> TabColor() const noexcept { return nullptr; }
         winrt::Windows::UI::Xaml::Media::Brush BackgroundBrush();
 

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -222,10 +222,15 @@ namespace winrt::TerminalApp::implementation
     //   tab's icon to that icon.
     // Arguments:
     // - tab: the Tab to update the title for.
-    void TerminalPage::_UpdateTabIcon(TerminalTab& tab)
+    // - isRefresh: Specified when the Icon is due to refresh due to a update e.g. Windows Theme Color Change, defaults to false
+    void TerminalPage::_UpdateTabIcon(TerminalTab& tab, bool isRefresh)
     {
         if (const auto content{ tab.GetActiveContent() })
         {
+            if (isRefresh)
+            {
+                content.IconRefresh();
+            }
             const auto& icon{ content.Icon() };
             const auto theme = _settings.GlobalSettings().CurrentTheme();
             const auto iconStyle = (theme && theme.Tab()) ? theme.Tab().IconStyle() : IconStyle::Default;

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -3561,7 +3561,7 @@ namespace winrt::TerminalApp::implementation
                 // Update the icon of the tab for the currently focused profile in that tab.
                 // Only do this for TerminalTabs. Other types of tabs won't have multiple panes
                 // and profiles so the Title and Icon will be set once and only once on init.
-                _UpdateTabIcon(*terminalTab);
+                _UpdateTabIcon(*terminalTab, true);
 
                 // Force the TerminalTab to re-grab its currently active control's title.
                 terminalTab->UpdateTitle();

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -332,7 +332,7 @@ namespace winrt::TerminalApp::implementation
         void _RegisterActionCallbacks();
 
         void _UpdateTitle(const TerminalTab& tab);
-        void _UpdateTabIcon(TerminalTab& tab);
+        void _UpdateTabIcon(TerminalTab& tab, bool isRefresh = false);
         void _UpdateTabView();
         void _UpdateTabWidthMode();
         void _SetBackgroundImage(const winrt::Microsoft::Terminal::Settings::Model::IAppearanceConfig& newAppearance);

--- a/src/cascadia/TerminalApp/TerminalPaneContent.cpp
+++ b/src/cascadia/TerminalApp/TerminalPaneContent.cpp
@@ -80,6 +80,11 @@ namespace winrt::TerminalApp::implementation
         }
     }
 
+    void TerminalPaneContent::IconRefresh() noexcept
+    {
+        _profile.ResetEvaluated();
+    }
+
     winrt::hstring TerminalPaneContent::Icon() const
     {
         return _profile.EvaluatedIcon();

--- a/src/cascadia/TerminalApp/TerminalPaneContent.h
+++ b/src/cascadia/TerminalApp/TerminalPaneContent.h
@@ -28,6 +28,7 @@ namespace winrt::TerminalApp::implementation
         winrt::Windows::Foundation::Size MinimumSize();
         void Focus(winrt::Windows::UI::Xaml::FocusState reason = winrt::Windows::UI::Xaml::FocusState::Programmatic);
         void Close();
+        void IconRefresh() noexcept;
 
         winrt::Microsoft::Terminal::Settings::Model::INewContentArgs GetNewTerminalArgs(BuildStartupKind kind) const;
 

--- a/src/cascadia/TerminalSettingsModel/Microsoft.Terminal.Settings.ModelLib.vcxproj
+++ b/src/cascadia/TerminalSettingsModel/Microsoft.Terminal.Settings.ModelLib.vcxproj
@@ -92,7 +92,10 @@
     <ClInclude Include="PowershellCoreProfileGenerator.h" />
     <ClInclude Include="Profile.h">
       <DependentUpon>Profile.idl</DependentUpon>
-    </ClInclude>
+	</ClInclude>
+	<ClInclude Include="ProfileIcon.h">
+      <DependentUpon>ProfileIcon.idl</DependentUpon>
+	</ClInclude>
     <ClInclude Include="AppearanceConfig.h">
       <DependentUpon>AppearanceConfig.idl</DependentUpon>
     </ClInclude>
@@ -206,6 +209,9 @@
     <ClCompile Include="MatchProfilesEntry.cpp">
       <DependentUpon>NewTabMenuEntry.idl</DependentUpon>
     </ClCompile>
+	<ClCompile Include="ProfileIcon.cpp">
+      <DependentUpon>ProfileIcon.idl</DependentUpon>	  
+	</ClCompile>
     <ClCompile Include="VsDevCmdGenerator.cpp" />
     <ClCompile Include="VsDevShellGenerator.cpp" />
     <ClCompile Include="VsSetupConfiguration.cpp" />
@@ -221,6 +227,7 @@
     <Midl Include="CascadiaSettings.idl" />
     <Midl Include="ColorScheme.idl" />
     <Midl Include="NewTabMenuEntry.idl" />
+    <Midl Include="ProfileIcon.idl" />
     <Midl Include="Theme.idl" />
     <Midl Include="Command.idl" />
     <Midl Include="DefaultTerminal.idl" />
@@ -258,7 +265,6 @@
     <ProjectReference Include="$(OpenConsoleDir)src\internal\internal.vcxproj">
       <Project>{ef3e32a7-5ff6-42b4-b6e2-96cd7d033f00}</Project>
     </ProjectReference>
-
     <!-- For whatever reason, we can't include the TerminalControl and
     TerminalSettings projects' winmds via project references. So we'll have to
     manually include the winmds as References below
@@ -271,7 +277,6 @@
 
     We do still need to separately reference the winmds manually below, which is annoying.
     -->
-
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalControl\dll\TerminalControl.vcxproj">
       <!-- Private:true and ReferenceOutputAssembly:false, in combination with
       the manual reference to TerminalControl.winmd below make sure that this
@@ -280,7 +285,6 @@
       <Private>true</Private>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-
   </ItemGroup>
   <ItemGroup>
     <!-- Manually add references to each of our dependent winmds. Mark them as private=false and CopyLocalSatelliteAssemblies=false, so that we don't
@@ -323,7 +327,6 @@
   <!-- ========================= Globals ======================== -->
   <Import Project="$(OpenConsoleDir)src\cppwinrt.build.post.props" />
   <Import Project="$(OpenConsoleDir)src\common.nugetversions.targets" />
-
   <!-- PowerShell version check, outputs error if the wrong version is installed. -->
   <Import Project="$(SolutionDir)build\rules\CollectWildcardResources.targets" />
   <Target Name="BeforeResourceCompile" Inputs="defaults.json;userDefaults.json;enableColorSelection.json" Outputs="Generated Files\defaults.json;Generated Files\userDefaults.json;Generated Files\enableColorSelection.json">
@@ -333,5 +336,4 @@
     <Exec Command="pwsh.exe -NoProfile -ExecutionPolicy Unrestricted &quot;$(OpenConsoleDir)\tools\CompressJson.ps1&quot; -JsonFile userDefaults.json -OutPath &quot;Generated Files\userDefaults.json&quot;" />
     <Exec Command="pwsh.exe -NoProfile -ExecutionPolicy Unrestricted &quot;$(OpenConsoleDir)\tools\CompressJson.ps1&quot; -JsonFile enableColorSelection.json -OutPath &quot;Generated Files\enableColorSelection.json&quot;" />
   </Target>
-
 </Project>

--- a/src/cascadia/TerminalSettingsModel/Microsoft.Terminal.Settings.ModelLib.vcxproj.filters
+++ b/src/cascadia/TerminalSettingsModel/Microsoft.Terminal.Settings.ModelLib.vcxproj.filters
@@ -115,6 +115,7 @@
     <Midl Include="DefaultTerminal.idl" />
     <Midl Include="ApplicationState.idl" />
     <Midl Include="NewTabMenuEntry.idl" />
+    <Midl Include="ProfileIcon.idl" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/cascadia/TerminalSettingsModel/Profile.h
+++ b/src/cascadia/TerminalSettingsModel/Profile.h
@@ -80,7 +80,6 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     public:
         Profile() noexcept = default;
         Profile(guid guid) noexcept;
-
         void CreateUnfocusedAppearance();
         void DeleteUnfocusedAppearance();
 
@@ -115,9 +114,16 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         winrt::hstring EvaluatedIcon();
         hstring Icon() const;
         void Icon(const hstring& value);
+        Model::ProfileIcon IconV2() const;
+        void IconV2(const Model::ProfileIcon& value);
         bool HasIcon() const;
+        bool HasIconV2() const;
         Model::Profile IconOverrideSource();
+        Model::Profile IconV2OverrideSource();
         void ClearIcon();
+        void ClearIconV2();
+        static bool IsDarkMode();
+        void ResetEvaluated() noexcept;
 
         WINRT_PROPERTY(bool, Deleted, false);
         WINRT_PROPERTY(bool, Orphaned, false);
@@ -145,6 +151,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         Model::IAppearanceConfig _DefaultAppearance{ winrt::make<AppearanceConfig>(weak_ref<Model::Profile>(*this)) };
         Model::FontConfig _FontInfo{ winrt::make<FontConfig>(weak_ref<Model::Profile>(*this)) };
 
+        std::optional<Model::ProfileIcon> _IconV2;
         std::optional<hstring> _Icon{ std::nullopt };
         std::optional<winrt::hstring> _evaluatedIcon{ std::nullopt };
         std::set<std::string> _changeLog;
@@ -154,7 +161,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         static guid _GenerateGuidForProfile(const std::wstring_view& name, const std::wstring_view& source) noexcept;
 
         winrt::hstring _evaluateIcon() const;
-        std::optional<hstring> _getIconImpl() const;
+        std::optional<hstring> _getIconImpl(bool dark = false) const;
         Model::Profile _getIconOverrideSourceImpl() const;
         void _logSettingSet(const std::string_view& setting);
         void _logSettingIfSet(const std::string_view& setting, const bool isSet);

--- a/src/cascadia/TerminalSettingsModel/Profile.idl
+++ b/src/cascadia/TerminalSettingsModel/Profile.idl
@@ -4,6 +4,7 @@
 import "IAppearanceConfig.idl";
 import "ISettingsModelObject.idl";
 import "FontConfig.idl";
+import "ProfileIcon.idl";
 #include "IInheritable.idl.h"
 
 #define INHERITABLE_PROFILE_SETTING(Type, Name) \
@@ -38,6 +39,7 @@ namespace Microsoft.Terminal.Settings.Model
 
         void CreateUnfocusedAppearance();
         void DeleteUnfocusedAppearance();
+        void ResetEvaluated();
 
         // True if the user explicitly removed this Profile from settings.json.
         Boolean Deleted { get; };
@@ -54,6 +56,7 @@ namespace Microsoft.Terminal.Settings.Model
         INHERITABLE_PROFILE_SETTING(Boolean, Hidden);
         INHERITABLE_PROFILE_SETTING(Guid, ConnectionType);
         INHERITABLE_PROFILE_SETTING(String, Icon);
+        INHERITABLE_PROFILE_SETTING(ProfileIcon, IconV2);
         INHERITABLE_PROFILE_SETTING(CloseOnExitMode, CloseOnExit);
         INHERITABLE_PROFILE_SETTING(String, TabTitle);
         INHERITABLE_PROFILE_SETTING(Windows.Foundation.IReference<Microsoft.Terminal.Core.Color>, TabColor);

--- a/src/cascadia/TerminalSettingsModel/ProfileIcon.cpp
+++ b/src/cascadia/TerminalSettingsModel/ProfileIcon.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
+#include "ProfileIcon.h"
+#include "JsonUtils.h"
+#include "Command.h"
+#include "ProfileIcon.g.cpp"
+
+using namespace winrt::Microsoft::Terminal::Control;
+using namespace winrt::Microsoft::Terminal::Settings::Model;
+
+namespace winrt::Microsoft::Terminal::Settings::Model::implementation
+{
+    ProfileIcon::ProfileIcon() noexcept
+    {
+    }
+
+    com_ptr<ProfileIcon> ProfileIcon::FromJson(const Json::Value& json)
+    {
+        auto result = make_self<ProfileIcon>();
+        return result->_layerJson(json) ? result : nullptr;
+    }
+
+    bool ProfileIcon::_layerJson(const Json::Value& json)
+    {
+        const auto FoundDarkMode = JsonUtils::GetValueForKey(json, DarkModeKey, _Dark);
+        const auto FoundLightMode = JsonUtils::GetValueForKey(json, LightModeKey, _Light);
+        // If one is found we can default to that else fail json
+        return FoundDarkMode || FoundLightMode;
+    }
+
+    Json::Value ProfileIcon::ToJson(const Model::ProfileIcon& val)
+    {
+        Json::Value json{ Json::ValueType::objectValue };
+        JsonUtils::SetValueForKey(json, DarkModeKey, val.Dark());
+        JsonUtils::SetValueForKey(json, LightModeKey, val.Light());
+        return json;
+    }
+}

--- a/src/cascadia/TerminalSettingsModel/ProfileIcon.h
+++ b/src/cascadia/TerminalSettingsModel/ProfileIcon.h
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+
+#include "ProfileIcon.g.h"
+#include "TerminalWarnings.h"
+#include "Command.g.h"
+#include "TerminalWarnings.h"
+#include "Profile.h"
+#include "ActionAndArgs.h"
+#include "SettingsTypes.h"
+
+namespace winrt::Microsoft::Terminal::Settings::Model::implementation
+{
+    static constexpr std::string_view LightModeKey{ "light" };
+    static constexpr std::string_view DarkModeKey{ "dark" };
+
+    struct ProfileIcon : public ProfileIconT<ProfileIcon>
+    {
+    public:
+        static Json::Value ToJson(const Model::ProfileIcon& val);
+        static com_ptr<ProfileIcon> FromJson(const Json::Value& json);
+        ProfileIcon() noexcept;
+        WINRT_PROPERTY(winrt::hstring, Dark);
+        WINRT_PROPERTY(winrt::hstring, Light);
+    private:
+        bool _layerJson(const Json::Value& json);
+    };
+}
+
+namespace winrt::Microsoft::Terminal::Settings::Model::factory_implementation
+{
+    BASIC_FACTORY(ProfileIcon);
+}
+
+namespace Microsoft::Terminal::Settings::Model::JsonUtils
+{
+    using namespace winrt::Microsoft::Terminal::Settings::Model;
+
+    template<>
+    struct ConversionTrait<ProfileIcon>
+    {
+        ProfileIcon FromJson(const Json::Value& json)
+        {
+            return *implementation::ProfileIcon::FromJson(json);
+        }
+
+        bool CanConvert(const Json::Value& json) const
+        {
+            return json.isObject();
+        }
+
+        Json::Value ToJson(const ProfileIcon& val)
+        {
+            return implementation::ProfileIcon::ToJson(val);
+        }
+
+        std::string TypeDescription() const
+        {
+            return "ProfileIcon";
+        }
+    };
+}

--- a/src/cascadia/TerminalSettingsModel/ProfileIcon.idl
+++ b/src/cascadia/TerminalSettingsModel/ProfileIcon.idl
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+namespace Microsoft.Terminal.Settings.Model
+{
+    [default_interface] runtimeclass ProfileIcon
+    {
+        ProfileIcon();
+        String Dark;
+        String Light;
+    };
+}


### PR DESCRIPTION
## Summary of the Pull Request

This PR adds the ability to swap between dark and light icons for a profile based off your windows theme (Dark Theme or Light Theme).
This is an additive change so you can either keep using the string icon or you can now swap to an object form in which you specify a light property for light theme and dark for dark theme, e.g. for testing i used:
```
{
                "commandline": "%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
                "guid": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}",
                "hidden": false,
                "icon": {
                    "light": ":)",
                    "dark": ":("
                }, <-- Complex Object Form
                "name": "Windows PowerShell"
            },
            {
                "colorScheme": "Color Scheme 15",
                "commandline": "%SystemRoot%\\System32\\cmd.exe",
                "guid": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}",
                "hidden": false,
                "icon": "!", <-- Normal String Icon
                "name": "Command Prompt"
            }
```

## References and Relevant Issues
https://github.com/microsoft/terminal/issues/15264

## Detailed Description of the Pull Request / Additional comments

This PR adds a new type ProfileIcon with relevant IDL, then it edits the profile IDL to allow setting the field 'icon' to either this complex type ProfileIcon or the original string type to maintain compatability without breaking people.

I tried to utilize some form of union in MIDL but got very confused (I'm not actually sort I can use a union in MIDL3.0?) so i ended up with hacky if statements.

I also edited it so that when a theme change occurs on windows which triggers the `RefreshUIForSettingsReload` method, it will now call a new method called 'ResetEvaluated' that just resets the evaluated icon forcing a new lookup, this makes it so if you do a update the terminal tabs have updated icons.

## Validation Steps Performed

Used above profile and tested locally for a bit, appears to work quite well

## PR Checklist
- [x] Closes #15264
- [ ] Tests added/passed => Need guidance as to what tests to add/edit
- [ ] Documentation updated => Will update to docs repo
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary) => Will Update
