### PR TITLE
Avoid generating SSH profiles using stale memory

### DIFF
--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -559,12 +559,7 @@ bool SettingsLoader::AddDynamicProfileFolders()
         folderEntry->Inlining(FolderEntryInlining::Auto);
         folderEntry->RawEntries(winrt::single_threaded_vector<Model::NewTabMenuEntry>({ *matchProfilesEntry }));
 
-        // We cannot edit globals.NewTabMenu directly because it could have been a temporary automatically-generated default value.
-        // If we want to make permanent changes to it, we need to expressly set it.
-        auto newTabMenu = userSettings.globals->NewTabMenu();
-        newTabMenu.Append(folderEntry.as<Model::NewTabMenuEntry>());
-        userSettings.globals->NewTabMenu(newTabMenu);
-
+        userSettings.globals->NewTabMenu().Append(folderEntry.as<Model::NewTabMenuEntry>());
         state->SSHFolderGenerated(true);
         return true;
     }

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -559,7 +559,12 @@ bool SettingsLoader::AddDynamicProfileFolders()
         folderEntry->Inlining(FolderEntryInlining::Auto);
         folderEntry->RawEntries(winrt::single_threaded_vector<Model::NewTabMenuEntry>({ *matchProfilesEntry }));
 
-        userSettings.globals->NewTabMenu().Append(folderEntry.as<Model::NewTabMenuEntry>());
+        // We cannot edit globals.NewTabMenu directly because it could have been a temporary automatically-generated default value.
+        // If we want to make permanent changes to it, we need to expressly set it.
+        auto newTabMenu = userSettings.globals->NewTabMenu();
+        newTabMenu.Append(folderEntry.as<Model::NewTabMenuEntry>());
+        userSettings.globals->NewTabMenu(newTabMenu);
+
         state->SSHFolderGenerated(true);
         return true;
     }

--- a/src/cascadia/TerminalSettingsModel/SshHostGenerator.cpp
+++ b/src/cascadia/TerminalSettingsModel/SshHostGenerator.cpp
@@ -35,19 +35,14 @@ using namespace winrt::Microsoft::Terminal::Settings::Model;
 
 /*static*/ const std::wregex SshHostGenerator::_configKeyValueRegex{ LR"(^\s*(\w+)\s+([^\s]+.*[^\s])\s*$)" };
 
-/*static*/ std::wstring_view SshHostGenerator::_getProfileName(const std::wstring_view& hostName) noexcept
+winrt::hstring _getProfileName(const std::wstring_view& hostName) noexcept
 {
-    return std::wstring_view{ L"" + PROFILE_TITLE_PREFIX + hostName };
+    return winrt::hstring{ fmt::format(FMT_COMPILE(L"{0}{1}"), PROFILE_TITLE_PREFIX, hostName) };
 }
 
-/*static*/ std::wstring_view SshHostGenerator::_getProfileIconPath() noexcept
+winrt::hstring _getProfileCommandLine(const std::wstring_view& sshExePath, const std::wstring_view& hostName) noexcept
 {
-    return PROFILE_ICON_PATH;
-}
-
-/*static*/ std::wstring_view SshHostGenerator::_getProfileCommandLine(const std::wstring_view& sshExePath, const std::wstring_view& hostName) noexcept
-{
-    return std::wstring_view{ L"\"" + sshExePath + L"\" " + hostName };
+    return winrt::hstring{ fmt::format(FMT_COMPILE(LR"("{0}" {1})"), sshExePath, hostName) };
 }
 
 /*static*/ bool SshHostGenerator::_tryFindSshExePath(std::wstring& sshExePath) noexcept
@@ -164,8 +159,8 @@ void SshHostGenerator::GenerateProfiles(std::vector<winrt::com_ptr<implementatio
         {
             const auto profile{ CreateDynamicProfile(_getProfileName(hostName)) };
 
-            profile->Commandline(winrt::hstring{ _getProfileCommandLine(sshExePath, hostName) });
-            profile->Icon(winrt::hstring{ _getProfileIconPath() });
+            profile->Commandline(_getProfileCommandLine(sshExePath, hostName));
+            profile->Icon(winrt::hstring{ PROFILE_ICON_PATH });
 
             profiles.emplace_back(profile);
         }

--- a/src/cascadia/TerminalSettingsModel/SshHostGenerator.h
+++ b/src/cascadia/TerminalSettingsModel/SshHostGenerator.h
@@ -31,10 +31,6 @@ namespace winrt::Microsoft::Terminal::Settings::Model
     private:
         static const std::wregex _configKeyValueRegex;
 
-        static std::wstring_view _getProfileName(const std::wstring_view& hostName) noexcept;
-        static std::wstring_view _getProfileIconPath() noexcept;
-        static std::wstring_view _getProfileCommandLine(const std::wstring_view& sshExePath, const std::wstring_view& hostName) noexcept;
-
         static bool _tryFindSshExePath(std::wstring& sshExePath) noexcept;
         static bool _tryParseConfigKeyValue(const std::wstring_view& line, std::wstring& key, std::wstring& value) noexcept;
         static void _getHostNamesFromConfigFile(const std::wstring_view& configPath, std::vector<std::wstring>& hostNames) noexcept;


### PR DESCRIPTION
You can't return a string_view to a temporary. It's a miracle this ever worked.