### PR TITLE
Revert "Disable PGO for nightly builds (#17749)"

### DIFF
--- a/build/pipelines/ob-nightly.yml
+++ b/build/pipelines/ob-nightly.yml
@@ -28,7 +28,7 @@ extends:
     official: true
     branding: Canary
     buildTerminal: true
-    pgoBuildMode: None # BODGY - OneBranch is on VS 17.10, which is known to be the worst
+    pgoBuildMode: Optimize
     codeSign: true
     signingIdentity:
       serviceName: $(SigningServiceName)


### PR DESCRIPTION
This reverts commit 408f3e2bfd2b419afd5ea5bdd9e8242a9a9822c1.

Now that we have #19810, it works again!