### PR TITLE
OSC 52: Gate clipboard writes on focus to prevent background clipboard hijacking

### DIFF
--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -784,6 +784,7 @@ TerminalInput::OutputType Terminal::SendCharEvent(const wchar_t ch, const WORD s
 // - none
 TerminalInput::OutputType Terminal::FocusChanged(const bool focused)
 {
+    _isFocused = focused;
     return _getTerminalInput().HandleFocus(focused);
 }
 

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -414,6 +414,7 @@ private:
     til::CoordType _scrollbackLines = 0;
     bool _detectURLs = false;
     bool _clipboardOperationsAllowed = true;
+    bool _isFocused = false;
 
     til::size _altBufferSize;
     std::optional<til::size> _deferredResize;

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -140,7 +140,8 @@ unsigned int Terminal::GetInputCodePage() const noexcept
 
 void Terminal::CopyToClipboard(wil::zwstring_view content)
 {
-    if (_clipboardOperationsAllowed)
+    // Only allow VT clipboard writes when the terminal has focus
+    if (_clipboardOperationsAllowed && _isFocused)
     {
         _pfnCopyToClipboard(content);
     }


### PR DESCRIPTION
This change scopes OSC 52 clipboard writes to when the terminal has focus.

Changes:
1. src/cascadia/TerminalCore/Terminal.hpp: add _isFocused flag.
2. src/cascadia/TerminalCore/Terminal.cpp: update FocusChanged to track focus state.
3. src/cascadia/TerminalCore/TerminalApi.cpp: require _isFocused alongside _clipboardOperationsAllowed in CopyToClipboard.

Rationale:
1. Addresses request in #19051 (“OSC 52 should only function while the terminal has focus”).
2. Prevents background sessions from silently writing to the system clipboard.
3. Notes:

Behavior remains unchanged when the window is focused.
1. This only gates VT-driven clipboard writes (OSC 52), not user-initiated copy.

Testing:
1. Verified clipboard write via OSC 52 succeeds when focused, does nothing when unfocused.
Lint passed locally.

Link:
Closes #19051.