### PR TITLE
Remove dependency on .NET 6 and Framework 4.8

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "XamlStyler.Console": {
-      "version": "3.2311.2",
+      "version": "3.2501.8",
       "commands": [
         "xstyler"
       ]

--- a/.vsconfig
+++ b/.vsconfig
@@ -17,7 +17,6 @@
     "Microsoft.VisualStudio.Component.AppInsights.Tools",
     "Microsoft.Net.Component.4.8.TargetingPack",
     "Microsoft.VisualStudio.Component.DiagnosticTools",
-    "Microsoft.NetCore.Component.Runtime.6.0",
     "Microsoft.VisualStudio.Component.ClassDesigner",
     "Microsoft.VisualStudio.Component.GraphDocument",
     "Microsoft.VisualStudio.Component.CodeMap",

--- a/build/config/esrp.build.batch.wpfdotnet.json
+++ b/build/config/esrp.build.batch.wpfdotnet.json
@@ -2,7 +2,7 @@
     {
         "MatchedPath": [
             "WpfTerminalControl/net472/Microsoft.Terminal.Wpf.dll",
-            "WpfTerminalControl/net6.0-windows/Microsoft.Terminal.Wpf.dll"
+            "WpfTerminalControl/net8.0-windows/Microsoft.Terminal.Wpf.dll"
         ],
         "SigningInfo": {
             "Operations": [

--- a/src/cascadia/WindowsTerminal_UIATests/WindowsTerminal.UIA.Tests.csproj
+++ b/src/cascadia/WindowsTerminal_UIATests/WindowsTerminal.UIA.Tests.csproj
@@ -6,7 +6,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WindowsTerminal.UIA.Tests</RootNamespace>
     <AssemblyName>WindowsTerminal.UIA.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/src/cascadia/WpfTerminalControl/WpfTerminalControl.csproj
+++ b/src/cascadia/WpfTerminalControl/WpfTerminalControl.csproj
@@ -1,8 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
-    <TargetFrameworks>net472;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
     <RootNamespace>Microsoft.Terminal.Wpf</RootNamespace>
     <AssemblyName>Microsoft.Terminal.Wpf</AssemblyName>
     <UseWpf>true</UseWpf>

--- a/src/cascadia/WpfTerminalTestNetCore/WpfTerminalTestNetCore.csproj
+++ b/src/cascadia/WpfTerminalTestNetCore/WpfTerminalTestNetCore.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
-    <RuntimeFrameworkVersion>6.0.9</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Platforms>AnyCPU;x64;x86;ARM64</Platforms>
   </PropertyGroup>

--- a/src/host/ft_uia/Host.Tests.UIA.csproj
+++ b/src/host/ft_uia/Host.Tests.UIA.csproj
@@ -6,7 +6,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Conhost.UIA.Tests</RootNamespace>
     <AssemblyName>Conhost.UIA.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/src/host/ft_uia/app.config
+++ b/src/host/ft_uia/app.config
@@ -13,6 +13,6 @@
     </assemblyBinding>
   </runtime>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
   </startup>
 </configuration>

--- a/src/tools/TerminalStress/TerminalStress.csproj
+++ b/src/tools/TerminalStress/TerminalStress.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeFrameworkVersion>6.0.9</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0-windows</TargetFramework>
   </PropertyGroup>
 
   <!-- This project has no PGO, but the build will fail if the target doesn't exist. -->

--- a/src/tools/vtapp/VTApp.csproj
+++ b/src/tools/vtapp/VTApp.csproj
@@ -7,7 +7,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>VTApp</RootNamespace>
     <AssemblyName>VTApp</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />


### PR DESCRIPTION
* .NET 6 is EOL
* Framework 4.7.2 comes by default with VS, but 4.8 doesn't