### PR TITLE
Fix AppendCommandLine missing from NewTerminalArgs serialization

### DIFF
--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -434,6 +434,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             JsonUtils::GetValueForKey(json, ElevateKey, args->_Elevate);
             JsonUtils::GetValueForKey(json, ReloadEnvironmentVariablesKey, args->_ReloadEnvironmentVariables);
             JsonUtils::GetValueForKey(json, ContentKey, args->_ContentId);
+            JsonUtils::GetValueForKey(json, AppendCommandLineKey, args->_AppendCommandLine);
             return *args;
         }
         static Json::Value ToJson(const Model::NewTerminalArgs& val)
@@ -456,6 +457,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             JsonUtils::SetValueForKey(json, ElevateKey, args->_Elevate);
             JsonUtils::SetValueForKey(json, ReloadEnvironmentVariablesKey, args->_ReloadEnvironmentVariables);
             JsonUtils::SetValueForKey(json, ContentKey, args->_ContentId);
+            JsonUtils::SetValueForKey(json, AppendCommandLineKey, args->_AppendCommandLine);
             return json;
         }
         Model::NewTerminalArgs Copy() const
@@ -473,6 +475,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             copy->_Elevate = _Elevate;
             copy->_ReloadEnvironmentVariables = _ReloadEnvironmentVariables;
             copy->_ContentId = _ContentId;
+            copy->_AppendCommandLine = _AppendCommandLine;
             return *copy;
         }
         size_t Hash() const
@@ -494,6 +497,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             h.write(Elevate());
             h.write(ReloadEnvironmentVariables());
             h.write(ContentId());
+            h.write(AppendCommandLine());
         }
     };
 


### PR DESCRIPTION
## Summary
- `AppendCommandLine` was defined as a property on `NewTerminalArgs` but omitted from `FromJson`, `ToJson`, `Copy`, and `Hash`
- This caused the property to be silently dropped during serialization round-trips (tab duplication, window restore, settings persistence)
- Adds `AppendCommandLine` to all four methods, consistent with every other property on `NewTerminalArgs`

## Details
Every other property on `NewTerminalArgs` (`Commandline`, `StartingDirectory`, `TabTitle`, `ProfileIndex`, `Profile`, `SessionId`, `TabColor`, `SuppressApplicationTitle`, `ColorScheme`, `Elevate`, `ReloadEnvironmentVariables`, `ContentId`) is present in all four serialization methods. `AppendCommandLine` was the only one missing.

## Validation
- Built and ran `SettingsModel.Unit.Tests.dll` — all tests pass
- Full solution build succeeds
- Manual test: tab duplication now correctly preserves all `NewTerminalArgs` properties

Fixes #14270