### PR TITLE
Update bot to replace Area-AtlasEngine w/ Area-Rendering

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -89,6 +89,19 @@ configuration:
           label: No-Recent-Activity
       - addReply:
           reply: This pull request has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **7 days**. It will be closed if no further activity occurs **within 7 days of this comment**.
+    - description: Replace "Area-AtlasEngine" label with "Area-Rendering"
+      frequencies:
+      - hourly:
+          hour: 3
+      filters:
+      - isIssue
+      - hasLabel:
+          label: Area-AtlasEngine
+      actions:
+      - removeLabel:
+          label: Area-AtlasEngine
+      - addLabel:
+          label: Area-Rendering
     eventResponderTasks:
     - description: Add "Needs-Triage" to new issues
       if:


### PR DESCRIPTION
Pretty straightforward.

Affected issues: https://github.com/microsoft/terminal/issues?q=is%3Aissue%20label%3AArea-AtlasEngine

I can also add an `isOpen` filter, if desired. I think the next step would be to wait for the bot to run, then delete the `Area-AtlasEngine` tag entirely.