### PR TITLE
Delete the KeyChordViewModel if we leave edit mode with no keys

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/ActionsViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ActionsViewModel.cpp
@@ -220,7 +220,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                         break;
                     }
                 }
-                actionsPageVM.DeleteKeyChord(args);
+                if (args)
+                {
+                    actionsPageVM.DeleteKeyChord(args);
+                }
             }
         });
         kcVM.PropertyChanged([weakThis{ get_weak() }](const IInspectable& sender, const Windows::UI::Xaml::Data::PropertyChangedEventArgs& args) {
@@ -1031,6 +1034,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         {
             // if we're in edit mode, populate the text box with the current keys
             ProposedKeys(_currentKeys);
+        }
+        else if (!_currentKeys)
+        {
+            // we have left edit mode but don't have any current keys - delete this view model
+            DeleteKeyChord();
         }
     }
 


### PR DESCRIPTION
## Summary of the Pull Request
There was an issue where if the user adds a new keybinding and then hits "cancel changes", the KeyChordViewModel is left in the keybinding list with an empty value. Nothing gets saved to the json, but visually there was an empty keychord box left behind. This commit fixes that.

## Validation Steps Performed
Adding a new keybinding and cancelling changes deletes the keybinding.

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
