### PR TITLE
Use `weakThisCopy` as a getter instead of `weakThis` in `cascadia/TerminalApp/Tab.cpp`

### DIFF
--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -2678,4 +2678,3 @@ namespace winrt::TerminalApp::implementation
         RestartTerminalRequested.raise(sender, args);
     }
 }
-


### PR DESCRIPTION
## Issue
In `terminal/src/cascadia/TerminalApp/Tab.cpp` there is always created a copy of `weakThis `called `weakThisCopy`

(e.g. in `        events.TabColorChanged = content.TabColorChanged(
            winrt::auto_revoke,
            [dispatcher, weakThis](auto&&, auto&&) -> safe_void_coroutine {
                const auto weakThisCopy = weakThis;
                co_await wil::resume_foreground(dispatcher);
                if (auto tab{ weakThisCopy.get() })
                {
                    // The control's tabColor changed, but it is not necessarily the
                    // active control in this tab. We'll just recalculate the
                    // current color anyways.
                    tab->_RecalculateAndApplyTabColor();
                    tab->_tabStatus.TabColorIndicator(tab->GetTabColor().value_or(Windows::UI::Colors::Transparent()));
                }
            });` or in `        events.ConnectionStateChanged = content.ConnectionStateChanged(
            winrt::auto_revoke,
            [dispatcher, weakThis](auto&&, auto&&) -> safe_void_coroutine {
                const auto weakThisCopy = weakThis;
                co_await wil::resume_foreground(dispatcher);
                if (auto tab{ weakThisCopy.get() })
                {
                    tab->_UpdateConnectionClosedState();
                }
            });`

)

while this copy is not used in one case

`        events.ReadOnlyChanged = content.ReadOnlyChanged(
            winrt::auto_revoke,
            [dispatcher, weakThis](auto&&, auto&&) -> safe_void_coroutine {
                const auto weakThisCopy = weakThis;
                co_await wil::resume_foreground(dispatcher);
                if (auto tab{ weakThis.get() })
                {
                    tab->_RecalculateAndApplyReadOnly();
                }
            });`

where only `weakThis` is used and in my opinion (it was not tested, it's just a code review) the copy of `weakThis`, so `weakThisCopy`, should be used because it's done so in the other cases as well and it makes sense to me because of potential changes during the execution of the code of `weakThis` itself. And I don't see any difference in this case to the other cases - while only it refers to something different (`ReadOnlyChanged'), but it still includes the creation of the `const auto weakThisCopy` which indicates to me that this should also be used (because otherwise the creation of the variable would not make any sense). And allover I'm pretty sure that there is no difference in `ReadOnlyChanged` to the other cases, so I'd recommend using the copy instead (but I've not tested it, it's just a code review, but I'm pretty confident that this is correct).

## Changes I made
We now use the copy of `weakThis `, so `weakThisCopy`, instead in order to ensure correct runtime execution (but I've not tested it, it's just a code review, but I'm pretty confident that this is correct).

## PR Checklist
- [ x] Closes #19855 
- [ ] Tests added/passed (I've not tested this as described in the issue, it's just a code review, but I'm pretty confident that it's correct)
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
