### PR TITLE
Capitalize 'Download' links in distribution table

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,10 +169,10 @@ The Portable ZIP distribution is a portable application. It will not automatical
 
 | Distribution  | Architecture    | Link                                                 |
 |---------------|:---------------:|------------------------------------------------------|
-| App Installer | x64, arm64, x86 | [download](https://aka.ms/terminal-canary-installer) |
-| Portable ZIP  | x64             | [download](https://aka.ms/terminal-canary-zip-x64)   |
-| Portable ZIP  | ARM64           | [download](https://aka.ms/terminal-canary-zip-arm64) |
-| Portable ZIP  | x86             | [download](https://aka.ms/terminal-canary-zip-x86)   |
+| App Installer | x64, arm64, x86 | [Download](https://aka.ms/terminal-canary-installer) |
+| Portable ZIP  | x64             | [Download](https://aka.ms/terminal-canary-zip-x64)   |
+| Portable ZIP  | ARM64           | [Download](https://aka.ms/terminal-canary-zip-arm64) |
+| Portable ZIP  | x86             | [Download](https://aka.ms/terminal-canary-zip-x86)   |
 
 _Learn more about the [types of Windows Terminal distributions](https://learn.microsoft.com/windows/terminal/distributions)._
 


### PR DESCRIPTION
## Summary of the Pull Request
Updated all 'download' link texts in the distribution table to use a capital 'D' for consistency and readability
