### PR TITLE
Remove action handling from term control's preview key down

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -326,6 +326,7 @@ namespace winrt::TerminalApp::implementation
         void _AboutButtonOnClick(const IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& eventArgs);
 
         void _KeyDownHandler(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Input::KeyRoutedEventArgs& e);
+        void _PreviewKeyDown(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Input::KeyRoutedEventArgs& e);
         static ::Microsoft::Terminal::Core::ControlKeyStates _GetPressedModifierKeys() noexcept;
         static void _ClearKeyboardState(const WORD vkey, const WORD scanCode) noexcept;
         void _HookupKeyBindings(const Microsoft::Terminal::Settings::Model::IActionMapView& actionMap) noexcept;
@@ -383,6 +384,7 @@ namespace winrt::TerminalApp::implementation
         }
 
         winrt::Microsoft::Terminal::Control::TermControl _GetActiveControl();
+        winrt::Microsoft::Terminal::Control::TermControl _GetFocusedElementIfControl();
         std::optional<uint32_t> _GetFocusedTabIndex() const noexcept;
         std::optional<uint32_t> _GetTabIndex(const TerminalApp::TabBase& tab) const noexcept;
         TerminalApp::TabBase _GetFocusedTab() const noexcept;
@@ -396,7 +398,7 @@ namespace winrt::TerminalApp::implementation
         winrt::Windows::Foundation::IAsyncOperation<bool> _PaneConfirmCloseReadOnly(std::shared_ptr<Pane> pane);
         void _AddPreviouslyClosedPaneOrTab(std::vector<Microsoft::Terminal::Settings::Model::ActionAndArgs>&& args);
 
-        void _Scroll(ScrollDirection scrollDirection, const Windows::Foundation::IReference<uint32_t>& rowsToScroll);
+        void _Scroll(ScrollDirection scrollDirection, const Windows::Foundation::IReference<uint32_t>& rowsToScroll, winrt::Microsoft::Terminal::Control::TermControl focusedControl);
 
         void _SplitPane(const winrt::com_ptr<TerminalTab>& tab,
                         const Microsoft::Terminal::Settings::Model::SplitDirection splitType,
@@ -405,8 +407,8 @@ namespace winrt::TerminalApp::implementation
         void _ResizePane(const Microsoft::Terminal::Settings::Model::ResizeDirection& direction);
         void _ToggleSplitOrientation();
 
-        void _ScrollPage(ScrollDirection scrollDirection);
-        void _ScrollToBufferEdge(ScrollDirection scrollDirection);
+        void _ScrollPage(ScrollDirection scrollDirection, winrt::Microsoft::Terminal::Control::TermControl focusedControl);
+        void _ScrollToBufferEdge(ScrollDirection scrollDirection, winrt::Microsoft::Terminal::Control::TermControl focusedControl);
         void _SetAcceleratorForMenuItem(Windows::UI::Xaml::Controls::MenuFlyoutItem& menuItem, const winrt::Microsoft::Terminal::Control::KeyChord& keyChord);
 
         safe_void_coroutine _PasteFromClipboardHandler(const IInspectable sender,
@@ -553,6 +555,7 @@ namespace winrt::TerminalApp::implementation
         winrt::Windows::UI::Xaml::Controls::MenuFlyout _CreateRunAsAdminFlyout(int profileIndex);
 
         winrt::Microsoft::Terminal::Control::TermControl _senderOrActiveControl(const winrt::Windows::Foundation::IInspectable& sender);
+        winrt::Microsoft::Terminal::Control::TermControl _senderOrFocusedElementIfControl(const winrt::Windows::Foundation::IInspectable& sender);
         winrt::com_ptr<TerminalTab> _senderOrFocusedTab(const IInspectable& sender);
 
         void _loadQueryExtension();

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -14,7 +14,8 @@
       mc:Ignorable="d">
 
     <Grid x:Name="Root"
-          Background="Transparent">
+          Background="Transparent"
+          PreviewKeyDown="_PreviewKeyDown">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
@@ -170,7 +171,6 @@
         <ContentPresenter x:Name="ExtensionPresenter"
                           Grid.Row="2"
                           VerticalAlignment="Stretch"
-                          PreviewKeyDown="_KeyDownHandler"
                           Visibility="Collapsed" />
 
         <local:SuggestionsControl x:Name="SuggestionsElement"

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1798,22 +1798,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             _altNumpadState = {};
         }
 
-        // GH#2235: Terminal::Settings hasn't been modified to differentiate
-        // between AltGr and Ctrl+Alt yet.
-        // -> Don't check for key bindings if this is an AltGr key combination.
-        //
-        // GH#4999: Only process keybindings on the keydown. If we don't check
-        // this at all, we'll process the keybinding twice. If we only process
-        // keybindings on the keyUp, then we'll still send the keydown to the
-        // connected terminal application, and something like ctrl+shift+T will
-        // emit a ^T to the pipe.
-        if (!modifiers.IsAltGrPressed() &&
-            keyDown &&
-            _TryHandleKeyBinding(vkey, scanCode, modifiers))
-        {
-            return true;
-        }
-
         if (_TrySendKeyEvent(vkey, scanCode, modifiers, keyDown))
         {
             return true;


### PR DESCRIPTION
## Summary of the Pull Request
- TermControl's `PreviewKeyDown` now no longer handles keybindings
- TerminalPage now has a `PreviewKeyDown` which checks for keybindings, and if the action required is a control-level action we execute it on the focused control (scroll, paste etc)

This way, we remove the previous flow of "control gets a keybinding and sends it over to the app which executes it back onto the control". 

## Validation Steps Performed


## PR Checklist
- [x] Closes #16589 
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
