### PR TITLE
Add scrollback source for suggestions

### DIFF
--- a/src/cascadia/TerminalApp/FilteredCommand.cpp
+++ b/src/cascadia/TerminalApp/FilteredCommand.cpp
@@ -19,12 +19,23 @@ using namespace winrt::Microsoft::Terminal::Settings::Model;
 
 namespace winrt::TerminalApp::implementation
 {
-    // This class is a wrapper of IPaletteItem, that is used as an item of a filterable list in CommandPalette.
+    int32_t FilteredCommand::Ordinal()
+    {
+        return _ordinal;
+    }
+
+    FilteredCommand::FilteredCommand(const winrt::TerminalApp::IPaletteItem& item) :
+        FilteredCommand(item, 0)
+    {
+    }
+
+    // This class is a wrapper of PaletteItem, that is used as an item of a filterable list in CommandPalette.
     // It manages a highlighted text that is computed by matching search filter characters to item name
-    FilteredCommand::FilteredCommand(const winrt::TerminalApp::IPaletteItem& item)
+    FilteredCommand::FilteredCommand(const winrt::TerminalApp::IPaletteItem& item, int32_t ordinal)
     {
         // Actually implement the ctor in _constructFilteredCommand
         _constructFilteredCommand(item);
+        _ordinal = ordinal;
     }
 
     // We need to actually implement the ctor in a separate helper. This is
@@ -111,6 +122,10 @@ namespace winrt::TerminalApp::implementation
 
         if (firstWeight == secondWeight)
         {
+            if (first.Ordinal() != second.Ordinal())
+            {
+                return first.Ordinal() < second.Ordinal();
+            }
             const auto firstName = first.Item().Name();
             const auto secondName = second.Item().Name();
             return til::compare_linguistic_insensitive(firstName, secondName) < 0;

--- a/src/cascadia/TerminalApp/FilteredCommand.h
+++ b/src/cascadia/TerminalApp/FilteredCommand.h
@@ -19,6 +19,7 @@ namespace winrt::TerminalApp::implementation
     {
         FilteredCommand() = default;
         FilteredCommand(const winrt::TerminalApp::IPaletteItem& item);
+        FilteredCommand(const winrt::TerminalApp::IPaletteItem& item, int32_t ordinal);
 
         virtual void UpdateFilter(std::shared_ptr<fzf::matcher::Pattern> pattern);
 
@@ -29,6 +30,9 @@ namespace winrt::TerminalApp::implementation
         WINRT_OBSERVABLE_PROPERTY(winrt::Windows::Foundation::Collections::IVector<winrt::TerminalApp::HighlightedRun>, NameHighlights, PropertyChanged.raise);
         WINRT_OBSERVABLE_PROPERTY(int, Weight, PropertyChanged.raise);
 
+    public:
+        int32_t Ordinal();
+
     protected:
         void _constructFilteredCommand(const winrt::TerminalApp::IPaletteItem& item);
 
@@ -36,6 +40,7 @@ namespace winrt::TerminalApp::implementation
         std::shared_ptr<fzf::matcher::Pattern> _pattern;
         void _update();
         Windows::UI::Xaml::Data::INotifyPropertyChanged::PropertyChanged_revoker _itemChangedRevoker;
+        int32_t _ordinal;
 
         friend class TerminalAppLocalTests::FilteredCommandTests;
     };

--- a/src/cascadia/TerminalApp/FilteredCommand.idl
+++ b/src/cascadia/TerminalApp/FilteredCommand.idl
@@ -10,9 +10,11 @@ namespace TerminalApp
     {
         FilteredCommand();
         FilteredCommand(IPaletteItem item);
+        FilteredCommand(IPaletteItem item, Int32 ordinal);
 
         IPaletteItem Item { get; };
         IVector<HighlightedRun> NameHighlights { get; };
         Int32 Weight;
+        Int32 Ordinal { get; };
     }
 }

--- a/src/cascadia/TerminalApp/SuggestionsControl.h
+++ b/src/cascadia/TerminalApp/SuggestionsControl.h
@@ -44,7 +44,8 @@ namespace winrt::TerminalApp::implementation
                   winrt::hstring filterText,
                   Windows::Foundation::Point anchor,
                   Windows::Foundation::Size space,
-                  float characterHeight);
+                  float characterHeight,
+                  bool sortResults);
 
         til::typed_event<winrt::TerminalApp::SuggestionsControl, Microsoft::Terminal::Settings::Model::Command> DispatchCommandRequested;
         til::typed_event<Windows::Foundation::IInspectable, Microsoft::Terminal::Settings::Model::Command> PreviewAction;
@@ -124,6 +125,8 @@ namespace winrt::TerminalApp::implementation
         Windows::Foundation::Collections::IVector<winrt::TerminalApp::FilteredCommand> _commandsToFilter();
         std::wstring _getTrimmedInput();
         uint32_t _getNumVisibleItems();
+        std::wstring _searchText;
+        bool _sortResults;
         friend class TerminalAppLocalTests::TabTests;
     };
 }

--- a/src/cascadia/TerminalApp/SuggestionsControl.idl
+++ b/src/cascadia/TerminalApp/SuggestionsControl.idl
@@ -38,7 +38,8 @@ namespace TerminalApp
         void SetCommands(Windows.Foundation.Collections.IVector<Microsoft.Terminal.Settings.Model.Command> actions);
         void SelectNextItem(Boolean moveDown);
 
-        void Open(SuggestionsMode mode, IVector<Microsoft.Terminal.Settings.Model.Command> commands, String filterText, Windows.Foundation.Point anchor, Windows.Foundation.Size space, Single characterHeight);
+        void Open(SuggestionsMode mode, IVector<Microsoft.Terminal.Settings.Model.Command> commands, String filterText, Windows.Foundation.Point anchor, Windows.Foundation.Size space, Single characterHeight, Boolean
+        sortResults);
 
         event Windows.Foundation.TypedEventHandler<SuggestionsControl, Microsoft.Terminal.Settings.Model.Command> DispatchCommandRequested;
         event Windows.Foundation.TypedEventHandler<Object, Microsoft.Terminal.Settings.Model.Command> PreviewAction;

--- a/src/cascadia/TerminalApp/SuggestionsControl.xaml
+++ b/src/cascadia/TerminalApp/SuggestionsControl.xaml
@@ -197,7 +197,11 @@
                       ItemsSource="{x:Bind FilteredActions}"
                       SelectionChanged="_listItemSelectionChanged"
                       SelectionMode="Single"
-                      Style="{StaticResource NoAnimationsPlease}" />
+                      Style="{StaticResource NoAnimationsPlease}">
+                <ListView.ItemContainerTransitions>
+                    <TransitionCollection />
+                </ListView.ItemContainerTransitions>
+            </ListView>
 
 
         </Grid>

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -4824,7 +4824,7 @@ namespace winrt::TerminalApp::implementation
                 if (const auto& page{ weakThis.get() })
                 {
                     // Open the Suggestions UI with the commands from the control
-                    page->_OpenSuggestions(sender.try_as<TermControl>(), commandsCollection, SuggestionsMode::Menu, L"");
+                    page->_OpenSuggestions(sender.try_as<TermControl>(), commandsCollection, SuggestionsMode::Menu, L"", false);
                 }
             });
         }
@@ -4835,7 +4835,8 @@ namespace winrt::TerminalApp::implementation
         const TermControl& sender,
         IVector<Command> commandsCollection,
         winrt::TerminalApp::SuggestionsMode mode,
-        winrt::hstring filterText)
+        winrt::hstring filterText,
+        bool sortResults)
 
     {
         // ON THE UI THREAD
@@ -4874,7 +4875,8 @@ namespace winrt::TerminalApp::implementation
                    filterText,
                    realCursorPos,
                    windowDimensions,
-                   characterSize.Height);
+                   characterSize.Height,
+                   sortResults);
     }
 
     void TerminalPage::_PopulateContextMenu(const TermControl& control,

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -519,7 +519,7 @@ namespace winrt::TerminalApp::implementation
 
         safe_void_coroutine _ControlCompletionsChangedHandler(const winrt::Windows::Foundation::IInspectable sender, const winrt::Microsoft::Terminal::Control::CompletionsChangedEventArgs args);
 
-        void _OpenSuggestions(const Microsoft::Terminal::Control::TermControl& sender, Windows::Foundation::Collections::IVector<winrt::Microsoft::Terminal::Settings::Model::Command> commandsCollection, winrt::TerminalApp::SuggestionsMode mode, winrt::hstring filterText);
+        void _OpenSuggestions(const Microsoft::Terminal::Control::TermControl& sender, Windows::Foundation::Collections::IVector<winrt::Microsoft::Terminal::Settings::Model::Command> commandsCollection, winrt::TerminalApp::SuggestionsMode mode, winrt::hstring filterText, bool sortResults);
 
         void _ShowWindowChangedHandler(const IInspectable sender, const winrt::Microsoft::Terminal::Control::ShowWindowArgs args);
         Windows::Foundation::IAsyncAction _SearchMissingCommandHandler(const IInspectable sender, const winrt::Microsoft::Terminal::Control::SearchMissingCommandEventArgs args);

--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -68,6 +68,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     {
         til::property<Windows::Foundation::Collections::IVector<winrt::hstring>> History;
         til::property<winrt::hstring> CurrentCommandline;
+        til::property<winrt::hstring> CurrentWordPrefix;
         til::property<Windows::Foundation::Collections::IVector<winrt::hstring>> QuickFixes;
 
         CommandHistoryContext(std::vector<winrt::hstring>&& history) :
@@ -228,6 +229,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void SetSelectionAnchor(const til::point position);
         void SetEndSelectionPoint(const til::point position);
 
+        Windows::Foundation::Collections::IVector<SuggestionSearchItem> SuggestionScrollBackSearch(hstring const& needle);
         SearchResults Search(SearchRequest request);
         const std::vector<til::point_span>& SearchResultRows() const noexcept;
         void ClearSearch();
@@ -368,6 +370,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             til::point_span (*getSpan)(const ::MarkExtents&));
 
         bool _clickedOnMark(const til::point& pos, bool (*filter)(const ::MarkExtents&));
+        hstring _getLineText(int32_t rowNumber) const;
 
         inline bool _IsClosing() const noexcept
         {

--- a/src/cascadia/TerminalControl/ControlCore.idl
+++ b/src/cascadia/TerminalControl/ControlCore.idl
@@ -67,6 +67,12 @@ namespace Microsoft.Terminal.Control
         Boolean SearchRegexInvalid;
     };
 
+    struct SuggestionSearchItem
+    {
+        String Row;
+        String Text;
+    };
+
     [default_interface] runtimeclass SelectionColor
     {
         SelectionColor();
@@ -80,6 +86,7 @@ namespace Microsoft.Terminal.Control
     {
         IVector<String> History { get; };
         String CurrentCommandline { get; };
+        String CurrentWordPrefix { get; };
         IVector<String> QuickFixes { get; };
     };
 
@@ -148,6 +155,7 @@ namespace Microsoft.Terminal.Control
         void ResumeRendering();
         void BlinkAttributeTick();
 
+        IVector<SuggestionSearchItem> SuggestionScrollBackSearch(String needle);
         SearchResults Search(SearchRequest request);
         void ClearSearch();
 

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1334,6 +1334,11 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         control->RaiseNotice.raise(*control, std::move(noticeArgs));
     }
 
+    Windows::Foundation::Collections::IVector<SuggestionSearchItem> TermControl::SuggestionScrollBackSearch(hstring const& needle)
+    {
+        return _core.SuggestionScrollBackSearch(needle);
+    }
+
     void TermControl::_AttachDxgiSwapChainToXaml(HANDLE swapChainHandle)
     {
         auto nativePanel = SwapChainPanel().as<ISwapChainPanelNative2>();

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -139,6 +139,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         safe_void_coroutine _RendererWarning(IInspectable sender,
                                              Control::RendererWarningArgs args);
 
+        Windows::Foundation::Collections::IVector<SuggestionSearchItem> SuggestionScrollBackSearch(hstring const& needle);
         void CreateSearchBoxControl();
 
         void SearchMatch(const bool goForward);

--- a/src/cascadia/TerminalControl/TermControl.idl
+++ b/src/cascadia/TerminalControl/TermControl.idl
@@ -107,6 +107,7 @@ namespace Microsoft.Terminal.Control
 
         void ScrollViewport(Int32 viewTop);
 
+        IVector<SuggestionSearchItem> SuggestionScrollBackSearch(String needle);
         void CreateSearchBoxControl();
         Boolean SearchBoxEditInFocus();
 

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -1581,6 +1581,21 @@ std::wstring Terminal::CurrentCommand() const
     return _activeBuffer().CurrentCommand();
 }
 
+std::wstring Terminal::CurrentWordPrefix() const
+{
+    const auto& buffer = _activeBuffer();
+    const auto cursorPos = buffer.GetCursor().GetPosition();
+
+    const auto start = buffer.GetWordStart2({ std::max(0, cursorPos.x - 1), cursorPos.y }, L"", false);
+
+    if (start == cursorPos)
+    {
+        return {};
+    }
+
+    return buffer.GetPlainText(start, cursorPos);
+}
+
 void Terminal::SerializeMainBuffer(const wchar_t* destination) const
 {
     _mainBuffer->SerializeToPath(destination);

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -125,6 +125,7 @@ public:
     til::property<bool> AlwaysNotifyOnBufferRotation;
 
     std::wstring CurrentCommand() const;
+    std::wstring CurrentWordPrefix() const;
 
     void SerializeMainBuffer(const wchar_t* destination) const;
 

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -225,7 +225,8 @@ protected:                                                                  \
 ////////////////////////////////////////////////////////////////////////////////
 #define SUGGESTIONS_ARGS(X)                                                 \
     X(SuggestionsSource, Source, "source", false, SuggestionsSource::Tasks) \
-    X(bool, UseCommandline, "useCommandline", false, false)
+    X(bool, UseCommandline, "useCommandline", false, false)                 \
+    X(winrt::hstring, Regex, "regex", false, L"[^\\s]{5,}") //Setting the default here may not be ok since other suggestion sources don't use a regex
 
 ////////////////////////////////////////////////////////////////////////////////
 #define FIND_MATCH_ARGS(X) \

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -121,6 +121,7 @@ namespace Microsoft.Terminal.Settings.Model
         CommandHistory = 0x2,
         DirectoryHistory = 0x4,
         QuickFixes = 0x8,
+        Scrollback = 0x10,
         All = 0xffffffff,
     };
 
@@ -348,9 +349,10 @@ namespace Microsoft.Terminal.Settings.Model
     [default_interface] runtimeclass SuggestionsArgs : IActionArgs
     {
         SuggestionsArgs();
-        SuggestionsArgs(SuggestionsSource source, Boolean useCommandline);
+        SuggestionsArgs(SuggestionsSource source, Boolean useCommandline, String regex);
         SuggestionsSource Source { get; };
         Boolean UseCommandline { get; };
+        String Regex { get; };
     };
 
     [default_interface] runtimeclass FindMatchArgs : IActionArgs

--- a/src/cascadia/TerminalSettingsModel/Command.cpp
+++ b/src/cascadia/TerminalSettingsModel/Command.cpp
@@ -742,6 +742,20 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         return winrt::single_threaded_vector<Model::Command>(std::move(result));
     }
 
+    Model::Command Command::ScrollBackSuggestionToCommand(winrt::hstring text, winrt::hstring currentWordPrefix, winrt::hstring rowText)
+    {
+        auto backspaces = std::wstring(currentWordPrefix.size(), L'\x7f');
+        auto args = winrt::make_self<SendInputArgs>(winrt::hstring{ fmt::format(FMT_COMPILE(L"{}{}"), backspaces, text) });
+        Model::ActionAndArgs actionAndArgs{ ShortcutAction::SendInput, *args };
+        auto command = winrt::make_self<Command>();
+        command->_ActionAndArgs = actionAndArgs;
+        command->_name = text;
+        //command->IconPath(L"\uE756");
+        command->_Description = rowText;
+
+        return *command;
+    }
+
     void Command::LogSettingChanges(std::set<std::string>& changes)
     {
         if (_IterateOn != ExpandCommandType::None)

--- a/src/cascadia/TerminalSettingsModel/Command.h
+++ b/src/cascadia/TerminalSettingsModel/Command.h
@@ -84,6 +84,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                                                                                            winrt::hstring currentCommandline,
                                                                                            bool directories,
                                                                                            hstring iconPath);
+        static Model::Command ScrollBackSuggestionToCommand(winrt::hstring text, winrt::hstring currentWordPrefix, winrt::hstring rowText);
 
         WINRT_PROPERTY(ExpandCommandType, IterateOn, ExpandCommandType::None);
         WINRT_PROPERTY(Model::ActionAndArgs, ActionAndArgs);

--- a/src/cascadia/TerminalSettingsModel/Command.idl
+++ b/src/cascadia/TerminalSettingsModel/Command.idl
@@ -50,6 +50,6 @@ namespace Microsoft.Terminal.Settings.Model
 
         static IVector<Command> ParsePowerShellMenuComplete(String json, Int32 replaceLength);
         static IVector<Command> HistoryToCommands(IVector<String> commandHistory, String commandline, Boolean directories, String iconPath);
-
+        static Command ScrollBackSuggestionToCommand(String text, String currentWordPrefix, String rowText);
     }
 }

--- a/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
@@ -503,13 +503,14 @@ JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::FindMatchDirecti
 
 JSON_FLAG_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::SuggestionsSource)
 {
-    static constexpr std::array<pair_type, 7> mappings = {
+    static constexpr std::array<pair_type, 8> mappings = {
         pair_type{ "none", AllClear },
         pair_type{ "tasks", ValueType::Tasks },
         pair_type{ "snippets", ValueType::Tasks },
         pair_type{ "commandHistory", ValueType::CommandHistory },
         pair_type{ "directoryHistory", ValueType::DirectoryHistory },
         pair_type{ "quickFix", ValueType::QuickFixes },
+        pair_type{ "scrollBack", ValueType::Scrollback },
         pair_type{ "all", AllSet },
     };
 };


### PR DESCRIPTION
## Summary of the Pull Request
Adds scroll back source to suggestions

There were 2 things that are different about this from my original screenshot in the feature request.
* In the feature request I had removed the MaxWidth on the _descriptionsBackdrop so that the control would expand for larger words.  This helped for file paths,  I decided to remove this change in case it affects the UX of the other sources.
* In the feature request I had changed the color of the highlights to VsCode blue.  When I tried this on a windows 10 machine I realized that the default accent color is blueish and the highlights were no longer visible so I reverted back to not setting the color.

I am not 100% sure on the performance of this.  When I list out all of the paths in my home dir and search, the UI stutters in debug mode but doesn't in the release build.  (I tried this on a really slow windows 10 machine with the release build and couldn't see any delay).
- I think listing and searching all the paths in my home dir is close to the worst case scenario, there is a chance that the regex is set to something that brings back every cell as a word, which would cause there to be millions of words but they would be fast to search over.

https://github.com/user-attachments/assets/dfe6df2e-1faf-4fda-be50-76aca402e79e

## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

## PR Checklist
- [ ] Closes #19061
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
