### PR TITLE
Fixing issue with command line parameter --startingDirectory

### DIFF
--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -707,6 +707,15 @@ NewTerminalArgs AppCommandlineArgs::_getNewTerminalArgs(AppCommandlineArgs::NewT
 
     if (*subcommand.startingDirectoryOption)
     {
+        // This is a fix for the way CommandLineToArgvW parse the command line removing
+        // the opening quote and maintaining the closing quote because of a trailing
+        // slash from the path.
+        // Example: --startingDirectory "C:\Users\my user\"
+        if (_startingDirectory.length() > 2 && _startingDirectory.front() != '\"' && _startingDirectory.back() == '\"')
+        {
+            _startingDirectory.pop_back();
+            _startingDirectory.push_back('\\');
+        }
         args.StartingDirectory(winrt::to_hstring(_startingDirectory));
     }
 


### PR DESCRIPTION
## Summary of the Pull Request
Fixing issue with command line parameter --startingDirectory ending in a wrong path because of the way CommandLineToArgvW do its parse.

## References and Relevant Issues
https://devblogs.microsoft.com/oldnewthing/20100917-00/?p=12833

## Detailed Description of the Pull Request / Additional comments
In this command line example: `--startingDirectory "C:\Users\My User\"` the CommandLineToArgvW method parses the path excluding the opening quote and maintaining the ending quote, because it is backed by a trailing slash.
I've done a very specific fix to only fix that usage of that parameter, so it doesn't end in any regression.

## Validation Steps Performed
Used to fail setting the starting directory (note the trailing backslash):
`wt.exe --startingDirectory "c:\A\B B\"`

Successfully sets the starting directory:
`wt.exe --startingDirectory "c:\A\B B"`

## PR Checklist
- [X] Closes #19362
- [X] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
