### PR TITLE
Disable focus mode by default in quake mode

### DIFF
--- a/src/cascadia/TerminalApp/TerminalWindow.cpp
+++ b/src/cascadia/TerminalApp/TerminalWindow.cpp
@@ -233,7 +233,7 @@ namespace winrt::TerminalApp::implementation
         // that the window size is _first_ set up as something sensible, so
         // leaving fullscreen returns to a reasonable size.
         const auto launchMode = this->GetLaunchMode();
-        if (_WindowProperties->IsQuakeWindow() || WI_IsFlagSet(launchMode, LaunchMode::FocusMode))
+        if (WI_IsFlagSet(launchMode, LaunchMode::FocusMode))
         {
             _root->SetFocusMode(true);
         }


### PR DESCRIPTION
## Summary
Quake mode currently forces focus mode to be enabled, which hides the tab bar. This PR removes that automatic behavior, allowing users to manually toggle focus mode on/off as needed.

## Changes
- Removed automatic focus mode activation when quake window is initialized
- Removed automatic focus mode activation when window name changes to "_quake"

## Motivation
Users should have control over whether focus mode is enabled in quake mode. The tab bar can be useful even in quake mode for managing multiple tabs.

## Test plan
- Launch terminal with quake mode
- Verify tab bar is visible by default
- Verify focus mode can still be manually toggled on/off

Related issue: [Please add issue number if there is one]