### PR TITLE
mark mode: begin selection at viewport when scrolled up

### DIFF
--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -364,8 +364,10 @@ void Terminal::ToggleMarkMode()
         // NOTE: directly set cursor state. We already should have locked before calling this function.
         if (!IsSelectionActive())
         {
-            // No selection --> start one at the cursor
-            const auto cursorPos{ _activeBuffer().GetCursor().GetPosition() };
+            // If we're scrolled up, use the viewport origin as the selection start.
+            // Otherwise, use the cursor position.
+            const auto cursorPos = _scrollOffset != 0 ? _GetVisibleViewport().Origin() :
+                                                        _activeBuffer().GetCursor().GetPosition();
             *_selection.write() = SelectionInfo{
                 .start = cursorPos,
                 .end = cursorPos,


### PR DESCRIPTION
## Summary of the Pull Request
Updates mark mode so that it starts at the viewport's origin (top-left) if we're not scrolled to the bottom. This is based on the discussion in #19488.

## Validation Steps Performed
✅ scrolled at bottom --> mark mode starts at cursor
✅ scrolled up --> mark mode starts at cursor

Closes #19488