### PR TITLE
Fix initial position parsing from -pos tag (#4247)

### DIFF
--- a/doc/specs/#1043 - Set the initial position of the Terminal/spec.md
+++ b/doc/specs/#1043 - Set the initial position of the Terminal/spec.md
@@ -27,6 +27,7 @@ Two new properties should be added in the json settings file:
 
 2. Both X value and Y values are optional. If any one of them is missing, or the value is invalid, system default value will be used. Examples:
 
+       "1000" equals (1000, 1000)
        ", 1000" equals (default, 1000)
        "1000, " equals (1000, default)
        "," equals (default, default)

--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -73,6 +73,8 @@ namespace TerminalAppLocalTests
 
         TEST_METHOD(TestElevateArg);
 
+        TEST_METHOD(TestInitialPositionParsing);
+
         TEST_CLASS_SETUP(ClassSetup)
         {
             return true;
@@ -1619,4 +1621,49 @@ namespace TerminalAppLocalTests
         }
     }
 
+    void SettingsTests::TestInitialPositionParsing()
+    {
+        {
+            const auto pos = LaunchPositionFromString("50");
+            VERIFY_IS_TRUE(pos.X.has_value());
+            VERIFY_IS_TRUE(pos.Y.has_value());
+            VERIFY_ARE_EQUAL(50, pos.X.Value());
+            VERIFY_ARE_EQUAL(50, pos.Y.Value());
+        }
+
+        {
+            const auto pos = LaunchPositionFromString("100,");
+            VERIFY_IS_TRUE(pos.X.has_value());
+            VERIFY_ARE_EQUAL(100, pos.X.Value());
+            VERIFY_IS_FALSE(pos.Y.has_value());
+        }
+
+        {
+            const auto pos = LaunchPositionFromString(",100");
+            VERIFY_IS_FALSE(pos.X.has_value());
+            VERIFY_IS_TRUE(pos.Y.has_value());
+            VERIFY_ARE_EQUAL(100, pos.Y.Value());
+        }
+
+        {
+            const auto pos = LaunchPositionFromString("50,50");
+            VERIFY_IS_TRUE(pos.X.has_value());
+            VERIFY_ARE_EQUAL(50, pos.X.Value());
+            VERIFY_IS_TRUE(pos.Y.has_value());
+            VERIFY_ARE_EQUAL(50, pos.Y.Value());
+        }
+
+        {
+            const auto pos = LaunchPositionFromString("abc,100");
+            VERIFY_IS_FALSE(pos.X.has_value());
+            VERIFY_IS_TRUE(pos.Y.has_value());
+            VERIFY_ARE_EQUAL(100, pos.Y.Value());
+        }
+
+        {
+            const auto pos = LaunchPositionFromString("abc");
+            VERIFY_IS_FALSE(pos.X.has_value());
+            VERIFY_IS_FALSE(pos.Y.has_value());
+        }
+    }
 }

--- a/src/cascadia/TerminalSettingsModel/ModelSerializationHelpers.h
+++ b/src/cascadia/TerminalSettingsModel/ModelSerializationHelpers.h
@@ -67,6 +67,10 @@ _TIL_INLINEPREFIX ::winrt::Microsoft::Terminal::Settings::Model::LaunchPosition 
         string,
         [&initialPosition](int32_t left) { initialPosition.X = left; },
         [&initialPosition](int32_t right) { initialPosition.Y = right; });
+    if (initialPosition.X && !initialPosition.Y && string.find(',') == std::string::npos)
+    {
+        initialPosition.Y = initialPosition.X;
+    }
     return initialPosition;
 }
 


### PR DESCRIPTION
## Summary of the Pull Request
Fixes #4247. Improves consistency in -pos tag parsing by supporting single-value input for both axes.

## References and Relevant Issues
#4247

## Detailed Description of the Pull Request / Additional comments
The change aligns -pos behavior with padding-style logic. Existing comma-separated behavior remains unchanged.
- A single value like "number" now sets both x and y positions to that value — similar to how padding behaves.
- A value like "number," (with a trailing comma) continues to set only x, leaving y unchanged.

## Validation Steps Performed
- Ran all unit and integration tests
- Added unit test to verify single-value and comma-separated inputs

## PR Checklist
- [x] Closes #4247
- [x] Tests added/passed
- [x] Documentation updated
https://github.com/MicrosoftDocs/terminal/pull/890
- [ ] Schema updated (if necessary)
