### PR TITLE
Adjust "Dimidium" color scheme

### DIFF
--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -85,7 +85,7 @@
             "background": "#141414",
             "foreground": "#BAB7B6",
             "cursorColor": "#37E57B",
-            "selectionBackground": "#FFFFFF",
+            "selectionBackground": "#8DB8E5",
             "black": "#000000",
             "red": "#CF494C",
             "green": "#60B442",
@@ -101,7 +101,7 @@
             "brightBlue": "#688DFD",
             "brightPurple": "#ED6FE9",
             "brightCyan": "#32E0FB",
-            "brightWhite": "#D3D8D9"
+            "brightWhite": "#DEE3E4"
         },
         {
             "name": "Ottosson",


### PR DESCRIPTION
- Add Selection BG color
- Make Bright white brighter

## Summary of the Pull Request
Final tune for Dimidium color scheme before its release.

## References and Relevant Issues
#18563

## Detailed Description of the Pull Request / Additional comments
I made little change to Dimidium color scheme.

<img width="640" height="174" alt="cmp-lightness1c" src="https://github.com/user-attachments/assets/2e4aa6ca-5864-4901-b323-2e2bb2bf00e8" />

![preview-terminal](https://github.com/user-attachments/assets/8a53c54d-942a-44a2-9ee7-9ff8a6d2dfab)

<img width="584" height="207" alt="image" src="https://github.com/user-attachments/assets/b70b0759-7961-4f8f-aaa7-762fc48e425b" />


- Adjusted "Bright white" slightly brighter, hoping it can be distinguished better from "White".
- Defined "Selection Background" color.

This will be the final tune for Dimidum color scheme.