### PR TITLE
Add AutoProp.Name to font features/axes controls

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Appearances.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.cpp
@@ -202,6 +202,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         return _isFontFeature;
     }
 
+    winrt::hstring FontKeyValuePair::AutomationName()
+    {
+        return hstring{ fmt::format(FMT_COMPILE(L"{}: {}"), KeyDisplayStringRef(), _value) };
+    }
+
     AppearanceViewModel::AppearanceViewModel(const Model::AppearanceConfig& appearance) :
         _appearance{ appearance }
     {

--- a/src/cascadia/TerminalSettingsEditor/Appearances.h
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.h
@@ -47,6 +47,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         uint32_t Key() const noexcept;
         float Value() const noexcept;
         void Value(float v);
+        winrt::hstring AutomationName();
 
         void SetValueDirect(float v);
         bool IsFontFeature() const noexcept;

--- a/src/cascadia/TerminalSettingsEditor/Appearances.idl
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.idl
@@ -28,6 +28,7 @@ namespace Microsoft.Terminal.Settings.Editor
         UInt32 Key { get; };
         String KeyDisplayString { get; };
         Single Value;
+        String AutomationName { get; };
     }
 
     runtimeclass AppearanceViewModel : Windows.UI.Xaml.Data.INotifyPropertyChanged

--- a/src/cascadia/TerminalSettingsEditor/Appearances.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.xaml
@@ -41,7 +41,8 @@
 
             <DataTemplate x:Key="FontKeyValuePairTemplate"
                           x:DataType="local:FontKeyValuePair">
-                <Grid ColumnSpacing="8">
+                <Grid AutomationProperties.Name="{x:Bind AutomationName}"
+                      ColumnSpacing="8">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="Auto" />
@@ -51,8 +52,10 @@
                                VerticalAlignment="Center"
                                Text="{x:Bind KeyDisplayString}" />
                     <muxc:NumberBox Grid.Column="1"
+                                    AutomationProperties.Name="{x:Bind KeyDisplayString}"
                                     Value="{x:Bind Value, Mode=TwoWay}" />
-                    <Button Grid.Column="2"
+                    <Button x:Uid="Profile_DeleteFontKeyValuePairButton"
+                            Grid.Column="2"
                             Click="DeleteFontKeyValuePair_Click"
                             Style="{StaticResource DeleteButtonStyle}"
                             Tag="{x:Bind (local:FontKeyValuePair)}">

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -834,6 +834,9 @@
   <data name="Profile_AddFontFeatureButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Add new font feature</value>
   </data>
+  <data name="Profile_DeleteFontKeyValuePairButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Delete</value>
+  </data>
   <data name="Profile_AddNewFontFeature.Text" xml:space="preserve">
     <value>Add new</value>
     <comment>Button label that adds a new font feature for the current font.</comment>


### PR DESCRIPTION
## Summary of the Pull Request
Explicitly adds the Name automation property to the list view items (via grid in data template), number boxes, and delete buttons for font features and axes.

## Validation Steps Performed
Narrator can read out...
✅ list view items
✅ number boxes
✅ delete button
Also validated using accessibility insights

Closes #19695
Closes #19689
