### PR TITLE
Close the TermControl when closing a TerminalPaneContent

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPaneContent.cpp
+++ b/src/cascadia/TerminalApp/TerminalPaneContent.cpp
@@ -68,6 +68,8 @@ namespace winrt::TerminalApp::implementation
     {
         _removeControlEvents();
 
+        _control.Close();
+
         // Clear out our media player callbacks, and stop any playing media. This
         // will prevent the callback from being triggered after we've closed, and
         // also make sure that our sound stops when we're closed.

--- a/src/cascadia/TerminalApp/TerminalPaneContent.cpp
+++ b/src/cascadia/TerminalApp/TerminalPaneContent.cpp
@@ -67,7 +67,7 @@ namespace winrt::TerminalApp::implementation
     void TerminalPaneContent::Close()
     {
         // We deliberately remove the event handlers before closing the control.
-        // This is to prevent re-entrancy issues, pointless callbacks, etc.
+        // This is to prevent reentrancy issues, pointless callbacks, etc.
         _removeControlEvents();
 
         _control.Close();

--- a/src/cascadia/TerminalApp/TerminalPaneContent.cpp
+++ b/src/cascadia/TerminalApp/TerminalPaneContent.cpp
@@ -66,6 +66,8 @@ namespace winrt::TerminalApp::implementation
     }
     void TerminalPaneContent::Close()
     {
+        // We deliberately remove the event handlers before closing the control.
+        // This is to prevent re-entrancy issues, pointless callbacks, etc.
         _removeControlEvents();
 
         _control.Close();


### PR DESCRIPTION
This fixes an issue where calling close on a tab/pane won't
raise a StateChange notification on the connection.