### PR TITLE
Improve luminosity ratio of links present in the Chat Settings page

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/AISettings.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AISettings.xaml
@@ -88,7 +88,7 @@
                                 </Grid.ColumnDefinitions>
                                 <Grid.Background>
                                     <SolidColorBrush Opacity="0.7"
-                                                     Color="#404040" />
+                                                     Color="{ThemeResource SystemBaseLowColor}" />
                                 </Grid.Background>
                                 <muxc:InfoBadge x:Name="GithubCopilotDescriptionInfoBadge"
                                                 Grid.Column="0"
@@ -189,7 +189,7 @@
                                 </Grid.ColumnDefinitions>
                                 <Grid.Background>
                                     <SolidColorBrush Opacity="0.7"
-                                                     Color="#404040" />
+                                                     Color="{ThemeResource SystemBaseLowColor}" />
                                 </Grid.Background>
                                 <muxc:InfoBadge x:Name="AzureOpenAIDescriptionInfoBadge"
                                                 Grid.Column="0"
@@ -315,7 +315,7 @@
                                 </Grid.ColumnDefinitions>
                                 <Grid.Background>
                                     <SolidColorBrush Opacity="0.7"
-                                                     Color="#404040" />
+                                                     Color="{ThemeResource SystemBaseLowColor}" />
                                 </Grid.Background>
                                 <muxc:InfoBadge x:Name="OpenAIDescriptionInfoBadge"
                                                 Grid.Column="0"


### PR DESCRIPTION
## Summary of the Pull Request
Update the background color of the information boxes in the Terminal Chat settings page so that the text complies with the luminosity ratio according to the accessibility guidelines.

## Validation Steps Performed
New luminosity ratio is above 4.5:1

## PR Checklist
- [x] Closes #19685 
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
