### PR TITLE
Fix SnapOnOutput not always snapping

### DIFF
--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -1720,7 +1720,7 @@ void SCREEN_INFORMATION::SnapOnInput(const WORD vkey)
 
 void SCREEN_INFORMATION::_makeCursorVisible()
 {
-    if (_textBuffer->GetCursor().IsOn())
+    if (_textBuffer->GetCursor().IsVisible())
     {
         MakeCursorVisible(_textBuffer->GetCursor().GetPosition());
     }


### PR DESCRIPTION
`IsOn` is the blinker on/off state, which `IsVisible`
is the actual cursor visibility on/off state.

## Validation Steps Performed
* Run bash/zsh in WSL
* (Repeatedly) Quickly scroll right and press A-Z
* Scrolls to the left ✅