### PR TITLE
Move newTabMenu creation to Settings Fixups

### DIFF
--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -559,6 +559,7 @@ bool SettingsLoader::AddDynamicProfileFolders()
         folderEntry->Inlining(FolderEntryInlining::Auto);
         folderEntry->RawEntries(winrt::single_threaded_vector<Model::NewTabMenuEntry>({ *matchProfilesEntry }));
 
+        // NewTabMenu is guaranteed to exist by FixupUserSettings, which runs before this fixup.
         userSettings.globals->NewTabMenu().Append(folderEntry.as<Model::NewTabMenuEntry>());
         state->SSHFolderGenerated(true);
         return true;
@@ -686,6 +687,16 @@ bool SettingsLoader::FixupUserSettings()
     {
         // migrate the user's opt-out to the profiles.defaults
         userSettings.baseLayerProfile->ForceVTInput(true);
+        fixedUp = true;
+    }
+
+    // Terminal 1.24
+    // Ensure that the user always has a newTabMenu. We used to do this last, after
+    // resolving all of the new tab menu entries, but there was no conceivable reason
+    // that it should happen so late.
+    if (!userSettings.globals->HasNewTabMenu())
+    {
+        userSettings.globals->NewTabMenu(winrt::single_threaded_vector<Model::NewTabMenuEntry>({ Model::RemainingProfilesEntry{} }));
         fixedUp = true;
     }
 
@@ -1263,8 +1274,8 @@ try
     // DisableDeletedProfiles returns true whenever we encountered any new generated/dynamic profiles.
     // Similarly FixupUserSettings returns true, when it encountered settings that were patched up.
     mustWriteToDisk |= loader.DisableDeletedProfiles();
-    mustWriteToDisk |= loader.AddDynamicProfileFolders();
     mustWriteToDisk |= loader.FixupUserSettings();
+    mustWriteToDisk |= loader.AddDynamicProfileFolders();
 
     // If this throws, the app will catch it and use the default settings.
     const auto settings = winrt::make_self<CascadiaSettings>(std::move(loader));
@@ -1744,16 +1755,6 @@ void CascadiaSettings::_resolveNewTabMenuProfiles() const
     if (remainingProfilesEntry != nullptr)
     {
         remainingProfilesEntry.Profiles(remainingProfiles);
-    }
-
-    // If the configuration does not have a "newTabMenu" field, GlobalAppSettings
-    // will return a default value containing just a "remainingProfiles" entry. However,
-    // this value is regenerated on every "get" operation, so the effect of setting
-    // the remaining profiles above will be undone. So only in the case that no custom
-    // value is present in GlobalAppSettings, we will store the modified default value.
-    if (!_globals->HasNewTabMenu())
-    {
-        _globals->NewTabMenu(entries);
     }
 }
 


### PR DESCRIPTION
Some of the other settings fixups require there to be a valid NewTabMenu, rather than just a temporary object. Since the resolving all the menu entries after loading already forces the user to have a `newTabMenu`, let's just codify it as a real fixup.

I've moved the SSH folder fixup after the settings fixup because it relies on there being a NTM.