### PR TITLE
Add focusBellTab action to navigate to tabs with bell indicators

### DIFF
--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -1633,4 +1633,37 @@ namespace winrt::TerminalApp::implementation
             args.Handled(handled);
         }
     }
+
+    void TerminalPage::_HandleFocusBellTab(const IInspectable& /*sender*/,
+                                           const ActionEventArgs& args)
+    {
+        // Navigate to the next tab that has a bell indicator showing.
+        // If no tabs have bells, do nothing.
+        const auto tabCount = _tabs.Size();
+        if (tabCount == 0)
+        {
+            args.Handled(false);
+            return;
+        }
+
+        // Start searching from the tab after the current one
+        const auto currentIdx = _GetFocusedTabIndex().value_or(0);
+
+        for (uint32_t offset = 1; offset <= tabCount; offset++)
+        {
+            const auto idx = (currentIdx + offset) % tabCount;
+            if (const auto tab{ _tabs.GetAt(idx).try_as<Tab>() })
+            {
+                if (tab->TabStatus().BellIndicator())
+                {
+                    _SelectTab(idx);
+                    args.Handled(true);
+                    return;
+                }
+            }
+        }
+
+        // No tabs with bells found
+        args.Handled(false);
+    }
 }

--- a/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
@@ -101,6 +101,7 @@ static constexpr std::string_view OpenScratchpadKey{ "experimental.openScratchpa
 static constexpr std::string_view OpenAboutKey{ "openAbout" };
 static constexpr std::string_view QuickFixKey{ "quickFix" };
 static constexpr std::string_view OpenCWDKey{ "openCWD" };
+static constexpr std::string_view FocusBellTabKey{ "focusBellTab" };
 
 static constexpr std::string_view ActionKey{ "action" };
 

--- a/src/cascadia/TerminalSettingsModel/AllShortcutActions.h
+++ b/src/cascadia/TerminalSettingsModel/AllShortcutActions.h
@@ -113,7 +113,8 @@
     ON_ALL_ACTIONS(OpenScratchpad)          \
     ON_ALL_ACTIONS(OpenAbout)               \
     ON_ALL_ACTIONS(QuickFix)                \
-    ON_ALL_ACTIONS(OpenCWD)
+    ON_ALL_ACTIONS(OpenCWD)                 \
+    ON_ALL_ACTIONS(FocusBellTab)
 
 #define ALL_SHORTCUT_ACTIONS_WITH_ARGS             \
     ON_ALL_ACTIONS_WITH_ARGS(AdjustFontSize)       \

--- a/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
@@ -340,6 +340,9 @@
   <data name="PrevTabCommandKey" xml:space="preserve">
     <value>Previous tab</value>
   </data>
+  <data name="FocusBellTabCommandKey" xml:space="preserve">
+    <value>Focus next bell tab</value>
+  </data>
   <data name="RenameTabCommandKey" xml:space="preserve">
     <value>Rename tab to "{0}"</value>
     <comment>{0} will be replaced with a user-defined string</comment>

--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -564,6 +564,7 @@
         { "command": "duplicateTab", "id": "Terminal.DuplicateTab" },
         { "command": "nextTab", "id": "Terminal.NextTab" },
         { "command": "prevTab", "id": "Terminal.PrevTab" },
+        { "command": "focusBellTab", "id": "Terminal.FocusBellTab", "keys": "ctrl+shift+b" },
         { "command": { "action": "switchToTab", "index": 0 }, "id": "Terminal.SwitchToTab0" },
         { "command": { "action": "switchToTab", "index": 1 }, "id": "Terminal.SwitchToTab1" },
         { "command": { "action": "switchToTab", "index": 2 }, "id": "Terminal.SwitchToTab2" },


### PR DESCRIPTION
## Summary

Adds a new `focusBellTab` action that navigates to the next tab showing a bell indicator (🔔).

**Fixes #19788**

## Changes

| File | Change |
|------|--------|
| `AllShortcutActions.h` | Register `FocusBellTab` action |
| `ActionAndArgs.cpp` | Add `focusBellTabKey` mapping |
| `AppActionHandlers.cpp` | Implement `_HandleFocusBellTab` handler |
| `defaults.json` | Add command with `Ctrl+Shift+B` keybinding |
| `Resources.resw` | Add "Focus next bell tab" string |

## Behavior

- Finds next tab (by index) with `BellIndicator == true`
- Wraps around to beginning if needed
- Repeated presses cycle through all bell tabs
- Does nothing if no bells are active

## Implementation Details

~40 lines of new code. The handler iterates `_tabs` checking `TabStatus().BellIndicator()`:

```cpp
for (uint32_t offset = 1; offset <= tabCount; offset++)
{
    const auto idx = (currentIdx + offset) % tabCount;
    if (tab->TabStatus().BellIndicator())
    {
        _SelectTab(idx);
        return;
    }
}
```

## Validation

- [x] Builds successfully (ARM64 Release)
- [ ] Manual testing with bell triggers
- [ ] Keybinding works (Ctrl+Shift+B)
- [ ] Command palette shows "Focus next bell tab"

## PR Checklist
- [x] Closes #19788
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Schema updated (not necessary)