### PR TITLE
Use theme tabRow color as acrylic tint (#19604)

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -4865,8 +4865,18 @@ namespace winrt::TerminalApp::implementation
             }
         }
 
+        // GH#19604: Get the theme's tabRow color to use as the acrylic tint.
+        const auto tabRowBg{ theme.TabRow() ? (_activated ? theme.TabRow().Background() :
+                                                            theme.TabRow().UnfocusedBackground()) :
+                                              ThemeColor{ nullptr } };
+
         if (_settings.GlobalSettings().UseAcrylicInTabRow())
         {
+            if (tabRowBg)
+            {
+                bgColor = ThemeColor::ColorFromBrush(tabRowBg.Evaluate(res, terminalBrush, true));
+            }
+
             const auto acrylicBrush = Media::AcrylicBrush();
             acrylicBrush.BackgroundSource(Media::AcrylicBackgroundSource::HostBackdrop);
             acrylicBrush.FallbackColor(bgColor);
@@ -4875,9 +4885,7 @@ namespace winrt::TerminalApp::implementation
 
             TitlebarBrush(acrylicBrush);
         }
-        else if (auto tabRowBg{ theme.TabRow() ? (_activated ? theme.TabRow().Background() :
-                                                               theme.TabRow().UnfocusedBackground()) :
-                                                 ThemeColor{ nullptr } })
+        else if (tabRowBg)
         {
             const auto themeBrush{ tabRowBg.Evaluate(res, terminalBrush, true) };
             bgColor = ThemeColor::ColorFromBrush(themeBrush);


### PR DESCRIPTION
## Summary of the Pull Request
When `useAcrylicInTabRow` is enabled, the theme's `tabRow.background` color is now used as the acrylic tint instead of being ignored.

## References and Relevant Issues
Fixes #19604

## Detailed Description of the Pull Request / Additional comments
Previously, the code had mutually exclusive branches for handling `useAcrylicInTabRow` and theme `tabRow.background`. When acrylic was enabled, the theme color was never evaluated.

This PR extracts the theme's tabRow color first, then uses it as the acrylic tint if set, falling back to the default if no theme color is specified.

## Validation Steps Performed
Tested with `useAcrylicInTabRow: true` and custom `tabRow.background` - acrylic now shows the theme color as tint 

## PR Checklist
Closes #19604
