### PR TITLE
control: focus terminal on click-drag while search is open

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1955,7 +1955,13 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         const auto point = args.GetCurrentPoint(*this);
         const auto type = ptr.PointerDeviceType();
 
-        if (!_focused)
+        // GH#19908: _focused can be true even when the search box has
+        // keyboard focus, because GotFocus bubbles from the search box
+        // child and _GotFocusHandler sets _focused=true. If the user
+        // click-drags in the terminal while the search box is focused,
+        // we need to explicitly call Focus() to move keyboard focus back
+        // to the terminal so that Ctrl+C copies the selection.
+        if (!_focused || (_searchBox && _searchBox->ContainsFocus()))
         {
             Focus(FocusState::Pointer);
         }


### PR DESCRIPTION
## Summary
- Fix inability to copy terminal text via Ctrl+C when the search dialog is open
- Root cause: click-and-drag doesn't call `Focus()` because `_focused` is already `true` (set by the search box's bubbling GotFocus)
- Fix: also focus the terminal when the search box contains keyboard focus

## Detailed Description of the Pull Request / Additional comments
When the search dialog is open and the user click-drags in the terminal to select text, `_PointerPressedHandler` skips `Focus(FocusState::Pointer)` because `_focused` is `true`. The `_focused` flag is `true` because the `SearchBoxControl` is a child of `TermControl` in the XAML visual tree, so `TermControl`'s `_GotFocusHandler` fires (via bubbling `GotFocus`) when the search box's `TextBox` gains focus, setting `_focused = true`.

The fix adds a `ContainsFocus()` check so that focus is explicitly moved to the terminal when the search box has keyboard focus. This makes click-drag behavior consistent with tap behavior (`_TappedHandler` already focuses unconditionally) and uses the same `ContainsFocus()` pattern already established at lines 1569 and 2366 in the same file.

## Validation Steps Performed
- Verified click-drag + Ctrl+C copies selected text when search dialog is open
- Verified simple click (tap) in terminal while search is open still works
- Verified clicking in the search box retains focus in the search box
- Verified typing in search box still works when it has focus
- Verified Escape still closes the search box
- Verified Ctrl+C with no selection while search is open doesn't break
- Code formatted with clang-format

## PR Checklist
 Closes #19908