### PR TITLE
Correct Japanese translation of DuplicatePaneCommandKey

### DIFF
--- a/src/cascadia/TerminalSettingsModel/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/ja-JP/Resources.resw
@@ -229,7 +229,7 @@
     <value>以前</value>
   </data>
   <data name="DuplicatePaneCommandKey" xml:space="preserve">
-    <value>ペインの複製する</value>
+    <value>ペインを複製する</value>
   </data>
   <data name="DuplicateTabCommandKey" xml:space="preserve">
     <value>タブを複製する</value>
@@ -976,4 +976,5 @@
   <data name="SplitSizeActionArgumentLocalized" xml:space="preserve">
     <value>分割サイズ</value>
   </data>
+
 </root>


### PR DESCRIPTION
## Summary of the Pull Request

This PR corrects Japanese translation of `DuplicatePaneCommandKey` text

## References and Relevant Issues

N/A

## Detailed Description of the Pull Request / Additional comments

No additional comment

## Validation Steps Performed

This is just a correction of the text so I didn't validate it.

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
