### PR TITLE
Fix dangling search selection using viewport pos

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -1791,8 +1791,13 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // GH #19358: select the focused search result before clearing search
         if (const auto focusedSearchResult = _terminal->GetSearchHighlightFocused())
         {
-            _terminal->SetSelectionAnchor(focusedSearchResult->start);
-            _terminal->SetSelectionEnd(focusedSearchResult->end);
+            // search results are buffer-relative, whereas the selection functions expect viewport-relative coordinates
+            const auto scrollOffset{ _terminal->GetScrollOffset() };
+            const auto startPos = til::point{ focusedSearchResult->start.x, focusedSearchResult->start.y - scrollOffset };
+            const auto endPos = til::point{ focusedSearchResult->end.x, focusedSearchResult->end.y - scrollOffset };
+
+            _terminal->SetSelectionAnchor(startPos);
+            _terminal->SetSelectionEnd(endPos);
             _renderer->TriggerSelection();
         }
 


### PR DESCRIPTION
## Summary of the Pull Request
Fixes a bug where the dangling selection from a search would be applied to the wrong position. Specifically, the issue is that `SetSelectionAnchor()` and `SetSelectionEnd()` expect viewport positions whereas the searcher outputs buffer positions.

This PR simply applies the scroll offset to the search result before calling the functions.

In a separate iteration, I changed the functions to allow for viewport-relative vs buffer-relative positions. However, that ended up feeling a bit odd because this is the only scenario where the functions were receiving buffer-relative positions. I chose this approach instead because it's smaller/cleaner, even though we convert to viewport-relative before the call just to change it to buffer-relative in the function.

Bug introduced in #19550

## Validation Steps Performed
The correct region is selected in the following scenarios:
✅ no scrollback
✅ with scrollback, at bottom
✅ with scrollback, not at bottom (selection isn't scrolled to, but I think that's ok. Can be fixed easily if requested)
✅ alt buffer