### PR TITLE
During session save, use the profile's GUID rather than its Name

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPaneContent.cpp
+++ b/src/cascadia/TerminalApp/TerminalPaneContent.cpp
@@ -95,7 +95,7 @@ namespace winrt::TerminalApp::implementation
         NewTerminalArgs args{};
         const auto& controlSettings = _control.Settings();
 
-        args.Profile(controlSettings.ProfileName());
+        args.Profile(::Microsoft::Console::Utils::GuidToString(_profile.Guid()));
         // If we know the user's working directory use it instead of the profile.
         if (const auto dir = _control.WorkingDirectory(); !dir.empty())
         {


### PR DESCRIPTION
This will prevent Terminal from erroneously selecting a hidden (deleted, disabled or otherwise) profile of the same name during restoration and subsequently using the wrong settings.

I am not certain why we used the name at all!

Closes #19105