### PR TITLE
Add SSH folder to NTM for dynamic profiles

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1057,7 +1057,7 @@ namespace winrt::TerminalApp::implementation
                 auto folderEntryItems = _CreateNewTabFlyoutItems(folderEntries);
 
                 // If the folder should auto-inline and there is only one item, do so.
-                if (folderEntry.Inlining() == FolderEntryInlining::Auto && folderEntries.Size() == 1)
+                if (folderEntry.Inlining() == FolderEntryInlining::Auto && folderEntryItems.size() == 1)
                 {
                     for (auto const& folderEntryItem : folderEntryItems)
                     {

--- a/src/cascadia/TerminalSettingsModel/ApplicationState.h
+++ b/src/cascadia/TerminalSettingsModel/ApplicationState.h
@@ -37,6 +37,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 #define MTSM_APPLICATION_STATE_FIELDS(X)                                                                                                                                  \
     X(FileSource::Shared, winrt::hstring, SettingsHash, "settingsHash")                                                                                                   \
     X(FileSource::Shared, std::unordered_set<winrt::guid>, GeneratedProfiles, "generatedProfiles")                                                                        \
+    X(FileSource::Shared, std::unordered_set<winrt::hstring>, GeneratedFolders, "generatedFolders")                                                                              \
     X(FileSource::Local, Windows::Foundation::Collections::IVector<Model::WindowLayout>, PersistedWindowLayouts, "persistedWindowLayouts")                                \
     X(FileSource::Shared, Windows::Foundation::Collections::IVector<hstring>, RecentCommands, "recentCommands")                                                           \
     X(FileSource::Shared, Windows::Foundation::Collections::IVector<winrt::Microsoft::Terminal::Settings::Model::InfoBarMessage>, DismissedMessages, "dismissedMessages") \

--- a/src/cascadia/TerminalSettingsModel/ApplicationState.h
+++ b/src/cascadia/TerminalSettingsModel/ApplicationState.h
@@ -37,7 +37,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 #define MTSM_APPLICATION_STATE_FIELDS(X)                                                                                                                                  \
     X(FileSource::Shared, winrt::hstring, SettingsHash, "settingsHash")                                                                                                   \
     X(FileSource::Shared, std::unordered_set<winrt::guid>, GeneratedProfiles, "generatedProfiles")                                                                        \
-    X(FileSource::Shared, std::unordered_set<winrt::hstring>, GeneratedFolders, "generatedFolders")                                                                              \
+    X(FileSource::Shared, std::unordered_set<winrt::hstring>, GeneratedFolders, "generatedFolders")                                                                       \
     X(FileSource::Local, Windows::Foundation::Collections::IVector<Model::WindowLayout>, PersistedWindowLayouts, "persistedWindowLayouts")                                \
     X(FileSource::Shared, Windows::Foundation::Collections::IVector<hstring>, RecentCommands, "recentCommands")                                                           \
     X(FileSource::Shared, Windows::Foundation::Collections::IVector<winrt::Microsoft::Terminal::Settings::Model::InfoBarMessage>, DismissedMessages, "dismissedMessages") \

--- a/src/cascadia/TerminalSettingsModel/ApplicationState.h
+++ b/src/cascadia/TerminalSettingsModel/ApplicationState.h
@@ -37,12 +37,12 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 #define MTSM_APPLICATION_STATE_FIELDS(X)                                                                                                                                  \
     X(FileSource::Shared, winrt::hstring, SettingsHash, "settingsHash")                                                                                                   \
     X(FileSource::Shared, std::unordered_set<winrt::guid>, GeneratedProfiles, "generatedProfiles")                                                                        \
-    X(FileSource::Shared, std::unordered_set<winrt::hstring>, GeneratedFolders, "generatedFolders")                                                                       \
     X(FileSource::Local, Windows::Foundation::Collections::IVector<Model::WindowLayout>, PersistedWindowLayouts, "persistedWindowLayouts")                                \
     X(FileSource::Shared, Windows::Foundation::Collections::IVector<hstring>, RecentCommands, "recentCommands")                                                           \
     X(FileSource::Shared, Windows::Foundation::Collections::IVector<winrt::Microsoft::Terminal::Settings::Model::InfoBarMessage>, DismissedMessages, "dismissedMessages") \
     X(FileSource::Local, Windows::Foundation::Collections::IVector<hstring>, AllowedCommandlines, "allowedCommandlines")                                                  \
-    X(FileSource::Local, std::unordered_set<hstring>, DismissedBadges, "dismissedBadges")
+    X(FileSource::Local, std::unordered_set<hstring>, DismissedBadges, "dismissedBadges")                                                                                 \
+    X(FileSource::Shared, bool, SSHFolderGenerated, "sshFolderGenerated", false)
 
     struct WindowLayout : WindowLayoutT<WindowLayout>
     {

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
@@ -101,6 +101,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         ParsedSettings userSettings;
         std::unordered_map<hstring, winrt::com_ptr<implementation::ExtensionPackage>> extensionPackageMap;
         bool duplicateProfile = false;
+        bool sshProfilesGenerated = false;
 
     private:
         struct JsonSettings

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
@@ -93,6 +93,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         void MergeFragmentIntoUserSettings(const winrt::hstring& source, const winrt::hstring& basePath, const std::string_view& content);
         void FinalizeLayering();
         bool DisableDeletedProfiles();
+        bool AddDynamicProfileFolders();
         bool RemapColorSchemeForProfile(const winrt::com_ptr<winrt::Microsoft::Terminal::Settings::Model::implementation::Profile>& profile);
         bool FixupUserSettings();
 


### PR DESCRIPTION
## Summary of the Pull Request
Automatically generates an "SSH" folder in the new tab menu that contains all profiles generated by the SSH profile generator. This folder is created if the SSH generator created some profiles and the folder hasn't been created before. Detecting if the folder was generated is done via the new `bool ApplicationState::SSHFolderGenerated`. The logic is similar to `SettingsLoader::DisableDeletedProfiles()`.

Found a bug on new tab menu's folder inlining feature where we were counting the number of raw entries to determine whether to inline or not. Since the folder only contained the match profiles entry, this bug made it so that the profile entries would always be inlined. The fix was very simple: count the number of _resolved_ entries instead of the raw entries. This can be pulled into its own PR and serviced, if desired.

## References and Relevant Issues
#18814 
#14042 

## Validation Steps Performed
✅ Existing users get an SSH folder if profiles were generated

## PR Checklist
Closes #19043