### PR TITLE
build: make sure the AnyCPU build sets BuildPlatform properly

### DIFF
--- a/build/pipelines/templates-v2/job-build-package-wpf.yml
+++ b/build/pipelines/templates-v2/job-build-package-wpf.yml
@@ -46,6 +46,7 @@ jobs:
           BuildConfiguration: ${{ config }}
   dependsOn: ${{ parameters.dependsOn }}
   variables:
+    BuildPlatform: Any CPU
     OutputBuildPlatform: AnyCPU
     Terminal.BinDir: $(Build.SourcesDirectory)/bin/$(OutputBuildPlatform)/$(BuildConfiguration)
     JobOutputDirectory: $(Build.ArtifactStagingDirectory)\nupkg


### PR DESCRIPTION
This caused the WPF-only build (packaging phase, really) to fail.

Fixes d6714f3ca94 (#19328)