### PR TITLE
Add support for Include directive in SSH config parser (#19555)

### DIFF
--- a/src/cascadia/TerminalSettingsModel/SshHostGenerator.h
+++ b/src/cascadia/TerminalSettingsModel/SshHostGenerator.h
@@ -34,5 +34,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model
         static bool _tryFindSshExePath(std::wstring& sshExePath) noexcept;
         static bool _tryParseConfigKeyValue(const std::wstring_view& line, std::wstring& key, std::wstring& value) noexcept;
         static void _getHostNamesFromConfigFile(const std::wstring_view& configPath, std::vector<std::wstring>& hostNames) noexcept;
+        static void _processIncludeDirective(const std::filesystem::path& configDir, const std::wstring_view& includePattern, std::vector<std::wstring>& hostNames) noexcept;
+        static bool _matchesPattern(const std::wstring_view& filename, const std::wstring_view& pattern) noexcept;
     };
 };


### PR DESCRIPTION
## Summary of the Pull Request

Adds support for the `Include` directive in SSH config parser, enabling Terminal to generate profiles from split SSH configuration files (e.g., `Include config.d/*`).

## References and Relevant Issues

Fixes #19555

## Detailed Description of the Pull Request / Additional comments

This PR implements SSH config `Include` directive support with the following features:

**Changes:**
- Added `Include` directive parsing in `SshHostGenerator::_getHostNamesFromConfigFile()`
- Implemented `_processIncludeDirective()` to handle file inclusion with wildcard pattern support
- Added `_matchesPattern()` for wildcard matching (`*` and `?` patterns)
- Recursively processes included config files relative to the parent config directory

**Behavior:**
- Supports direct includes: `Include ~/.ssh/config.d/work`
- Supports wildcard includes: `Include config.d/*`
- Handles relative paths from config file location
- Maintains backward compatibility with existing configs

**Implementation:**
- Modified: `SshHostGenerator.cpp` (+107 lines)
- Modified: `SshHostGenerator.h` (+2 function declarations)

## Validation Steps Performed

- Tested with direct file includes
- Tested with wildcard patterns (`config.d/*`)
- Verified recursive parsing of included files
- Confirmed profiles generated correctly from split configs

## PR Checklist
- [x] Closes #19555
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Schema updated (if necessary)
