### PR TITLE
Fix pasting text via mouse when broadcast input is enabled

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -3381,24 +3381,6 @@ namespace winrt::TerminalApp::implementation
     // - Paste text from the Windows Clipboard to the focused terminal
     void TerminalPage::_PasteText()
     {
-        // First, check if we're in broadcast input mode. If so, let's tell all
-        // the controls to paste.
-        if (const auto& tab{ _GetFocusedTabImpl() })
-        {
-            if (tab->TabStatus().IsInputBroadcastActive())
-            {
-                tab->GetRootPane()->WalkTree([](auto&& pane) {
-                    if (auto control = pane->GetTerminalControl())
-                    {
-                        control.PasteTextFromClipboard();
-                    }
-                });
-                return;
-            }
-        }
-
-        // The focused tab wasn't in broadcast mode. No matter. Just ask the
-        // current one to paste.
         if (const auto& control{ _GetActiveControl() })
         {
             control.PasteTextFromClipboard();


### PR DESCRIPTION
## Summary of the Pull Request
Pretty straightforward. Does exactly what it says on the tin.

## Validation Steps Performed
Pasting works when broadcast input is enabled...
✅ paste w/ mouse
✅ paste w/ keyboard (untouched)

Closes #18821