### PR TITLE
Refactor SCREEN_INFORMATION to use in-class initializers (#962)

### DIFF
--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -22,23 +22,9 @@ SCREEN_INFORMATION::SCREEN_INFORMATION(
     _In_ IWindowMetrics* pMetrics,
     const TextAttribute popupAttributes,
     const FontInfo fontInfo) :
-    OutputMode{ ENABLE_PROCESSED_OUTPUT | ENABLE_WRAP_AT_EOL_OUTPUT },
-    WheelDelta{ 0 },
-    HWheelDelta{ 0 },
-    _textBuffer{ nullptr },
-    Next{ nullptr },
-    WriteConsoleDbcsLeadByte{ 0, 0 },
-    FillOutDbcsLeadChar{ 0 },
-    ScrollScale{ 1ul },
     _pConsoleWindowMetrics{ pMetrics },
-    _api{ *this },
-    _stateMachine{ nullptr },
     _viewport(Viewport::Empty()),
-    _psiAlternateBuffer{ nullptr },
-    _psiMainBuffer{ nullptr },
-    _fAltWindowChanged{ false },
     _PopupAttributes{ popupAttributes },
-    _virtualBottom{ 0 },
     _currentFont{ fontInfo },
     _desiredFont{ fontInfo }
 {

--- a/src/host/screenInfo.hpp
+++ b/src/host/screenInfo.hpp
@@ -166,20 +166,20 @@ public:
     InputBuffer* const GetActiveInputBuffer() const override;
 #pragma endregion
 
-    DWORD OutputMode;
+    DWORD OutputMode{ ENABLE_PROCESSED_OUTPUT | ENABLE_WRAP_AT_EOL_OUTPUT };
 
-    short WheelDelta;
-    short HWheelDelta;
+    short WheelDelta{ 0 };
+    short HWheelDelta{ 0 };
 
 private:
-    std::unique_ptr<TextBuffer> _textBuffer;
+    std::unique_ptr<TextBuffer> _textBuffer{ nullptr };
 
 public:
-    SCREEN_INFORMATION* Next;
-    BYTE WriteConsoleDbcsLeadByte[2];
-    BYTE FillOutDbcsLeadChar;
+    SCREEN_INFORMATION* Next{ nullptr };
+    BYTE WriteConsoleDbcsLeadByte[2]{ 0, 0 };
+    BYTE FillOutDbcsLeadChar{ 0 };
 
-    UINT ScrollScale;
+    UINT ScrollScale{ 1u };
 
     bool IsActiveScreenBuffer() const;
 
@@ -259,20 +259,20 @@ private:
     bool _IsInPtyMode() const;
     bool _IsInVTMode() const;
 
-    ConhostInternalGetSet _api;
+    ConhostInternalGetSet _api{ *this };
 
-    std::shared_ptr<Microsoft::Console::VirtualTerminal::StateMachine> _stateMachine;
+    std::shared_ptr<Microsoft::Console::VirtualTerminal::StateMachine> _stateMachine{ nullptr };
 
     // Specifies which coordinates of the screen buffer are visible in the
     //      window client (the "viewport" into the buffer)
     Microsoft::Console::Types::Viewport _viewport;
 
-    SCREEN_INFORMATION* _psiAlternateBuffer; // The VT "Alternate" screen buffer.
-    SCREEN_INFORMATION* _psiMainBuffer; // A pointer to the main buffer, if this is the alternate buffer.
+    SCREEN_INFORMATION* _psiAlternateBuffer{ nullptr }; // The VT "Alternate" screen buffer.
+    SCREEN_INFORMATION* _psiMainBuffer{ nullptr }; // A pointer to the main buffer, if this is the alternate buffer.
 
-    til::rect _rcAltSavedClientNew;
-    til::rect _rcAltSavedClientOld;
-    bool _fAltWindowChanged;
+    til::rect _rcAltSavedClientNew{};
+    til::rect _rcAltSavedClientOld{};
+    bool _fAltWindowChanged{ false };
 
     TextAttribute _PopupAttributes;
 
@@ -282,7 +282,7 @@ private:
     // Tracks the last virtual position the viewport was at. This is not
     //  affected by the user scrolling the viewport, only when API calls cause
     //  the viewport to move (SetBufferInfo, WriteConsole, etc)
-    til::CoordType _virtualBottom;
+    til::CoordType _virtualBottom{ 0 };
 
     std::optional<til::size> _deferredPtyResize{ std::nullopt };
     std::atomic<bool> _conptyCursorPositionMayBeWrong = false;


### PR DESCRIPTION
## Refactor `SCREEN_INFORMATION` Constructor Initializers

### Summary

This PR refactors the legacy `SCREEN_INFORMATION` class to use **in-class member initializers** for members with constant or default values, replacing equivalent entries in the constructor initializer list.

This change aligns the class with **C++ Core Guidelines C.48** (*“Prefer in-class initializers to member initializers in constructors for constant initializers”*) while preserving existing behavior.

---

### Motivation

`SCREEN_INFORMATION` relied heavily on constructor member initializers for values that are constant or represent default state. This made it harder to reason about default object state and conflicted with the guideline the project references.

This PR addresses the issue in a **minimal, mechanical, and well-scoped way**, without attempting a broad codebase migration.

---

### Changes

#### `src/host/screenInfo.hpp`
- Added in-class default member initializers for members previously initialized with constant values.
- Examples include:
  - `WheelDelta`, `HWheelDelta`
  - `_textBuffer`
  - `Next`
  - `WriteConsoleDbcsLeadByte`, `FillOutDbcsLeadChar`
  - `ScrollScale`
  - `_api`, `_stateMachine`
  - `_psiAlternateBuffer`, `_psiMainBuffer`
  - `_fAltWindowChanged`
  - `_virtualBottom`

#### `src/host/screenInfo.cpp`
- Removed redundant constructor member initializers corresponding to the in-class defaults.
- Members that depend on constructor parameters remain in the initializer list.

---

### Verification

#### Automated Tests
- **Status:** Not run
- **Reason:** Build and test tools (`msbuild`, `vstest.console.exe`) are not available in the current environment.

#### Manual Verification
- Performed strict code inspection to ensure a one-to-one correspondence between removed constructor initializers and added in-class initializers.
- Verified that initialization semantics remain unchanged.

---

### Notes

- This is a **mechanical refactor** only; no functional or behavioral changes are intended.
- No members with parameter-dependent initialization were moved to in-class initializers.
- The scope is intentionally limited to a single legacy class and may serve as a reference for similar refactors in the future.
