### PR TITLE
Fix window count going out of sync when headless

### DIFF
--- a/src/cascadia/WindowsTerminal/WindowEmperor.h
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.h
@@ -81,7 +81,6 @@ private:
     bool _needsPersistenceCleanup = false;
     SafeDispatcherTimer _persistStateTimer;
     std::optional<bool> _currentSystemThemeIsDark;
-    int32_t _windowCount = 0;
     int32_t _messageBoxCount = 0;
 
 #ifdef NDEBUG


### PR DESCRIPTION
In headless mode, `WM_CLOSE_TERMINAL_WINDOW` would still decrement
`_windowCount`. While the count technically doesn't matter,
it going out of sync with the actual count felt wrong.

## Validation Steps Performed
* TBD