### PR TITLE
build: switch Touchdown to Federated Identity

### DIFF
--- a/build/pipelines/daily-loc-submission.yml
+++ b/build/pipelines/daily-loc-submission.yml
@@ -51,8 +51,8 @@ steps:
   displayName: 'Touchdown Build - 7105, PRODEXT'
   inputs:
     teamId: 7105
-    TDBuildServiceConnection: $(TouchdownServiceConnection)
-    authType: SubjectNameIssuer
+    FederatedIdentityTDBuildServiceConnection: $(TouchdownServiceConnection)
+    authType: FederatedIdentityTDBuild
     resourceFilePath: |
      **\en-US\*.resw
      build\StoreSubmission\Stable\PDPs\en-us\PDP.xml


### PR DESCRIPTION
This is required as part of offboarding our non-user service account.