### PR TITLE
Fix docs: remove misleading git submodule instruction

### DIFF
--- a/doc/building.md
+++ b/doc/building.md
@@ -1,12 +1,6 @@
 
 # How to build OpenConsole
 
-This repository uses [git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) for some of its dependencies. To make sure submodules are restored or updated, be sure to run the following prior to building:
-
-```shell
-git submodule update --init --recursive
-```
-
 OpenConsole.slnx may be built from within Visual Studio or from the command-line using a set of convenience scripts & tools in the **/tools** directory:
 
 When using Visual Studio, be sure to set up the path for code formatting. To download the required clang-format.exe file, follow one of the building instructions below and run:


### PR DESCRIPTION
Fixes #17880. Removes the git submodule instruction from the building documentation since the repository does not have a .gitmodules file, making the command ineffective for users.