### PR TITLE
Stop using Settings to shuttle IKeyBindings around

### DIFF
--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -1419,7 +1419,7 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(L"profile0", terminalArgs.Profile());
             VERIFY_IS_NULL(terminalArgs.Elevate());
 
-            const auto termSettingsResult = TerminalSettings::CreateWithNewTerminalArgs(settings, terminalArgs, nullptr);
+            const auto termSettingsResult = TerminalSettings::CreateWithNewTerminalArgs(settings, terminalArgs);
             const auto termSettings = termSettingsResult.DefaultSettings();
             VERIFY_ARE_EQUAL(L"cmd.exe", termSettings.Commandline());
             VERIFY_ARE_EQUAL(false, termSettings.Elevate());
@@ -1442,7 +1442,7 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(L"profile1", terminalArgs.Profile());
             VERIFY_IS_NULL(terminalArgs.Elevate());
 
-            const auto termSettingsResult = TerminalSettings::CreateWithNewTerminalArgs(settings, terminalArgs, nullptr);
+            const auto termSettingsResult = TerminalSettings::CreateWithNewTerminalArgs(settings, terminalArgs);
             const auto termSettings = termSettingsResult.DefaultSettings();
             VERIFY_ARE_EQUAL(L"pwsh.exe", termSettings.Commandline());
             VERIFY_ARE_EQUAL(true, termSettings.Elevate());
@@ -1465,7 +1465,7 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(L"profile2", terminalArgs.Profile());
             VERIFY_IS_NULL(terminalArgs.Elevate());
 
-            const auto termSettingsResult = TerminalSettings::CreateWithNewTerminalArgs(settings, terminalArgs, nullptr);
+            const auto termSettingsResult = TerminalSettings::CreateWithNewTerminalArgs(settings, terminalArgs);
             const auto termSettings = termSettingsResult.DefaultSettings();
             VERIFY_ARE_EQUAL(L"wsl.exe", termSettings.Commandline());
             VERIFY_ARE_EQUAL(false, termSettings.Elevate());
@@ -1490,7 +1490,7 @@ namespace TerminalAppLocalTests
             VERIFY_IS_NOT_NULL(terminalArgs.Elevate());
             VERIFY_IS_FALSE(terminalArgs.Elevate().Value());
 
-            const auto termSettingsResult = TerminalSettings::CreateWithNewTerminalArgs(settings, terminalArgs, nullptr);
+            const auto termSettingsResult = TerminalSettings::CreateWithNewTerminalArgs(settings, terminalArgs);
             const auto termSettings = termSettingsResult.DefaultSettings();
             VERIFY_ARE_EQUAL(L"cmd.exe", termSettings.Commandline());
             VERIFY_ARE_EQUAL(false, termSettings.Elevate());
@@ -1514,7 +1514,7 @@ namespace TerminalAppLocalTests
             VERIFY_IS_NOT_NULL(terminalArgs.Elevate());
             VERIFY_IS_FALSE(terminalArgs.Elevate().Value());
 
-            const auto termSettingsResult = TerminalSettings::CreateWithNewTerminalArgs(settings, terminalArgs, nullptr);
+            const auto termSettingsResult = TerminalSettings::CreateWithNewTerminalArgs(settings, terminalArgs);
             const auto termSettings = termSettingsResult.DefaultSettings();
             VERIFY_ARE_EQUAL(L"pwsh.exe", termSettings.Commandline());
             VERIFY_ARE_EQUAL(false, termSettings.Elevate());
@@ -1538,7 +1538,7 @@ namespace TerminalAppLocalTests
             VERIFY_IS_NOT_NULL(terminalArgs.Elevate());
             VERIFY_IS_FALSE(terminalArgs.Elevate().Value());
 
-            const auto termSettingsResult = TerminalSettings::CreateWithNewTerminalArgs(settings, terminalArgs, nullptr);
+            const auto termSettingsResult = TerminalSettings::CreateWithNewTerminalArgs(settings, terminalArgs);
             const auto termSettings = termSettingsResult.DefaultSettings();
             VERIFY_ARE_EQUAL(L"wsl.exe", termSettings.Commandline());
             VERIFY_ARE_EQUAL(false, termSettings.Elevate());
@@ -1563,7 +1563,7 @@ namespace TerminalAppLocalTests
             VERIFY_IS_NOT_NULL(terminalArgs.Elevate());
             VERIFY_IS_TRUE(terminalArgs.Elevate().Value());
 
-            const auto termSettingsResult = TerminalSettings::CreateWithNewTerminalArgs(settings, terminalArgs, nullptr);
+            const auto termSettingsResult = TerminalSettings::CreateWithNewTerminalArgs(settings, terminalArgs);
             const auto termSettings = termSettingsResult.DefaultSettings();
             VERIFY_ARE_EQUAL(L"cmd.exe", termSettings.Commandline());
             VERIFY_ARE_EQUAL(true, termSettings.Elevate());
@@ -1586,7 +1586,7 @@ namespace TerminalAppLocalTests
             VERIFY_IS_NOT_NULL(terminalArgs.Elevate());
             VERIFY_IS_TRUE(terminalArgs.Elevate().Value());
 
-            const auto termSettingsResult = TerminalSettings::CreateWithNewTerminalArgs(settings, terminalArgs, nullptr);
+            const auto termSettingsResult = TerminalSettings::CreateWithNewTerminalArgs(settings, terminalArgs);
             const auto termSettings = termSettingsResult.DefaultSettings();
             VERIFY_ARE_EQUAL(L"pwsh.exe", termSettings.Commandline());
             VERIFY_ARE_EQUAL(true, termSettings.Elevate());
@@ -1610,7 +1610,7 @@ namespace TerminalAppLocalTests
             VERIFY_IS_NOT_NULL(terminalArgs.Elevate());
             VERIFY_IS_TRUE(terminalArgs.Elevate().Value());
 
-            const auto termSettingsResult = TerminalSettings::CreateWithNewTerminalArgs(settings, terminalArgs, nullptr);
+            const auto termSettingsResult = TerminalSettings::CreateWithNewTerminalArgs(settings, terminalArgs);
             const auto termSettings = termSettingsResult.DefaultSettings();
             VERIFY_ARE_EQUAL(L"wsl.exe", termSettings.Commandline());
             VERIFY_ARE_EQUAL(true, termSettings.Elevate());

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -74,7 +74,7 @@ namespace winrt::TerminalApp::implementation
             {
                 return S_FALSE;
             }
-            const auto settings{ TerminalSettings::CreateWithNewTerminalArgs(_settings, newTerminalArgs, *_bindings) };
+            const auto settings{ TerminalSettings::CreateWithNewTerminalArgs(_settings, newTerminalArgs) };
 
             // Try to handle auto-elevation
             if (_maybeElevate(newTerminalArgs, settings, profile))

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -270,7 +270,7 @@ namespace winrt::TerminalApp::implementation
         if (_settings == nullptr)
         {
             // Create this only on the first time we load the settings.
-            _terminalSettingsCache = std::make_shared<TerminalSettingsCache>(settings, *_bindings);
+            _terminalSettingsCache = std::make_shared<TerminalSettingsCache>(settings);
         }
         _settings = settings;
 
@@ -1597,7 +1597,7 @@ namespace winrt::TerminalApp::implementation
         {
             // TODO GH#5047 If we cache the NewTerminalArgs, we no longer need to do this.
             profile = GetClosestProfileForDuplicationOfProfile(profile);
-            controlSettings = TerminalSettings::CreateWithProfile(_settings, profile, *_bindings);
+            controlSettings = TerminalSettings::CreateWithProfile(_settings, profile);
 
             // Replace the Starting directory with the CWD, if given
             const auto workingDirectory = control.WorkingDirectory();
@@ -3437,7 +3437,7 @@ namespace winrt::TerminalApp::implementation
             // don't, then when we move the content to another thread, and it
             // tries to handle a key, it'll callback on the original page's
             // stack, inevitably resulting in a wrong_thread
-            return _SetupControl(TermControl::NewControlByAttachingContent(content, *_bindings));
+            return _SetupControl(TermControl::NewControlByAttachingContent(content));
         }
         return nullptr;
     }
@@ -3456,6 +3456,8 @@ namespace winrt::TerminalApp::implementation
         {
             term.OwningHwnd(reinterpret_cast<uint64_t>(*_hostingHwnd));
         }
+
+        term.KeyBindings(*_bindings);
 
         _RegisterTerminalEvents(term);
         return term;
@@ -3503,7 +3505,7 @@ namespace winrt::TerminalApp::implementation
             {
                 // TODO GH#5047 If we cache the NewTerminalArgs, we no longer need to do this.
                 profile = GetClosestProfileForDuplicationOfProfile(profile);
-                controlSettings = TerminalSettings::CreateWithProfile(_settings, profile, *_bindings);
+                controlSettings = TerminalSettings::CreateWithProfile(_settings, profile);
                 const auto workingDirectory = tabImpl->GetActiveTerminalControl().WorkingDirectory();
                 const auto validWorkingDirectory = !workingDirectory.empty();
                 if (validWorkingDirectory)
@@ -3515,7 +3517,7 @@ namespace winrt::TerminalApp::implementation
         if (!profile)
         {
             profile = _settings.GetProfileForArgs(newTerminalArgs);
-            controlSettings = TerminalSettings::CreateWithNewTerminalArgs(_settings, newTerminalArgs, *_bindings);
+            controlSettings = TerminalSettings::CreateWithNewTerminalArgs(_settings, newTerminalArgs);
         }
 
         // Try to handle auto-elevation
@@ -3774,7 +3776,7 @@ namespace winrt::TerminalApp::implementation
         // updating terminal panes, so that we don't have to build a _new_
         // TerminalSettings for every profile we update - we can just look them
         // up the previous ones we built.
-        _terminalSettingsCache->Reset(_settings, *_bindings);
+        _terminalSettingsCache->Reset(_settings);
 
         for (const auto& tab : _tabs)
         {

--- a/src/cascadia/TerminalApp/TerminalSettingsCache.cpp
+++ b/src/cascadia/TerminalApp/TerminalSettingsCache.cpp
@@ -13,9 +13,9 @@ namespace winrt
 
 namespace winrt::TerminalApp::implementation
 {
-    TerminalSettingsCache::TerminalSettingsCache(const MTSM::CascadiaSettings& settings, const TerminalApp::AppKeyBindings& bindings)
+    TerminalSettingsCache::TerminalSettingsCache(const MTSM::CascadiaSettings& settings)
     {
-        Reset(settings, bindings);
+        Reset(settings);
     }
 
     MTSM::TerminalSettingsCreateResult TerminalSettingsCache::TryLookup(const MTSM::Profile& profile)
@@ -30,7 +30,7 @@ namespace winrt::TerminalApp::implementation
             auto& pair{ found->second };
             if (!pair.second)
             {
-                pair.second = MTSM::TerminalSettings::CreateWithProfile(_settings, pair.first, _bindings);
+                pair.second = MTSM::TerminalSettings::CreateWithProfile(_settings, pair.first);
             }
             return pair.second;
         }
@@ -38,10 +38,9 @@ namespace winrt::TerminalApp::implementation
         return nullptr;
     }
 
-    void TerminalSettingsCache::Reset(const MTSM::CascadiaSettings& settings, const TerminalApp::AppKeyBindings& bindings)
+    void TerminalSettingsCache::Reset(const MTSM::CascadiaSettings& settings)
     {
         _settings = settings;
-        _bindings = bindings;
 
         // Mapping by GUID isn't _excellent_ because the defaults profile doesn't have a stable GUID; however,
         // when we stabilize its guid this will become fully safe.

--- a/src/cascadia/TerminalApp/TerminalSettingsCache.h
+++ b/src/cascadia/TerminalApp/TerminalSettingsCache.h
@@ -20,13 +20,12 @@ namespace winrt::TerminalApp::implementation
 {
     struct TerminalSettingsCache
     {
-        TerminalSettingsCache(const Microsoft::Terminal::Settings::Model::CascadiaSettings& settings, const TerminalApp::AppKeyBindings& bindings);
+        TerminalSettingsCache(const Microsoft::Terminal::Settings::Model::CascadiaSettings& settings);
         Microsoft::Terminal::Settings::Model::TerminalSettingsCreateResult TryLookup(const Microsoft::Terminal::Settings::Model::Profile& profile);
-        void Reset(const Microsoft::Terminal::Settings::Model::CascadiaSettings& settings, const TerminalApp::AppKeyBindings& bindings);
+        void Reset(const Microsoft::Terminal::Settings::Model::CascadiaSettings& settings);
 
     private:
         Microsoft::Terminal::Settings::Model::CascadiaSettings _settings{ nullptr };
-        TerminalApp::AppKeyBindings _bindings{ nullptr };
         std::unordered_map<winrt::guid, std::pair<Microsoft::Terminal::Settings::Model::Profile, Microsoft::Terminal::Settings::Model::TerminalSettingsCreateResult>> profileGuidSettingsMap;
     };
 }

--- a/src/cascadia/TerminalApp/TerminalWindow.cpp
+++ b/src/cascadia/TerminalApp/TerminalWindow.cpp
@@ -613,7 +613,7 @@ namespace winrt::TerminalApp::implementation
         if ((_appArgs && _appArgs->ParsedArgs().GetSize().has_value()) || (proposedSize.Width == 0 && proposedSize.Height == 0))
         {
             // Use the default profile to determine how big of a window we need.
-            const auto settings{ TerminalSettings::CreateWithNewTerminalArgs(_settings, nullptr, nullptr) };
+            const auto settings{ TerminalSettings::CreateWithNewTerminalArgs(_settings, nullptr) };
 
             const til::size emptySize{};
             const auto commandlineSize = _appArgs ? _appArgs->ParsedArgs().GetSize().value_or(emptySize) : til::size{};

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -265,9 +265,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         shared->updateScrollBar.reset();
     }
 
-    void ControlCore::AttachToNewControl(const Microsoft::Terminal::Control::IKeyBindings& keyBindings)
+    void ControlCore::AttachToNewControl()
     {
-        _settings->KeyBindings(keyBindings);
         _setupDispatcherAndCallbacks();
         const auto actualNewSize = _actualFont.GetSize();
         // Bubble this up, so our new control knows how big we want the font.

--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -105,7 +105,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         ::Microsoft::Console::Render::Renderer* GetRenderer() const noexcept;
         uint64_t SwapChainHandle() const;
-        void AttachToNewControl(const Microsoft::Terminal::Control::IKeyBindings& keyBindings);
+        void AttachToNewControl();
 
         void SizeChanged(const float width, const float height);
         void ScaleChanged(const float scale);

--- a/src/cascadia/TerminalControl/ControlInteractivity.cpp
+++ b/src/cascadia/TerminalControl/ControlInteractivity.cpp
@@ -84,9 +84,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         _core->Detach();
     }
 
-    void ControlInteractivity::AttachToNewControl(const Microsoft::Terminal::Control::IKeyBindings& keyBindings)
+    void ControlInteractivity::AttachToNewControl()
     {
-        _core->AttachToNewControl(keyBindings);
+        _core->AttachToNewControl();
     }
 
     // Method Description:

--- a/src/cascadia/TerminalControl/ControlInteractivity.h
+++ b/src/cascadia/TerminalControl/ControlInteractivity.h
@@ -89,7 +89,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void SetEndSelectionPoint(const Core::Point pixelPosition);
 
         uint64_t Id();
-        void AttachToNewControl(const Microsoft::Terminal::Control::IKeyBindings& keyBindings);
+        void AttachToNewControl();
 
         til::typed_event<IInspectable, Control::OpenHyperlinkEventArgs> OpenHyperlink;
         til::typed_event<IInspectable, Control::PasteFromClipboardEventArgs> PasteFromClipboard;

--- a/src/cascadia/TerminalControl/ControlInteractivity.idl
+++ b/src/cascadia/TerminalControl/ControlInteractivity.idl
@@ -25,7 +25,7 @@ namespace Microsoft.Terminal.Control
 
         UInt64 Id { get; };
 
-        void AttachToNewControl(Microsoft.Terminal.Control.IKeyBindings keyBindings);
+        void AttachToNewControl();
         void Detach();
 
         void Close();

--- a/src/cascadia/TerminalControl/IControlSettings.idl
+++ b/src/cascadia/TerminalControl/IControlSettings.idl
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import "IKeyBindings.idl";
 import "IControlAppearance.idl";
 import "EventArgs.idl";
 
@@ -52,8 +51,6 @@ namespace Microsoft.Terminal.Control
         Boolean EnableColorGlyphs { get; };
         String CellWidth { get; };
         String CellHeight { get; };
-
-        Microsoft.Terminal.Control.IKeyBindings KeyBindings { get; };
 
         Boolean CopyOnSelect { get; };
         Microsoft.Terminal.Control.CopyFormat CopyFormatting { get; };

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -487,25 +487,22 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // Function Description:
     // - Static helper for building a new TermControl from an already existing
     //   content. We'll attach the existing swapchain to this new control's
-    //   SwapChainPanel. The IKeyBindings might belong to a non-agile object on
-    //   a new thread, so we'll hook up the core to these new bindings.
+    //   SwapChainPanel.
     // Arguments:
     // - content: The preexisting ControlInteractivity to connect to.
-    // - keybindings: The new IKeyBindings instance to use for this control.
     // Return Value:
     // - The newly constructed TermControl.
-    Control::TermControl TermControl::NewControlByAttachingContent(Control::ControlInteractivity content,
-                                                                   const Microsoft::Terminal::Control::IKeyBindings& keyBindings)
+    Control::TermControl TermControl::NewControlByAttachingContent(Control::ControlInteractivity content)
     {
         const auto term{ winrt::make_self<TermControl>(content) };
-        term->_initializeForAttach(keyBindings);
+        term->_initializeForAttach();
         return *term;
     }
 
-    void TermControl::_initializeForAttach(const Microsoft::Terminal::Control::IKeyBindings& keyBindings)
+    void TermControl::_initializeForAttach()
     {
         _AttachDxgiSwapChainToXaml(reinterpret_cast<HANDLE>(_core.SwapChainHandle()));
-        _interactivity.AttachToNewControl(keyBindings);
+        _interactivity.AttachToNewControl();
 
         // Initialize the terminal only once the swapchainpanel is loaded - that
         //      way, we'll be able to query the real pixel size it got on layout
@@ -1848,13 +1845,12 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             return true;
         }
 
-        auto bindings = _core.Settings().KeyBindings();
-        if (!bindings)
+        if (!_keyBindings)
         {
             return false;
         }
 
-        auto success = bindings.TryKeyChord({
+        auto success = _keyBindings.TryKeyChord({
             modifiers.IsCtrlPressed(),
             modifiers.IsAltPressed(),
             modifiers.IsShiftPressed(),

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -50,11 +50,13 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         TermControl(IControlSettings settings, Control::IControlAppearance unfocusedAppearance, TerminalConnection::ITerminalConnection connection);
 
-        static Control::TermControl NewControlByAttachingContent(Control::ControlInteractivity content, const Microsoft::Terminal::Control::IKeyBindings& keyBindings);
+        static Control::TermControl NewControlByAttachingContent(Control::ControlInteractivity content);
 
         void UpdateControlSettings(Control::IControlSettings settings);
         void UpdateControlSettings(Control::IControlSettings settings, Control::IControlAppearance unfocusedAppearance);
         IControlSettings Settings() const;
+
+        void KeyBindings(const Control::IKeyBindings& bindings) { _keyBindings = bindings; }
 
         uint64_t ContentId() const;
 
@@ -249,6 +251,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         Control::TermControlAutomationPeer _automationPeer{ nullptr };
         Control::ControlInteractivity _interactivity{ nullptr };
         Control::ControlCore _core{ nullptr };
+        Control::IKeyBindings _keyBindings{ nullptr };
         TsfDataProvider _tsfDataProvider{ this };
         winrt::com_ptr<SearchBoxControl> _searchBox;
 
@@ -340,7 +343,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             return _closing;
         }
 
-        void _initializeForAttach(const Microsoft::Terminal::Control::IKeyBindings& keyBindings);
+        void _initializeForAttach();
 
         void _UpdateSettingsFromUIThread();
         void _UpdateAppearanceFromUIThread(Control::IControlAppearance newAppearance);

--- a/src/cascadia/TerminalControl/TermControl.idl
+++ b/src/cascadia/TerminalControl/TermControl.idl
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import "IKeyBindings.idl";
 import "IMouseWheelListener.idl";
 import "IControlSettings.idl";
 import "ControlInteractivity.idl";
@@ -36,7 +37,7 @@ namespace Microsoft.Terminal.Control
                     IControlAppearance unfocusedAppearance,
                     Microsoft.Terminal.TerminalConnection.ITerminalConnection connection);
 
-        static TermControl NewControlByAttachingContent(ControlInteractivity content, Microsoft.Terminal.Control.IKeyBindings keyBindings);
+        static TermControl NewControlByAttachingContent(ControlInteractivity content);
 
         static Windows.Foundation.Size GetProposedDimensions(IControlSettings settings,
                                                              UInt32 dpi,
@@ -51,6 +52,9 @@ namespace Microsoft.Terminal.Control
         UInt64 ContentId{ get; };
 
         Microsoft.Terminal.Control.IControlSettings Settings { get; };
+
+        // MIDL 3 does not support setter-only properties.
+        void KeyBindings(Microsoft.Terminal.Control.IKeyBindings KeyBindings);
 
         event Windows.Foundation.TypedEventHandler<Object, TitleChangedEventArgs> TitleChanged;
         event Windows.Foundation.TypedEventHandler<Object, WriteToClipboardEventArgs> WriteToClipboard;

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
@@ -79,14 +79,12 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     // Arguments:
     // - appSettings: the set of settings being used to construct the new terminal
     // - profileGuid: the unique identifier (guid) of the profile
-    // - keybindings: the keybinding handler
     // Return Value:
     // - A TerminalSettingsCreateResult, which contains a pair of TerminalSettings objects,
     //   one for when the terminal is focused and the other for when the terminal is unfocused
-    Model::TerminalSettingsCreateResult TerminalSettings::CreateWithProfile(const Model::CascadiaSettings& appSettings, const Model::Profile& profile, const IKeyBindings& keybindings)
+    Model::TerminalSettingsCreateResult TerminalSettings::CreateWithProfile(const Model::CascadiaSettings& appSettings, const Model::Profile& profile)
     {
         const auto settings = _CreateWithProfileCommon(appSettings, profile);
-        settings->_KeyBindings = keybindings;
 
         Model::TerminalSettings child{ nullptr };
         if (const auto& unfocusedAppearance{ profile.UnfocusedAppearance() })
@@ -114,16 +112,14 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     //   * Additionally, we'll use other values (such as Commandline,
     //     StartingDirectory) in this object to override the settings directly from
     //     the profile.
-    // - keybindings: the keybinding handler
     // Return Value:
     // - A TerminalSettingsCreateResult object, which contains a pair of TerminalSettings
     //   objects. One for when the terminal is focused and one for when the terminal is unfocused.
     Model::TerminalSettingsCreateResult TerminalSettings::CreateWithNewTerminalArgs(const CascadiaSettings& appSettings,
-                                                                                    const NewTerminalArgs& newTerminalArgs,
-                                                                                    const IKeyBindings& keybindings)
+                                                                                    const NewTerminalArgs& newTerminalArgs)
     {
         const auto profile = appSettings.GetProfileForArgs(newTerminalArgs);
-        auto settingsPair{ CreateWithProfile(appSettings, profile, keybindings) };
+        auto settingsPair{ CreateWithProfile(appSettings, profile) };
         auto defaultSettings = settingsPair.DefaultSettings();
 
         if (newTerminalArgs)

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.h
@@ -59,12 +59,10 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         static Model::TerminalSettings CreateForPreview(const Model::CascadiaSettings& appSettings, const Model::Profile& profile);
 
         static Model::TerminalSettingsCreateResult CreateWithProfile(const Model::CascadiaSettings& appSettings,
-                                                                     const Model::Profile& profile,
-                                                                     const Control::IKeyBindings& keybindings);
+                                                                     const Model::Profile& profile);
 
         static Model::TerminalSettingsCreateResult CreateWithNewTerminalArgs(const Model::CascadiaSettings& appSettings,
-                                                                             const Model::NewTerminalArgs& newTerminalArgs,
-                                                                             const Control::IKeyBindings& keybindings);
+                                                                             const Model::NewTerminalArgs& newTerminalArgs);
 
         void ApplyColorScheme(const Model::ColorScheme& scheme);
 
@@ -144,8 +142,6 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         INHERITABLE_SETTING(Model::TerminalSettings, winrt::Windows::UI::Xaml::Media::Stretch, BackgroundImageStretchMode, winrt::Windows::UI::Xaml::Media::Stretch::UniformToFill);
         INHERITABLE_SETTING(Model::TerminalSettings, winrt::Windows::UI::Xaml::HorizontalAlignment, BackgroundImageHorizontalAlignment, winrt::Windows::UI::Xaml::HorizontalAlignment::Center);
         INHERITABLE_SETTING(Model::TerminalSettings, winrt::Windows::UI::Xaml::VerticalAlignment, BackgroundImageVerticalAlignment, winrt::Windows::UI::Xaml::VerticalAlignment::Center);
-
-        INHERITABLE_SETTING(Model::TerminalSettings, Microsoft::Terminal::Control::IKeyBindings, KeyBindings, nullptr);
 
         INHERITABLE_SETTING(Model::TerminalSettings, hstring, Commandline);
         INHERITABLE_SETTING(Model::TerminalSettings, hstring, StartingDirectory);

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.idl
@@ -31,8 +31,8 @@ namespace Microsoft.Terminal.Settings.Model
         Windows.Foundation.Collections.IMap<String COMMA String> EnvironmentVariables;
 
         static TerminalSettings CreateForPreview(CascadiaSettings appSettings, Profile profile);
-        static TerminalSettingsCreateResult CreateWithProfile(CascadiaSettings appSettings, Profile profile, Microsoft.Terminal.Control.IKeyBindings keybindings);
-        static TerminalSettingsCreateResult CreateWithNewTerminalArgs(CascadiaSettings appSettings, NewTerminalArgs newTerminalArgs, Microsoft.Terminal.Control.IKeyBindings keybindings);
+        static TerminalSettingsCreateResult CreateWithProfile(CascadiaSettings appSettings, Profile profile);
+        static TerminalSettingsCreateResult CreateWithNewTerminalArgs(CascadiaSettings appSettings, NewTerminalArgs newTerminalArgs);
 
         void ApplyColorScheme(ColorScheme scheme);
 

--- a/src/cascadia/UnitTests_SettingsModel/TerminalSettingsTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/TerminalSettingsTests.cpp
@@ -330,7 +330,7 @@ namespace SettingsModelUnitTests
             VERIFY_IS_TRUE(terminalArgs.Profile().empty());
 
             const auto profile{ settings->GetProfileForArgs(terminalArgs) };
-            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, terminalArgs, nullptr) };
+            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, terminalArgs) };
             const auto termSettings = settingsStruct.DefaultSettings();
             VERIFY_ARE_EQUAL(guid0, profile.Guid());
             VERIFY_ARE_EQUAL(L"cmd.exe", termSettings.Commandline());
@@ -354,7 +354,7 @@ namespace SettingsModelUnitTests
             VERIFY_ARE_EQUAL(L"{6239a42c-1111-49a3-80bd-e8fdd045185c}", terminalArgs.Profile());
 
             const auto profile{ settings->GetProfileForArgs(terminalArgs) };
-            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, terminalArgs, nullptr) };
+            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, terminalArgs) };
             const auto termSettings = settingsStruct.DefaultSettings();
             VERIFY_ARE_EQUAL(guid1, profile.Guid());
             VERIFY_ARE_EQUAL(L"pwsh.exe", termSettings.Commandline());
@@ -378,7 +378,7 @@ namespace SettingsModelUnitTests
             VERIFY_ARE_EQUAL(L"profile1", terminalArgs.Profile());
 
             const auto profile{ settings->GetProfileForArgs(terminalArgs) };
-            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, terminalArgs, nullptr) };
+            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, terminalArgs) };
             const auto termSettings = settingsStruct.DefaultSettings();
             VERIFY_ARE_EQUAL(guid1, profile.Guid());
             VERIFY_ARE_EQUAL(L"pwsh.exe", termSettings.Commandline());
@@ -402,7 +402,7 @@ namespace SettingsModelUnitTests
             VERIFY_ARE_EQUAL(L"profile2", terminalArgs.Profile());
 
             const auto profile{ settings->GetProfileForArgs(terminalArgs) };
-            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, terminalArgs, nullptr) };
+            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, terminalArgs) };
             const auto termSettings = settingsStruct.DefaultSettings();
             VERIFY_ARE_EQUAL(profile2Guid, profile.Guid());
             VERIFY_ARE_EQUAL(L"wsl.exe", termSettings.Commandline());
@@ -426,7 +426,7 @@ namespace SettingsModelUnitTests
             VERIFY_ARE_EQUAL(L"foo.exe", terminalArgs.Commandline());
 
             const auto profile{ settings->GetProfileForArgs(terminalArgs) };
-            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, terminalArgs, nullptr) };
+            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, terminalArgs) };
             const auto termSettings = settingsStruct.DefaultSettings();
             // This action specified a command but no profile; it gets reassigned to the base profile
             VERIFY_ARE_EQUAL(settings->ProfileDefaults(), profile);
@@ -452,7 +452,7 @@ namespace SettingsModelUnitTests
             VERIFY_ARE_EQUAL(L"foo.exe", terminalArgs.Commandline());
 
             const auto profile{ settings->GetProfileForArgs(terminalArgs) };
-            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, terminalArgs, nullptr) };
+            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, terminalArgs) };
             const auto termSettings = settingsStruct.DefaultSettings();
             VERIFY_ARE_EQUAL(guid1, profile.Guid());
             VERIFY_ARE_EQUAL(L"foo.exe", termSettings.Commandline());
@@ -474,7 +474,7 @@ namespace SettingsModelUnitTests
             VERIFY_IS_TRUE(terminalArgs.Profile().empty());
 
             const auto profile{ settings->GetProfileForArgs(terminalArgs) };
-            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, terminalArgs, nullptr) };
+            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, terminalArgs) };
             const auto termSettings = settingsStruct.DefaultSettings();
             VERIFY_ARE_EQUAL(guid0, profile.Guid());
             VERIFY_ARE_EQUAL(L"cmd.exe", termSettings.Commandline());
@@ -497,7 +497,7 @@ namespace SettingsModelUnitTests
             VERIFY_ARE_EQUAL(L"c:\\foo", terminalArgs.StartingDirectory());
 
             const auto profile{ settings->GetProfileForArgs(terminalArgs) };
-            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, terminalArgs, nullptr) };
+            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, terminalArgs) };
             const auto termSettings = settingsStruct.DefaultSettings();
             VERIFY_ARE_EQUAL(guid0, profile.Guid());
             VERIFY_ARE_EQUAL(L"cmd.exe", termSettings.Commandline());
@@ -522,7 +522,7 @@ namespace SettingsModelUnitTests
             VERIFY_ARE_EQUAL(L"profile2", terminalArgs.Profile());
 
             const auto profile{ settings->GetProfileForArgs(terminalArgs) };
-            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, terminalArgs, nullptr) };
+            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, terminalArgs) };
             const auto termSettings = settingsStruct.DefaultSettings();
             VERIFY_ARE_EQUAL(profile2Guid, profile.Guid());
             VERIFY_ARE_EQUAL(L"wsl.exe", termSettings.Commandline());
@@ -546,7 +546,7 @@ namespace SettingsModelUnitTests
             VERIFY_ARE_EQUAL(L"bar", terminalArgs.TabTitle());
 
             const auto profile{ settings->GetProfileForArgs(terminalArgs) };
-            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, terminalArgs, nullptr) };
+            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, terminalArgs) };
             const auto termSettings = settingsStruct.DefaultSettings();
             VERIFY_ARE_EQUAL(guid0, profile.Guid());
             VERIFY_ARE_EQUAL(L"cmd.exe", termSettings.Commandline());
@@ -571,7 +571,7 @@ namespace SettingsModelUnitTests
             VERIFY_ARE_EQUAL(L"profile2", terminalArgs.Profile());
 
             const auto profile{ settings->GetProfileForArgs(terminalArgs) };
-            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, terminalArgs, nullptr) };
+            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, terminalArgs) };
             const auto termSettings = settingsStruct.DefaultSettings();
             VERIFY_ARE_EQUAL(profile2Guid, profile.Guid());
             VERIFY_ARE_EQUAL(L"wsl.exe", termSettings.Commandline());
@@ -598,7 +598,7 @@ namespace SettingsModelUnitTests
             VERIFY_ARE_EQUAL(L"profile1", terminalArgs.Profile());
 
             const auto profile{ settings->GetProfileForArgs(terminalArgs) };
-            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, terminalArgs, nullptr) };
+            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, terminalArgs) };
             const auto termSettings = settingsStruct.DefaultSettings();
             VERIFY_ARE_EQUAL(guid1, profile.Guid());
             VERIFY_ARE_EQUAL(L"foo.exe", termSettings.Commandline());
@@ -637,7 +637,7 @@ namespace SettingsModelUnitTests
 
         try
         {
-            auto terminalSettings{ TerminalSettings::CreateWithProfile(*settings, profile1, nullptr) };
+            auto terminalSettings{ TerminalSettings::CreateWithProfile(*settings, profile1) };
             VERIFY_ARE_NOT_EQUAL(nullptr, terminalSettings);
             VERIFY_ARE_EQUAL(1, terminalSettings.DefaultSettings().HistorySize());
         }
@@ -648,7 +648,7 @@ namespace SettingsModelUnitTests
 
         try
         {
-            auto terminalSettings{ TerminalSettings::CreateWithProfile(*settings, profile2, nullptr) };
+            auto terminalSettings{ TerminalSettings::CreateWithProfile(*settings, profile2) };
             VERIFY_ARE_NOT_EQUAL(nullptr, terminalSettings);
             VERIFY_ARE_EQUAL(2, terminalSettings.DefaultSettings().HistorySize());
         }
@@ -659,7 +659,7 @@ namespace SettingsModelUnitTests
 
         try
         {
-            const auto termSettings{ TerminalSettings::CreateWithNewTerminalArgs(*settings, nullptr, nullptr) };
+            const auto termSettings{ TerminalSettings::CreateWithNewTerminalArgs(*settings, nullptr) };
             VERIFY_ARE_NOT_EQUAL(nullptr, termSettings);
             VERIFY_ARE_EQUAL(1, termSettings.DefaultSettings().HistorySize());
         }
@@ -698,7 +698,7 @@ namespace SettingsModelUnitTests
         VERIFY_ARE_EQUAL(settings->GlobalSettings().DefaultProfile(), settings->ActiveProfiles().GetAt(0).Guid());
         try
         {
-            const auto termSettings{ TerminalSettings::CreateWithNewTerminalArgs(*settings, nullptr, nullptr) };
+            const auto termSettings{ TerminalSettings::CreateWithNewTerminalArgs(*settings, nullptr) };
             VERIFY_ARE_NOT_EQUAL(nullptr, termSettings);
             VERIFY_ARE_EQUAL(1, termSettings.DefaultSettings().HistorySize());
         }
@@ -839,58 +839,58 @@ namespace SettingsModelUnitTests
         { // just a profile (profile wins)
             NewTerminalArgs args{};
             args.Profile(L"profile0");
-            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, args, nullptr) };
+            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, args) };
             VERIFY_ARE_EQUAL(L"profile0", settingsStruct.DefaultSettings().StartingTitle());
         }
         { // profile and command line -> no promotion (profile wins)
             NewTerminalArgs args{};
             args.Profile(L"profile0");
             args.Commandline(L"foo.exe");
-            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, args, nullptr) };
+            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, args) };
             VERIFY_ARE_EQUAL(L"profile0", settingsStruct.DefaultSettings().StartingTitle());
         }
         { // just a title -> it is propagated
             NewTerminalArgs args{};
             args.TabTitle(L"Analog Kid");
-            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, args, nullptr) };
+            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, args) };
             VERIFY_ARE_EQUAL(L"Analog Kid", settingsStruct.DefaultSettings().StartingTitle());
         }
         { // title and command line -> no promotion
             NewTerminalArgs args{};
             args.TabTitle(L"Digital Man");
             args.Commandline(L"foo.exe");
-            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, args, nullptr) };
+            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, args) };
             VERIFY_ARE_EQUAL(L"Digital Man", settingsStruct.DefaultSettings().StartingTitle());
         }
         { // just a commandline -> promotion
             NewTerminalArgs args{};
             args.Commandline(L"foo.exe");
-            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, args, nullptr) };
+            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, args) };
             VERIFY_ARE_EQUAL(L"foo.exe", settingsStruct.DefaultSettings().StartingTitle());
         }
         // various typesof commandline follow
         {
             NewTerminalArgs args{};
             args.Commandline(L"foo.exe bar");
-            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, args, nullptr) };
+            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, args) };
             VERIFY_ARE_EQUAL(L"foo.exe", settingsStruct.DefaultSettings().StartingTitle());
         }
         {
             NewTerminalArgs args{};
             args.Commandline(L"\"foo exe.exe\" bar");
-            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, args, nullptr) };
+            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, args) };
             VERIFY_ARE_EQUAL(L"foo exe.exe", settingsStruct.DefaultSettings().StartingTitle());
         }
         {
             NewTerminalArgs args{};
             args.Commandline(L"\"\" grand designs");
-            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, args, nullptr) };
+            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, args) };
             VERIFY_ARE_EQUAL(L"", settingsStruct.DefaultSettings().StartingTitle());
         }
         {
             NewTerminalArgs args{};
             args.Commandline(L" imagine a man");
-            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, args, nullptr) };
+            const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, args) };
             VERIFY_ARE_EQUAL(L"", settingsStruct.DefaultSettings().StartingTitle());
         }
     }

--- a/src/cascadia/inc/ControlProperties.h
+++ b/src/cascadia/inc/ControlProperties.h
@@ -72,7 +72,6 @@
     X(bool, EnableColorGlyphs, true)                                                                                                                     \
     X(winrt::hstring, CellWidth)                                                                                                                         \
     X(winrt::hstring, CellHeight)                                                                                                                        \
-    X(winrt::Microsoft::Terminal::Control::IKeyBindings, KeyBindings, nullptr)                                                                           \
     X(winrt::hstring, Commandline)                                                                                                                       \
     X(winrt::hstring, StartingDirectory)                                                                                                                 \
     X(winrt::Microsoft::Terminal::Control::ScrollbarState, ScrollState, winrt::Microsoft::Terminal::Control::ScrollbarState::Visible)                    \


### PR DESCRIPTION
For some reason, we went real hard on an architecture where the settings object contained the key bindings handler for the terminal. To make this work, we had to wind it through tons of layers: `TermControl`, `ControlInteractivity`, `ControlCore` (which saved it on `ControlSettings`), `ControlSettings`. Of course, because we have no clear delineation of concerns at the App layer this required us to put the bindings into the Settings Cache[^1].

Well, `TermControl` used `ControlCore` to get the Settings, to get the Bindings, to dispatch keys.

Yes, `TermControl` stored `IKeyBindings` down three layers _only to fish it back out and use it itself._

There is one place in the application where `TermControl`s are hooked up to their owners. Instead of passing the key bindings dispatcher in through nine hundred layers, we can just set it once--definitively!--there.

[^1]: This was the last thing that made the settings cache page-specific...