### PR TITLE
build: update all Azure DevOps pools to windows-latest

### DIFF
--- a/build/pipelines/ci-caching.yml
+++ b/build/pipelines/ci-caching.yml
@@ -61,7 +61,6 @@ stages:
                 name: SHINE-INT-L
               ${{ else }}:
                 name: SHINE-OSS-L
-              demands: ImageOverride -equals SHINE-VS17-Latest-2022
             buildPlatforms: [x64]
             buildConfigurations: [AuditMode]
             buildEverything: true
@@ -79,7 +78,6 @@ stages:
                 name: SHINE-INT-L
               ${{ else }}:
                 name: SHINE-OSS-L
-              demands: ImageOverride -equals SHINE-VS17-Latest-2022
             buildPlatforms:
               - ${{ platform }}
             buildConfigurations: [Release]

--- a/build/pipelines/ci.yml
+++ b/build/pipelines/ci.yml
@@ -59,7 +59,6 @@ stages:
                 name: SHINE-INT-L
               ${{ else }}:
                 name: SHINE-OSS-L
-              demands: ImageOverride -equals SHINE-VS17-Latest-2022
             buildPlatforms: [x64]
             buildConfigurations: [AuditMode]
             buildEverything: true
@@ -83,7 +82,6 @@ stages:
                 name: SHINE-INT-L
               ${{ else }}:
                 name: SHINE-OSS-L
-              demands: ImageOverride -equals SHINE-VS17-Latest-2022
             buildPlatforms:
               - ${{ platform }}
             buildConfigurations: [Release]

--- a/build/pipelines/feature-flag-ci.yml
+++ b/build/pipelines/feature-flag-ci.yml
@@ -32,7 +32,6 @@ stages:
           parameters:
             pool: # This only runs in CI
               name: SHINE-OSS-L
-              demands: ImageOverride -equals SHINE-VS17-Latest-2022
             buildPlatforms: [x64]
             buildConfigurations: [Release]
             buildEverything: true

--- a/build/pipelines/fuzz.yml
+++ b/build/pipelines/fuzz.yml
@@ -28,7 +28,6 @@ stages:
               name: SHINE-INT-L
             ${{ else }}:
               name: SHINE-OSS-L
-            demands: ImageOverride -equals SHINE-VS17-Latest-2022
           buildPlatforms: [x64]
           buildConfigurations: [Fuzzing]
           buildEverything: true

--- a/build/pipelines/pgo.yml
+++ b/build/pipelines/pgo.yml
@@ -44,7 +44,6 @@ stages:
               name: SHINE-INT-L
             ${{ else }}:
               name: SHINE-OSS-L
-            demands: ImageOverride -equals SHINE-VS17-Latest-2022
           branding: ${{ parameters.branding }}
           buildPlatforms: ${{ parameters.buildPlatforms }}
           buildConfigurations: [Release]


### PR DESCRIPTION
I will follow this up by switching our default pool build image to Windows Server 2022.