### PR TITLE
Move ConPTY handoff logic into WindowEmperor

### DIFF
--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -756,7 +756,7 @@ namespace winrt::TerminalApp::implementation
             if (!actions.empty())
             {
                 actionArgs.Handled(true);
-                ProcessStartupActions(std::move(actions), false);
+                ProcessStartupActions(std::move(actions));
             }
         }
     }

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -962,18 +962,6 @@ std::vector<ActionAndArgs>& AppCommandlineArgs::GetStartupActions()
 }
 
 // Method Description:
-// - Returns whether we should start listening for inbound PTY connections
-//   coming from the operating system default application feature.
-// Arguments:
-// - <none>
-// Return Value:
-// - True if the listener should be started. False otherwise.
-bool AppCommandlineArgs::IsHandoffListener() const noexcept
-{
-    return _isHandoffListener;
-}
-
-// Method Description:
 // - Get the string of text that should be displayed to the user on exit. This
 //   is usually helpful for cases where the user entered some sort of invalid
 //   commandline. It's additionally also used when the user has requested the
@@ -1015,34 +1003,28 @@ bool AppCommandlineArgs::ShouldExitEarly() const noexcept
 // - <none>
 void AppCommandlineArgs::ValidateStartupCommands()
 {
-    // Only check over the actions list for the potential to add a new-tab
-    // command if we are not starting for the purposes of receiving an inbound
-    // handoff connection from the operating system.
-    if (!_isHandoffListener)
+    // If we only have a single x-save command, then set our target to the
+    // current terminal window. This will prevent us from spawning a new
+    // window just to save the commandline.
+    if (_startupActions.size() == 1 &&
+        _startupActions.front().Action() == ShortcutAction::SaveSnippet &&
+        _windowTarget.empty())
     {
-        // If we only have a single x-save command, then set our target to the
-        // current terminal window. This will prevent us from spawning a new
-        // window just to save the commandline.
-        if (_startupActions.size() == 1 &&
-            _startupActions.front().Action() == ShortcutAction::SaveSnippet &&
-            _windowTarget.empty())
-        {
-            _windowTarget = "0";
-        }
-        // If we parsed no commands, or the first command we've parsed is not a new
-        // tab action, prepend a new-tab command to the front of the list.
-        // (also, we don't need to do this if the only action is a x-save)
-        else if (_startupActions.empty() ||
-                 (_startupActions.front().Action() != ShortcutAction::NewTab &&
-                  _startupActions.front().Action() != ShortcutAction::SaveSnippet))
-        {
-            // Build the NewTab action from the values we've parsed on the commandline.
-            NewTerminalArgs newTerminalArgs{};
-            NewTabArgs args{ newTerminalArgs };
-            ActionAndArgs newTabAction{ ShortcutAction::NewTab, args };
-            // push the arg onto the front
-            _startupActions.insert(_startupActions.begin(), 1, newTabAction);
-        }
+        _windowTarget = "0";
+    }
+    // If we parsed no commands, or the first command we've parsed is not a new
+    // tab action, prepend a new-tab command to the front of the list.
+    // (also, we don't need to do this if the only action is a x-save)
+    else if (_startupActions.empty() ||
+             (_startupActions.front().Action() != ShortcutAction::NewTab &&
+              _startupActions.front().Action() != ShortcutAction::SaveSnippet))
+    {
+        // Build the NewTab action from the values we've parsed on the commandline.
+        NewTerminalArgs newTerminalArgs{};
+        NewTabArgs args{ newTerminalArgs };
+        ActionAndArgs newTabAction{ ShortcutAction::NewTab, args };
+        // push the arg onto the front
+        _startupActions.insert(_startupActions.begin(), 1, newTabAction);
     }
 }
 std::optional<uint32_t> AppCommandlineArgs::GetPersistedLayoutIdx() const noexcept
@@ -1082,13 +1064,9 @@ std::optional<til::size> AppCommandlineArgs::GetSize() const noexcept
 // - 0 if the commandline was successfully parsed
 int AppCommandlineArgs::ParseArgs(winrt::array_view<const winrt::hstring> args)
 {
-    for (const auto& arg : args)
+    if (args.size() == 2 && args[1] == L"-Embedding")
     {
-        if (arg == L"-Embedding")
-        {
-            _isHandoffListener = true;
-            return 0;
-        }
+        return 0;
     }
 
     auto commands = ::TerminalApp::AppCommandlineArgs::BuildCommands(args);
@@ -1195,7 +1173,6 @@ void AppCommandlineArgs::FullResetState()
     _startupActions.clear();
     _exitMessage = "";
     _shouldExitEarly = false;
-    _isHandoffListener = false;
 
     _windowTarget = {};
 }

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.h
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.h
@@ -35,7 +35,6 @@ public:
 
     void ValidateStartupCommands();
     std::vector<winrt::Microsoft::Terminal::Settings::Model::ActionAndArgs>& GetStartupActions();
-    bool IsHandoffListener() const noexcept;
     const std::string& GetExitMessage() const noexcept;
     bool ShouldExitEarly() const noexcept;
 
@@ -132,7 +131,6 @@ private:
     std::optional<winrt::Microsoft::Terminal::Settings::Model::LaunchMode> _launchMode{ std::nullopt };
     std::optional<winrt::Microsoft::Terminal::Settings::Model::LaunchPosition> _position{ std::nullopt };
     std::optional<til::size> _size{ std::nullopt };
-    bool _isHandoffListener{ false };
     std::vector<winrt::Microsoft::Terminal::Settings::Model::ActionAndArgs> _startupActions;
     std::string _exitMessage;
     bool _shouldExitEarly{ false };

--- a/src/cascadia/TerminalApp/Remoting.cpp
+++ b/src/cascadia/TerminalApp/Remoting.cpp
@@ -15,19 +15,6 @@ using namespace winrt::Windows::Foundation;
 
 namespace winrt::TerminalApp::implementation
 {
-    CommandlineArgs::CommandlineArgs(winrt::array_view<const winrt::hstring> args, winrt::hstring currentDirectory, uint32_t showWindowCommand, winrt::hstring envString) :
-        _args{ args.begin(), args.end() },
-        CurrentDirectory{ std::move(currentDirectory) },
-        ShowWindowCommand{ showWindowCommand },
-        CurrentEnvironment{ std::move(envString) }
-    {
-        _parseResult = _parsed.ParseArgs(_args);
-        if (_parseResult == 0)
-        {
-            _parsed.ValidateStartupCommands();
-        }
-    }
-
     ::TerminalApp::AppCommandlineArgs& CommandlineArgs::ParsedArgs() noexcept
     {
         return _parsed;
@@ -56,6 +43,11 @@ namespace winrt::TerminalApp::implementation
     void CommandlineArgs::Commandline(const winrt::array_view<const winrt::hstring>& value)
     {
         _args = { value.begin(), value.end() };
+        _parseResult = _parsed.ParseArgs(_args);
+        if (_parseResult == 0)
+        {
+            _parsed.ValidateStartupCommands();
+        }
     }
 
     winrt::com_array<winrt::hstring> CommandlineArgs::Commandline()

--- a/src/cascadia/TerminalApp/Remoting.h
+++ b/src/cascadia/TerminalApp/Remoting.h
@@ -13,21 +13,17 @@ namespace winrt::TerminalApp::implementation
 {
     struct CommandlineArgs : public CommandlineArgsT<CommandlineArgs>
     {
-        CommandlineArgs() = default;
-        CommandlineArgs(winrt::array_view<const winrt::hstring> args, winrt::hstring currentDirectory, uint32_t showWindowCommand, winrt::hstring envString);
-
         ::TerminalApp::AppCommandlineArgs& ParsedArgs() noexcept;
         winrt::com_array<winrt::hstring>& CommandlineRef() noexcept;
 
         // These bits are exposed via WinRT:
-    public:
         int32_t ExitCode() const noexcept;
         winrt::hstring ExitMessage() const;
         winrt::hstring TargetWindow() const;
 
+        til::property<winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection> Connection;
         void Commandline(const winrt::array_view<const winrt::hstring>& value);
         winrt::com_array<winrt::hstring> Commandline();
-
         til::property<winrt::hstring> CurrentDirectory;
         til::property<winrt::hstring> CurrentEnvironment;
         til::property<uint32_t> ShowWindowCommand{ static_cast<uint32_t>(SW_NORMAL) }; // SW_NORMAL is 1, 0 is SW_HIDE
@@ -86,11 +82,9 @@ namespace winrt::TerminalApp::implementation
 
         WINRT_PROPERTY(uint64_t, Id);
         WINRT_PROPERTY(winrt::hstring, WindowName);
-        WINRT_PROPERTY(TerminalApp::CommandlineArgs, Command);
+        WINRT_PROPERTY(TerminalApp::CommandlineArgs, Command, nullptr);
         WINRT_PROPERTY(winrt::hstring, Content);
         WINRT_PROPERTY(Windows::Foundation::IReference<Windows::Foundation::Rect>, InitialBounds);
-
-    private:
     };
 }
 

--- a/src/cascadia/TerminalApp/Remoting.idl
+++ b/src/cascadia/TerminalApp/Remoting.idl
@@ -6,16 +6,16 @@ namespace TerminalApp
     runtimeclass CommandlineArgs
     {
         CommandlineArgs();
-        CommandlineArgs(String[] args, String cwd, UInt32 showWindowCommand, String env);
 
         Int32 ExitCode { get; };
         String ExitMessage { get; };
         String TargetWindow { get; };
 
+        Microsoft.Terminal.TerminalConnection.ITerminalConnection Connection;
         String[] Commandline;
-        String CurrentDirectory { get; };
-        UInt32 ShowWindowCommand { get; };
-        String CurrentEnvironment { get; };
+        String CurrentDirectory;
+        UInt32 ShowWindowCommand;
+        String CurrentEnvironment;
     };
 
     enum MonitorBehavior

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -129,8 +129,8 @@ namespace winrt::TerminalApp::implementation
         void RequestSetMaximized(bool newMaximized);
 
         void SetStartupActions(std::vector<Microsoft::Terminal::Settings::Model::ActionAndArgs> actions);
+        void SetStartupConnection(winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection connection);
 
-        void SetInboundListener(bool isEmbedding);
         static std::vector<Microsoft::Terminal::Settings::Model::ActionAndArgs> ConvertExecuteCommandlineToActions(const Microsoft::Terminal::Settings::Model::ExecuteCommandlineArgs& args);
 
         winrt::TerminalApp::IDialogPresenter DialogPresenter() const;
@@ -147,9 +147,9 @@ namespace winrt::TerminalApp::implementation
         void ShowTerminalWorkingDirectory();
 
         safe_void_coroutine ProcessStartupActions(std::vector<Microsoft::Terminal::Settings::Model::ActionAndArgs> actions,
-                                                  const bool initial,
                                                   const winrt::hstring cwd = winrt::hstring{},
                                                   const winrt::hstring env = winrt::hstring{});
+        void CreateTabFromConnection(winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection connection);
 
         TerminalApp::WindowProperties WindowProperties() const noexcept { return _WindowProperties; };
 
@@ -257,8 +257,7 @@ namespace winrt::TerminalApp::implementation
         StartupState _startupState{ StartupState::NotInitialized };
 
         std::vector<Microsoft::Terminal::Settings::Model::ActionAndArgs> _startupActions;
-        bool _shouldStartInboundListener{ false };
-        bool _isEmbeddingInboundListener{ false };
+        winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection _startupConnection{ nullptr };
 
         std::shared_ptr<Toast> _windowIdToast{ nullptr };
         std::shared_ptr<Toast> _actionSavedToast{ nullptr };
@@ -281,8 +280,6 @@ namespace winrt::TerminalApp::implementation
             winrt::com_ptr<winrt::TerminalApp::implementation::TabBase> draggedTab{ nullptr };
             winrt::Windows::Foundation::Point dragOffset{ 0, 0 };
         } _stashed;
-
-        winrt::Microsoft::Terminal::TerminalConnection::ConptyConnection::NewConnection_revoker _newConnectionRevoker;
 
         safe_void_coroutine _NewTerminalByDrop(const Windows::Foundation::IInspectable&, winrt::Windows::UI::Xaml::DragEventArgs e);
 
@@ -468,8 +465,6 @@ namespace winrt::TerminalApp::implementation
 
         void _SetNewTabButtonColor(const Windows::UI::Color& color, const Windows::UI::Color& accentColor);
         void _ClearNewTabButtonColor();
-
-        void _StartInboundListener();
 
         safe_void_coroutine _CompleteInitialization();
 

--- a/src/cascadia/TerminalApp/TerminalWindow.cpp
+++ b/src/cascadia/TerminalApp/TerminalWindow.cpp
@@ -152,38 +152,23 @@ namespace winrt::TerminalApp::implementation
         //   instead.
         // * if we have commandline arguments, Pass commandline args into the
         //   TerminalPage.
-        if (!_initialContentArgs.empty())
+        if (_startupConnection)
         {
-            _root->SetStartupActions(_initialContentArgs);
+            _root->SetStartupConnection(std::move(_startupConnection));
         }
-        else
+        else if (!_initialContentArgs.empty())
+        {
+            _root->SetStartupActions(std::move(_initialContentArgs));
+        }
+        else if (const auto& layout = LoadPersistedLayout())
         {
             // layout will only ever be non-null if there were >0 tabs persisted in
             // .TabLayout(). We can re-evaluate that as a part of TODO: GH#12633
-            if (const auto& layout = LoadPersistedLayout())
-            {
-                std::vector<Settings::Model::ActionAndArgs> actions;
-                for (const auto& a : layout.TabLayout())
-                {
-                    actions.emplace_back(a);
-                }
-                _root->SetStartupActions(actions);
-            }
-            else if (_appArgs)
-            {
-                _root->SetStartupActions(_appArgs->ParsedArgs().GetStartupActions());
-            }
+            _root->SetStartupActions(wil::to_vector(layout.TabLayout()));
         }
-
-        // Check if we were started as a COM server for inbound connections of console sessions
-        // coming out of the operating system default application feature. If so,
-        // tell TerminalPage to start the listener as we have to make sure it has the chance
-        // to register a handler to hear about the requests first and is all ready to receive
-        // them before the COM server registers itself. Otherwise, the request might come
-        // in and be routed to an event with no handlers or a non-ready Page.
-        if (_appArgs && _appArgs->ParsedArgs().IsHandoffListener())
+        else if (_appArgs)
         {
-            _root->SetInboundListener(true);
+            _root->SetStartupActions(_appArgs->ParsedArgs().GetStartupActions());
         }
 
         return _root->Initialize(hwnd);
@@ -1054,6 +1039,7 @@ namespace winrt::TerminalApp::implementation
     int32_t TerminalWindow::SetStartupCommandline(TerminalApp::CommandlineArgs args)
     {
         _appArgs = winrt::get_self<CommandlineArgs>(args);
+        _startupConnection = args.Connection();
         auto& parsedArgs = _appArgs->ParsedArgs();
 
         _WindowProperties->SetInitialCwd(_appArgs->CurrentDirectory());
@@ -1114,13 +1100,16 @@ namespace winrt::TerminalApp::implementation
             auto& parsedArgs = _appArgs->ParsedArgs();
             auto& actions = parsedArgs.GetStartupActions();
 
-            _root->ProcessStartupActions(actions, false, _appArgs->CurrentDirectory(), _appArgs->CurrentEnvironment());
-
-            if (parsedArgs.IsHandoffListener())
+            if (auto conn = args.Connection())
             {
-                _root->SetInboundListener(true);
+                _root->CreateTabFromConnection(std::move(conn));
+            }
+            else if (!actions.empty())
+            {
+                _root->ProcessStartupActions(actions, _appArgs->CurrentDirectory(), _appArgs->CurrentEnvironment());
             }
         }
+
         // Return the result of parsing with commandline, though it may or may not be used.
         return _appArgs->ExitCode();
     }

--- a/src/cascadia/TerminalApp/TerminalWindow.h
+++ b/src/cascadia/TerminalApp/TerminalWindow.h
@@ -169,6 +169,7 @@ namespace winrt::TerminalApp::implementation
         winrt::com_ptr<TerminalPage> _root{ nullptr };
 
         wil::com_ptr<CommandlineArgs> _appArgs{ nullptr };
+        winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection _startupConnection{ nullptr };
         bool _hasCommandLineArguments{ false };
         bool _gotSettingsStartupActions{ false };
         std::vector<winrt::Microsoft::Terminal::Settings::Model::ActionAndArgs> _settingsStartupArgs{};

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -77,6 +77,11 @@ AppHost::AppHost(WindowEmperor* manager, const winrt::TerminalApp::AppLogic& log
     _windowCallbacks.ShouldExitFullscreen = _window->ShouldExitFullscreen({ &_windowLogic, &winrt::TerminalApp::TerminalWindow::RequestExitFullscreen });
 
     _window->MakeWindow();
+
+    // Does window creation mean the window was activated (WM_ACTIVATE)? No.
+    // But it simplifies `WindowEmperor::_mostRecentWindow()`, because now the creation of a
+    // new window marks it as the most recent one immediately, even before it becomes active.
+    QueryPerformanceCounter(&_lastActivatedTime);
 }
 
 bool AppHost::OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool down)

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -345,20 +345,31 @@ void WindowEmperor::HandleCommandlineArgs(int nCmdShow)
             for (const auto layout : layouts)
             {
                 hstring args[] = { L"wt", L"-w", L"new", L"-s", winrt::to_hstring(startIdx) };
-                _dispatchCommandline({ args, cwd, showCmd, env });
+                _dispatchCommandlineCommon(args, cwd, env, showCmd);
                 startIdx += 1;
             }
         }
 
-        // Create another window if needed: There aren't any yet, or we got an explicit command line.
         const auto args = commandlineToArgArray(GetCommandLineW());
-        if (_windows.empty() || args.size() != 1)
-        {
-            _dispatchCommandline({ args, cwd, showCmd, env });
-        }
 
-        // If we created no windows, e.g. because the args are "/?" we can just exit now.
-        _postQuitMessageIfNeeded();
+        if (args.size() == 2 && args[1] == L"-Embedding")
+        {
+            // We were launched for ConPTY handoff. We have no windows and also don't want to exit.
+            //
+            // TODO: Here we could start a timer and exit after, say, 5 seconds
+            // if no windows are created. But that's a minor concern.
+        }
+        else
+        {
+            // Create another window if needed: There aren't any yet, OR we got an explicit command line.
+            if (_windows.empty() || args.size() != 1)
+            {
+                _dispatchCommandlineCommon(args, cwd, env, showCmd);
+            }
+
+            // If we created no windows, e.g. because the args are "/?" we can just exit now.
+            _postQuitMessageIfNeeded();
+        }
     }
 
     // ALWAYS change the _real_ CWD of the Terminal to system32,
@@ -384,6 +395,19 @@ void WindowEmperor::HandleCommandlineArgs(int nCmdShow)
                 SetParent(coreHandle, _window.get());
             }
         }
+    }
+
+    {
+        TerminalConnection::ConptyConnection::NewConnection([this](TerminalConnection::ConptyConnection conn) {
+            TerminalApp::CommandlineArgs args;
+            args.ShowWindowCommand(conn.ShowWindow());
+            args.Connection(std::move(conn));
+            _dispatchCommandline(std::move(args));
+            _summonWindow(SummonWindowSelectionArgs{
+                .SummonBehavior = nullptr,
+            });
+        });
+        TerminalConnection::ConptyConnection::StartInboundListener();
     }
 
     // Main message loop. It pumps all windows.
@@ -586,6 +610,16 @@ void WindowEmperor::_dispatchCommandline(winrt::TerminalApp::CommandlineArgs arg
         request.WindowName(std::move(windowName));
         CreateNewWindow(std::move(request));
     }
+}
+
+void WindowEmperor::_dispatchCommandlineCommon(winrt::array_view<const winrt::hstring> args, std::wstring_view currentDirectory, std::wstring_view envString, uint32_t showWindowCommand)
+{
+    winrt::TerminalApp::CommandlineArgs c;
+    c.Commandline(args);
+    c.CurrentDirectory(currentDirectory);
+    c.CurrentEnvironment(envString);
+    c.ShowWindowCommand(showWindowCommand);
+    _dispatchCommandline(std::move(c));
 }
 
 // This is an implementation-detail of _dispatchCommandline().
@@ -896,10 +930,8 @@ LRESULT WindowEmperor::_messageHandler(HWND window, UINT const message, WPARAM c
             {
                 const auto handoff = deserializeHandoffPayload(static_cast<const uint8_t*>(cds->lpData), static_cast<const uint8_t*>(cds->lpData) + cds->cbData);
                 const winrt::hstring args{ handoff.args };
-                const winrt::hstring env{ handoff.env };
-                const winrt::hstring cwd{ handoff.cwd };
                 const auto argv = commandlineToArgArray(args.c_str());
-                _dispatchCommandline({ argv, cwd, gsl::narrow_cast<uint32_t>(handoff.show), env });
+                _dispatchCommandlineCommon(argv, handoff.cwd, handoff.env, handoff.show);
             }
             return 0;
         case WM_HOTKEY:
@@ -1198,7 +1230,7 @@ void WindowEmperor::_hotkeyPressed(const long hotkeyIndex)
     const wil::unique_environstrings_ptr envMem{ GetEnvironmentStringsW() };
     const auto env = stringFromDoubleNullTerminated(envMem.get());
     const auto cwd = wil::GetCurrentDirectoryW<std::wstring>();
-    _dispatchCommandline({ argv, cwd, SW_SHOWDEFAULT, std::move(env) });
+    _dispatchCommandlineCommon(argv, cwd, env, SW_SHOWDEFAULT);
 }
 
 void WindowEmperor::_registerHotKey(const int index, const winrt::Microsoft::Terminal::Control::KeyChord& hotkey) noexcept

--- a/src/cascadia/WindowsTerminal/WindowEmperor.h
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.h
@@ -52,10 +52,10 @@ private:
     void _summonAllWindows() const;
     void _dispatchSpecialKey(const MSG& msg) const;
     void _dispatchCommandline(winrt::TerminalApp::CommandlineArgs args);
+    void _dispatchCommandlineCommon(winrt::array_view<const winrt::hstring> args, std::wstring_view currentDirectory, std::wstring_view envString, uint32_t showWindowCommand);
     safe_void_coroutine _dispatchCommandlineCurrentDesktop(winrt::TerminalApp::CommandlineArgs args);
     LRESULT _messageHandler(HWND window, UINT message, WPARAM wParam, LPARAM lParam) noexcept;
     void _createMessageWindow(const wchar_t* className);
-    bool _shouldSkipClosingWindows() const;
     void _postQuitMessageIfNeeded() const;
     safe_void_coroutine _showMessageBox(winrt::hstring message, bool error);
     void _notificationAreaMenuRequested(WPARAM wParam);

--- a/src/cascadia/WindowsTerminal/pch.h
+++ b/src/cascadia/WindowsTerminal/pch.h
@@ -67,8 +67,9 @@ Abstract:
 #include <winrt/Windows.UI.Composition.h>
 
 #include <winrt/TerminalApp.h>
-#include <winrt/Microsoft.Terminal.Settings.Model.h>
 #include <winrt/Microsoft.Terminal.Control.h>
+#include <winrt/Microsoft.Terminal.Settings.Model.h>
+#include <winrt/Microsoft.Terminal.TerminalConnection.h>
 #include <winrt/Microsoft.Terminal.UI.h>
 
 #include <wil/cppwinrt.h>


### PR DESCRIPTION
This changes the ConPTY handoff COM server from `REGCLS_SINGLEUSE`
to `REGCLS_MULTIPLEUSE`. The former causes a race condition, because
handoff runs concurrently with the creation of WinUI windows.
This can then result in the a window getting the wrong handoff.

It then moves the "root" of ConPTY handoff from `TerminalPage`
(WindowEmperor -> AppHost -> TerminalWindow -> TerminalPage)
into `WindowEmperor` (WindowEmperor).

Closes #19049

## Validation Steps Performed
* Launching cmd from the Start Menu shows a "Command Prompt" tab ✅
* Win+R -> `cmd` creates windows in the foreground ✅
* Win+R -> `cmd /c start /max cmd` creates a fullscreen tab ✅
  * This even works for multiple windows, unlike with Canary ✅
* Win+R -> `cmd /c start /min cmd` does not work ❌
  * It also doesn't work in Canary, so it's not a bug in this PR ✅