### PR TITLE
Update key chord styling in actions page

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Actions.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Actions.xaml
@@ -57,13 +57,12 @@
                            TargetType="Border">
                         <Setter Property="BorderThickness" Value="1" />
                         <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}" />
-                        <Setter Property="Background" Value="{ThemeResource SubtleFillColorSecondaryBrush}" />
-                        <Setter Property="BorderBrush" Value="{ThemeResource DividerStrokeColorDefaultBrush}" />
-                        <Setter Property="Padding" Value="4,4,4,4" />
+                        <Setter Property="Background" Value="{ThemeResource SystemAltMediumLowColor}" />
+                        <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
                     </Style>
                     <Style x:Key="KeyChordTextBlockStyle"
                            TargetType="TextBlock">
-                        <Setter Property="Foreground" Value="{ThemeResource TextFillColorSecondaryBrush}" />
+                        <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
                     </Style>
 
                 </ResourceDictionary>
@@ -100,13 +99,12 @@
                         <Setter Property="BorderThickness" Value="1" />
                         <Setter Property="BorderThickness" Value="1" />
                         <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}" />
-                        <Setter Property="Background" Value="{ThemeResource SubtleFillColorSecondaryBrush}" />
-                        <Setter Property="BorderBrush" Value="{ThemeResource DividerStrokeColorDefaultBrush}" />
-                        <Setter Property="Padding" Value="4,4,4,4" />
+                        <Setter Property="Background" Value="{ThemeResource SystemAltMediumLowColor}" />
+                        <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
                     </Style>
                     <Style x:Key="KeyChordTextBlockStyle"
                            TargetType="TextBlock">
-                        <Setter Property="Foreground" Value="{ThemeResource TextFillColorSecondaryBrush}" />
+                        <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
                     </Style>
 
                 </ResourceDictionary>
@@ -209,7 +207,7 @@
 
                         <!--  Key Chord Text  -->
                         <Border Grid.Column="1"
-                                Padding="8,4,8,4"
+                                Padding="2,0,2,0"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="Center"
                                 Style="{ThemeResource KeyChordBorderStyle}"


### PR DESCRIPTION
## Summary of the Pull Request
Reverts most of the styling changes done in #19001 to the key chords displayed in the SUI's Actions page. The `CornerRadius` was kept at the updated value of `ControlCornerRadius` for consistency.

The only other changes in #19001 that were kept for this page include:
- `EditButtonIconSize`: 15 --> 14
- `AccentEditButtonStyle` > `Padding`: 3 --> 4
- Command name's `FontWeight` reduced to `Normal`
- `AddNewButton` > `Margin` added (set to `0,12,0,0` to provide spacing between breadcrumb header and button)