### PR TITLE
Expose a library's Resource Loader, allow a user to "subset" it

### DIFF
--- a/src/cascadia/WinRTUtils/LibraryResources.cpp
+++ b/src/cascadia/WinRTUtils/LibraryResources.cpp
@@ -90,15 +90,13 @@ CATCH_FAIL_FAST()
 winrt::hstring GetLibraryResourceString(const std::wstring_view key)
 try
 {
-    static auto loader{ GetLibraryResourceLoader() };
-    return loader.GetLocalizedString(key);
+    return GetLibraryResourceLoader().GetLocalizedString(key);
 }
 CATCH_FAIL_FAST()
 
 bool HasLibraryResourceWithName(const std::wstring_view key)
 try
 {
-    static auto loader{ GetLibraryResourceLoader() };
-    return loader.HasResourceWithName(key);
+    return GetLibraryResourceLoader().HasResourceWithName(key);
 }
 CATCH_FAIL_FAST()

--- a/src/cascadia/WinRTUtils/LibraryResources.cpp
+++ b/src/cascadia/WinRTUtils/LibraryResources.cpp
@@ -76,10 +76,10 @@ static void EnsureAllResourcesArePresent(const ScopedResourceLoader& loader)
 
 #endif
 
-static ScopedResourceLoader GetLibraryResourceLoader()
+const ScopedResourceLoader& GetLibraryResourceLoader()
 try
 {
-    ScopedResourceLoader loader{ g_WinRTUtilsLibraryResourceScope };
+    static ScopedResourceLoader loader{ g_WinRTUtilsLibraryResourceScope };
 #ifdef _DEBUG
     EnsureAllResourcesArePresent(loader);
 #endif

--- a/src/cascadia/WinRTUtils/ScopedResourceLoader.cpp
+++ b/src/cascadia/WinRTUtils/ScopedResourceLoader.cpp
@@ -50,7 +50,7 @@ bool ScopedResourceLoader::HasResourceWithName(const std::wstring_view resourceN
 ScopedResourceLoader::ScopedResourceLoader(winrt::Windows::ApplicationModel::Resources::Core::ResourceMap map, winrt::Windows::ApplicationModel::Resources::Core::ResourceContext context) :
     _resourceMap{ std::move(map) }, _resourceContext{ std::move(context) } {}
 
-ScopedResourceLoader ScopedResourceLoader::WithQualifier(const std::wstring_view qualifierName, const std::wstring_view qualifierValue) const
+ScopedResourceLoader ScopedResourceLoader::WithQualifier(const wil::zwstring_view qualifierName, const wil::zwstring_view qualifierValue) const
 {
     auto newContext = _resourceContext.Clone();
     auto qualifierValues = newContext.QualifierValues();

--- a/src/cascadia/WinRTUtils/ScopedResourceLoader.cpp
+++ b/src/cascadia/WinRTUtils/ScopedResourceLoader.cpp
@@ -46,3 +46,14 @@ bool ScopedResourceLoader::HasResourceWithName(const std::wstring_view resourceN
 {
     return _resourceMap.HasKey(resourceName);
 }
+
+ScopedResourceLoader::ScopedResourceLoader(winrt::Windows::ApplicationModel::Resources::Core::ResourceMap map, winrt::Windows::ApplicationModel::Resources::Core::ResourceContext context) :
+    _resourceMap{ std::move(map) }, _resourceContext{ std::move(context) } {}
+
+ScopedResourceLoader ScopedResourceLoader::WithQualifier(const std::wstring_view qualifierName, const std::wstring_view qualifierValue) const
+{
+    auto newContext = _resourceContext.Clone();
+    auto qualifierValues = newContext.QualifierValues();
+    qualifierValues.Insert(qualifierName, qualifierValue); // mutable!
+    return ScopedResourceLoader{ _resourceMap, std::move(newContext) };
+}

--- a/src/cascadia/WinRTUtils/ScopedResourceLoader.cpp
+++ b/src/cascadia/WinRTUtils/ScopedResourceLoader.cpp
@@ -47,7 +47,7 @@ bool ScopedResourceLoader::HasResourceWithName(const std::wstring_view resourceN
     return _resourceMap.HasKey(resourceName);
 }
 
-ScopedResourceLoader::ScopedResourceLoader(winrt::Windows::ApplicationModel::Resources::Core::ResourceMap map, winrt::Windows::ApplicationModel::Resources::Core::ResourceContext context) :
+ScopedResourceLoader::ScopedResourceLoader(winrt::Windows::ApplicationModel::Resources::Core::ResourceMap map, winrt::Windows::ApplicationModel::Resources::Core::ResourceContext context) noexcept :
     _resourceMap{ std::move(map) }, _resourceContext{ std::move(context) } {}
 
 ScopedResourceLoader ScopedResourceLoader::WithQualifier(const wil::zwstring_view qualifierName, const wil::zwstring_view qualifierValue) const

--- a/src/cascadia/WinRTUtils/inc/LibraryResources.h
+++ b/src/cascadia/WinRTUtils/inc/LibraryResources.h
@@ -67,6 +67,9 @@ namespace Microsoft::Console::Utils
     __pragma(warning(suppress : 26485));       \
     __declspec(selectany) extern const wchar_t* g_WinRTUtilsLibraryResourceScope{ (x) };
 
+class ScopedResourceLoader;
+
+const ScopedResourceLoader& GetLibraryResourceLoader();
 winrt::hstring GetLibraryResourceString(const std::wstring_view key);
 bool HasLibraryResourceWithName(const std::wstring_view key);
 

--- a/src/cascadia/WinRTUtils/inc/ScopedResourceLoader.h
+++ b/src/cascadia/WinRTUtils/inc/ScopedResourceLoader.h
@@ -11,7 +11,10 @@ public:
     winrt::hstring GetLocalizedString(const std::wstring_view resourceName) const;
     bool HasResourceWithName(const std::wstring_view resourceName) const;
 
+    ScopedResourceLoader WithQualifier(const std::wstring_view qualifierName, const std::wstring_view qualifierValue) const;
+
 private:
+    ScopedResourceLoader(winrt::Windows::ApplicationModel::Resources::Core::ResourceMap map, winrt::Windows::ApplicationModel::Resources::Core::ResourceContext context);
     winrt::Windows::ApplicationModel::Resources::Core::ResourceMap _resourceMap;
     winrt::Windows::ApplicationModel::Resources::Core::ResourceContext _resourceContext;
 };

--- a/src/cascadia/WinRTUtils/inc/ScopedResourceLoader.h
+++ b/src/cascadia/WinRTUtils/inc/ScopedResourceLoader.h
@@ -14,7 +14,7 @@ public:
     ScopedResourceLoader WithQualifier(const wil::zwstring_view qualifierName, const wil::zwstring_view qualifierValue) const;
 
 private:
-    ScopedResourceLoader(winrt::Windows::ApplicationModel::Resources::Core::ResourceMap map, winrt::Windows::ApplicationModel::Resources::Core::ResourceContext context);
+    ScopedResourceLoader(winrt::Windows::ApplicationModel::Resources::Core::ResourceMap map, winrt::Windows::ApplicationModel::Resources::Core::ResourceContext context) noexcept;
     winrt::Windows::ApplicationModel::Resources::Core::ResourceMap _resourceMap;
     winrt::Windows::ApplicationModel::Resources::Core::ResourceContext _resourceContext;
 };

--- a/src/cascadia/WinRTUtils/inc/ScopedResourceLoader.h
+++ b/src/cascadia/WinRTUtils/inc/ScopedResourceLoader.h
@@ -11,7 +11,7 @@ public:
     winrt::hstring GetLocalizedString(const std::wstring_view resourceName) const;
     bool HasResourceWithName(const std::wstring_view resourceName) const;
 
-    ScopedResourceLoader WithQualifier(const std::wstring_view qualifierName, const std::wstring_view qualifierValue) const;
+    ScopedResourceLoader WithQualifier(const wil::zwstring_view qualifierName, const wil::zwstring_view qualifierValue) const;
 
 private:
     ScopedResourceLoader(winrt::Windows::ApplicationModel::Resources::Core::ResourceMap map, winrt::Windows::ApplicationModel::Resources::Core::ResourceContext context);


### PR DESCRIPTION
This pull request elevates ScopedResourceLoader to the API surface of LibraryResources, which will allow any library resource consumer to directly interact with its resource loader.

One of those new interactions is to make a sub-context with a specific narrowed-down qualifier. Like this:

```c++
auto englishOnlyLoader = GetLibraryResourceLoader().WithQualifier(L"language", L"en-us");
/* auto foo = */ englishOnlyLoader.GetLocalizedString(USES_RESOURCE(L"AppName"));
```