### PR TITLE
build: fix the target names after the slnx switch

### DIFF
--- a/build/pipelines/templates-v2/job-build-project.yml
+++ b/build/pipelines/templates-v2/job-build-project.yml
@@ -133,11 +133,11 @@ jobs:
           $SignFragments += "wpfdotnet"
         }
         If ([bool]::Parse("${{ parameters.buildWPF }}")) {
-          $BuildTargets += "Terminal\Control\Microsoft_Terminal_Control"
+          $BuildTargets += "Terminal\Control\TerminalControl"
           $SignFragments += "wpf"
         }
         If ([bool]::Parse("${{ parameters.buildConPTY }}")) {
-          $BuildTargets += "Conhost\Host_EXE;Conhost\winconpty_DLL"
+          $BuildTargets += "Conhost\Host_EXE;Conhost\winconptydll"
           $SignFragments += "conpty"
         }
         Write-Host "Targets: $($BuildTargets -Join ";")"


### PR DESCRIPTION
It looks like the targets are named after their project _files_ rather than their names now.