### PR TITLE
Refactor IconPathConverter::IconWUX to not set icon size (#19806)

### DIFF
--- a/src/cascadia/UIHelpers/IconPathConverter.cpp
+++ b/src/cascadia/UIHelpers/IconPathConverter.cpp
@@ -331,8 +331,6 @@ namespace winrt::Microsoft::Terminal::UI::implementation
 
         winrt::Microsoft::UI::Xaml::Controls::ImageIcon icon{};
         icon.Source(bitmapSource);
-        icon.Width(32);
-        icon.Height(32);
         return icon;
     }
 }


### PR DESCRIPTION
Fixes #19806

## Summary
Removed hardcoded Width(32) and Height(32) from ImageIcon in IconPathConverter::IconWUX().

## Changes
- Icons now scale appropriately to their container size instead of being forced to 32x32 pixels
- Makes IconWUX consistent with IconSourceMUX which already follows this pattern

## Why This Matters
- Improves icon display across different UI contexts
- More flexible and maintainable code