### PR TITLE
Add --session option to focus-tab command

### DIFF
--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -482,6 +482,31 @@ namespace winrt::TerminalApp::implementation
     {
         if (const auto& realArgs = args.ActionArgs().try_as<SwitchToTabArgs>())
         {
+            // Check if we're targeting by session ID
+            if (realArgs.SessionId() != winrt::guid{})
+            {
+                // Find the tab containing this session
+                const auto sessionId = realArgs.SessionId();
+                uint32_t tabIndex = 0;
+                
+                for (const auto& tab : _tabs)
+                {
+                    auto tabImpl = winrt::get_self<implementation::Tab>(tab);
+                    if (tabImpl && tabImpl->FocusPaneBySessionId(sessionId))
+                    {
+                        _SelectTab(tabIndex);
+                        args.Handled(true);
+                        return;
+                    }
+                    tabIndex++;
+                }
+                
+                // Session not found in this window
+                args.Handled(false);
+                return;
+            }
+            
+            // Fall back to tab index
             _SelectTab({ realArgs.TabIndex() });
             args.Handled(true);
         }

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.h
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.h
@@ -121,6 +121,7 @@ private:
     int _focusTabIndex{ -1 };
     bool _focusNextTab{ false };
     bool _focusPrevTab{ false };
+    std::string _focusTabSession;  // GUID string for --session targeting
 
     int _focusPaneTarget{ -1 };
     std::string _saveInputName;

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -318,6 +318,9 @@
   <data name="CmdFocusTabTargetArgDesc" xml:space="preserve">
     <value>Move focus the tab at the given index</value>
   </data>
+  <data name="CmdFocusTabSessionArgDesc" xml:space="preserve">
+    <value>Move focus to the tab containing the given WT_SESSION GUID</value>
+  </data>
   <data name="CmdMovePaneTabArgDesc" xml:space="preserve">
     <value>Move focused pane to the tab at the given index</value>
   </data>

--- a/src/cascadia/TerminalApp/Tab.h
+++ b/src/cascadia/TerminalApp/Tab.h
@@ -57,6 +57,7 @@ namespace winrt::TerminalApp::implementation
         bool NavigateFocus(const winrt::Microsoft::Terminal::Settings::Model::FocusDirection& direction);
         bool SwapPane(const winrt::Microsoft::Terminal::Settings::Model::FocusDirection& direction);
         bool FocusPane(const uint32_t id);
+        bool FocusPaneBySessionId(const winrt::guid& sessionId);
 
         void UpdateSettings(const winrt::Microsoft::Terminal::Settings::Model::CascadiaSettings& settings);
         void UpdateTitle();

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2258,7 +2258,7 @@ namespace winrt::TerminalApp::implementation
         {
             ActionAndArgs action;
             action.Action(ShortcutAction::SwitchToTab);
-            SwitchToTabArgs switchToTabArgs{ idx.value() };
+            SwitchToTabArgs switchToTabArgs{ idx.value(), winrt::guid{} };
             action.Args(switchToTabArgs);
 
             actions.emplace_back(std::move(action));

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -118,7 +118,8 @@ protected:                                                                  \
 
 ////////////////////////////////////////////////////////////////////////////////
 #define SWITCH_TO_TAB_ARGS(X) \
-    X(uint32_t, TabIndex, "index", false, ArgTypeHint::None, 0)
+    X(uint32_t, TabIndex, "index", false, ArgTypeHint::None, 0) \
+    X(winrt::guid, SessionId, "sessionId", false, ArgTypeHint::None, winrt::guid{})
 
 ////////////////////////////////////////////////////////////////////////////////
 #define RESIZE_PANE_ARGS(X) \

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -226,8 +226,10 @@ namespace Microsoft.Terminal.Settings.Model
 
     [default_interface] runtimeclass SwitchToTabArgs : IActionArgs, IActionArgsDescriptorAccess
     {
-        SwitchToTabArgs(UInt32 tabIndex);
+        SwitchToTabArgs();
+        SwitchToTabArgs(UInt32 tabIndex, Guid sessionId);
         UInt32 TabIndex;
+        Guid SessionId;  // WT_SESSION GUID to focus - if set, takes precedence over TabIndex
     };
 
     [default_interface] runtimeclass ResizePaneArgs : IActionArgs, IActionArgsDescriptorAccess


### PR DESCRIPTION
## Summary of the Pull Request

Adds a `--session` / `-s` option to the `wt focus-tab` command that accepts a `WT_SESSION` GUID. This allows external processes to programmatically focus the exact terminal tab and pane where a specific shell session is running.

**Primary use case:** AI coding agents (GitHub Copilot CLI, Claude Code, Cursor, Aider, etc.) run long-running tasks in terminal sessions. When the task completes, users have often alt-tabbed away and opened many other tabs. This feature lets agents bring users back to the correct tab automatically:

```powershell
# Agent saves session at startup
$mySession = $env:WT_SESSION

# ... long task runs, user alt-tabs away ...

# Agent brings user back to the right place
wt focus-tab --session $mySession
```

## References and Relevant Issues

- Fixes #19783
- Related: #17963 (WT_WINDOWID discussion)
- Related: #16568 (programmatic terminal API)

## Detailed Description of the Pull Request / Additional comments

### Usage

```powershell
wt focus-tab --session $env:WT_SESSION
wt ft -s $env:WT_SESSION
```

### What it does

1. **Finds the tab** containing the pane with the matching `WT_SESSION` GUID
2. **Switches to that tab** (routing to the correct window on the current desktop)
3. **Focuses the specific pane** if the tab has split panes

### Implementation

| File | Change |
|------|--------|
| `AppCommandlineArgs.cpp` | Added `--session`/`-s` option with GUID parsing. Auto-sets `-w 0`. Updated `ValidateStartupCommands()`. |
| `AppCommandlineArgs.h` | Added `_focusTabSession` member |
| `ActionArgs.idl` | Extended `SwitchToTabArgs` with `Guid SessionId` property |
| `ActionArgs.h` | Updated `SWITCH_TO_TAB_ARGS` macro |
| `AppActionHandlers.cpp` | Modified `_HandleSwitchToTab()` to find session and call `FocusPaneBySessionId()` |
| `Tab.cpp` | Added `FocusPaneBySessionId()` - walks pane tree, calls `_rootPane->FocusPane(pane)` |
| `Tab.h` | Declaration for `FocusPaneBySessionId()` |
| `Resources.resw` | Added help string |
| `TerminalPage.cpp` | Constructor call fix |

### Design decisions

- **GUID format flexibility:** Accepts both `12345678-1234-...` and `{12345678-...}` formats
- **Implicit window routing:** Auto-implies `-w 0` since session GUID uniquely identifies a pane
- **Pane focus:** Focuses specific pane within split tabs
- **Mutual exclusion:** `--session` excludes `--target`, `--next`, `--previous`

## Validation Steps Performed

- [x] Builds successfully (ARM64 Release)
- [x] `wt focus-tab --help` shows new `--session` option
- [x] Single tab focus works
- [x] Multi-tab focus works
- [x] Split pane focus works (focuses specific pane)
- [x] IPC handoff from external process works
- [x] Invalid/non-existent GUID handled gracefully

## PR Checklist

- [x] Closes #19783
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Schema updated (if necessary)
