### PR TITLE
Guard IslandWindow shutdown against exploding?

### DIFF
--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -102,7 +102,15 @@ void IslandWindow::Close()
         // WinUI will strongly hold onto the first DesktopWindowXamlSource that is created.
         // If we don't manually set the Content() to null first, closing that first window
         // will leak all of its contents permanently.
-        _source.Content(nullptr);
+        //
+        // However, sometimes resetting the content during showdown throws an exception.
+        // We want to continue shutting down, even if this failed (and just leak the
+        // content if that's what it is going to do.)
+        try
+        {
+            _source.Content(nullptr);
+        }
+        CATCH_LOG();
 
         _source.Close();
         _source = nullptr;


### PR DESCRIPTION
During shutdown (specifically from the right-click menu in the terminal) XAML would throw an exception that we traced back to resetting the content of the Island.

```
Exception thrown at 0x00007FF95E72B5EC (KernelBase.dll) in
WindowsTerminal.exe: WinRT originate error - 0x800F1000 : 'Child
collection must not be modified during measure or arrange.'.
```

This made it out into the catch around the window message handler and resulted in the window not being closed after being emptied out.

Closes #19312