### PR TITLE
Restore downlevel operation

### DIFF
--- a/src/cascadia/WinRTUtils/inc/ThrottledFunc.h
+++ b/src/cascadia/WinRTUtils/inc/ThrottledFunc.h
@@ -116,7 +116,7 @@ private:
         }
         else if (schedule)
         {
-            SetThreadpoolTimerEx(_timer.get(), &_delay, 0, 0);
+            SetThreadpoolTimer(_timer.get(), &_delay, 0, 0);
         }
     }
 
@@ -152,7 +152,7 @@ private:
 
                     if (schedule)
                     {
-                        SetThreadpoolTimerEx(self->_timer.get(), &self->_delay, 0, 0);
+                        SetThreadpoolTimer(self->_timer.get(), &self->_delay, 0, 0);
                     }
                 }
             });

--- a/src/host/AccessibilityNotifier.cpp
+++ b/src/host/AccessibilityNotifier.cpp
@@ -335,7 +335,7 @@ void AccessibilityNotifier::_timerSet() noexcept
     else if (!_state.timerScheduled)
     {
         _state.timerScheduled = true;
-        SetThreadpoolTimerEx(_timer.get(), _delay, 0, _delayWindow);
+        SetThreadpoolTimer(_timer.get(), _delay, 0, _delayWindow);
     }
 }
 
@@ -347,7 +347,7 @@ void NTAPI AccessibilityNotifier::_timerEmitMSAA(PTP_CALLBACK_INSTANCE, PVOID co
     // Make a copy of _state, because UIA and MSAA are very slow (up to 1ms per call).
     // Holding a lock while _emitEventsCallback would mean that the IO thread can't proceed.
     //
-    // The only concern I have is whether calling SetThreadpoolTimerEx() again on
+    // The only concern I have is whether calling SetThreadpoolTimer() again on
     // _timer while we're still executing will properly schedule another run.
     // The docs say to read the "Remarks" and the remarks just don't clarify it. Great.
     // FWIW we can't just create two timer objects since that may (theoretically)

--- a/src/host/AccessibilityNotifier.h
+++ b/src/host/AccessibilityNotifier.h
@@ -82,12 +82,12 @@ namespace Microsoft::Console
         // It's null if the delay is set to 0.
         wil::unique_threadpool_timer _timer;
         // The delay to use for MSAA/UIA events, in filetime units (100ns units).
-        // The value will be negative because that's what SetThreadpoolTimerEx needs.
+        // The value will be negative because that's what SetThreadpoolTimer needs.
         int64_t _msaaDelay = 0;
         int64_t _uiaDelay = 0;
         // Depending on whether we have a UIA provider or not, this points to either _msaaDelay or _uiaDelay.
         FILETIME* _delay = nullptr;
-        // The delay window to use for SetThreadpoolTimerEx, in milliseconds.
+        // The delay window to use for SetThreadpoolTimer, in milliseconds.
         DWORD _delayWindow = 0;
         // Whether MSAA and UIA are enabled.
         bool _msaaEnabled = false;

--- a/src/host/PtySignalInputThread.cpp
+++ b/src/host/PtySignalInputThread.cpp
@@ -303,7 +303,10 @@ void PtySignalInputThread::_DoSetWindowParent(const SetParentData& data)
     RETURN_LAST_ERROR_IF_NULL(hThread);
     _hThread.reset(hThread);
     _dwThreadId = dwThreadId;
-    LOG_IF_FAILED(SetThreadDescription(hThread, L"ConPTY Signal Handler Thread"));
+    if (const auto func = GetProcAddressByFunctionDeclaration(GetModuleHandleW(L"kernel32.dll"), SetThreadDescription))
+    {
+        LOG_IF_FAILED(func(hThread, L"ConPTY Signal Handler Thread"));
+    }
 
     return S_OK;
 }

--- a/src/host/VtInputThread.cpp
+++ b/src/host/VtInputThread.cpp
@@ -180,7 +180,10 @@ void VtInputThread::_InputThread()
     RETURN_LAST_ERROR_IF_NULL(hThread);
     _hThread.reset(hThread);
     _dwThreadId = dwThreadId;
-    LOG_IF_FAILED(SetThreadDescription(hThread, L"ConPTY Input Handler Thread"));
+    if (const auto func = GetProcAddressByFunctionDeclaration(GetModuleHandleW(L"kernel32.dll"), SetThreadDescription))
+    {
+        LOG_IF_FAILED(func(hThread, L"ConPTY Input Handler Thread"));
+    }
 
     return S_OK;
 }

--- a/src/host/srvinit.cpp
+++ b/src/host/srvinit.cpp
@@ -360,7 +360,10 @@ HRESULT ConsoleCreateIoThread(_In_ HANDLE Server,
     // (If we didn't make one, it should be no problem to release the empty unique_ptr.)
     heapConnectMessage.release();
 
-    LOG_IF_FAILED(SetThreadDescription(hThread, L"Console Driver Message IO Thread"));
+    if (const auto func = GetProcAddressByFunctionDeclaration(GetModuleHandleW(L"kernel32.dll"), SetThreadDescription))
+    {
+        LOG_IF_FAILED(func(hThread, L"Console Driver Message IO Thread"));
+    }
     LOG_IF_WIN32_BOOL_FALSE(CloseHandle(hThread)); // The thread will run on its own and close itself. Free the associated handle.
 
     // See MSFT:19918626

--- a/src/inc/til/throttled_func.h
+++ b/src/inc/til/throttled_func.h
@@ -142,7 +142,7 @@ namespace til
 
             if (!timerRunning || _debounce)
             {
-                SetThreadpoolTimerEx(_timer.get(), &_delay, 0, 0);
+                SetThreadpoolTimer(_timer.get(), &_delay, 0, 0);
             }
         }
 

--- a/src/interactivity/base/HostSignalInputThread.cpp
+++ b/src/interactivity/base/HostSignalInputThread.cpp
@@ -189,7 +189,10 @@ bool HostSignalInputThread::_GetData(std::span<std::byte> buffer)
                                 &_dwThreadId));
 
     RETURN_LAST_ERROR_IF_NULL(_hThread.get());
-    LOG_IF_FAILED(SetThreadDescription(_hThread.get(), L"Host Signal Handler Thread"));
+    if (const auto func = GetProcAddressByFunctionDeclaration(GetModuleHandleW(L"kernel32.dll"), SetThreadDescription))
+    {
+        LOG_IF_FAILED(func(_hThread.get(), L"Host Signal Handler Thread"));
+    }
 
     return S_OK;
 }

--- a/src/interactivity/win32/ConsoleInputThread.cpp
+++ b/src/interactivity/win32/ConsoleInputThread.cpp
@@ -27,7 +27,10 @@ HANDLE ConsoleInputThread::Start()
     {
         _hThread = hThread;
         _dwThreadId = dwThreadId;
-        LOG_IF_FAILED(SetThreadDescription(hThread, L"Win32 Window Message Input Thread"));
+        if (const auto func = GetProcAddressByFunctionDeclaration(GetModuleHandleW(L"kernel32.dll"), SetThreadDescription))
+        {
+            LOG_IF_FAILED(func(hThread, L"Win32 Window Message Input Thread"));
+        }
     }
 
     return hThread;


### PR DESCRIPTION
- `SetThreadpoolTimer` is equivalent in every way to `SetThreadpoolTimerEx` for our use case (we throw away the return value)
- `SetThreadDescription` is optional