### PR TITLE
Remove ProfileName from the surface of CoreSettings

### DIFF
--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -1161,10 +1161,12 @@ void Pane::SetActive()
 //   focused, else the profile of the last control to be focused
 Profile Pane::GetFocusedProfile()
 {
-    auto lastFocused = GetActivePane();
-    if (const auto& terminalPane{ lastFocused->_getTerminalContent() })
+    if (auto lastFocused{ GetActivePane() })
     {
-        return terminalPane.GetProfile();
+        if (const auto& terminalPane{ lastFocused->_getTerminalContent() })
+        {
+            return terminalPane.GetProfile();
+        }
     }
     return nullptr;
 }

--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -2127,9 +2127,9 @@ namespace winrt::TerminalApp::implementation
     // - The value to populate in the title run of the tool tip
     winrt::hstring Tab::_CreateToolTipTitle()
     {
-        if (const auto& control{ GetActiveTerminalControl() })
+        if (const auto profile{ GetFocusedProfile() })
         {
-            const auto profileName{ control.Settings().ProfileName() };
+            const auto profileName{ profile.Name() };
             if (profileName != Title())
             {
                 return winrt::hstring{ fmt::format(FMT_COMPILE(L"{}: {}"), profileName, Title()) };

--- a/src/cascadia/TerminalControl/IControlSettings.idl
+++ b/src/cascadia/TerminalControl/IControlSettings.idl
@@ -38,8 +38,6 @@ namespace Microsoft.Terminal.Control
     interface IControlSettings requires Microsoft.Terminal.Core.ICoreSettings,
                                Microsoft.Terminal.Control.IControlAppearance
     {
-        String ProfileName;
-
         Boolean EnableUnfocusedAcrylic { get; };
         Guid SessionId { get; };
         ScrollbarState ScrollState { get; };

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2610,9 +2610,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         return _core.Title();
     }
 
-    hstring TermControl::GetProfileName() const
+    hstring TermControl::GetStartingTitle() const
     {
-        return _core.Settings().ProfileName();
+        return _core.Settings().StartingTitle();
     }
 
     hstring TermControl::WorkingDirectory() const

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -58,7 +58,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         uint64_t ContentId() const;
 
-        hstring GetProfileName() const;
+        hstring GetStartingTitle() const;
 
         bool CopySelectionToClipboard(bool dismissSelection, bool singleLine, bool withControlSequences, const CopyFormat formats);
         void PasteTextFromClipboard();

--- a/src/cascadia/TerminalControl/TermControlAutomationPeer.cpp
+++ b/src/cascadia/TerminalControl/TermControlAutomationPeer.cpp
@@ -308,14 +308,14 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // fall back to title if profile name is empty
         if (auto control{ _termControl.get() })
         {
-            const auto profileName = control->GetProfileName();
-            if (profileName.empty())
+            const auto originalName = control->GetStartingTitle();
+            if (originalName.empty())
             {
                 return control->Title();
             }
             else
             {
-                return profileName;
+                return originalName;
             }
         }
 

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.h
@@ -121,8 +121,6 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         // ------------------------ End of Core Settings -----------------------
 
-        INHERITABLE_SETTING(Model::TerminalSettings, hstring, ProfileName);
-
         INHERITABLE_SETTING(Model::TerminalSettings, guid, SessionId);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, EnableUnfocusedAcrylic, false);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, UseAcrylic, false);

--- a/src/cascadia/inc/ControlProperties.h
+++ b/src/cascadia/inc/ControlProperties.h
@@ -60,7 +60,6 @@
 // --------------------------- Control Settings ---------------------------
 //  All of these settings are defined in IControlSettings.
 #define CONTROL_SETTINGS(X)                                                                                                                              \
-    X(winrt::hstring, ProfileName)                                                                                                                       \
     X(winrt::guid, SessionId)                                                                                                                            \
     X(bool, EnableUnfocusedAcrylic, false)                                                                                                               \
     X(winrt::hstring, Padding, DEFAULT_PADDING)                                                                                                          \


### PR DESCRIPTION
You know how much I hate squirreling away information on objects we have to pass halfway across the universe just to get back.

In this case, `StartingTitle` will always be the name of the profile. We only used ProfileName in places where we _needed a Title_, so this makes it much more obvious what we're doing.