### PR TITLE
Use a new API to propagate foreground state to child processes

### DIFF
--- a/dep/nuget/packages.config
+++ b/dep/nuget/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.Internal.PGO-Helpers.Cpp" version="0.2.34" targetFramework="native" />
   <package id="Microsoft.Taef" version="10.93.240607003" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230207.1" targetFramework="native" />
-  <package id="Microsoft.Internal.Windows.Terminal.ThemeHelpers" version="0.7.230706001" targetFramework="native" />
+  <package id="Microsoft.Internal.Windows.Terminal.ThemeHelpers" version="0.8.250811004" targetFramework="native" />
   <package id="Microsoft.VisualStudio.Setup.Configuration.Native" version="2.3.2262" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.UI.Xaml" version="2.8.4" targetFramework="native" />
   <package id="Microsoft.Web.WebView2" version="1.0.1661.34" targetFramework="native" />

--- a/src/cascadia/LocalTests_TerminalApp/TerminalApp.LocalTests.vcxproj
+++ b/src/cascadia/LocalTests_TerminalApp/TerminalApp.LocalTests.vcxproj
@@ -24,6 +24,7 @@
   <PropertyGroup Label="NuGet Dependencies">
     <!-- TerminalCppWinrt is intentionally not set -->
     <TerminalMUX>true</TerminalMUX>
+    <TerminalThemeHelpers>true</TerminalThemeHelpers>
   </PropertyGroup>
 
   <Import Project="$(SolutionDir)\common.openconsole.props" Condition="'$(OpenConsoleDir)'==''" />

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -1009,6 +1009,8 @@ namespace winrt::TerminalApp::implementation
                 auto profile = tabImpl->GetFocusedProfile();
                 _UpdateBackground(profile);
             }
+
+            _adjustProcessPriorityGivenFocusState(_activated);
         }
         CATCH_LOG();
     }

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -1010,7 +1010,7 @@ namespace winrt::TerminalApp::implementation
                 _UpdateBackground(profile);
             }
 
-            _adjustProcessPriorityGivenFocusState(_activated);
+            _adjustProcessPriorityThrottled->Run();
         }
         CATCH_LOG();
     }

--- a/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
+++ b/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
@@ -26,6 +26,7 @@
     <TerminalCppWinrt>true</TerminalCppWinrt>
     <TerminalMUX>true</TerminalMUX>
     <TerminalWinGetInterop>true</TerminalWinGetInterop>
+    <TerminalThemeHelpers>true</TerminalThemeHelpers>
   </PropertyGroup>
   <Import Project="..\..\..\common.openconsole.props" Condition="'$(OpenConsoleDir)'==''" />
   <Import Project="$(OpenConsoleDir)src\common.nugetversions.props" />

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -4962,11 +4962,11 @@ namespace winrt::TerminalApp::implementation
             }
             if (control)
             {
-                if (auto conn = control.Connection())
+                if (const auto conn{ control.Connection() })
                 {
-                    if (auto pty = conn.try_as<winrt::Microsoft::Terminal::TerminalConnection::ConptyConnection>())
+                    if (const auto pty{ conn.try_as<winrt::Microsoft::Terminal::TerminalConnection::ConptyConnection>() })
                     {
-                        if (uint64_t process = pty.RootProcessHandle())
+                        if (const uint64_t process{ pty.RootProcessHandle() }; process != 0)
                         {
                             *it++ = reinterpret_cast<HANDLE>(process);
                         }
@@ -4981,12 +4981,12 @@ namespace winrt::TerminalApp::implementation
             // under it to the window so they all go into the background at the same time.
             for (auto&& tab : _tabs)
             {
-                if (auto t{ _GetTerminalTabImpl(tab) })
+                if (auto tabImpl{ _GetTabImpl(tab) })
                 {
-                    if (const auto pane = t->GetRootPane())
+                    if (const auto pane{ tabImpl->GetRootPane() })
                     {
-                        pane->WalkTree([&](auto p) {
-                            if (const auto& control{ p->GetTerminalControl() })
+                        pane->WalkTree([&](auto&& child) {
+                            if (const auto& control{ child->GetTerminalControl() })
                             {
                                 appendFromControl(control);
                             }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -5003,7 +5003,7 @@ namespace winrt::TerminalApp::implementation
         }
 
         const auto count{ gsl::narrow_cast<DWORD>(it - processes.begin()) };
-        auto hr = TerminalTrySetWindowForegroundProcesses(_hostingHwnd.value(), count, count ? processes.data() : nullptr);
+        auto hr = TerminalTrySetWindowAssociatedProcesses(_hostingHwnd.value(), count, count ? processes.data() : nullptr);
         TraceLoggingWrite(
             g_hTerminalAppProvider,
             "CalledNtUserQoSAPI",
@@ -5016,7 +5016,7 @@ namespace winrt::TerminalApp::implementation
             supported = false;
         }
 #ifdef _DEBUG
-        OutputDebugStringW(fmt::format(FMT_COMPILE(L"Submitted {} processes to SetAdditionalPowerThrottlingProcess; return=0x{:08x}\n"), count, hr).c_str());
+        OutputDebugStringW(fmt::format(FMT_COMPILE(L"Submitted {} processes to TerminalTrySetWindowAssociatedProcesses; return=0x{:08x}\n"), count, hr).c_str());
 #endif
     }
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -5013,7 +5013,7 @@ namespace winrt::TerminalApp::implementation
 
         TraceLoggingWrite(
             g_hTerminalAppProvider,
-            "CalledNtUserQoSAPI",
+            "CalledNewQoSAPI",
             TraceLoggingValue(reinterpret_cast<uintptr_t>(_hostingHwnd.value()), "hwnd"),
             TraceLoggingValue(count),
             TraceLoggingHResult(hr));

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -4946,7 +4946,7 @@ namespace winrt::TerminalApp::implementation
     {
         static bool supported{ true };
 
-        if (!supported)
+        if (!supported || !_hostingHwnd.has_value())
         {
             return;
         }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -4998,7 +4998,7 @@ namespace winrt::TerminalApp::implementation
         else
         {
             // When a window is in focus, propagate our foreground boost (if we have one)
-            // to the active tab and all panes inside it.
+            // to current active pane.
             appendFromControl(_GetActiveControl());
         }
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -4987,7 +4987,7 @@ namespace winrt::TerminalApp::implementation
             }
         };
 
-        auto&& appendFromTab = [](auto&& tabImpl) {
+        auto&& appendFromTab = [&](auto&& tabImpl) {
             if (const auto pane{ tabImpl->GetRootPane() })
             {
                 pane->WalkTree([&](auto&& child) {

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <ThrottledFunc.h>
+
 #include "TerminalPage.g.h"
 #include "Tab.h"
 #include "AppKeyBindings.h"
@@ -359,10 +361,11 @@ namespace winrt::TerminalApp::implementation
         bool _MovePane(const Microsoft::Terminal::Settings::Model::MovePaneArgs args);
         bool _MoveTab(winrt::com_ptr<Tab> tab, const Microsoft::Terminal::Settings::Model::MoveTabArgs args);
 
-        void _adjustProcessPriorityGivenFocusState(const bool focused) const;
+        std::shared_ptr<ThrottledFunc<>> _adjustProcessPriorityThrottled;
+        void _adjustProcessPriority() const;
 
         template<typename F>
-        bool _ApplyToActiveControls(F f)
+        bool _ApplyToActiveControls(F f) const
         {
             if (const auto tab{ _GetFocusedTabImpl() })
             {

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -359,6 +359,8 @@ namespace winrt::TerminalApp::implementation
         bool _MovePane(const Microsoft::Terminal::Settings::Model::MovePaneArgs args);
         bool _MoveTab(winrt::com_ptr<Tab> tab, const Microsoft::Terminal::Settings::Model::MoveTabArgs args);
 
+        void _adjustProcessPriorityGivenFocusState(const bool focused) const;
+
         template<typename F>
         bool _ApplyToActiveControls(F f)
         {
@@ -379,7 +381,7 @@ namespace winrt::TerminalApp::implementation
             return false;
         }
 
-        winrt::Microsoft::Terminal::Control::TermControl _GetActiveControl();
+        winrt::Microsoft::Terminal::Control::TermControl _GetActiveControl() const;
         std::optional<uint32_t> _GetFocusedTabIndex() const noexcept;
         std::optional<uint32_t> _GetTabIndex(const TerminalApp::Tab& tab) const noexcept;
         TerminalApp::Tab _GetFocusedTab() const noexcept;

--- a/src/cascadia/TerminalApp/dll/TerminalApp.vcxproj
+++ b/src/cascadia/TerminalApp/dll/TerminalApp.vcxproj
@@ -16,6 +16,7 @@
   <PropertyGroup Label="NuGet Dependencies">
     <TerminalCppWinrt>true</TerminalCppWinrt>
     <TerminalMUX>true</TerminalMUX>
+    <TerminalThemeHelpers>true</TerminalThemeHelpers>
   </PropertyGroup>
   <Import Project="..\..\..\..\common.openconsole.props" Condition="'$(OpenConsoleDir)'==''" />
   <Import Project="$(OpenConsoleDir)src\common.nugetversions.props" />

--- a/src/cascadia/TerminalConnection/ConptyConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConptyConnection.cpp
@@ -345,7 +345,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         if (!ownedClient)
         {
             // If we couldn't reopen the handle with SET_INFORMATION, which may be required to do things like QoS management, fall back.
-            THROW_IF_WIN32_BOOL_FALSE(DuplicateHandle(GetCurrentProcess(), client, GetCurrentProcess(), ownedClient.addressof(), 0, FALSE, DUPLICATE_SAME_ACCESS));
+            ownedClient = duplicateHandle(client);
         }
 
         THROW_IF_FAILED(ConptyPackPseudoConsole(ownedServer.get(), ownedReference.get(), ownedSignal.get(), &_hPC));

--- a/src/cascadia/TerminalConnection/ConptyConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConptyConnection.cpp
@@ -657,8 +657,9 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         }
     }
 
-    uint64_t ConptyConnection::RootProcessHandle()
+    uint64_t ConptyConnection::RootProcessHandle() noexcept
     {
+#pragma warning(disable : 26490) // Don't use reinterpret_cast (type.1).
         return reinterpret_cast<uint64_t>(_piClient.hProcess);
     }
 

--- a/src/cascadia/TerminalConnection/ConptyConnection.h
+++ b/src/cascadia/TerminalConnection/ConptyConnection.h
@@ -30,6 +30,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         void ShowHide(const bool show);
 
         void ReparentWindow(const uint64_t newParent);
+        uint64_t RootProcessHandle();
 
         winrt::hstring Commandline() const;
         winrt::hstring StartingTitle() const;

--- a/src/cascadia/TerminalConnection/ConptyConnection.h
+++ b/src/cascadia/TerminalConnection/ConptyConnection.h
@@ -30,7 +30,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         void ShowHide(const bool show);
 
         void ReparentWindow(const uint64_t newParent);
-        uint64_t RootProcessHandle();
+        uint64_t RootProcessHandle() noexcept;
 
         winrt::hstring Commandline() const;
         winrt::hstring StartingTitle() const;

--- a/src/cascadia/TerminalConnection/ConptyConnection.idl
+++ b/src/cascadia/TerminalConnection/ConptyConnection.idl
@@ -21,6 +21,8 @@ namespace Microsoft.Terminal.TerminalConnection
 
         void ReparentWindow(UInt64 newParent);
 
+        UInt64 RootProcessHandle();
+
         static event NewConnectionHandler NewConnection;
         static void StartInboundListener();
 

--- a/src/common.nugetversions.targets
+++ b/src/common.nugetversions.targets
@@ -47,7 +47,7 @@
     <Import Project="$(MSBuildThisFileDirectory)..\packages\Microsoft.Taef.10.93.240607003\build\Microsoft.Taef.targets" Condition="'$(TerminalTAEF)' == 'true' and Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Taef.10.93.240607003\build\Microsoft.Taef.targets')" />
 
     <!-- TerminalThemeHelpers -->
-    <Import Project="$(MSBuildThisFileDirectory)..\packages\Microsoft.Internal.Windows.Terminal.ThemeHelpers.0.7.230706001\build\native\Microsoft.Internal.Windows.Terminal.ThemeHelpers.targets" Condition="'$(TerminalThemeHelpers)' == 'true' and Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Internal.Windows.Terminal.ThemeHelpers.0.7.230706001\build\native\Microsoft.Internal.Windows.Terminal.ThemeHelpers.targets')" />
+    <Import Project="$(MSBuildThisFileDirectory)..\packages\Microsoft.Internal.Windows.Terminal.ThemeHelpers.0.8.250811004\build\native\Microsoft.Internal.Windows.Terminal.ThemeHelpers.targets" Condition="'$(TerminalThemeHelpers)' == 'true' and Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Internal.Windows.Terminal.ThemeHelpers.0.8.250811004\build\native\Microsoft.Internal.Windows.Terminal.ThemeHelpers.targets')" />
 
     <!-- VisualStudioSetup -->
     <Import Project="$(MSBuildThisFileDirectory)..\packages\Microsoft.VisualStudio.Setup.Configuration.Native.2.3.2262\build\native\Microsoft.VisualStudio.Setup.Configuration.Native.targets" Condition="'$(TerminalVisualStudioSetup)' == 'true' and Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.VisualStudio.Setup.Configuration.Native.2.3.2262\build\native\Microsoft.VisualStudio.Setup.Configuration.Native.targets')" />
@@ -85,7 +85,7 @@
     <Error Condition="'$(TerminalTAEF)' == 'true' AND !Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Taef.10.93.240607003\build\Microsoft.Taef.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(MSBuildThisFileDirectory)..\packages\Microsoft.Taef.10.93.240607003\build\Microsoft.Taef.targets'))" />
 
     <!-- TerminalThemeHelpers -->
-    <Error Condition="'$(TerminalThemeHelpers)' == 'true' AND !Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Internal.Windows.Terminal.ThemeHelpers.0.7.230706001\build\native\Microsoft.Internal.Windows.Terminal.ThemeHelpers.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(MSBuildThisFileDirectory)..\packages\Microsoft.Internal.Windows.Terminal.ThemeHelpers.0.7.230706001\build\native\Microsoft.Internal.Windows.Terminal.ThemeHelpers.targets'))" />
+    <Error Condition="'$(TerminalThemeHelpers)' == 'true' AND !Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Internal.Windows.Terminal.ThemeHelpers.0.8.250811004\build\native\Microsoft.Internal.Windows.Terminal.ThemeHelpers.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(MSBuildThisFileDirectory)..\packages\Microsoft.Internal.Windows.Terminal.ThemeHelpers.0.8.250811004\build\native\Microsoft.Internal.Windows.Terminal.ThemeHelpers.targets'))" />
 
     <!-- VisualStudioSetup -->
     <Error Condition="'$(TerminalVisualStudioSetup)' == 'true' AND !Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.VisualStudio.Setup.Configuration.Native.2.3.2262\build\native\Microsoft.VisualStudio.Setup.Configuration.Native.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(MSBuildThisFileDirectory)..\packages\Microsoft.VisualStudio.Setup.Configuration.Native.2.3.2262\build\native\Microsoft.VisualStudio.Setup.Configuration.Native.targets'))" />

--- a/src/host/srvinit.cpp
+++ b/src/host/srvinit.cpp
@@ -463,7 +463,7 @@ try
                       TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
                       TraceLoggingKeyword(TIL_KEYWORD_TRACE));
 
-    wil::unique_handle clientProcess{ OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ | SYNCHRONIZE, TRUE, static_cast<DWORD>(connectMessage->Descriptor.Process)) };
+    wil::unique_handle clientProcess{ OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ | PROCESS_SET_INFORMATION | SYNCHRONIZE, TRUE, static_cast<DWORD>(connectMessage->Descriptor.Process)) };
     RETURN_LAST_ERROR_IF_NULL(clientProcess.get());
 
     TraceLoggingWrite(g_hConhostV2EventTraceProvider,


### PR DESCRIPTION
Windows 11 uses some additional signals to determine what the user cares
about and give it a bit of a QoS boost. One of those signals is whether
it is associated with a window that is in the foreground or which has
input focus.

Association today takes two forms:
- Process has a window which is in the foreground or which has input
  focus
- Process has a *parent* that meets the above criterion.

Console applications that are spawned "inside" terminal by handoff do
not fall into either bucket. They don't have a window. Their parent is
`dllhost` or `explorer`, who is definitely not in focus.

We are piloting a new API that allows us to associate those processes
with Terminal's window.

When Terminal is in focus, it will attach every process from the active
tab to its QoS group. This means that whatever is running in that tab
is put into the "foreground" bucket, and everything running in other
background tabs is not.

When Terminal is out of focus, it attaches every process to its QoS
group. This ensures that they all go into the "background" bucket
together, following the window.