### PR TITLE
build: separate vpack creation from vpack publication

### DIFF
--- a/build/config/GitCheckin.json
+++ b/build/config/GitCheckin.json
@@ -4,7 +4,7 @@
         "collection": "microsoft",
         "project": "OS",
         "repo": "os.2020",
-        "name": "official/rs_we_adept_e4d2",
+        "name": "official/ge_current_directwinpd_deep",
         "workitem": "38106206",
         "CheckinFiles": [
           {

--- a/build/pipelines/ob-release.yml
+++ b/build/pipelines/ob-release.yml
@@ -53,8 +53,12 @@ parameters:
     displayName: "Publish Symbols to MSDL"
     type: boolean
     default: true
+  - name: createVpack
+    displayName: "Create a VPack for Windows"
+    type: boolean
+    default: false
   - name: publishVpackToWindows
-    displayName: "Publish VPack to Windows"
+    displayName: "Publish above VPack to Windows"
     type: boolean
     default: false
 
@@ -89,6 +93,7 @@ extends:
       clientId: $(SigningOriginalClientId)
     terminalInternalPackageVersion: ${{ parameters.terminalInternalPackageVersion }}
     publishSymbolsToPublic: ${{ parameters.publishSymbolsToPublic }}
+    createVpack: ${{ parameters.createVpack }}
     publishVpackToWindows: ${{ parameters.publishVpackToWindows }}
     symbolPublishingSubscription: $(SymbolPublishingServiceConnection)
     symbolPublishingProject: $(SymbolPublishingProject)

--- a/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
@@ -49,6 +49,9 @@ parameters:
   - name: symbolExpiryTime
     type: string
     default: 36530 # This is the default from PublishSymbols@2
+  - name: createVpack
+    type: boolean
+    default: false
   - name: publishVpackToWindows
     type: boolean
     default: false
@@ -192,8 +195,8 @@ extends:
                   ob_outputDirectory: $(JobOutputDirectory)
                   ob_artifactBaseName: $(JobOutputArtifactName)
                   ### This job is also in charge of submitting the vpack to Windows if it's enabled
-                  ob_createvpack_enabled: ${{ and(parameters.buildTerminal, parameters.publishVpackToWindows) }}
-                  ob_updateOSManifest_enabled: ${{ and(parameters.buildTerminal, parameters.publishVpackToWindows) }}
+                  ob_createvpack_enabled: ${{ and(parameters.buildTerminal, parameters.createVpack) }}
+                  ob_updateOSManifest_enabled: ${{ and(parameters.buildTerminal, parameters.createVpack, parameters.publishVpackToWindows) }}
                   ### If enabled above, these options are in play.
                   ob_createvpack_packagename: 'WindowsTerminal.app'
                   ob_createvpack_owneralias: 'conhost@microsoft.com'
@@ -229,7 +232,7 @@ extends:
                       New-Item "$(JobOutputDirectory)/vpack" -Type Directory
                     displayName: Make sure the vpack directory exists
 
-                  - ${{ if parameters.publishVpackToWindows }}:
+                  - ${{ if parameters.createVpack }}:
                     - pwsh: |-
                         Copy-Item -Verbose -Path "$(MsixBundlePath)" -Destination (Join-Path "$(JobOutputDirectory)/vpack" 'Microsoft.WindowsTerminal_8wekyb3d8bbwe.msixbundle')
                       displayName: Stage msixbundle for vpack


### PR DESCRIPTION
This will allow us to publish vpacks without making the build fail waiting for us to *merge* those vpacks into Windows. It also gives us better control over when and where the vpack update gets merged.