### PR TITLE
Command: realize resource-key names when they are requested, not at load

### DIFF
--- a/src/cascadia/TerminalSettingsModel/Command.h
+++ b/src/cascadia/TerminalSettingsModel/Command.h
@@ -44,6 +44,12 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 {
     struct Command : CommandT<Command>
     {
+        struct CommandNameOrResource
+        {
+            std::wstring name;
+            std::wstring resource;
+        };
+
         Command();
         com_ptr<Command> Copy() const;
 
@@ -93,7 +99,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     private:
         Json::Value _originalJson;
         Windows::Foundation::Collections::IMap<winrt::hstring, Model::Command> _subcommands{ nullptr };
-        std::optional<std::wstring> _name;
+        std::optional<CommandNameOrResource> _name;
         std::wstring _ID;
         bool _IDWasGenerated{ false };
         std::optional<std::wstring> _iconPath;


### PR DESCRIPTION
Right now, when a Command's name is `{"key": "ResourceName"}` we resolve the resource immediately at load time. That prevents us from looking it up later in another language if we need to.

This pull request introduces an intermediate representation for command names which is be resolved during `Command::Name`.

Refs #7039