### PR TITLE
Throttle incoming handoffs so WinUI can layout them

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -149,7 +149,7 @@ namespace winrt::TerminalApp::implementation
         safe_void_coroutine ProcessStartupActions(std::vector<Microsoft::Terminal::Settings::Model::ActionAndArgs> actions,
                                                   const winrt::hstring cwd = winrt::hstring{},
                                                   const winrt::hstring env = winrt::hstring{});
-        void CreateTabFromConnection(winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection connection);
+        safe_void_coroutine CreateTabFromConnection(winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection connection);
 
         TerminalApp::WindowProperties WindowProperties() const noexcept { return _WindowProperties; };
 


### PR DESCRIPTION
As explained in the diff itself.

Closes #13136

## Validation Steps Performed
* In conhost, with `wtd` not running, execute:
  ```pwsh
  1..10 | % { wt -w 1 nt --title=$_ pwsh -NoExit -Command "Get-Date -Format HH:mm:ss.ffff" }
  ```
* Every tab is up and running immediately ✅