### PR TITLE
conhost: atlas: prevent D3DCompile/hot shader reload in CHK builds

### DIFF
--- a/src/renderer/atlas/Backend.h
+++ b/src/renderer/atlas/Backend.h
@@ -12,7 +12,11 @@ namespace Microsoft::Console::Render::Atlas
 #ifdef NDEBUG
 #define ATLAS_DEBUG__IS_DEBUG 0
 #else
+#ifdef __INSIDE_WINDOWS
+#define ATLAS_DEBUG__IS_DEBUG 0
+#else
 #define ATLAS_DEBUG__IS_DEBUG 1
+#endif
 #endif
 
     // If set to 1, this will cause the entire viewport to be invalidated at all times.


### PR DESCRIPTION
Whoops. `chk` builds are failing because Atlas tries to do hot shader reload in `DEBUG` builds.

That works in our public repo, but here there is not usually going to be access to the source code.

Reviewed-by: Leonard Hecker <lhecker@microsoft.com>