### PR TITLE
When a new keybinding is added, focus the KeyChordListener

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/ActionsViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ActionsViewModel.cpp
@@ -175,6 +175,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         kbdVM->IsInEditMode(true);
         _RegisterKeyChordVMEvents(*kbdVM);
         KeyChordList().Append(*kbdVM);
+        FocusContainer.raise(*this, *kbdVM);
     }
 
     winrt::hstring CommandViewModel::ActionNameTextBoxAutomationPropName()

--- a/src/cascadia/TerminalSettingsEditor/EditAction.cpp
+++ b/src/cascadia/TerminalSettingsEditor/EditAction.cpp
@@ -36,6 +36,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 {
                     if (auto kcVM{ args.try_as<KeyChordViewModel>() })
                     {
+                        // Force a layout update in case this key chord was newly added
+                        page->KeyChordListView().ScrollIntoView(*kcVM);
+                        page->KeyChordListView().UpdateLayout();
                         if (const auto& container = page->KeyChordListView().ContainerFromItem(*kcVM))
                         {
                             container.as<Controls::ListViewItem>().Focus(FocusState::Programmatic);


### PR DESCRIPTION
Previously, when the user clicked "add new keybinding", the `KeyChordListener` box would then need to manually be clicked to actually input the `KeyChord`. This commit fixes that behaviour by moving focus automatically to the `KeyChordListener`.
