### PR TITLE
Remove the leading fire from the taskbar progress handler

### DIFF
--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -1062,7 +1062,6 @@ namespace winrt::TerminalApp::implementation
             dispatcher,
             til::throttled_func_options{
                 .delay = std::chrono::milliseconds{ 200 },
-                .leading = true,
                 .trailing = true,
             },
             [weakThis]() {


### PR DESCRIPTION
If the progress state hasn't been set for more than 200ms, we shouldn't even bother flickering the old state.

This prevents applications from making the tab (and the taskbar icon) flicker.

We were reviewing #19394 and decided that the _original_ behavior before Leonard's throttling fix was somewhat unfortunate as well. An application that sets an indeterminate state for 10ms and then clears it shouldn't be able to make any part of the application flicker, fast _or_ slow.

Removing the leading fire time from the throttled function ensures that it will only fire once every 200ms, and only with the state most recently set. It will not debounce (so setting the progress every 150ms will not prevent it from updating.)

Closes #19394