### PR TITLE
Fix terminal profile schema to allow null in keybinding id

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2302,8 +2302,15 @@
       "additionalProperties": false,
       "properties": {
         "id": {
-          "description": "The ID of the command this keybinding should execute.",
-          "type": "string"
+          "description": "The ID of the command this keybinding should execute (or null to disable a default).",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "keys": {
           "description": "Defines the key combinations used to call the command. It must be composed of...\n -any number of modifiers (ctrl/alt/shift)\n -a non-modifier key",


### PR DESCRIPTION
feat(doc/cascadia/profiles.schema.json): ✨ extend the “id” property to accept null so default keybindings can be disabled

## Summary of the Pull Request

Fixes the terminal profile jsonschema to allow for null in the id.  This is to match the current implementation when disabling a built in default keybind.

## References and Relevant Issues

I didnt submit an issue on this as the fix is less lines of code change than even filing a new defecct.   But I can if you want me to.

## Detailed Description of the Pull Request / Additional comments

Simply adding an oneOf and allowing a null type

## Validation Steps Performed

I tested that this no longer generates schema violation errors when keybindings are set to null and using an editor like vscode or neovim to edit the settings.json file

I looked thru the code base but didnt find an explicit tests for confirming json schema validation of the settings.json file.   There are tests that look to do roundtrip validation of writing to json and reading back.

## PR Checklist
- [] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [X] Schema updated (if necessary)
