### PR TITLE
Remove IconElement caching from PaletteItem

### DIFF
--- a/src/cascadia/TerminalApp/BasePaletteItem.h
+++ b/src/cascadia/TerminalApp/BasePaletteItem.h
@@ -14,14 +14,14 @@ namespace winrt::TerminalApp::implementation
         Windows::UI::Xaml::Controls::IconElement ResolvedIcon()
         {
             const auto icon{ static_cast<T*>(this)->Icon() };
-            if (!_resolvedIcon && !icon.empty())
+            if (!icon.empty())
             {
                 const auto resolvedIcon{ Microsoft::Terminal::UI::IconPathConverter::IconWUX(icon) };
                 resolvedIcon.Width(16);
                 resolvedIcon.Height(16);
-                _resolvedIcon = resolvedIcon;
+                return resolvedIcon;
             }
-            return _resolvedIcon;
+            return nullptr;
         }
 
         til::property_changed_event PropertyChanged;
@@ -34,11 +34,7 @@ namespace winrt::TerminalApp::implementation
 
         void InvalidateResolvedIcon()
         {
-            _resolvedIcon = nullptr;
             BaseRaisePropertyChanged(L"ResolvedIcon");
         }
-
-    private:
-        Windows::UI::Xaml::Controls::IconElement _resolvedIcon{ nullptr };
     };
 }


### PR DESCRIPTION
In #19132, we introduced caching for BasePaletteItem::ResolvedIcon as a late optimization.

We actually can't cache those, because they're UI elements, with parents and relationships and all. When you filter a list with icons and the list elements change physical position, they're assigned new templates-- and new parents.

Fixes e7939bb4e