### PR TITLE
Add telemetry for settings UI traffic

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Actions.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Actions.cpp
@@ -12,6 +12,8 @@ using namespace winrt::Windows::UI::Xaml::Navigation;
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
+    static constexpr std::wstring_view ActionsPageId{ L"page.actions" };
+
     Actions::Actions()
     {
         InitializeComponent();
@@ -66,6 +68,14 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 }
             }
         });
+
+        TraceLoggingWrite(
+            g_hTerminalSettingsEditorProvider,
+            "NavigatedToPage",
+            TraceLoggingDescription("Event emitted when the user navigates to a page in the settings UI"),
+            TraceLoggingValue(ActionsPageId.data(), "PageId", "The identifier of the page that was navigated to"),
+            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+            TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
     }
 
     void Actions::AddNew_Click(const IInspectable& /*sender*/, const RoutedEventArgs& /*eventArgs*/)

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
@@ -26,6 +26,8 @@ namespace winrt
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
+    static constexpr std::wstring_view ColorSchemesPageId{ L"page.colorSchemes" };
+
     ColorSchemes::ColorSchemes()
     {
         InitializeComponent();
@@ -44,6 +46,14 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
             ColorSchemeListView().Focus(FocusState::Programmatic);
         });
+
+        TraceLoggingWrite(
+            g_hTerminalSettingsEditorProvider,
+            "NavigatedToPage",
+            TraceLoggingDescription("Event emitted when the user navigates to a page in the settings UI"),
+            TraceLoggingValue(ColorSchemesPageId.data(), "PageId", "The identifier of the page that was navigated to"),
+            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+            TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
     }
 
     void ColorSchemes::AddNew_Click(const IInspectable& /*sender*/, const RoutedEventArgs& /*e*/)

--- a/src/cascadia/TerminalSettingsEditor/Compatibility.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.cpp
@@ -12,6 +12,8 @@ using namespace winrt::Microsoft::Terminal::Settings::Model;
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
+    static constexpr std::wstring_view CompatibilityPageId{ L"page.compatibility" };
+
     CompatibilityViewModel::CompatibilityViewModel(Model::CascadiaSettings settings) :
         _settings{ settings }
     {
@@ -25,11 +27,25 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     void CompatibilityViewModel::ResetApplicationState()
     {
+        TraceLoggingWrite(
+            g_hTerminalSettingsEditorProvider,
+            "ResetApplicationState",
+            TraceLoggingDescription("Event emitted when the user resets their application state"),
+            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+            TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
+
         _settings.ResetApplicationState();
     }
 
     void CompatibilityViewModel::ResetToDefaultSettings()
     {
+        TraceLoggingWrite(
+            g_hTerminalSettingsEditorProvider,
+            "ResetToDefaultSettings",
+            TraceLoggingDescription("Event emitted when the user resets their settings to their default value"),
+            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+            TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
+
         _settings.ResetToDefaultSettings();
     }
 
@@ -41,6 +57,14 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     void Compatibility::OnNavigatedTo(const NavigationEventArgs& e)
     {
         _ViewModel = e.Parameter().as<Editor::CompatibilityViewModel>();
+
+        TraceLoggingWrite(
+            g_hTerminalSettingsEditorProvider,
+            "NavigatedToPage",
+            TraceLoggingDescription("Event emitted when the user navigates to a page in the settings UI"),
+            TraceLoggingValue(CompatibilityPageId.data(), "PageId", "The identifier of the page that was navigated to"),
+            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+            TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
     }
 
     void Compatibility::ResetApplicationStateButton_Click(const Windows::Foundation::IInspectable& /*sender*/, const Windows::UI::Xaml::RoutedEventArgs& /*e*/)

--- a/src/cascadia/TerminalSettingsEditor/EditColorScheme.cpp
+++ b/src/cascadia/TerminalSettingsEditor/EditColorScheme.cpp
@@ -25,6 +25,8 @@ namespace winrt
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
+    static constexpr std::wstring_view EditColorSchemePageId{ L"page.editColorScheme" };
+
     EditColorScheme::EditColorScheme()
     {
         InitializeComponent();
@@ -42,7 +44,17 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         _ViewModel = e.Parameter().as<Editor::ColorSchemeViewModel>();
 
-        NameBox().Text(_ViewModel.Name());
+        const auto schemeName = _ViewModel.Name();
+        NameBox().Text(schemeName);
+
+        TraceLoggingWrite(
+            g_hTerminalSettingsEditorProvider,
+            "NavigatedToPage",
+            TraceLoggingDescription("Event emitted when the user navigates to a page in the settings UI"),
+            TraceLoggingValue(EditColorSchemePageId.data(), "PageId", "The identifier of the page that was navigated to"),
+            TraceLoggingValue(schemeName.data(), "SchemeName", "The name of the color scheme that's being edited"),
+            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+            TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
     }
 
     void EditColorScheme::ColorPickerChanged(const IInspectable& sender,

--- a/src/cascadia/TerminalSettingsEditor/Extensions.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Extensions.cpp
@@ -41,6 +41,15 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         vmImpl->ExtensionPackageIdentifierTemplateSelector(_extensionPackageIdentifierTemplateSelector);
         vmImpl->LazyLoadExtensions();
         vmImpl->MarkAsVisited();
+
+        TraceLoggingWrite(
+            g_hTerminalSettingsEditorProvider,
+            "NavigatedToPage",
+            TraceLoggingDescription("Event emitted when the user navigates to a page in the settings UI"),
+            TraceLoggingValue(ExtensionPageId.data(), "PageId", "The identifier of the page that was navigated to"),
+            TraceLoggingValue(_ViewModel.IsExtensionView(), "IsExtensionView", "If the page is representing a view of an extension. Otherwise, it represents a view of the root, which lists all extensions."),
+            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+            TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
     }
 
     void Extensions::ExtensionNavigator_Click(const IInspectable& sender, const RoutedEventArgs& /*args*/)

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.cpp
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.cpp
@@ -17,6 +17,8 @@ using namespace winrt::Windows::Foundation::Collections;
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
+    static constexpr std::wstring_view GlobalAppearancePageId{ L"page.globalAppearance" };
+
     GlobalAppearance::GlobalAppearance()
     {
         InitializeComponent();
@@ -25,5 +27,13 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     void GlobalAppearance::OnNavigatedTo(const NavigationEventArgs& e)
     {
         _ViewModel = e.Parameter().as<Editor::GlobalAppearanceViewModel>();
+
+        TraceLoggingWrite(
+            g_hTerminalSettingsEditorProvider,
+            "NavigatedToPage",
+            TraceLoggingDescription("Event emitted when the user navigates to a page in the settings UI"),
+            TraceLoggingValue(GlobalAppearancePageId.data(), "PageId", "The identifier of the page that was navigated to"),
+            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+            TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Interaction.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Interaction.cpp
@@ -10,6 +10,8 @@ using namespace winrt::Microsoft::Terminal::Settings::Model;
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
+    static constexpr std::wstring_view InteractionPageId{ L"page.interaction" };
+
     Interaction::Interaction()
     {
         InitializeComponent();
@@ -18,5 +20,13 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     void Interaction::OnNavigatedTo(const NavigationEventArgs& e)
     {
         _ViewModel = e.Parameter().as<Editor::InteractionViewModel>();
+
+        TraceLoggingWrite(
+            g_hTerminalSettingsEditorProvider,
+            "NavigatedToPage",
+            TraceLoggingDescription("Event emitted when the user navigates to a page in the settings UI"),
+            TraceLoggingValue(InteractionPageId.data(), "PageId", "The identifier of the page that was navigated to"),
+            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+            TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Launch.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Launch.cpp
@@ -16,6 +16,8 @@ using namespace winrt::Microsoft::Terminal::Settings::Model;
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
+    static constexpr std::wstring_view LaunchPageId{ L"page.startup" };
+
     Launch::Launch()
     {
         InitializeComponent();
@@ -43,5 +45,13 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _ViewModel = e.Parameter().as<Editor::LaunchViewModel>();
         auto innerViewModel{ winrt::get_self<Editor::implementation::LaunchViewModel>(_ViewModel) };
         /* coroutine dispatch */ innerViewModel->PrepareStartOnUserLoginSettings();
+
+        TraceLoggingWrite(
+            g_hTerminalSettingsEditorProvider,
+            "NavigatedToPage",
+            TraceLoggingDescription("Event emitted when the user navigates to a page in the settings UI"),
+            TraceLoggingValue(LaunchPageId.data(), "PageId", "The identifier of the page that was navigated to"),
+            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+            TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -25,6 +25,14 @@
 #include <LibraryResources.h>
 #include <dwmapi.h>
 
+// Note: Generate GUID using TlgGuid.exe tool
+TRACELOGGING_DEFINE_PROVIDER(
+    g_hTerminalSettingsEditorProvider,
+    "Microsoft.Windows.Terminal.Settings.Editor",
+    // {1b16317d-b594-51f8-c552-5d50572b5efc}
+    (0x1b16317d, 0xb594, 0x51f8, 0xc5, 0x52, 0x5d, 0x50, 0x57, 0x2b, 0x5e, 0xfc),
+    TraceLoggingOptionMicrosoftTelemetry());
+
 namespace winrt
 {
     namespace MUX = Microsoft::UI::Xaml;
@@ -374,6 +382,15 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                     const auto altPressed = WI_IsFlagSet(lAltState, CoreVirtualKeyStates::Down) ||
                                             WI_IsFlagSet(rAltState, CoreVirtualKeyStates::Down);
                     const auto target = altPressed ? SettingsTarget::DefaultsFile : SettingsTarget::SettingsFile;
+
+                    TraceLoggingWrite(
+                        g_hTerminalSettingsEditorProvider,
+                        "OpenJson",
+                        TraceLoggingDescription("Event emitted when the user clicks the Open JSON button in the settings UI"),
+                        TraceLoggingValue(target == SettingsTarget::DefaultsFile ? "DefaultsFile" : "SettingsFile", "SettingsTarget", "The target settings file"),
+                        TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+                        TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
+
                     OpenJson.raise(nullptr, target);
                     return;
                 }

--- a/src/cascadia/TerminalSettingsEditor/NewTabMenu.cpp
+++ b/src/cascadia/TerminalSettingsEditor/NewTabMenu.cpp
@@ -18,6 +18,8 @@ using namespace winrt::Microsoft::Terminal::Settings::Model;
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
+    static constexpr std::wstring_view NewTabMenuPageId{ L"page.newTabMenu" };
+
     NewTabMenu::NewTabMenu()
     {
         InitializeComponent();
@@ -44,6 +46,15 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     void NewTabMenu::OnNavigatedTo(const NavigationEventArgs& e)
     {
         _ViewModel = e.Parameter().as<Editor::NewTabMenuViewModel>();
+
+        TraceLoggingWrite(
+            g_hTerminalSettingsEditorProvider,
+            "NavigatedToPage",
+            TraceLoggingDescription("Event emitted when the user navigates to a page in the settings UI"),
+            TraceLoggingValue(NewTabMenuPageId.data(), "PageId", "The identifier of the page that was navigated to"),
+            TraceLoggingValue(_ViewModel.IsFolderView(), "IsFolderView", "If the page is representing a folder view. Otherwise, it represents a view of the root."),
+            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+            TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
     }
 
     void NewTabMenu::FolderPickerDialog_Opened(const IInspectable& /*sender*/, const Controls::ContentDialogOpenedEventArgs& /*e*/)

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.cpp
@@ -17,6 +17,8 @@ using namespace winrt::Windows::UI::Xaml::Navigation;
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
+    static constexpr std::wstring_view ProfilesAdvancedPageId{ L"page.profile.advanced" };
+
     Profiles_Advanced::Profiles_Advanced()
     {
         InitializeComponent();
@@ -29,6 +31,17 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         const auto args = e.Parameter().as<Editor::NavigateToProfileArgs>();
         _Profile = args.Profile();
         _windowRoot = args.WindowRoot();
+
+        TraceLoggingWrite(
+            g_hTerminalSettingsEditorProvider,
+            "NavigatedToPage",
+            TraceLoggingDescription("Event emitted when the user navigates to a page in the settings UI"),
+            TraceLoggingValue(ProfilesAdvancedPageId.data(), "PageId", "The identifier of the page that was navigated to"),
+            TraceLoggingValue(_Profile.IsBaseLayer(), "IsProfileDefaults", "If the modified profile is the profile.defaults object"),
+            TraceLoggingValue(to_hstring(_Profile.Guid()).c_str(), "ProfileGuid", "The guid of the profile that was navigated to"),
+            TraceLoggingValue(_Profile.Source().c_str(), "ProfileSource", "The source of the profile that was navigated to"),
+            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+            TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
     }
 
     void Profiles_Advanced::OnNavigatedFrom(const NavigationEventArgs& /*e*/)

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.cpp
@@ -14,6 +14,8 @@ using namespace winrt::Windows::UI::Xaml::Navigation;
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
+    static constexpr std::wstring_view ProfilesAppearancePageId{ L"page.profile.appearance" };
+
     Profiles_Appearance::Profiles_Appearance()
     {
         InitializeComponent();
@@ -44,6 +46,19 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // The Appearances object handles updating the values in the settings UI, but
         // we still need to listen to the changes here just to update the preview control
         _AppearanceViewModelChangedRevoker = _Profile.DefaultAppearance().PropertyChanged(winrt::auto_revoke, { this, &Profiles_Appearance::_onProfilePropertyChanged });
+
+        TraceLoggingWrite(
+            g_hTerminalSettingsEditorProvider,
+            "NavigatedToPage",
+            TraceLoggingDescription("Event emitted when the user navigates to a page in the settings UI"),
+            TraceLoggingValue(ProfilesAppearancePageId.data(), "PageId", "The identifier of the page that was navigated to"),
+            TraceLoggingValue(_Profile.IsBaseLayer(), "IsProfileDefaults", "If the modified profile is the profile.defaults object"),
+            TraceLoggingValue(to_hstring(_Profile.Guid()).c_str(), "ProfileGuid", "The guid of the profile that was navigated to"),
+            TraceLoggingValue(_Profile.Source().c_str(), "ProfileSource", "The source of the profile that was navigated to"),
+            TraceLoggingValue(_Profile.DefaultAppearance().BackgroundImageSettingsVisible(), "HasBackgroundImage", "If the profile has a background image defined"),
+            TraceLoggingValue(_Profile.HasUnfocusedAppearance(), "HasUnfocusedAppearance", "If the profile has an unfocused appearance defined"),
+            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+            TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
     }
 
     void Profiles_Appearance::OnNavigatedFrom(const NavigationEventArgs& /*e*/)
@@ -54,6 +69,16 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     void Profiles_Appearance::CreateUnfocusedAppearance_Click(const IInspectable& /*sender*/, const RoutedEventArgs& /*e*/)
     {
+        TraceLoggingWrite(
+            g_hTerminalSettingsEditorProvider,
+            "CreateUnfocusedAppearance",
+            TraceLoggingDescription("Event emitted when the user creates an unfocused appearance for a profile"),
+            TraceLoggingValue(_Profile.IsBaseLayer(), "IsProfileDefaults", "If the modified profile is the profile.defaults object"),
+            TraceLoggingValue(to_hstring(_Profile.Guid()).c_str(), "ProfileGuid", "The guid of the profile that was navigated to"),
+            TraceLoggingValue(_Profile.Source().c_str(), "ProfileSource", "The source of the profile that was navigated to"),
+            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+            TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
+
         _Profile.CreateUnfocusedAppearance();
     }
 

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.cpp
@@ -15,6 +15,8 @@ using namespace winrt::Windows::UI::Xaml::Navigation;
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
+    static constexpr std::wstring_view ProfilesBasePageId{ L"page.profile" };
+
     Profiles_Base::Profiles_Base()
     {
         InitializeComponent();
@@ -55,6 +57,18 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 _Profile.FocusDeleteButton(false);
             }
         });
+
+        TraceLoggingWrite(
+            g_hTerminalSettingsEditorProvider,
+            "NavigatedToPage",
+            TraceLoggingDescription("Event emitted when the user navigates to a page in the settings UI"),
+            TraceLoggingValue(ProfilesBasePageId.data(), "PageId", "The identifier of the page that was navigated to"),
+            TraceLoggingValue(_Profile.IsBaseLayer(), "IsProfileDefaults", "If the modified profile is the profile.defaults object"),
+            TraceLoggingValue(to_hstring(_Profile.Guid()).c_str(), "ProfileGuid", "The guid of the profile that was navigated to"),
+            TraceLoggingValue(_Profile.Source().c_str(), "ProfileSource", "The source of the profile that was navigated to"),
+            TraceLoggingValue(false, "Orphaned", "Tracks if the profile was orphaned"),
+            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+            TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
     }
 
     void Profiles_Base::OnNavigatedFrom(const NavigationEventArgs& /*e*/)
@@ -79,6 +93,16 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     void Profiles_Base::DeleteConfirmation_Click(const IInspectable& /*sender*/, const RoutedEventArgs& /*e*/)
     {
+        TraceLoggingWrite(
+            g_hTerminalSettingsEditorProvider,
+            "DeleteProfile",
+            TraceLoggingDescription("Event emitted when the user deletes a profile"),
+            TraceLoggingValue(to_hstring(_Profile.Guid()).c_str(), "ProfileGuid", "The guid of the profile that was navigated to"),
+            TraceLoggingValue(_Profile.Source().c_str(), "ProfileSource", "The source of the profile that was navigated to"),
+            TraceLoggingValue(false, "Orphaned", "Tracks if the profile was orphaned"),
+            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+            TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
+
         winrt::get_self<ProfileViewModel>(_Profile)->DeleteProfile();
     }
 

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base_Orphaned.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base_Orphaned.cpp
@@ -15,6 +15,8 @@ using namespace winrt::Windows::UI::Xaml::Navigation;
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
+    static constexpr std::wstring_view ProfilesBaseOrphanedPageId{ L"page.profile" };
+
     Profiles_Base_Orphaned::Profiles_Base_Orphaned()
     {
         InitializeComponent();
@@ -41,6 +43,18 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 _Profile.FocusDeleteButton(false);
             }
         });
+
+        TraceLoggingWrite(
+            g_hTerminalSettingsEditorProvider,
+            "NavigatedToPage",
+            TraceLoggingDescription("Event emitted when the user navigates to a page in the settings UI"),
+            TraceLoggingValue(ProfilesBaseOrphanedPageId.data(), "PageId", "The identifier of the page that was navigated to"),
+            TraceLoggingValue(_Profile.IsBaseLayer(), "IsProfileDefaults", "If the modified profile is the profile.defaults object"),
+            TraceLoggingValue(to_hstring(_Profile.Guid()).c_str(), "ProfileGuid", "The guid of the profile that was navigated to"),
+            TraceLoggingValue(_Profile.Source().c_str(), "ProfileSource", "The source of the profile that was navigated to"),
+            TraceLoggingValue(true, "Orphaned", "Tracks if the profile was orphaned"),
+            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+            TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
     }
 
     void Profiles_Base_Orphaned::DeleteConfirmation_Click(const IInspectable& /*sender*/, const RoutedEventArgs& /*e*/)

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Terminal.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Terminal.cpp
@@ -14,6 +14,8 @@ using namespace winrt::Windows::UI::Xaml::Navigation;
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
+    static constexpr std::wstring_view ProfilesTerminalPageId{ L"page.profile.terminal" };
+
     Profiles_Terminal::Profiles_Terminal()
     {
         InitializeComponent();
@@ -22,6 +24,17 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     void Profiles_Terminal::OnNavigatedTo(const NavigationEventArgs& e)
     {
         _Profile = e.Parameter().as<Editor::ProfileViewModel>();
+
+        TraceLoggingWrite(
+            g_hTerminalSettingsEditorProvider,
+            "NavigatedToPage",
+            TraceLoggingDescription("Event emitted when the user navigates to a page in the settings UI"),
+            TraceLoggingValue(ProfilesTerminalPageId.data(), "PageId", "The identifier of the page that was navigated to"),
+            TraceLoggingValue(_Profile.IsBaseLayer(), "IsProfileDefaults", "If the modified profile is the profile.defaults object"),
+            TraceLoggingValue(to_hstring(_Profile.Guid()).c_str(), "ProfileGuid", "The guid of the profile that was navigated to"),
+            TraceLoggingValue(_Profile.Source().c_str(), "ProfileSource", "The source of the profile that was navigated to"),
+            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+            TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
     }
 
     void Profiles_Terminal::OnNavigatedFrom(const NavigationEventArgs& /*e*/)

--- a/src/cascadia/TerminalSettingsEditor/Rendering.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Rendering.cpp
@@ -9,6 +9,8 @@ using namespace winrt::Windows::UI::Xaml::Navigation;
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
+    static constexpr std::wstring_view RenderingPageId{ L"page.rendering" };
+
     Rendering::Rendering()
     {
         InitializeComponent();
@@ -17,5 +19,13 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     void Rendering::OnNavigatedTo(const NavigationEventArgs& e)
     {
         _ViewModel = e.Parameter().as<Editor::RenderingViewModel>();
+
+        TraceLoggingWrite(
+            g_hTerminalSettingsEditorProvider,
+            "NavigatedToPage",
+            TraceLoggingDescription("Event emitted when the user navigates to a page in the settings UI"),
+            TraceLoggingValue(RenderingPageId.data(), "PageId", "The identifier of the page that was navigated to"),
+            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+            TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/pch.h
+++ b/src/cascadia/TerminalSettingsEditor/pch.h
@@ -56,6 +56,13 @@
 #include <winrt/Microsoft.Terminal.Settings.Model.h>
 #include <winrt/Microsoft.Terminal.UI.h>
 
+// Including TraceLogging essentials for the binary
+#include <TraceLoggingProvider.h>
+#include <winmeta.h>
+TRACELOGGING_DECLARE_PROVIDER(g_hTerminalSettingsEditorProvider);
+#include <telemetry/ProjectTelemetry.h>
+#include <TraceLoggingActivity.h>
+
 #include <shlobj.h>
 #include <shobjidl_core.h>
 #include <dwrite_3.h>


### PR DESCRIPTION
## Summary of the Pull Request
Adds a telemetry provider to the Terminal.Settings.Editor project as well as new telemetry events to track traffic through the settings UI. Specifically, the following events were added:
- `NavigatedToPage`: Event emitted when the user navigates to a page in the settings UI
   - Has a `PageId` parameter that includes the identifier of the page that was navigated to
   - (conditionally added when PageId = `page.editColorScheme`) `SchemeName` parameter tracks the name of the color scheme that's being edited
   - (conditionally added when PageId = `page.extensions`) if the page is representing a view of an extension
   - (conditionally added when PageID = `page.newTabMenu`) if the page is representing a folder view
   - conditionally added when PageID = `page.profile.*`:
      - `IsProfileDefaults`: if the modified profile is the profile.defaults object
      - `ProfileGuid`: the guid of the profile that was navigated to
      - `ProfileSource`: the source of the profile that was navigated to
      - (conditionally added when PageID = `page.profile`) `Orphaned`: tracks if the profile was orphaned
      - (conditionally added when PageID = `page.profile.appearance`) `HasBackgroundImage`: `if the profile has a background image defined`
      - (conditionally added when PageID = `page.profile.appearance`) `HasUnfocusedAppearance`: `if the profile has an unfocused appearance defined`
- `AddNewProfile`: Event emitted when the user adds a new profile `IsExtensionView` parameter tracks if the page is representing a view of an extension
   - Has a `Type` parameter that represents the type of the creation method (i.e. empty profile, duplicate)
- `ResetApplicationState`: Event emitted when the user resets their application state (via the UI)
- `ResetToDefaultSettings`: Event emitted when the user resets their settings to their default value (via the UI)
- `OpenJson`: Event emitted when the user clicks the Open JSON button in the settings UI
   - Has a `SettingsTarget` parameter that represents the target settings file (i.e. settings.json vs defaults.json)
- `CreateUnfocusedAppearance`: Event emitted when the user creates an unfocused appearance for a profile
   - `IsProfileDefaults`: if the modified profile is the profile.defaults object
   - `ProfileGuid`: the guid of the profile that was navigated to
   - `ProfileSource`: the source of the profile that was navigated to
- `DeleteProfile`: Event emitted when the user deletes a profile
   - also includes `ProfileGuid`, `ProfileSource`, `Orphaned` from the `NavigatedToPage` section above

The page ids can be reused later as a serialized reference to the page. We already use the one for the extensions page for the "new" badge. 