### PR TITLE
Profiles Editor: make sure we notify the IconPath property

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
@@ -108,6 +108,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                                L"UsingImageIcon",
                                L"LocalizedIcon",
                                L"IconPreview",
+                               L"IconPath",
                                L"EvaluatedIcon");
             }
             else if (viewModelProperty == L"CurrentBuiltInIcon")

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
@@ -98,7 +98,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void IconPath(const winrt::hstring& path)
         {
             Icon(Model::MediaResourceHelper::FromString(path));
-            _NotifyChanges(L"Icon");
+            _NotifyChanges(L"Icon", L"IconPath");
         }
 
         // starting directory


### PR DESCRIPTION
There were instances where changing the icon or resetting it did not result in the text box changing.

Regressed in #19143