### PR TITLE
fix(ControlCore): prevent cursor repositioning during mouse selection

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -2069,13 +2069,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             _terminal->MultiClickSelection(terminalPosition, mode);
             selectionNeedsToBeCopied = true;
         }
-        else if (_settings->RepositionCursorWithMouse()) // This is also mode==Char && !shiftEnabled
+        else if (_settings->RepositionCursorWithMouse() && !selectionNeedsToBeCopied) // Don't reposition cursor if this is part of a selection operation
         {
-            // Don't reposition cursor if this is part of a selection operation
-            if (!selectionNeedsToBeCopied)
-            {
-                _repositionCursorWithMouse(terminalPosition);
-            }
+            _repositionCursorWithMouse(terminalPosition);
         }
         _updateSelectionUI();
     }

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -2071,7 +2071,11 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         }
         else if (_settings->RepositionCursorWithMouse()) // This is also mode==Char && !shiftEnabled
         {
-            _repositionCursorWithMouse(terminalPosition);
+            // Don't reposition cursor if this is part of a selection operation
+            if (!selectionNeedsToBeCopied)
+            {
+                _repositionCursorWithMouse(terminalPosition);
+            }
         }
         _updateSelectionUI();
     }


### PR DESCRIPTION

## References and Relevant Issues
https://github.com/microsoft/terminal/issues/19181

## Detailed Description of the Pull Request / Additional comments
- Modify the cursor repositioning logic to check if a selection is in progress
- Only reposition the cursor when the mouse is used for positioning, not during selection operations

