### PR TITLE
Fix unfocused appearance UI in settings

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Appearances.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.xaml
@@ -68,6 +68,7 @@
         <StackPanel Style="{StaticResource PivotStackStyle}">
             <!--  Grouping: Text  -->
             <TextBlock x:Uid="Profile_TextHeader"
+                       Margin="0,0,0,4"
                        Style="{StaticResource TextBlockSubHeaderStyle}" />
             <!--  Color Scheme  -->
             <!--  This currently only display the Dark color scheme, even if the user has a pair of schemes set.  -->

--- a/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
+++ b/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
@@ -160,6 +160,13 @@
         <Setter Property="Margin" Value="0,32,0,4" />
     </Style>
 
+    <Style x:Key="TextBlockSubtitleStyle"
+           BasedOn="{StaticResource SubtitleTextBlockStyle}"
+           TargetType="TextBlock">
+        <Setter Property="MaxWidth" Value="{StaticResource StandardControlMaxWidth}" />
+        <Setter Property="Margin" Value="0,32,0,4" />
+    </Style>
+
     <!--  Used for disclaimers  -->
     <Style x:Key="DisclaimerStyle"
            TargetType="TextBlock">

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.xaml
@@ -64,6 +64,7 @@
                     Style="{StaticResource SettingsStackStyle}">
             <!--  Control Preview  -->
             <Border MaxWidth="{StaticResource StandardControlMaxWidth}"
+                    Margin="0,0,0,32"
                     CornerRadius="{StaticResource ControlCornerRadius}">
                 <Border x:Name="ControlPreview"
                         Width="400"
@@ -205,9 +206,10 @@
                 <StackPanel Orientation="Horizontal"
                             Visibility="{x:Bind Profile.EditableUnfocusedAppearance, Mode=OneWay}">
                     <TextBlock x:Uid="Profile_UnfocusedAppearanceTextBlock"
-                               Style="{StaticResource TitleTextBlockStyle}" />
+                               Style="{StaticResource TextBlockSubtitleStyle}" />
                     <Button x:Uid="Profile_CreateUnfocusedAppearanceButton"
                             Margin="8,0,0,0"
+                            VerticalAlignment="Bottom"
                             Click="CreateUnfocusedAppearance_Click"
                             Style="{StaticResource BaseButtonStyle}"
                             Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(Profile.HasUnfocusedAppearance), Mode=OneWay}">
@@ -224,6 +226,7 @@
                     </Button>
                     <Button x:Uid="Profile_DeleteUnfocusedAppearanceButton"
                             Margin="8,0,0,0"
+                            VerticalAlignment="Bottom"
                             Click="DeleteUnfocusedAppearance_Click"
                             Style="{StaticResource DeleteButtonStyle}"
                             Visibility="{x:Bind Profile.HasUnfocusedAppearance, Mode=OneWay}">


### PR DESCRIPTION
The unfocused appearance section in the settings UI looks a little off. Specifically, the header was too large (larger than the breadcrumbs!) and the button was weirdly aligned.

This PR reduces the size of the header and creates a style in CommonResources that manages it. This is the only place it's used, for now. A vertical alignment was added to the "create appearance" and "delete appearance" buttons to make them look better. The top margin of the "Text" header was also removed so that there isn't an awkward gap in the unfocused appearance section (the 32 that was there was moved to the bottom of the control preview so that that area remains unaffected.)

Follow-up from #19001