### PR TITLE
Re-enable web-source icons in Stable and Preview builds

### DIFF
--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -499,9 +499,14 @@ static bool _validateSingleMediaResource(std::wstring_view resource)
             return false;
         }
 
-        const auto scheme{ resourceUri.SchemeName() };
-        // Only file: URIs and ms-* URIs are permissible. http, https, ftp, gopher, etc. are not.
-        return til::equals_insensitive_ascii(scheme, L"file") || til::starts_with_insensitive_ascii(scheme, L"ms-");
+        if constexpr (Feature_DisableWebSourceIcons::IsEnabled())
+        {
+            const auto scheme{ resourceUri.SchemeName() };
+            // Only file: URIs and ms-* URIs are permissible. http, https, ftp, gopher, etc. are not.
+            return til::equals_insensitive_ascii(scheme, L"file") || til::starts_with_insensitive_ascii(scheme, L"ms-");
+        }
+
+        return true;
     }
     catch (...)
     {

--- a/src/features.xml
+++ b/src/features.xml
@@ -202,4 +202,15 @@
         <alwaysDisabledReleaseTokens/>
     </feature>
 
+    <feature>
+        <name>Feature_DisableWebSourceIcons</name>
+        <description>Disables icon paths that make web requests</description>
+        <id>19075</id>
+        <stage>AlwaysDisabled</stage>
+        <alwaysEnabledBrandingTokens>
+            <brandingToken>Dev</brandingToken>
+            <brandingToken>Canary</brandingToken>
+        </alwaysEnabledBrandingTokens>
+    </feature>
+
 </featureStaging>


### PR DESCRIPTION
Disables a controversial part of #19044.

Refs #19075
