### PR TITLE
chore: Remove extra semicolons from Equals method implementations

### DIFF
--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -606,7 +606,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                 return otherAsUs->_ContentArgs.Equals(_ContentArgs);
             }
             return false;
-        };
+        }
         static FromJsonResult FromJson(const Json::Value& json)
         {
             // LOAD BEARING: Not using make_self here _will_ break you in the future!
@@ -707,7 +707,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                        otherAsUs->_SplitMode == _SplitMode;
             }
             return false;
-        };
+        }
         static FromJsonResult FromJson(const Json::Value& json)
         {
             // LOAD BEARING: Not using make_self here _will_ break you in the future!
@@ -835,7 +835,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                 return otherAsUs->_ContentArgs.Equals(_ContentArgs);
             }
             return false;
-        };
+        }
         static FromJsonResult FromJson(const Json::Value& json)
         {
             // LOAD BEARING: Not using make_self here _will_ break you in the future!
@@ -985,7 +985,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                 return otherAsUs->_Actions == _Actions;
             }
             return false;
-        };
+        }
         static FromJsonResult FromJson(const Json::Value& json)
         {
             // LOAD BEARING: Not using make_self here _will_ break you in the future!


### PR DESCRIPTION
## Summary of the Pull Request

Removes unnecessary extra semicolons at the end of `Equals` method implementations in various ActionArgs classes.

## References and Relevant Issues

Closes #19404

## Detailed Description of the Pull Request / Additional comments

This pull request addresses code style and static analysis warnings by removing stray semicolons after the closing braces of `Equals` methods. These extra semicolons do not affect runtime but trigger warnings and fail strict code style checks.

## Validation Steps Performed

- Code compiles successfully (if CI passes, that validates the change).
- No functional changes; this is a code cleanup.

## PR Checklist
- [x] Closes #19404 
-  Tests added/passed (N/A - No functional change)
-  Documentation updated (N/A)

- Schema updated (if necessary) (N/A)