### PR TITLE
Fix cursor being hidden when pressing modifier keys

### DIFF
--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -194,6 +194,22 @@ static wil::unique_mutex acquireMutexOrAttemptHandoff(const wchar_t* className, 
     return {};
 }
 
+static constexpr bool IsInputKey(WORD vkey) noexcept
+{
+    return vkey != VK_CONTROL &&
+           vkey != VK_LCONTROL &&
+           vkey != VK_RCONTROL &&
+           vkey != VK_MENU &&
+           vkey != VK_LMENU &&
+           vkey != VK_RMENU &&
+           vkey != VK_SHIFT &&
+           vkey != VK_LSHIFT &&
+           vkey != VK_RSHIFT &&
+           vkey != VK_LWIN &&
+           vkey != VK_RWIN &&
+           vkey != VK_SNAPSHOT;
+}
+
 HWND WindowEmperor::GetMainWindow() const noexcept
 {
     _assertIsMainThread();
@@ -486,14 +502,10 @@ void WindowEmperor::HandleCommandlineArgs(int nCmdShow)
 
             if (msg.message == WM_KEYDOWN)
             {
-                const bool modifierKey = (msg.wParam == VK_SHIFT ||
-                                          msg.wParam == VK_CONTROL ||
-                                          msg.wParam == VK_MENU ||
-                                          msg.wParam == VK_LWIN ||
-                                          msg.wParam == VK_RWIN);
+                const auto vkey = static_cast<WORD>(msg.wParam);
 
-                // Hide the cursor only when the key pressed is not a modifier key.
-                if (!modifierKey)
+                // Hide the cursor only when the key pressed is an input key (ignore modifier keys).
+                if (IsInputKey(vkey))
                 {
                     IslandWindow::HideCursor();
                 }


### PR DESCRIPTION
## Summary of the Pull Request

Added a check to ensure IslandWindow::HideCursor() is only called when a non-modifier key (e.g., not Shift, Control, Alt, or Windows keys) is pressed. This prevents unintended cursor hiding when only modifier keys are used.

## References and Relevant Issues

[19445](https://github.com/microsoft/terminal/issues/19445) - The mouse pointer has disappeared when press CTRL or SHIFT

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

Built and deployed CascadiaPackage through VS, tested the deployed Terminal Dev app on local machine.

## PR Checklist
- [x] Closes #19445
- [x] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
