### PR TITLE
Enable DECRQCRA at compile time for all Terminal builds

### DIFF
--- a/src/features.xml
+++ b/src/features.xml
@@ -123,10 +123,14 @@
         <name>Feature_VtChecksumReport</name>
         <description>Enables the DECRQCRA checksum report, which can be used to read the screen contents</description>
         <id>14974</id>
-        <stage>AlwaysDisabled</stage>
-        <alwaysEnabledBrandingTokens>
-            <brandingToken>Dev</brandingToken>
-        </alwaysEnabledBrandingTokens>
+        <stage>AlwaysEnabled</stage>
+        <alwaysDisabledBrandingTokens>
+            <!--
+                Since we have a way to turn this on and off in Terminal, we don't need to hide it behind a feature
+                flag any longer; however, conhost has no way to turn it off so let's just compile it out for now.
+            -->
+            <brandingToken>WindowsInbox</brandingToken>
+        </alwaysDisabledBrandingTokens>
     </feature>
 
     <feature>


### PR DESCRIPTION
Support for DECRQCRA Request Checksum of Rectangular Area was added in #14989, but left disabled at build time because it could be considered a security risk.

In #17895, we unconditionally added a toggle for it to Terminal's settings UI and settings schema (`compatibility.allowDECRQCRA`). For users on Stable and Preview, it didn't actually enable anything. Whoops.

Since we have a way to turn it off (and in so doing, mitigate the risk) in Terminal, it's high time for us to remove the feature gating.

Conhost doesn't support turning it off for now and so conhost can still have it compiled out, as a treat.