### PR TITLE
mark mode: begin selection at focused search result

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -1787,6 +1787,15 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void ControlCore::ClearSearch()
     {
         const auto lock = _terminal->LockForWriting();
+
+        // GH #19358: select the focused search result before clearing search
+        if (const auto focusedSearchResult = _terminal->GetSearchHighlightFocused())
+        {
+            _terminal->SetSelectionAnchor(focusedSearchResult->start);
+            _terminal->SetSelectionEnd(focusedSearchResult->end);
+            _renderer->TriggerSelection();
+        }
+
         _terminal->SetSearchHighlights({});
         _terminal->SetSearchHighlightFocused(0);
         _renderer->TriggerSearchHighlight(_searcher.Results());


### PR DESCRIPTION
## Summary of the Pull Request
Searching in terminal highlights all search results. However, those results are considered separate from a selection. In the past, the highlighted result would be selected, resulting in it being the initial position for mark mode. Now that it's separate, mark mode doesn't start there.

To fix this, there's 2 changes here:
1. When we exit the search, we now select the focused search result. This becomes the initial position for mark mode.
2. When we're in the middle of a search and mark mode becomes enabled, the focused search result becomes the initial position for mark mode.

With this change, mark mode's initial position is determined in this order:
1. the position of an active selection
2. the position of the focused search result (if one is available)
3. the top-left position of the viewport (if there is a scrollback) (see #19549)
4. the current cursor position

## Validation Steps Performed
Entering mark mode in scenario X results in a starting position of Y:
✅ selected text during a search --> selected text
   - NOTE: this seems to only occur if you start a search, then manually click on the terminal to bring focus there, but keep the search results active

✅ performed a search and results are available -->focused search result
✅ performed a search and no results are available
   - scrolled up --> top-left of viewport
   - no scrollback --> cursor position

✅ performed a search, got results, then closed search --> focused search result

Closes #19358