### PR TITLE
Switch to the @Local view on TerminalDependencies

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -4,7 +4,7 @@
         <clear />
         <!-- Dependencies that we can turn on to force override for testing purposes before uploading. -->
         <!--<add key="Static Package Dependencies" value="dep\packages" />-->
-        <add key="TerminalDependencies" value="https://pkgs.dev.azure.com/shine-oss/terminal/_packaging/TerminalDependencies/nuget/v3/index.json" />
+        <add key="TerminalDependencies" value="https://pkgs.dev.azure.com/shine-oss/terminal/_packaging/TerminalDependencies%40Local/nuget/v3/index.json" />
     </packageSources>
     <disabledPackageSources>
         <clear />

--- a/build/pipelines/templates-v2/job-deploy-to-azure-storage.yml
+++ b/build/pipelines/templates-v2/job-deploy-to-azure-storage.yml
@@ -86,7 +86,7 @@ jobs:
         $MachineToken = $env:SYSTEM_ACCESSTOKEN | ConvertTo-SecureString -AsPlainText -Force
         $Credential = [PSCredential]::new("ONEBRANCH_TOKEN", $MachineToken)
         $MachineToken = $null
-        $Feed = "https://pkgs.dev.azure.com/shine-oss/terminal/_packaging/TerminalDependencies/nuget/v3/index.json"
+        $Feed = "https://pkgs.dev.azure.com/shine-oss/terminal/_packaging/TerminalDependencies%40Local/nuget/v3/index.json"
         Register-PSResourceRepository -Name "PSGalleryUpstream" -Uri $Feed -Trusted
         Get-PSResourceRepository
 


### PR DESCRIPTION
Due to an unexpected decision on behalf of the Azure Artifacts folks, the default view for a feed with upstream sources reports all packages, even if they are not actually populated into the feed.

This results in (uncontrolled) 401 errors whenever a new package appears upstream, because the feed tells our users and our build system that it is available, but fails when the download actually begins because it is not allowed to "write" the upstream version to the feed.