### PR TITLE
Use the actual process image instead of module filename to dedup session

### DIFF
--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -315,7 +315,7 @@ void WindowEmperor::HandleCommandlineArgs(int nCmdShow)
     }
     if (!IsPackaged())
     {
-        const auto path = wil::GetModuleFileNameW<std::wstring>(nullptr);
+        const auto path = wil::QueryFullProcessImageNameW<std::wstring>();
         const auto hash = til::hash(path);
 #ifdef _WIN64
         fmt::format_to(std::back_inserter(windowClassName), FMT_COMPILE(L" {:016x}"), hash);


### PR DESCRIPTION
Apparently, `GetModuleFileNameW` returns exactly the path (or prefix, in case of a DLL) passed to `CreateProcess` casing and all. Since we were using it to generate the uniquing hash for Portable and Unpackaged instances, this meant that `C:\Terminal\wt` and `C:\TeRmInAl\wt` were considered different instances. Whoops.

Using `QueryFullProcessImageNameW` instead results in canonicalization. Maybe the kernel does it. I don't know. What I do know is that it works more correctly.

(`Query...` goes through the kernel, while `GetModule...` goes through the loader. Interesting!)

Closes #19253