### PR TITLE
Wrap window shutdown in a top-level exception handler

### DIFF
--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -910,9 +910,18 @@ LRESULT WindowEmperor::_messageHandler(HWND window, UINT const message, WPARAM c
                         // which would change the _windows array, and invalidate our iterator and crash.
                         //
                         // We can prevent this by deferring Close() until after the erase() call.
+                        //
+                        // Wrapping it in an exception handler will prevent us from losing track of the window count, at
+                        // the perceived cost of leaking all the resources. However, the resources were being leaked
+                        // anyway (since we threw and exited this message handler) so this at least gives back our
+                        // deterministic window count management.
                         const auto strong = *it;
                         _windows.erase(it);
-                        strong->Close();
+                        try
+                        {
+                            strong->Close();
+                        }
+                        CATCH_LOG();
                         break;
                     }
                 }


### PR DESCRIPTION
The resources were going to leak either way; this just allows us to keep closer track of the window count and--critically--exit terminal when it hits 0.

Closes #19446