### PR TITLE
Add periodic buffer persistence to protect against unexpected termination

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -131,6 +131,7 @@ branchconfig
 brandings
 Browsable
 Bspace
+BSOD
 BTNFACE
 bufferout
 buffersize

--- a/src/cascadia/WindowsTerminal/WindowEmperor.h
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.h
@@ -66,6 +66,7 @@ private:
     void _setupGlobalHotkeys();
     void _setupSessionPersistence(bool enabled);
     void _persistState(const winrt::Microsoft::Terminal::Settings::Model::ApplicationState& state) const;
+    std::unordered_set<std::wstring, til::transparent_hstring_hash, til::transparent_hstring_equal_to> _persistBuffers() const;
     void _finalizeSessionPersistence() const;
     void _checkWindowsForNotificationIcon();
 


### PR DESCRIPTION
## Summary

This PR adds periodic buffer persistence to protect against unexpected termination (BSOD, power failure, Task Manager kill). 

Fixes #19804

### The Problem

Previously, terminal buffer content was only persisted on graceful exit:
- At end of message loop (normal quit)
- On `WM_ENDSESSION` (graceful OS shutdown)

The 5-minute persistence timer only saved **layout** (tabs, panes, positions), not buffer content. This meant:

| What Gets Saved | When | Survives Unexpected Termination |
|-----------------|------|--------------------------------|
| Tab layout | Every 5 minutes | ✅ Yes |
| Buffer content | Only on graceful exit | ❌ **No** |

Users running long-lived sessions (Claude Code, SSH, development environments) would lose hours of terminal history on crash, even though tabs appeared to be "restored."

### The Solution

- Extract buffer persistence into a new `_persistBuffers()` function
- Call `_persistBuffers()` on the existing 5-minute persistence timer
- Refactor `_finalizeSessionPersistence()` to use the shared function

Now buffer content is saved every 5 minutes alongside layout.

## Validation Steps Performed

- [x] Code review for correctness
- [x] Verified refactored `_finalizeSessionPersistence()` maintains cleanup behavior
- [x] Confirmed `_persistBuffers()` respects `FirstWindowPreference::PersistedLayoutAndContent` setting

## PR Checklist

- [x] Closes #19804
- [x] Tests added/passed (N/A - existing persistence tests cover this code path)
- [x] Documentation updated (N/A - no user-facing changes, existing setting controls behavior)
- [x] Schema updated (N/A - no new settings)

---

🤖 Generated with [Claude Code](https://claude.ai/code)