### PR TITLE
Fix Application Title Being Stuck After Swapping "showTerminalTitleInTitlebar" From False to True

### DIFF
--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -295,7 +295,7 @@ void AppHost::Initialize()
             _window->ShowWindowChanged(show);
         });
 
-    _window->UpdateTitle(_windowLogic.Title());
+    _SetDefaultWindowTitle();
 
     // Set up the content of the application. If the app has a custom titlebar,
     // set that content as well.
@@ -388,6 +388,11 @@ void AppHost::_revokeWindowCallbacks()
     _window->DragRegionClicked(_windowCallbacks.DragRegionClicked);
     _window->WindowVisibilityChanged(_windowCallbacks.WindowVisibilityChanged);
     _window->MaximizeChanged(_windowCallbacks.MaximizeChanged);
+}
+
+void AppHost::_SetDefaultWindowTitle()
+{
+    _window->UpdateTitle(_windowLogic.Title());
 }
 
 // Method Description:
@@ -982,6 +987,16 @@ void AppHost::_updateTheme()
     }
 }
 
+void AppHost::_updateWindowTitleIfNeeded()
+{
+    const auto& shouldBeDefaultTitle = !_appLogic.Settings().GlobalSettings().ShowTitleInTitlebar();
+    const auto& windowTitleIsNotDefaultApplicationTitle = [this]() { return _window->GetTitle() != _windowLogic.Title(); };
+    if (shouldBeDefaultTitle && windowTitleIsNotDefaultApplicationTitle())
+    {
+        _SetDefaultWindowTitle();
+    }
+}
+
 void AppHost::_startFrameTimer()
 {
     // Instantiate the frame color timer, if we haven't already. We'll only ever
@@ -1028,6 +1043,7 @@ void AppHost::_HandleSettingsChanged(const winrt::Windows::Foundation::IInspecta
     _window->SetAutoHideWindow(_windowLogic.AutoHideWindow());
     _window->SetShowTabsFullscreen(_windowLogic.ShowTabsFullscreen());
     _updateTheme();
+    _updateWindowTitleIfNeeded();
 }
 
 void AppHost::_IsQuakeWindowChanged(const winrt::Windows::Foundation::IInspectable&,

--- a/src/cascadia/WindowsTerminal/AppHost.h
+++ b/src/cascadia/WindowsTerminal/AppHost.h
@@ -50,6 +50,8 @@ private:
 
     void _revokeWindowCallbacks();
 
+    void _SetDefaultWindowTitle();
+
     void _HandleCommandlineArgs(const winrt::TerminalApp::WindowRequestedArgs& args);
 
     winrt::Microsoft::Terminal::Settings::Model::LaunchPosition _GetWindowLaunchPosition();
@@ -109,6 +111,8 @@ private:
                             const winrt::Microsoft::Terminal::Control::WindowSizeChangedEventArgs& args);
 
     void _updateTheme();
+
+    void _updateWindowTitleIfNeeded();
 
     void _PropertyChangedHandler(const winrt::Windows::Foundation::IInspectable& sender,
                                  const winrt::Windows::UI::Xaml::Data::PropertyChangedEventArgs& args);

--- a/src/cascadia/WindowsTerminal/BaseWindow.h
+++ b/src/cascadia/WindowsTerminal/BaseWindow.h
@@ -177,6 +177,11 @@ public:
         PostMessageW(_window.get(), CM_UPDATE_TITLE, 0, reinterpret_cast<LPARAM>(nullptr));
     }
 
+    std::wstring_view GetTitle() const noexcept
+    {
+        return _title;
+    }
+
     // Method Description:
     // Reset the current dpi of the window. This method is only called after we change the
     // initial launch position. This makes sure the dpi is consistent with the monitor on which


### PR DESCRIPTION
## Summary of the Pull Request

This PR makes is so that if you are in showTabsInTitlebar = false and showTerminalTitleInTitlebar = true, then you swap showTerminalTitleInTitlebar = false. The Window title will reset back to "Terminal", this leads to a better UX of seeing Terminal instead of whatever page you were last on (in issue its Settings but really it could be anything).

## References and Relevant Issues

https://github.com/microsoft/terminal/issues/12871

## Detailed Description of the Pull Request / Additional comments

Introduced a check on apphost when settings update, if it needs to reset title it will

## Validation Steps Performed

- Tested with set to false
- Tested with set to true
- Tested with multiple windows

## PR Checklist
- [x] Closes #12871
- [ ] Tests added/passed -> Not sure if needed, happy to add
- [N/A] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [N/A] Schema updated (if necessary)
