### PR TITLE
env: don't explode when GetShortPathNameW fails

### DIFF
--- a/src/inc/til/env.h
+++ b/src/inc/til/env.h
@@ -366,12 +366,13 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
             if (til::compare_ordinal_insensitive(var, temp) == 0 ||
                 til::compare_ordinal_insensitive(var, tmp) == 0)
             {
-                return til::details::wil_env::GetShortPathNameW<std::wstring, 256>(value.data());
+                try
+                {
+                    return til::details::wil_env::GetShortPathNameW<std::wstring, 256>(value.data());
+                }
+                CATCH_LOG();
             }
-            else
-            {
-                return std::wstring{ value };
-            }
+            return std::wstring{ value };
         }
 
         static bool is_path_var(std::wstring_view input) noexcept

--- a/src/inc/til/env.h
+++ b/src/inc/til/env.h
@@ -366,11 +366,11 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
             if (til::compare_ordinal_insensitive(var, temp) == 0 ||
                 til::compare_ordinal_insensitive(var, tmp) == 0)
             {
-                try
+                std::wstring shortPath;
+                if (SUCCEEDED((til::details::wil_env::GetShortPathNameW<std::wstring, 256>(value.data(), shortPath))))
                 {
-                    return til::details::wil_env::GetShortPathNameW<std::wstring, 256>(value.data());
+                    return shortPath;
                 }
-                CATCH_LOG();
             }
             return std::wstring{ value };
         }


### PR DESCRIPTION
It fails inside app containers (!) such as the one used by LocalTests.