### PR TITLE
Fix ampersand in german translation

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
@@ -2337,7 +2337,7 @@
     <comment>Name for a control to select how file and directory paths are translated.</comment>
   </data>
   <data name="Profile_PathTranslationStyle.HelpText" xml:space="preserve">
-    <value>Steuert, wie Datei- und Verzeichnispfade bei Drag &amp;amp; Drop-Vorgängen übersetzt werden.</value>
+    <value>Steuert, wie Datei- und Verzeichnispfade bei Drag &amp; Drop-Vorgängen übersetzt werden.</value>
     <comment>A description for what the "path translation" setting does. Presented near "Profile_PathTranslationStyle.Header".</comment>
   </data>
   <data name="Profile_PathTranslationStyleNone.Content" xml:space="preserve">


### PR DESCRIPTION
## Summary of the Pull Request
Removes the unnecessary `amp;` form the translation

## References and Relevant Issues
[#19600](https://github.com/microsoft/terminal/issues/19600)

## Detailed Description of the Pull Request / Additional comments
Removed the `amp;`
<img width="149" height="59" alt="image" src="https://github.com/user-attachments/assets/af84b88f-8252-4ce2-92d6-70a5a93be04c" />

## Validation Steps Performed

## PR Checklist
- [x] Closes #19600
- [x] Tests added/passed
- [x] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
