### PR TITLE
Minor fixes to the settings schema

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2480,8 +2480,9 @@
           "type": "boolean"
         },
         "experimental.input.forceVT": {
-          "description": "Force the terminal to use the legacy input encoding. Certain keys in some applications may stop working when enabling this setting.",
-          "type": "boolean"
+          "type": "boolean",
+          "description": "[Deprecated] Replaced with the \"compatibility.input.forceVT\" setting.",
+          "deprecated": true
         },
         "experimental.useBackgroundImageForWindow": {
           "default": false,

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2945,6 +2945,11 @@
           "description": "When set to true, marks added to the buffer via the addMark action will appear on the scrollbar.",
           "type": "boolean"
         },
+        "experimental.rainbowSuggestions": {
+          "type": "boolean",
+          "description": "Enables displaying command suggestions in the terminal in RGB (all the colors of the rainbow!).",
+          "default": false
+        },
         "experimental.rightClickContextMenu": {
           "default": false,
           "description": "When true, right-click shows a context menu; otherwise, it pastes from the clipboard or copies selection.",

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2582,9 +2582,12 @@
           "$ref": "#/$defs/NewTabMenu"
         },
         "language": {
-          "default": "",
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Sets an override for the app's preferred language, expressed as a BCP-47 language tag like en-US.",
-          "type": "string"
+          "default": null
         },
         "theme": {
           "default": "dark",

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2529,14 +2529,14 @@
           "type": "string"
         },
         "rowsToScroll": {
-          "default": "system",
-          "description": "This parameter once allowed you to override the systemwide \"choose how many lines to scroll at one time\" setting. It no longer does so. However, you can customize the number of lines to scroll in \"scrollUp\" and \"scrollDown\" bindings.",
-          "maximum": 999,
-          "minimum": 0,
           "type": [
             "integer",
             "string"
           ],
+          "description": "[Deprecated] This setting no longer has any effect. However, you can customize the number of lines to scroll using the \"scrollUp\" and \"scrollDown\" key bindings.",
+          "default": "system",
+          "minimum": 0,
+          "maximum": 999,
           "deprecated": true
         },
         "minimizeToNotificationArea": {
@@ -2648,19 +2648,19 @@
           "type": "boolean"
         },
         "useTabSwitcher": {
+          "description": "[Deprecated] Replaced with the \"tabSwitcherMode\" setting.",
           "default": true,
-          "description": "Deprecated. Please use \"tabSwitcherMode\" instead.",
           "oneOf": [
             {
               "type": "boolean"
             },
             {
+              "type": "string",
               "enum": [
                 "mru",
                 "inOrder",
                 "disabled"
-              ],
-              "type": "string"
+              ]
             }
           ],
           "deprecated": true
@@ -2717,12 +2717,12 @@
       "type": "object",
       "properties": {
         "acrylicOpacity": {
+          "type": "number",
+          "description": "[Deprecated] Replaced with the \"opacity\" setting.",
           "default": 0.5,
-          "description": "[deprecated] Please use `opacity` instead.",
-          "deprecated": true,
-          "maximum": 1,
           "minimum": 0,
-          "type": "number"
+          "maximum": 1,
+          "deprecated": true
         },
         "antialiasingMode": {
           "default": "grayscale",
@@ -2924,18 +2924,18 @@
           "type": "boolean"
         },
         "experimental.autoMarkPrompts": {
-          "deprecated": true,
-          "description": "This has been replaced by autoMarkPrompts in 1.21",
-          "type": "boolean"
+          "type": "boolean",
+          "description": "[Deprecated] Replaced with the \"autoMarkPrompts\" setting.",
+          "deprecated": true
         },
         "experimental.retroTerminalEffect": {
           "description": "When set to true, enable retro terminal effects. This is an experimental feature, and its continued existence is not guaranteed.",
           "type": "boolean"
         },
         "experimental.showMarksOnScrollbar": {
-          "deprecated": true,
-          "description": "This has been replaced by showMarksOnScrollbar in 1.21",
-          "type": "boolean"
+          "type": "boolean",
+          "description": "[Deprecated] Replaced with the \"showMarksOnScrollbar\" setting.",
+          "deprecated": true
         },
         "showMarksOnScrollbar": {
           "default": false,
@@ -2957,23 +2957,29 @@
           "type": "string"
         },
         "fontFace": {
-          "default": "Cascadia Mono",
-          "description": "[deprecated] Define 'face' within the 'font' object instead.",
           "type": "string",
+          "description": "[Deprecated] Replaced with the \"face\" setting within the \"font\" object.",
+          "default": "Cascadia Mono",
           "deprecated": true
         },
         "fontSize": {
-          "default": 12,
-          "description": "[deprecated] Define 'size' within the 'font' object instead.",
-          "minimum": 1,
           "type": "number",
+          "description": "[Deprecated] Replaced with the \"size\" setting within the \"font\" object.",
+          "default": 12,
+          "minimum": 1,
           "deprecated": true
         },
         "fontWeight": {
+          "description": "[Deprecated] Replaced with the \"weight\" setting within the \"font\" object.",
           "default": "normal",
-          "description": "[deprecated] Define 'weight' within the 'font' object instead.",
           "oneOf": [
             {
+              "type": "integer",
+              "minimum": 100,
+              "maximum": 990
+            },
+            {
+              "type": "string",
               "enum": [
                 "thin",
                 "extra-light",
@@ -2986,13 +2992,7 @@
                 "extra-bold",
                 "black",
                 "extra-black"
-              ],
-              "type": "string"
-            },
-            {
-              "maximum": 990,
-              "minimum": 100,
-              "type": "integer"
+              ]
             }
           ],
           "deprecated": true

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2481,7 +2481,7 @@
         },
         "experimental.input.forceVT": {
           "type": "boolean",
-          "description": "[Deprecated] Replaced with the \"compatibility.input.forceVT\" setting.",
+          "description": "[Deprecated] Replaced with the \"compatibility.input.forceVT\" profile setting.",
           "deprecated": true
         },
         "experimental.useBackgroundImageForWindow": {
@@ -2533,7 +2533,7 @@
             "integer",
             "string"
           ],
-          "description": "[Deprecated] This setting no longer has any effect. However, you can customize the number of lines to scroll using the \"scrollUp\" and \"scrollDown\" key bindings.",
+          "description": "[Deprecated] This setting no longer has any effect. However, you can customize the number of lines to scroll using the \"rowsToScroll\" argument on the \"scrollUp\" and \"scrollDown\" actions.",
           "default": "system",
           "minimum": 0,
           "maximum": 999,

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2466,6 +2466,7 @@
           "description": "Direct3D 11 provides a more performant and feature-rich experience, whereas Direct2D is more stable. The default option \"Automatic\" will pick the API that best fits your graphics hardware. If you experience significant issues, consider using Direct2D.",
           "type": "string",
           "enum": [
+            "automatic",
             "direct2d",
             "direct3d11"
           ]
@@ -2744,6 +2745,11 @@
         "compatibility.reloadEnvironmentVariables": {
           "default": true,
           "description": "When set to true, when opening a new tab or pane it will get reloaded environment variables.",
+          "type": "boolean"
+        },
+        "compatibility.input.forceVT": {
+          "default": false,
+          "description": "Force the terminal to use the legacy input encoding. Certain keys in some applications may stop working when enabling this setting.",
           "type": "boolean"
         },
         "compatibility.allowDECRQCRA": {
@@ -3096,7 +3102,10 @@
         },
         "answerbackMessage": {
           "description": "The response that is sent when an ENQ control character is received.",
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "source": {
           "description": "Stores the name of the profile generator that originated this profile.",


### PR DESCRIPTION
## Summary of the Pull Request
Fixes a couple of minor issues in the settings schema which can result in erroneous settings validation failures.

## References and Relevant Issues
None

## Detailed Description of the Pull Request / Additional comments
- `answerbackMessage`  
  Permit `null` type (corresponds to the default value).
- `compatibility.input.forceVT`  
  Add missing setting (previously was `experimental.input.forceVT`).
- `rendering.graphicsAPI`  
  Add missing `automatic` enumeration value.
- Mark several settings as deprecated using the same format and direct the user to the updated settings to use.

## Validation Steps Performed
Tested updated schema against configuration with above settings present.

## PR Checklist
- [X] Schema updated (if necessary)
