### PR TITLE
Remove the suggestion chosen handler from EditAction's ShortcutActionBox

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/EditAction.cpp
+++ b/src/cascadia/TerminalSettingsEditor/EditAction.cpp
@@ -105,14 +105,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
     }
 
-    void EditAction::ShortcutActionBox_SuggestionChosen(const AutoSuggestBox& sender, const AutoSuggestBoxSuggestionChosenEventArgs& args)
-    {
-        if (const auto selectedAction = args.SelectedItem().try_as<winrt::hstring>())
-        {
-            sender.Text(*selectedAction);
-        }
-    }
-
     void EditAction::ShortcutActionBox_QuerySubmitted(const AutoSuggestBox& sender, const AutoSuggestBoxQuerySubmittedEventArgs& args)
     {
         const auto submittedText = args.QueryText();

--- a/src/cascadia/TerminalSettingsEditor/EditAction.h
+++ b/src/cascadia/TerminalSettingsEditor/EditAction.h
@@ -22,7 +22,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         void ShortcutActionBox_GotFocus(const winrt::Windows::Foundation::IInspectable& sender, const winrt::Windows::UI::Xaml::RoutedEventArgs& args);
         void ShortcutActionBox_TextChanged(const winrt::Windows::UI::Xaml::Controls::AutoSuggestBox& sender, const winrt::Windows::UI::Xaml::Controls::AutoSuggestBoxTextChangedEventArgs& args);
-        void ShortcutActionBox_SuggestionChosen(const winrt::Windows::UI::Xaml::Controls::AutoSuggestBox& sender, const winrt::Windows::UI::Xaml::Controls::AutoSuggestBoxSuggestionChosenEventArgs& args);
         void ShortcutActionBox_QuerySubmitted(const winrt::Windows::UI::Xaml::Controls::AutoSuggestBox& sender, const winrt::Windows::UI::Xaml::Controls::AutoSuggestBoxQuerySubmittedEventArgs& args);
         void ShortcutActionBox_LostFocus(const winrt::Windows::Foundation::IInspectable& sender, const winrt::Windows::UI::Xaml::RoutedEventArgs& args);
 

--- a/src/cascadia/TerminalSettingsEditor/EditAction.xaml
+++ b/src/cascadia/TerminalSettingsEditor/EditAction.xaml
@@ -707,7 +707,6 @@
                             GotFocus="ShortcutActionBox_GotFocus"
                             LostFocus="ShortcutActionBox_LostFocus"
                             QuerySubmitted="ShortcutActionBox_QuerySubmitted"
-                            SuggestionChosen="ShortcutActionBox_SuggestionChosen"
                             TextChanged="ShortcutActionBox_TextChanged" />
             <TextBlock x:Uid="Actions_Keybindings"
                        Grid.Row="3"


### PR DESCRIPTION
## Summary of the Pull Request
There is an issue where clicking an item (with the mouse) from the auto suggest box's dropdown would fail on the first try, but the dropdown gets reopened automatically and clicking an item after that works. This is because `AutoSuggestBox` has `UpdateTextOnSelect` defaulted to `True`, but we also have a `SuggestionChosen` handler that effectively does the same thing, and the two were conflicting. This commit fixes that by removing our `SuggestionChosen` handler.

## Verification steps performed
Selecting an item from the dropdown with mouse works on first try. Keyboard flow continues to work as expected.

