### PR TITLE
Updated strings of "Move tab" commands to include "left" and "right"

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -2045,12 +2045,12 @@
     <comment>An option to choose from for the "move tab direction". No movement.</comment>
   </data>
   <data name="Actions_MoveTabDirectionForward.Content" xml:space="preserve">
-    <value>Forward</value>
-    <comment>An option to choose from for the "move tab direction". Moves the tab forward.</comment>
+    <value>Forward (right)</value>
+    <comment>An option to choose from for the "move tab direction". Moves the tab forward (right).</comment>
   </data>
   <data name="Actions_MoveTabDirectionBackward.Content" xml:space="preserve">
-    <value>Backward</value>
-    <comment>An option to choose from for the "move tab direction". Moves the tab backward.</comment>
+    <value>Backward (left)</value>
+    <comment>An option to choose from for the "move tab direction". Moves the tab backward (left).</comment>
   </data>
   <data name="Actions_ScrollToMarkDirectionPrevious.Content" xml:space="preserve">
     <value>Previous</value>

--- a/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
@@ -172,7 +172,7 @@
   </data>
   <data name="MoveTabCommandKey" xml:space="preserve">
     <value>Move tab {0}</value>
-    <comment>{0} will be replaced with a "forward" / "backward"</comment>
+    <comment>{0} will be replaced with a "forward (right)" / "backward (left)"</comment>
   </data>
   <data name="MoveTabToWindowCommandKey" xml:space="preserve">
     <value>Move tab to window "{0}"</value>
@@ -182,10 +182,10 @@
     <value>Move tab to a new window</value>
   </data>
   <data name="MoveTabDirectionForward" xml:space="preserve">
-    <value>forward</value>
+    <value>forward (right)</value>
   </data>
   <data name="MoveTabDirectionBackward" xml:space="preserve">
-    <value>backward</value>
+    <value>backward (left)</value>
   </data>
   <data name="CloseTabsAfterDefaultCommandKey" xml:space="preserve">
     <value>Close all tabs after the current tab</value>


### PR DESCRIPTION
## Summary of the Pull Request
* As per the discussions in [#19228](https://github.com/microsoft/terminal/issues/19228), updated the command palette strings.
* Similar change is done for the strings used in Terminal settings editor as well.

## PR Checklist
Closes #19228
