### PR TITLE
Disable the creation of issues without using a template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 
 contact_links:
   - name: Microsoft Security Response Center 🔐


### PR DESCRIPTION
We've seen an uptick in "language model" "people" submitting issues without using the template. Easy fix.