### PR TITLE
Move adjustProcessPriorityThrottled ctor earlier

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -220,16 +220,6 @@ namespace winrt::TerminalApp::implementation
             }
         }
 
-        _adjustProcessPriorityThrottled = std::make_shared<ThrottledFunc<>>(
-            DispatcherQueue::GetForCurrentThread(),
-            til::throttled_func_options{
-                .delay = std::chrono::milliseconds{ 100 },
-                .debounce = true,
-                .trailing = true,
-            },
-            [=]() {
-                _adjustProcessPriority();
-            });
         _hostingHwnd = hwnd;
         return S_OK;
     }
@@ -410,6 +400,17 @@ namespace winrt::TerminalApp::implementation
         // them.
 
         _tabRow.ShowElevationShield(IsRunningElevated() && _settings.GlobalSettings().ShowAdminShield());
+
+        _adjustProcessPriorityThrottled = std::make_shared<ThrottledFunc<>>(
+            DispatcherQueue::GetForCurrentThread(),
+            til::throttled_func_options{
+                .delay = std::chrono::milliseconds{ 100 },
+                .debounce = true,
+                .trailing = true,
+            },
+            [=]() {
+                _adjustProcessPriority();
+            });
     }
 
     Windows::UI::Xaml::Automation::Peers::AutomationPeer TerminalPage::OnCreateAutomationPeer()


### PR DESCRIPTION
Test Impact: The LocalTests do not call `Initialize(HWND)`, so we would fail on launch.
Also, we have `Create()` and `Initialize()` and `event Initialized` (the last of which is not called from either of the first two...)