### PR TITLE
atlas: turn AtlasEngine on in WindowsInbox builds

### DIFF
--- a/src/features.xml
+++ b/src/features.xml
@@ -27,8 +27,8 @@
     </feature>
 
     <feature>
-        <name>Feature_ConhostAtlasEngine</name>
-        <description>Controls whether conhost supports the Atlas engine</description>
+        <name>Feature_ConhostAtlasEngineCustomShaders</name>
+        <description>Controls whether conhost supports custom shaders in Atlas engine</description>
         <stage>AlwaysEnabled</stage>
         <alwaysDisabledBrandingTokens>
             <brandingToken>WindowsInbox</brandingToken>

--- a/src/host/sources.inc
+++ b/src/host/sources.inc
@@ -182,6 +182,7 @@ TARGETLIBS = \
     $(WINCORE_OBJ_PATH)\console\open\src\renderer\base\lib\$(O)\ConRenderBase.lib \
     $(WINCORE_OBJ_PATH)\console\open\src\renderer\gdi\lib\$(O)\ConRenderGdi.lib \
     $(WINCORE_OBJ_PATH)\console\open\src\renderer\wddmcon\lib\$(O)\ConRenderWddmCon.lib \
+    $(WINCORE_OBJ_PATH)\console\open\src\renderer\atlas\$(O)\ConRenderAtlas.lib \
     $(WINCORE_OBJ_PATH)\console\open\src\server\lib\$(O)\ConServer.lib \
     $(WINCORE_OBJ_PATH)\console\open\src\interactivity\base\lib\$(O)\ConInteractivityBaseLib.lib \
     $(WINCORE_OBJ_PATH)\console\open\src\interactivity\win32\lib\$(O)\ConInteractivityWin32Lib.lib \

--- a/src/interactivity/win32/ut_interactivity_win32/sources
+++ b/src/interactivity/win32/ut_interactivity_win32/sources
@@ -96,6 +96,7 @@ TARGETLIBS = \
     $(WINCORE_OBJ_PATH)\console\open\src\renderer\base\lib\$(O)\ConRenderBase.lib \
     $(WINCORE_OBJ_PATH)\console\open\src\renderer\gdi\lib\$(O)\ConRenderGdi.lib \
     $(WINCORE_OBJ_PATH)\console\open\src\renderer\wddmcon\lib\$(O)\ConRenderWddmCon.lib \
+    $(WINCORE_OBJ_PATH)\console\open\src\renderer\atlas\$(O)\ConRenderAtlas.lib \
     $(WINCORE_OBJ_PATH)\console\open\src\server\lib\$(O)\ConServer.lib \
     $(WINCORE_OBJ_PATH)\console\open\src\interactivity\base\lib\$(O)\ConInteractivityBaseLib.lib \
     $(WINCORE_OBJ_PATH)\console\open\src\interactivity\onecore\lib\$(O)\ConInteractivityOneCoreLib.lib \

--- a/src/interactivity/win32/window.cpp
+++ b/src/interactivity/win32/window.cpp
@@ -24,10 +24,7 @@
 
 #include "../../renderer/base/renderer.hpp"
 #include "../../renderer/gdi/gdirenderer.hpp"
-
-#if TIL_FEATURE_CONHOSTATLASENGINE_ENABLED
 #include "../../renderer/atlas/AtlasEngine.h"
-#endif
 
 #include "../inc/ServiceLocator.hpp"
 #include "../../types/inc/Viewport.hpp"
@@ -67,9 +64,7 @@ Window::~Window()
     // reducing the change for existing race conditions to turn into deadlocks.
 #ifndef NDEBUG
     delete pGdiEngine;
-#if TIL_FEATURE_CONHOSTATLASENGINE_ENABLED
     delete pAtlasEngine;
-#endif
 #endif
 }
 
@@ -208,14 +203,12 @@ void Window::_UpdateSystemMetrics() const
     const auto useDx = pSettings->GetUseDx();
     try
     {
-#if TIL_FEATURE_CONHOSTATLASENGINE_ENABLED
         if (useDx)
         {
             pAtlasEngine = new AtlasEngine();
             g.pRender->AddRenderEngine(pAtlasEngine);
         }
         else
-#endif
         {
             pGdiEngine = new GdiEngine();
             g.pRender->AddRenderEngine(pGdiEngine);
@@ -309,14 +302,12 @@ void Window::_UpdateSystemMetrics() const
         {
             _hWnd = hWnd;
 
-#if TIL_FEATURE_CONHOSTATLASENGINE_ENABLED
             if (pAtlasEngine)
             {
                 const auto hr = pAtlasEngine->SetHwnd(hWnd);
                 status = NTSTATUS_FROM_HRESULT(hr);
             }
             else
-#endif
             {
                 const auto hr = pGdiEngine->SetHwnd(hWnd);
                 status = NTSTATUS_FROM_HRESULT(hr);

--- a/src/interactivity/win32/window.hpp
+++ b/src/interactivity/win32/window.hpp
@@ -110,9 +110,7 @@ namespace Microsoft::Console::Interactivity::Win32
         HWND _hWnd;
 
         Render::GdiEngine* pGdiEngine = nullptr;
-#if TIL_FEATURE_CONHOSTATLASENGINE_ENABLED
         Render::AtlasEngine* pAtlasEngine = nullptr;
-#endif
 
         [[nodiscard]] NTSTATUS _InternalSetWindowSize();
         void _UpdateWindowSize(const til::size sizeNew);

--- a/src/propslib/RegistrySerialization.cpp
+++ b/src/propslib/RegistrySerialization.cpp
@@ -66,9 +66,7 @@ const RegistrySerialization::_RegPropertyMap RegistrySerialization::s_PropertyMa
     { _RegPropertyType::Dword,          L"TextMeasurement",                             SET_FIELD_AND_SIZE(_textMeasurement)             },
     { _RegPropertyType::Dword,          L"MSAADelay",                                   SET_FIELD_AND_SIZE(_msaaDelay)                   },
     { _RegPropertyType::Dword,          L"UIADelay",                                    SET_FIELD_AND_SIZE(_uiaDelay)                    },
-#if TIL_FEATURE_CONHOSTATLASENGINE_ENABLED
     { _RegPropertyType::Boolean,        L"EnableBuiltinGlyphs",                         SET_FIELD_AND_SIZE(_fEnableBuiltinGlyphs)        },
-#endif
 
     // Special cases that are handled manually in Registry::LoadFromRegistry:
     // - CONSOLE_REGISTRY_WINDOWPOS

--- a/src/renderer/atlas/BackendD3D.cpp
+++ b/src/renderer/atlas/BackendD3D.cpp
@@ -6,8 +6,11 @@
 
 #include <til/unicode.h>
 
+#if TIL_FEATURE_CONHOSTATLASENGINECUSTOMSHADERS_ENABLED
 #include <custom_shader_ps.h>
 #include <custom_shader_vs.h>
+#endif
+
 #include <shader_ps.h>
 #include <shader_vs.h>
 
@@ -362,6 +365,9 @@ void BackendD3D::_d2dRenderTargetUpdateFontSettings(const RenderingPayload& p) c
 
 void BackendD3D::_recreateCustomShader(const RenderingPayload& p)
 {
+    UNREFERENCED_PARAMETER(p);
+
+#if TIL_FEATURE_CONHOSTATLASENGINECUSTOMSHADERS_ENABLED
     _customRenderTargetView.reset();
     _customOffscreenTexture.reset();
     _customOffscreenTextureView.reset();
@@ -527,6 +533,7 @@ void BackendD3D::_recreateCustomShader(const RenderingPayload& p)
         _customShaderPerfTickMod = freq * 1000;
         _customShaderSecsPerPerfTick = 1.0f / freq;
     }
+#endif
 }
 
 void BackendD3D::_recreateCustomRenderTargetView(const RenderingPayload& p)
@@ -2301,6 +2308,9 @@ void BackendD3D::_debugDumpRenderTarget(const RenderingPayload& p)
 
 void BackendD3D::_executeCustomShader(RenderingPayload& p)
 {
+    UNREFERENCED_PARAMETER(p);
+
+#if TIL_FEATURE_CONHOSTATLASENGINECUSTOMSHADERS_ENABLED
     {
         // See the comment in _recreateCustomShader() which initializes the two members below and explains what they do.
         const auto now = queryPerfCount();
@@ -2382,6 +2392,7 @@ void BackendD3D::_executeCustomShader(RenderingPayload& p)
     // With custom shaders, everything might be invalidated, so we have to
     // indirectly disable Present1() and its dirty rects this way.
     p.dirtyRectInPx = { 0, 0, p.s->targetSize.x, p.s->targetSize.y };
+#endif
 }
 
 TIL_FAST_MATH_END

--- a/src/renderer/atlas/sources
+++ b/src/renderer/atlas/sources
@@ -6,7 +6,7 @@ TARGETTYPE = LIBRARY
 PRECOMPILED_CXX         = 1
 PRECOMPILED_INCLUDE     = pch.h
 
-MSC_WARNING_LEVEL       = $(MSC_WARNING_LEVEL) /wd4201
+MSC_WARNING_LEVEL       = $(MSC_WARNING_LEVEL) /wd4201 /wd4505
 
 FXC_FLAGS               = /nologo /Emain /WX /all_resources_bound /Zi
 FXC_PROFILE_VERSION     = 4_0

--- a/src/terminal/adapter/ut_adapter/sources
+++ b/src/terminal/adapter/ut_adapter/sources
@@ -94,6 +94,7 @@ TARGETLIBS = \
     $(WINCORE_OBJ_PATH)\console\open\src\renderer\base\lib\$(O)\ConRenderBase.lib \
     $(WINCORE_OBJ_PATH)\console\open\src\renderer\gdi\lib\$(O)\ConRenderGdi.lib \
     $(WINCORE_OBJ_PATH)\console\open\src\renderer\wddmcon\lib\$(O)\ConRenderWddmCon.lib \
+    $(WINCORE_OBJ_PATH)\console\open\src\renderer\atlas\$(O)\ConRenderAtlas.lib \
     $(WINCORE_OBJ_PATH)\console\open\src\server\lib\$(O)\ConServer.lib \
     $(WINCORE_OBJ_PATH)\console\open\src\interactivity\base\lib\$(O)\ConInteractivityBaseLib.lib \
     $(WINCORE_OBJ_PATH)\console\open\src\interactivity\win32\lib\$(O)\ConInteractivityWin32Lib.lib \

--- a/src/terminal/parser/ut_parser/sources
+++ b/src/terminal/parser/ut_parser/sources
@@ -82,6 +82,7 @@ TARGETLIBS = \
     $(CONSOLE_OBJ_PATH)\renderer\base\lib\$(O)\ConRenderBase.lib \
     $(CONSOLE_OBJ_PATH)\renderer\gdi\lib\$(O)\ConRenderGdi.lib \
     $(CONSOLE_OBJ_PATH)\renderer\wddmcon\lib\$(O)\ConRenderWddmCon.lib \
+    $(CONSOLE_OBJ_PATH)\renderer\atlas\$(O)\ConRenderAtlas.lib \
     $(CONSOLE_OBJ_PATH)\audio\midi\lib\$(O)\ConAudioMidi.lib \
     $(CONSOLE_OBJ_PATH)\server\lib\$(O)\ConServer.lib \
     $(CONSOLE_OBJ_PATH)\interactivity\base\lib\$(O)\ConInteractivityBaseLib.lib \


### PR DESCRIPTION
This pull request removes the feature flag blocking Atlas from being built into conhost, and introduces a new one preventing Atlas from using _custom shaders_ in conhost.

This prevents us from taking a new dependency on `d3dcompiler_47.dll`.

It also adds all the build rules necessary to link Atlas in properly.

It is worth noting that Atlas does not work in WinPE, because there's no DXGI/D2D or anything of note.