### PR TITLE
Added rounded cursor shape option

### DIFF
--- a/src/cascadia/TerminalCore/ICoreSettings.idl
+++ b/src/cascadia/TerminalCore/ICoreSettings.idl
@@ -16,7 +16,9 @@ namespace Microsoft.Terminal.Core
         Underscore,
         DoubleUnderscore,
         FilledBox,
-        EmptyBox
+        EmptyBox,
+        RoundedFilledBox, // NEW
+        RoundedEmptyBox // NEW
     };
 
     enum AdjustTextMode

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -170,6 +170,12 @@ void Terminal::UpdateAppearance(const ICoreAppearance& appearance)
     auto cursorShape = CursorType::VerticalBar;
     switch (appearance.CursorShape())
     {
+	case CursorStyle::RoundedFilledBox:           //new
+		cursorShape = CursorType::RoundedFullBox;  //new
+		break;                                      //new
+	case CursorStyle::RoundedEmptyBox:             //new
+		cursorShape = CursorType::RoundedEmptyBox; //new
+		break;                                      //new
     case CursorStyle::Underscore:
         cursorShape = CursorType::Underscore;
         break;
@@ -189,7 +195,7 @@ void Terminal::UpdateAppearance(const ICoreAppearance& appearance)
     case CursorStyle::Bar:
         cursorShape = CursorType::VerticalBar;
         break;
-    }
+}
 
     // We're checking if the main buffer exists here, but then setting the
     // appearance of the active one. If the main buffer exists, then at least

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -951,6 +951,14 @@
     <value>Filled box ( █ )</value>
     <comment>{Locked="█"} An option to choose from for the "cursor shape" setting. When selected, the cursor will look like a filled box. The character in the parentheses is used to show what it looks like.</comment>
   </data>
+  <data name="Profile_CursorShapeRoundedFilledBox.Content" xml:space="preserve">
+    <value>Rounded filled box ( ⬮ )</value>
+    <comment>{Locked="⬮"} An option to choose the rounded filled box cursor shape</comment>
+  </data>
+  <data name="Profile_CursorShapeRoundedEmptyBox.Content" xml:space="preserve">
+    <value>Rounded empty box ( ⬯ )</value>
+    <comment>{Locked="⬯"} An option to choose the rounded empty box cursor shape</comment>
+  </data>
   <data name="Profile_CursorShapeUnderscore.Content" xml:space="preserve">
     <value>Underscore ( ▁ )</value>
     <comment>{Locked="▁"} An option to choose from for the "cursor shape" setting. When selected, the cursor will look like an underscore. The character in the parentheses is used to show what it looks like.</comment>

--- a/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
@@ -22,13 +22,15 @@ Abstract:
 
 JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Core::CursorStyle)
 {
-    static constexpr std::array<pair_type, 6> mappings = {
+    static constexpr std::array<pair_type, 8> mappings = {
         pair_type{ "bar", ValueType::Bar },
         pair_type{ "vintage", ValueType::Vintage },
         pair_type{ "underscore", ValueType::Underscore },
         pair_type{ "doubleUnderscore", ValueType::DoubleUnderscore },
         pair_type{ "filledBox", ValueType::FilledBox },
-        pair_type{ "emptyBox", ValueType::EmptyBox }
+        pair_type{ "emptyBox", ValueType::EmptyBox },
+        pair_type{ "roundedFilledBox", ValueType::RoundedFilledBox }, // ADD THIS
+        pair_type{ "roundedEmptyBox", ValueType::RoundedEmptyBox } // ADD THIS
     };
 };
 

--- a/src/inc/conattrs.hpp
+++ b/src/inc/conattrs.hpp
@@ -44,7 +44,9 @@ enum class CursorType : unsigned int
     Underscore = 0x2, // a single horizontal underscore, smaller that the min height legacy cursor.
     EmptyBox = 0x3, // Just the outline of a full box
     FullBox = 0x4, // a full box, similar to legacy with height=100%
-    DoubleUnderscore = 0x5 // a double horizontal underscore
+    DoubleUnderscore = 0x5, // a double horizontal underscore
+    RoundedFullBox = 0x6, // NEW: Rounded filled box
+    RoundedEmptyBox = 0x7 // NEW: Rounded empty box
 };
 
 // Valid COLORREFs are of the pattern 0x00bbggrr. -1 works as an invalid color,


### PR DESCRIPTION
## Summary of the Pull Request
Added roundedFilledBox and roundedEmptyBox cursor options. Uses circular arc approximation in BackendD3D. Corner radius is set to 25% of cursor's smallest dimension. Closes issue #1446.
<img width="432" height="27" alt="roundfilled" src="https://github.com/user-attachments/assets/bdca169e-084d-4e4d-99bc-2b0e24b409fc" />
<img width="410" height="27" alt="roundempty" src="https://github.com/user-attachments/assets/c92c1d6d-bbb6-4d64-b560-0f81e3e9690c" />
## References and Relevant Issues
issue #1446
## Detailed Description of the Pull Request / Additional comments
Only implemented in BackendD3D, BackendD2D should be easy enough to add. Additional suggestions welcome!
## Validation Steps Performed
Tested in both debug and release
## PR Checklist
- [x] Closes #1446
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
