### PR TITLE
Check for command palette's visibility before responding to search text changes

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -928,7 +928,7 @@ namespace winrt::TerminalApp::implementation
     void CommandPalette::_filterTextChanged(const IInspectable& /*sender*/,
                                             const Windows::UI::Xaml::RoutedEventArgs& /*args*/)
     {
-        // Only respond to this change if we are visible:
+        // GH#18737: Only respond to this change if we are visible:
         // _close calls _searchBox().Text(L"") to reset the search text, which lands us
         // in here after the command palette is dismissed. Since we have a code path here that
         // could potentially lead to an action being previewed (specifically if there is a


### PR DESCRIPTION
## Summary of the Pull Request
Only respond to any search changes in the command palette if the command palette is visible. Without this check, a previewable action's preview can appear after the command palette is closed.

## Validation Steps Performed
Preview no longer appears after the command palette is closed

## PR Checklist
Closes #18737 
