### PR TITLE
Fix unfocusedBackground being used as active tab color

### DIFF
--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -2417,7 +2417,7 @@ namespace winrt::TerminalApp::implementation
             const auto& currentDictionary = v.as<ResourceDictionary>();
 
             // TabViewItem.Background
-            currentDictionary.Insert(winrt::box_value(L"TabViewItemHeaderBackground"), deselectedTabBrush);
+            currentDictionary.Insert(winrt::box_value(L"TabViewItemHeaderBackground"), selectedTabBrush);
             currentDictionary.Insert(winrt::box_value(L"TabViewItemHeaderBackgroundSelected"), selectedTabBrush);
             currentDictionary.Insert(winrt::box_value(L"TabViewItemHeaderBackgroundPointerOver"), isHighContrast ? fontBrush : hoverTabBrush);
             currentDictionary.Insert(winrt::box_value(L"TabViewItemHeaderBackgroundPressed"), selectedTabBrush);


### PR DESCRIPTION
## Summary of the Pull Request
Turns out that the `"TabViewItemHeaderBackground"` resource should be set to the _selected_ color instead of the _deselected_ color.

In 1.22, (pre-#18109) we actually didn't set this resource. But we do actually need it for high contrast mode! (verified)

## Validation Steps Performed
✅ High contrast mode looks right
✅ "Snazzy" theme from bug report looks right

## PR Checklist
 Closes #19343