### PR TITLE
Extend lead/trail edge support for throttled_func

### DIFF
--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -135,12 +135,19 @@ namespace winrt::TerminalApp::implementation
         _isElevated = ::Microsoft::Console::Utils::IsRunningElevated();
         _canDragDrop = ::Microsoft::Console::Utils::CanUwpDragDrop();
 
-        _reloadSettings = std::make_shared<ThrottledFuncTrailing<>>(winrt::Windows::System::DispatcherQueue::GetForCurrentThread(), std::chrono::milliseconds(100), [weakSelf = get_weak()]() {
-            if (auto self{ weakSelf.get() })
-            {
-                self->ReloadSettings();
-            }
-        });
+        _reloadSettings = std::make_shared<ThrottledFunc<>>(
+            DispatcherQueue::GetForCurrentThread(),
+            til::throttled_func_options{
+                .delay = std::chrono::milliseconds{ 100 },
+                .debounce = true,
+                .trailing = true,
+            },
+            [weakSelf = get_weak()]() {
+                if (auto self{ weakSelf.get() })
+                {
+                    self->ReloadSettings();
+                }
+            });
 
         _languageProfileNotifier = winrt::make_self<LanguageProfileNotifier>([this]() {
             _reloadSettings->Run();

--- a/src/cascadia/TerminalApp/AppLogic.h
+++ b/src/cascadia/TerminalApp/AppLogic.h
@@ -64,7 +64,7 @@ namespace winrt::TerminalApp::implementation
         bool _hasSettingsStartupActions{ false };
         ::TerminalApp::AppCommandlineArgs _settingsAppArgs;
 
-        std::shared_ptr<ThrottledFuncTrailing<>> _reloadSettings;
+        std::shared_ptr<ThrottledFunc<>> _reloadSettings;
 
         std::vector<Microsoft::Terminal::Settings::Model::SettingsLoadWarnings> _warnings{};
 

--- a/src/cascadia/TerminalApp/MinMaxCloseControl.cpp
+++ b/src/cascadia/TerminalApp/MinMaxCloseControl.cpp
@@ -35,17 +35,23 @@ namespace winrt::TerminalApp::implementation
         // (which should be the default, see:
         // https://docs.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-trackmouseevent#remarks)
         unsigned int hoverTimeoutMillis{ 400 };
-        LOG_IF_WIN32_BOOL_FALSE(SystemParametersInfoW(SPI_GETMOUSEHOVERTIME, 0, &hoverTimeoutMillis, 0));
-        const auto toolTipInterval = std::chrono::milliseconds(hoverTimeoutMillis);
+        if (FAILED(SystemParametersInfoW(SPI_GETMOUSEHOVERTIME, 0, &hoverTimeoutMillis, 0)))
+        {
+            hoverTimeoutMillis = 400;
+        }
 
         // Create a ThrottledFunc for opening the tooltip after the hover
         // timeout. If we hover another button, we should make sure to call
         // Run() with the new button. Calling `_displayToolTip.Run(nullptr)`,
         // which will cause us to not display a tooltip, which is used when we
         // leave the control entirely.
-        _displayToolTip = std::make_shared<ThrottledFuncTrailing<Controls::Button>>(
+        _displayToolTip = std::make_shared<ThrottledFunc<Controls::Button>>(
             dispatcher,
-            toolTipInterval,
+            til::throttled_func_options{
+                .delay = std::chrono::milliseconds{ hoverTimeoutMillis },
+                .debounce = true,
+                .trailing = true,
+            },
             [weakThis = get_weak()](Controls::Button button) {
                 // If we provide a button, then open the tooltip on that button.
                 // We can "dismiss" this throttled func by calling it with null,

--- a/src/cascadia/TerminalApp/MinMaxCloseControl.h
+++ b/src/cascadia/TerminalApp/MinMaxCloseControl.h
@@ -32,7 +32,7 @@ namespace winrt::TerminalApp::implementation
         til::typed_event<TerminalApp::MinMaxCloseControl, winrt::Windows::UI::Xaml::RoutedEventArgs> MaximizeClick;
         til::typed_event<TerminalApp::MinMaxCloseControl, winrt::Windows::UI::Xaml::RoutedEventArgs> CloseClick;
 
-        std::shared_ptr<ThrottledFuncTrailing<winrt::Windows::UI::Xaml::Controls::Button>> _displayToolTip{ nullptr };
+        std::shared_ptr<ThrottledFunc<winrt::Windows::UI::Xaml::Controls::Button>> _displayToolTip{ nullptr };
         std::optional<CaptionButton> _lastPressedButton{ std::nullopt };
     };
 }

--- a/src/cascadia/TerminalApp/Tab.h
+++ b/src/cascadia/TerminalApp/Tab.h
@@ -6,7 +6,6 @@
 #include "ColorPickupFlyout.h"
 #include "Tab.h"
 #include "Tab.g.h"
-#include "ThrottledFunc.h"
 
 // fwdecl unittest classes
 namespace TerminalAppLocalTests

--- a/src/cascadia/TerminalApp/Tab.h
+++ b/src/cascadia/TerminalApp/Tab.h
@@ -6,6 +6,7 @@
 #include "ColorPickupFlyout.h"
 #include "Tab.h"
 #include "Tab.g.h"
+#include "ThrottledFunc.h"
 
 // fwdecl unittest classes
 namespace TerminalAppLocalTests

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -4876,8 +4876,6 @@ namespace winrt::TerminalApp::implementation
     safe_void_coroutine TerminalPage::_ControlCompletionsChangedHandler(const IInspectable sender,
                                                                         const CompletionsChangedEventArgs args)
     {
-        // This will come in on a background (not-UI, not output) thread.
-
         // This won't even get hit if the velocity flag is disabled - we gate
         // registering for the event based off of
         // Feature_ShellCompletions::IsEnabled back in _RegisterTerminalEvents

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -97,45 +97,45 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         Connection(connection);
 
-        // GH#8969: pre-seed working directory to prevent potential races
-        _terminal->SetWorkingDirectory(_settings->StartingDirectory());
-
         _terminal->SetWriteInputCallback([this](std::wstring_view wstr) {
             _pendingResponses.append(wstr);
         });
-        _terminal->SetCopyToClipboardCallback([this](auto&& PH1) {
-            _terminalCopyToClipboard(std::forward<decltype(PH1)>(PH1));
-        });
-        _terminal->SetWarningBellCallback([this] {
-            _terminalWarningBell();
-        });
-        _terminal->SetTitleChangedCallback([this](auto&& PH1) {
-            _terminalTitleChanged(std::forward<decltype(PH1)>(PH1));
-        });
-        _terminal->SetScrollPositionChangedCallback([this](auto&& PH1, auto&& PH2, auto&& PH3) {
-            _terminalScrollPositionChanged(std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2), std::forward<decltype(PH3)>(PH3));
-        });
-        _terminal->TaskbarProgressChangedCallback([this] {
-            _terminalTaskbarProgressChanged();
-        });
-        _terminal->SetShowWindowCallback([this](auto&& PH1) {
-            _terminalShowWindowChanged(std::forward<decltype(PH1)>(PH1));
-        });
-        _terminal->SetPlayMidiNoteCallback([this](auto&& PH1, auto&& PH2, auto&& PH3) {
-            _terminalPlayMidiNote(std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2), std::forward<decltype(PH3)>(PH3));
-        });
-        _terminal->CompletionsChangedCallback([=](auto&& menuJson, auto&& replaceLength) {
-            _terminalCompletionsChanged(menuJson, replaceLength);
-        });
-        _terminal->SetSearchMissingCommandCallback([this](auto&& PH1, auto&& PH2) {
-            _terminalSearchMissingCommand(std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
-        });
-        _terminal->SetClearQuickFixCallback([this] {
-            ClearQuickFix();
-        });
-        _terminal->SetWindowSizeChangedCallback([this](auto&& PH1, auto&& PH2) {
-            _terminalWindowSizeChanged(std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
-        });
+
+        // GH#8969: pre-seed working directory to prevent potential races
+        _terminal->SetWorkingDirectory(_settings->StartingDirectory());
+
+        auto pfnCopyToClipboard = [this](auto&& PH1) { _terminalCopyToClipboard(std::forward<decltype(PH1)>(PH1)); };
+        _terminal->SetCopyToClipboardCallback(pfnCopyToClipboard);
+
+        auto pfnWarningBell = [this] { _terminalWarningBell(); };
+        _terminal->SetWarningBellCallback(pfnWarningBell);
+
+        auto pfnTitleChanged = [this](auto&& PH1) { _terminalTitleChanged(std::forward<decltype(PH1)>(PH1)); };
+        _terminal->SetTitleChangedCallback(pfnTitleChanged);
+
+        auto pfnScrollPositionChanged = [this](auto&& PH1, auto&& PH2, auto&& PH3) { _terminalScrollPositionChanged(std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2), std::forward<decltype(PH3)>(PH3)); };
+        _terminal->SetScrollPositionChangedCallback(pfnScrollPositionChanged);
+
+        auto pfnTerminalTaskbarProgressChanged = [this] { _terminalTaskbarProgressChanged(); };
+        _terminal->TaskbarProgressChangedCallback(pfnTerminalTaskbarProgressChanged);
+
+        auto pfnShowWindowChanged = [this](auto&& PH1) { _terminalShowWindowChanged(std::forward<decltype(PH1)>(PH1)); };
+        _terminal->SetShowWindowCallback(pfnShowWindowChanged);
+
+        auto pfnPlayMidiNote = [this](auto&& PH1, auto&& PH2, auto&& PH3) { _terminalPlayMidiNote(std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2), std::forward<decltype(PH3)>(PH3)); };
+        _terminal->SetPlayMidiNoteCallback(pfnPlayMidiNote);
+
+        auto pfnCompletionsChanged = [=](auto&& menuJson, auto&& replaceLength) { _terminalCompletionsChanged(menuJson, replaceLength); };
+        _terminal->CompletionsChangedCallback(pfnCompletionsChanged);
+
+        auto pfnSearchMissingCommand = [this](auto&& PH1, auto&& PH2) { _terminalSearchMissingCommand(std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2)); };
+        _terminal->SetSearchMissingCommandCallback(pfnSearchMissingCommand);
+
+        auto pfnClearQuickFix = [this] { ClearQuickFix(); };
+        _terminal->SetClearQuickFixCallback(pfnClearQuickFix);
+
+        auto pfnWindowSizeChanged = [this](auto&& PH1, auto&& PH2) { _terminalWindowSizeChanged(std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2)); };
+        _terminal->SetWindowSizeChangedCallback(pfnWindowSizeChanged);
 
         // MSFT 33353327: Initialize the renderer in the ctor instead of Initialize().
         // We need the renderer to be ready to accept new engines before the SwapChainPanel is ready to go.
@@ -2931,7 +2931,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             {
                 continue;
             }
-
             // If they clicked _anywhere_ in the mark...
             const auto [markStart, markEnd] = m.GetExtent();
             if (markStart <= pos &&

--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -307,9 +307,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     private:
         struct SharedState
         {
-            std::unique_ptr<til::debounced_func_trailing<>> outputIdle;
-            std::unique_ptr<til::debounced_func_trailing<bool>> focusChanged;
-            std::shared_ptr<ThrottledFuncTrailing<Control::ScrollPositionChangedArgs>> updateScrollBar;
+            std::unique_ptr<til::throttled_func<>> outputIdle;
+            std::unique_ptr<til::throttled_func<bool>> focusChanged;
+            std::shared_ptr<ThrottledFunc<Control::ScrollPositionChangedArgs>> updateScrollBar;
         };
 
         void _setupDispatcherAndCallbacks();
@@ -339,7 +339,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void _terminalSearchMissingCommand(std::wstring_view missingCommand, const til::CoordType& bufferRow);
         void _terminalWindowSizeChanged(int32_t width, int32_t height);
 
-        safe_void_coroutine _terminalCompletionsChanged(std::wstring_view menuJson, unsigned int replaceLength);
+        void _terminalCompletionsChanged(std::wstring_view menuJson, unsigned int replaceLength);
 #pragma endregion
 
 #pragma region RendererCallbacks

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -358,9 +358,12 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // These three throttled functions are triggered by terminal output and interact with the UI.
         // Since Close() is the point after which we are removed from the UI, but before the
         // destructor has run, we MUST check control->_IsClosing() before actually doing anything.
-        _playWarningBell = std::make_shared<ThrottledFuncLeading>(
+        _playWarningBell = std::make_shared<ThrottledFunc<>>(
             dispatcher,
-            TerminalWarningBellInterval,
+            til::throttled_func_options{
+                .delay = TerminalWarningBellInterval,
+                .leading = true,
+            },
             [weakThis = get_weak()]() {
                 if (auto control{ weakThis.get() }; control && !control->_IsClosing())
                 {
@@ -368,9 +371,12 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                 }
             });
 
-        _updateScrollBar = std::make_shared<ThrottledFuncTrailing<ScrollBarUpdate>>(
+        _updateScrollBar = std::make_shared<ThrottledFunc<ScrollBarUpdate>>(
             dispatcher,
-            ScrollBarUpdateInterval,
+            til::throttled_func_options{
+                .delay = ScrollBarUpdateInterval,
+                .trailing = true,
+            },
             [weakThis = get_weak()](const auto& update) {
                 if (auto control{ weakThis.get() }; control && !control->_IsClosing())
                 {

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -284,7 +284,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         bool _quickFixesAvailable{ false };
         til::CoordType _quickFixBufferPos{};
 
-        std::shared_ptr<ThrottledFuncLeading> _playWarningBell;
+        std::shared_ptr<ThrottledFunc<>> _playWarningBell;
 
         struct ScrollBarUpdate
         {
@@ -294,7 +294,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             double newViewportSize;
         };
 
-        std::shared_ptr<ThrottledFuncTrailing<ScrollBarUpdate>> _updateScrollBar;
+        std::shared_ptr<ThrottledFunc<ScrollBarUpdate>> _updateScrollBar;
 
         bool _isInternalScrollBarUpdate;
 

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.cpp
@@ -66,9 +66,13 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         if (!_updatePreviewControl)
         {
-            _updatePreviewControl = std::make_shared<ThrottledFuncTrailing<>>(
+            _updatePreviewControl = std::make_shared<ThrottledFunc<>>(
                 winrt::Windows::System::DispatcherQueue::GetForCurrentThread(),
-                std::chrono::milliseconds{ 100 },
+                til::throttled_func_options{
+                    .delay = std::chrono::milliseconds{ 100 },
+                    .debounce = true,
+                    .trailing = true,
+                },
                 [this]() {
                     const auto settings = _Profile.TermSettings();
                     _previewConnection->DisplayPowerlineGlyphs(_Profile.DefaultAppearance().HasPowerlineCharacters());

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.h
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.h
@@ -33,7 +33,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         winrt::com_ptr<PreviewConnection> _previewConnection{ nullptr };
         Microsoft::Terminal::Control::TermControl _previewControl{ nullptr };
-        std::shared_ptr<ThrottledFuncTrailing<>> _updatePreviewControl;
+        std::shared_ptr<ThrottledFunc<>> _updatePreviewControl;
         Windows::UI::Xaml::Data::INotifyPropertyChanged::PropertyChanged_revoker _ViewModelChangedRevoker;
         Windows::UI::Xaml::Data::INotifyPropertyChanged::PropertyChanged_revoker _AppearanceViewModelChangedRevoker;
         Editor::IHostedInWindow _windowRoot;

--- a/src/cascadia/TerminalSettingsModel/ApplicationState.cpp
+++ b/src/cascadia/TerminalSettingsModel/ApplicationState.cpp
@@ -96,7 +96,14 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     ApplicationState::ApplicationState(const std::filesystem::path& stateRoot) noexcept :
         _sharedPath{ stateRoot / stateFileName },
         _elevatedPath{ stateRoot / elevatedStateFileName },
-        _throttler{ std::chrono::seconds(1), [this]() { _write(); } }
+        _throttler{
+            til::throttled_func_options{
+                .delay = std::chrono::seconds{ 1 },
+                .debounce = true,
+                .trailing = true,
+            },
+            [this]() { _write(); }
+        }
     {
         _read();
     }

--- a/src/cascadia/TerminalSettingsModel/ApplicationState.h
+++ b/src/cascadia/TerminalSettingsModel/ApplicationState.h
@@ -91,7 +91,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         til::shared_mutex<state_t> _state;
         std::filesystem::path _sharedPath;
         std::filesystem::path _elevatedPath;
-        til::throttled_func_trailing<> _throttler;
+        til::throttled_func<> _throttler;
 
         void _write() const noexcept;
         void _read() const noexcept;

--- a/src/cascadia/WinRTUtils/inc/ThrottledFunc.h
+++ b/src/cascadia/WinRTUtils/inc/ThrottledFunc.h
@@ -3,40 +3,44 @@
 
 #pragma once
 
-#include "til/throttled_func.h"
+#include <til/throttled_func.h>
 
 // ThrottledFunc is a copy of til::throttled_func,
 // specialized for the use with a WinRT Dispatcher.
-template<bool leading, typename... Args>
-class ThrottledFunc : public std::enable_shared_from_this<ThrottledFunc<leading, Args...>>
+template<typename... Args>
+class ThrottledFunc : public std::enable_shared_from_this<ThrottledFunc<Args...>>
 {
 public:
-    using filetime_duration = std::chrono::duration<int64_t, std::ratio<1, 10000000>>;
+    using filetime_duration = til::throttled_func_options::filetime_duration;
     using function = std::function<void(Args...)>;
 
-    // Throttles invocations to the given `func` to not occur more often than `delay`.
+    // Throttles invocations to the given `func` to not occur more often than specified in options.
     //
-    // If this is a:
-    // * ThrottledFuncLeading: `func` will be invoked immediately and
-    //   further invocations prevented until `delay` time has passed.
-    // * ThrottledFuncTrailing: On the first invocation a timer of `delay` time will
-    //   be started. After the timer has expired `func` will be invoked just once.
+    // Options:
+    // * delay: The minimum time between invocations
+    // * leading: If true, `func` will be invoked immediately on first call
+    // * trailing: If true, `func` will be invoked after the delay
+    // * debounce: If true, resets the timer on each call
     //
-    // After `func` was invoked the state is reset and this cycle is repeated again.
-    ThrottledFunc(
-        winrt::Windows::System::DispatcherQueue dispatcher,
-        filetime_duration delay,
-        function func) :
+    // At least one of leading or trailing must be true.
+    ThrottledFunc(winrt::Windows::System::DispatcherQueue dispatcher, til::throttled_func_options opts, function func) :
         _dispatcher{ std::move(dispatcher) },
         _func{ std::move(func) },
-        _timer{ _create_timer() }
+        _timer{ _create_timer() },
+        _debounce{ opts.debounce },
+        _leading{ opts.leading },
+        _trailing{ opts.trailing }
     {
-        const auto d = -delay.count();
+        if (!_leading && !_trailing)
+        {
+            throw std::invalid_argument("neither leading nor trailing");
+        }
+
+        const auto d = -opts.delay.count();
         if (d >= 0)
         {
             throw std::invalid_argument("non-positive delay specified");
         }
-
         memcpy(&_delay, &d, sizeof(d));
     }
 
@@ -54,88 +58,119 @@ public:
     template<typename... MakeArgs>
     void Run(MakeArgs&&... args)
     {
-        if (!_storage.emplace(std::forward<MakeArgs>(args)...))
-        {
-            _leading_edge();
-        }
+        _lead(std::make_tuple(std::forward<MakeArgs>(args)...));
     }
 
-    // Modifies the pending arguments for the next function
-    // invocation, if there is one pending currently.
-    //
-    // `func` will be invoked as func(Args...). Make sure to bind any
-    // arguments in `func` by reference if you'd like to modify them.
     template<typename F>
     void ModifyPending(F func)
     {
-        _storage.modify_pending(func);
+        const auto guard = _lock.lock_exclusive();
+        if (_pendingRunArgs)
+        {
+            std::apply(func, *_pendingRunArgs);
+        }
     }
 
 private:
     static void __stdcall _timer_callback(PTP_CALLBACK_INSTANCE /*instance*/, PVOID context, PTP_TIMER /*timer*/) noexcept
+    try
     {
-        static_cast<ThrottledFunc*>(context)->_trailing_edge();
+        static_cast<ThrottledFunc*>(context)->_trail();
     }
+    CATCH_LOG()
 
-    void _leading_edge()
-    {
-        if constexpr (leading)
-        {
-            _dispatcher.TryEnqueue(winrt::Windows::System::DispatcherQueuePriority::Normal, [weakSelf = this->weak_from_this()]() {
-                if (auto self{ weakSelf.lock() })
-                {
-                    try
-                    {
-                        self->_func();
-                    }
-                    CATCH_LOG();
-
-                    SetThreadpoolTimerEx(self->_timer.get(), &self->_delay, 0, 0);
-                }
-            });
-        }
-        else
-        {
-            SetThreadpoolTimerEx(_timer.get(), &_delay, 0, 0);
-        }
-    }
-
-    void _trailing_edge()
-    {
-        if constexpr (leading)
-        {
-            _storage.reset();
-        }
-        else
-        {
-            _dispatcher.TryEnqueue(winrt::Windows::System::DispatcherQueuePriority::Normal, [weakSelf = this->weak_from_this()]() {
-                if (auto self{ weakSelf.lock() })
-                {
-                    try
-                    {
-                        self->_storage.apply(self->_func);
-                    }
-                    CATCH_LOG();
-                }
-            });
-        }
-    }
-
-    inline wil::unique_threadpool_timer _create_timer()
+    wil::unique_threadpool_timer _create_timer()
     {
         wil::unique_threadpool_timer timer{ CreateThreadpoolTimer(&_timer_callback, this, nullptr) };
         THROW_LAST_ERROR_IF(!timer);
         return timer;
     }
 
-    FILETIME _delay;
+    void _lead(std::tuple<Args...> args)
+    {
+        bool timerRunning = false;
+
+        {
+            const auto guard = _lock.lock_exclusive();
+
+            timerRunning = _timerRunning;
+            _timerRunning = true;
+
+            if (!timerRunning && _leading)
+            {
+                // Call the function immediately on the leading edge.
+                // See below (out of lock).
+            }
+            else if (_trailing)
+            {
+                _pendingRunArgs.emplace(std::move(args));
+            }
+        }
+
+        const auto execute = !timerRunning && _leading;
+        const auto schedule = !timerRunning || _debounce;
+
+        if (execute)
+        {
+            _execute(std::move(args), schedule);
+        }
+        else if (schedule)
+        {
+            SetThreadpoolTimerEx(_timer.get(), &_delay, 0, 0);
+        }
+    }
+
+    void _trail()
+    {
+        decltype(_pendingRunArgs) args;
+
+        {
+            const auto guard = _lock.lock_exclusive();
+
+            _timerRunning = false;
+            args = std::exchange(_pendingRunArgs, std::nullopt);
+        }
+
+        if (args)
+        {
+            _execute(std::move(*args), false);
+        }
+    }
+
+    void _execute(std::tuple<Args...> args, bool schedule)
+    {
+        _dispatcher.TryEnqueue(
+            winrt::Windows::System::DispatcherQueuePriority::Normal,
+            [weakSelf = this->weak_from_this(), args = std::move(args), schedule]() mutable {
+                if (auto self{ weakSelf.lock() })
+                {
+                    try
+                    {
+                        std::apply(self->_func, std::move(args));
+                    }
+                    CATCH_LOG();
+
+                    if (schedule)
+                    {
+                        SetThreadpoolTimerEx(self->_timer.get(), &self->_delay, 0, 0);
+                    }
+                }
+            });
+    }
+
     winrt::Windows::System::DispatcherQueue _dispatcher;
+
+    // Everything below this point is just like til::throttled_func.
+
     function _func;
-
     wil::unique_threadpool_timer _timer;
-    til::details::throttled_func_storage<Args...> _storage;
-};
+    FILETIME _delay;
 
-template<typename... Args>
-using ThrottledFuncTrailing = ThrottledFunc<false, Args...>;
-using ThrottledFuncLeading = ThrottledFunc<true>;
+    wil::srwlock _lock;
+    std::optional<std::tuple<Args...>> _pendingRunArgs;
+    bool _timerRunning = false;
+
+    bool _debounce;
+    bool _leading;
+    bool _trailing;
+};

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -288,9 +288,12 @@ void AppHost::Initialize()
     // the PTY requesting a change to the window state and the Terminal
     // realizing it, but should mitigate issues where the Terminal and PTY get
     // de-sync'd.
-    _showHideWindowThrottler = std::make_shared<ThrottledFuncTrailing<bool>>(
+    _showHideWindowThrottler = std::make_shared<ThrottledFunc<bool>>(
         winrt::Windows::System::DispatcherQueue::GetForCurrentThread(),
-        std::chrono::milliseconds(200),
+        til::throttled_func_options{
+            .delay = std::chrono::milliseconds{ 200 },
+            .trailing = true,
+        },
         [this](const bool show) {
             _window->ShowWindowChanged(show);
         });

--- a/src/cascadia/WindowsTerminal/AppHost.h
+++ b/src/cascadia/WindowsTerminal/AppHost.h
@@ -39,7 +39,7 @@ private:
     std::unique_ptr<IslandWindow> _window;
     winrt::TerminalApp::AppLogic _appLogic{ nullptr };
     winrt::TerminalApp::TerminalWindow _windowLogic{ nullptr };
-    std::shared_ptr<ThrottledFuncTrailing<bool>> _showHideWindowThrottler;
+    std::shared_ptr<ThrottledFunc<bool>> _showHideWindowThrottler;
     SafeDispatcherTimer _frameTimer;
     LARGE_INTEGER _lastActivatedTime{};
     winrt::guid _virtualDesktopId{};

--- a/src/til/ut_til/throttled_func.cpp
+++ b/src/til/ut_til/throttled_func.cpp
@@ -19,21 +19,25 @@ class ThrottledFuncTests
     TEST_METHOD(Basic)
     {
         using namespace std::chrono_literals;
-        using throttled_func = til::throttled_func_trailing<bool>;
+        using throttled_func = til::throttled_func<bool>;
 
         til::latch latch{ 2 };
 
         std::unique_ptr<throttled_func> tf;
-        tf = std::make_unique<throttled_func>(10ms, [&](bool reschedule) {
-            latch.count_down();
+        tf = std::make_unique<throttled_func>(
+            til::throttled_func_options{
+                .delay = 10ms,
+                .trailing = true },
+            [&](bool reschedule) {
+                latch.count_down();
 
-            // This will ensure that the callback is called even if we
-            // invoke the throttled_func from inside the callback itself.
-            if (reschedule)
-            {
-                tf->operator()(false);
-            }
-        });
+                // This will ensure that the callback is called even if we
+                // invoke the throttled_func from inside the callback itself.
+                if (reschedule)
+                {
+                    tf->operator()(false);
+                }
+            });
         // This will ensure that the throttled_func invokes the callback in general.
         tf->operator()(true);
 


### PR DESCRIPTION
You can now create throttled functions which trigger both on the leading
and trailing edge. This was then also ported to `ThrottledFunc` for
`DispatcherQueue`s and used for title/taskbar updates.

Closes #19188

## Validation Steps Performed
* In CMD run:
  ```batch
  FOR /L %N IN () DO @echo %time%
  ```
* Doesn't hang the UI ✅