### PR TITLE
Add telemetry for new tab menu traffic

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1255,7 +1255,7 @@ namespace winrt::TerminalApp::implementation
 
         TraceLoggingWrite(
             g_hTerminalAppProvider,
-            "NewTabMenuOpenedNewTerminalSession",
+            "NewTabMenuCreatedNewTerminalSession",
             TraceLoggingDescription("Event emitted when a new terminal was created via the new tab menu"),
             TraceLoggingValue(NumberOfTabs(), "NewTabCount", "The count of tabs currently opened in this window"),
             TraceLoggingValue(sessionType.c_str(), "SessionType", "The type of session that was created"),

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1467,7 +1467,6 @@ namespace winrt::TerminalApp::implementation
         {
             target = SettingsTarget::DefaultsFile;
         }
-        _LaunchSettings(target);
 
         const auto targetAsString = [&target]() {
             switch (target)
@@ -1485,11 +1484,13 @@ namespace winrt::TerminalApp::implementation
             g_hTerminalAppProvider,
             "NewTabMenuItemClicked",
             TraceLoggingDescription("Event emitted when an item from the new tab menu is invoked"),
-            TraceLoggingValue(NumberOfTabs(), "NewTabCount", "The count of tabs currently opened in this window"),
+            TraceLoggingValue(NumberOfTabs(), "TabCount", "The count of tabs currently opened in this window"),
             TraceLoggingValue("Settings", "ItemType", "The type of item that was clicked in the new tab menu"),
             TraceLoggingValue(targetAsString, "SettingsTarget", "The target settings file or UI"),
             TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
             TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
+
+        _LaunchSettings(target);
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1202,7 +1202,7 @@ namespace winrt::TerminalApp::implementation
 
         const auto dispatchToElevatedWindow = ctrlPressed && !IsRunningElevated();
 
-        const char* sessionType;
+        auto sessionType = "";
         if ((shiftPressed || dispatchToElevatedWindow) && !debugTap)
         {
             // Manually fill in the evaluated profile.

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1202,7 +1202,7 @@ namespace winrt::TerminalApp::implementation
 
         const auto dispatchToElevatedWindow = ctrlPressed && !IsRunningElevated();
 
-        std::string sessionType;
+        const char* sessionType;
         if ((shiftPressed || dispatchToElevatedWindow) && !debugTap)
         {
             // Manually fill in the evaluated profile.
@@ -1258,7 +1258,7 @@ namespace winrt::TerminalApp::implementation
             "NewTabMenuCreatedNewTerminalSession",
             TraceLoggingDescription("Event emitted when a new terminal was created via the new tab menu"),
             TraceLoggingValue(NumberOfTabs(), "NewTabCount", "The count of tabs currently opened in this window"),
-            TraceLoggingValue(sessionType.c_str(), "SessionType", "The type of session that was created"),
+            TraceLoggingValue(sessionType, "SessionType", "The type of session that was created"),
             TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
             TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
     }
@@ -1471,12 +1471,13 @@ namespace winrt::TerminalApp::implementation
         const auto targetAsString = [&target]() {
             switch (target)
             {
-            case SettingsTarget::SettingsUI:
-                return "UI";
             case SettingsTarget::SettingsFile:
                 return "SettingsFile";
             case SettingsTarget::DefaultsFile:
                 return "DefaultsFile";
+            case SettingsTarget::SettingsUI:
+            default:
+                return "UI";
             }
         }();
 


### PR DESCRIPTION
## Summary of the Pull Request
Adds new telemetry events to track traffic through the new tab menu. Specifically, the following events are added:
- `NewTabMenuDefaultButtonClicked`: Event emitted when the default button from the new tab split button is invoked
- `NewTabMenuOpened`: Event emitted when the new tab menu is opened
- `NewTabMenuClosed`: Event emitted when the new tab menu is closed
- `NewTabMenuItemClicked`: Event emitted when an item from the new tab menu is invoked
   - Has an `ItemType` parameter that can be set to `Settings`, `CommandPalette`, `About, `Profile`, `Action`
   - Has a `TabCount` parameter that keeps tracked of the number of tabs in the window before changing the state
- `NewTabMenuCreatedNewTerminalSession`: Event emitted when a new terminal was created via the new tab menu
   - Has a `SessionType` parameter that can be set to `ElevatedWindow`, `Window`, `Pane`, `Tab`
   - Instead of `TabCount`, has a `NewTabCount` that keeps track of the _new_ number of tabs after the session has been created
- `NewTabMenuItemElevateSubmenuItemClicked`: Event emitted when the elevate submenu item from the new tab menu is invoked

## Validation Steps Performed
Used TVPP to see events generated from interacting with the new tab menu.