### PR TITLE
Make sure UIHelpers' resources are included in the final PRI file

### DIFF
--- a/src/cascadia/UIHelpers/UIHelpers.vcxproj
+++ b/src/cascadia/UIHelpers/UIHelpers.vcxproj
@@ -86,4 +86,5 @@
   <Import Project="$(OpenConsoleDir)src\cppwinrt.build.post.props" />
   <!-- This -must- go after cppwinrt.build.post.props because that includes many VS-provided props including appcontainer.common.props, which stomps on what cppwinrt.targets did. -->
   <Import Project="$(OpenConsoleDir)src\common.nugetversions.targets" />
+  <Import Project="$(OpenConsoleDir)build\rules\CollectWildcardResources.targets" />
 </Project>


### PR DESCRIPTION
OCWildcardResource requires the inclusion of a magic MSBuild target that we wrote. We forgot to include it here. Oops.

Closes #19444