### PR TITLE
ci: turn on SARIF reporting unconditionally for check-spelling

### DIFF
--- a/.github/workflows/spelling2.yml
+++ b/.github/workflows/spelling2.yml
@@ -104,7 +104,7 @@ jobs:
           report-timing: 1
           warnings: bad-regex,binary-file,deprecated-feature,ignored-expect-variant,large-file,limited-references,no-newline-at-eof,noisy-file,non-alpha-in-dictionary,token-is-substring,unexpected-line-ending,whitespace-in-dictionary,minified-file,unsupported-configuration,no-files-to-check,unclosed-block-ignore-begin,unclosed-block-ignore-end
           experimental_apply_changes_via_bot: ${{ github.repository_owner != 'microsoft' && 1 }}
-          use_sarif: ${{ (!github.event.pull_request || (github.event.pull_request.head.repo.full_name == github.repository)) && 1 }}
+          use_sarif: 1
           check_extra_dictionaries: ""
           dictionary_source_prefixes: >
             {


### PR DESCRIPTION
The logic currently present occasionally fails to enable reporting for some PRs.