### PR TITLE
Avoid reentrancy issues when dropping AppHost

### DIFF
--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -544,6 +544,8 @@ void WindowEmperor::_dispatchSpecialKey(const MSG& msg) const
 
 void WindowEmperor::_dispatchCommandline(winrt::TerminalApp::CommandlineArgs args)
 {
+    _assertIsMainThread();
+
     const auto exitCode = args.ExitCode();
 
     if (const auto msg = args.ExitMessage(); !msg.empty())
@@ -681,6 +683,8 @@ safe_void_coroutine WindowEmperor::_dispatchCommandlineCurrentDesktop(winrt::Ter
 
 bool WindowEmperor::_summonWindow(const SummonWindowSelectionArgs& args) const
 {
+    _assertIsMainThread();
+
     AppHost* window = nullptr;
 
     if (args.WindowID)
@@ -721,6 +725,8 @@ bool WindowEmperor::_summonWindow(const SummonWindowSelectionArgs& args) const
 
 void WindowEmperor::_summonAllWindows() const
 {
+    _assertIsMainThread();
+
     TerminalApp::SummonWindowBehavior args;
     args.ToggleVisibility(false);
 

--- a/src/cascadia/WindowsTerminal/WindowEmperor.h
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.h
@@ -84,14 +84,14 @@ private:
     int32_t _windowCount = 0;
     int32_t _messageBoxCount = 0;
 
-#ifdef NDEBUG
+#ifdef 0 //NDEBUG
     static constexpr void _assertIsMainThread() noexcept
     {
     }
 #else
     void _assertIsMainThread() const noexcept
     {
-        assert(_mainThreadId == GetCurrentThreadId());
+        WI_ASSERT_MSG(_mainThreadId == GetCurrentThreadId(), "This part of WindowEmperor must be accessed from the UI thread");
     }
     DWORD _mainThreadId = GetCurrentThreadId();
 #endif

--- a/src/cascadia/WindowsTerminal/WindowEmperor.h
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.h
@@ -84,7 +84,7 @@ private:
     int32_t _windowCount = 0;
     int32_t _messageBoxCount = 0;
 
-#ifdef 0 //NDEBUG
+#if 0 // #ifdef NDEBUG
     static constexpr void _assertIsMainThread() noexcept
     {
     }


### PR DESCRIPTION
tl;dr: ~Apphost() may pump the message loop.
That's no bueno. See comments in the diff.

Additionally, this PR enables `_assertIsMainThread` in
release to trace down mysterious crashes in those builds.