### PR TITLE
Fix behavior of split-plane for existing windows

### DIFF
--- a/src/cascadia/TerminalApp/Remoting.cpp
+++ b/src/cascadia/TerminalApp/Remoting.cpp
@@ -44,10 +44,6 @@ namespace winrt::TerminalApp::implementation
     {
         _args = { value.begin(), value.end() };
         _parseResult = _parsed.ParseArgs(_args);
-        if (_parseResult == 0)
-        {
-            _parsed.ValidateStartupCommands();
-        }
     }
 
     winrt::com_array<winrt::hstring> CommandlineArgs::Commandline()

--- a/src/cascadia/TerminalApp/TerminalWindow.cpp
+++ b/src/cascadia/TerminalApp/TerminalWindow.cpp
@@ -1050,6 +1050,11 @@ namespace winrt::TerminalApp::implementation
         // (or called TerminalWindow::Initialize)
         if (_appArgs->ExitCode() == 0)
         {
+            // The existing logic (before this commit) strictly relied on
+            // ValidateStartupCommands() only to be called for new windows.
+            // It modifies the actions it stores.
+            parsedArgs.ValidateStartupCommands();
+
             // If the size of the arguments list is 1,
             // then it contains only the executable name and no other arguments.
             _hasCommandLineArguments = _appArgs->CommandlineRef().size() > 1;


### PR DESCRIPTION
Closes #18815

## Validation Steps Performed
* `wt -w 0 sp` splits the current tab ✅