### PR TITLE
fix(input): re-resolve scancode keybindings on keyboard layout change

### DIFF
--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -148,10 +148,17 @@ namespace winrt::TerminalApp::implementation
                 }
             });
 
-        _languageProfileNotifier = winrt::make_self<LanguageProfileNotifier>([this]() {
-            // TODO: This is really bad, because we reset any current user customizations.
-            // See GH#11522.
-            ReloadSettingsThrottled();
+        _languageProfileNotifier = winrt::make_self<LanguageProfileNotifier>([weakSelf = get_weak(), dispatcher = DispatcherQueue::GetForCurrentThread()]() {
+            // GH#11522: Re-resolve only scancode-based keybindings for the new layout.
+            // sc(nnn) bindings translate scancode to VK via MapVirtualKeyW at parse time,
+            // but the mapping is layout-dependent. A full ReloadSettingsThrottled() would
+            // unnecessarily reset font zoom, VT colors, and other runtime state.
+            dispatcher.TryEnqueue([weakSelf]() {
+                if (auto self{ weakSelf.get() })
+                {
+                    self->_settings.GlobalSettings().ActionMap().NotifyKeyboardLayoutChanged();
+                }
+            });
         });
 
         // Do this here, rather than at the top of main. This will prevent us from

--- a/src/cascadia/TerminalSettingsModel/ActionMap.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionMap.cpp
@@ -647,6 +647,76 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         _AllCommandsCache = single_threaded_vector(std::move(allCommandsVector));
     }
 
+    // Method Description:
+    // - Re-resolve scancode-based keybindings after a keyboard layout change.
+    //   sc(nnn) bindings translate scancode to VK via MapVirtualKeyW at KeyChord
+    //   construction, but the mapping is layout-dependent. This method updates
+    //   stale VK codes without a full settings reload, preserving runtime state
+    //   (font zoom, VT colors, etc.). See GH#11522.
+    // - Must be called on the UI thread. Uses GetKeyboardLayout(0) to query the
+    //   calling thread's active layout, which is guaranteed correct after
+    //   TryEnqueue dispatch (the input language change has propagated by then).
+    void ActionMap::NotifyKeyboardLayoutChanged()
+    {
+        const auto layout = GetKeyboardLayout(0);
+        _ResolveScancodeBindings(layout);
+        _NameMapCache = nullptr;
+        _RefreshKeyBindingCaches();
+    }
+
+    // Method Description:
+    // - Walks _KeyMap for entries with a non-zero ScanCode, re-resolves their
+    //   VK via MapVirtualKeyExW under the given layout, and reinserts any that
+    //   changed (since the VK is part of the hash key). Recurses into parents
+    //   and invalidates their caches for lazy rebuild.
+    // Arguments:
+    // - layout: the HKL to resolve scancodes against.
+    void ActionMap::_ResolveScancodeBindings(HKL layout)
+    {
+        std::vector<std::pair<KeyChord, winrt::hstring>> toReinsert;
+        std::vector<KeyChord> toRemove;
+
+        for (const auto& [keys, cmdID] : _KeyMap)
+        {
+            const auto scanCode = keys.ScanCode();
+            if (scanCode != 0)
+            {
+                const auto newVkey = static_cast<int32_t>(MapVirtualKeyExW(scanCode, MAPVK_VSC_TO_VK_EX, layout));
+                if (newVkey == 0)
+                {
+                    // Layout doesn't map this scancode -- keep the existing binding
+                    // rather than making it unmatchable.
+                    continue;
+                }
+                if (newVkey != keys.Vkey())
+                {
+                    toRemove.emplace_back(keys);
+                    toReinsert.emplace_back(KeyChord{ keys.Modifiers(), newVkey, scanCode }, cmdID);
+                }
+            }
+        }
+
+        for (const auto& oldKeys : toRemove)
+        {
+            _KeyMap.erase(oldKeys);
+        }
+
+        for (auto& [newKeys, cmdID] : toReinsert)
+        {
+            _KeyMap.insert_or_assign(std::move(newKeys), std::move(cmdID));
+        }
+
+        for (const auto& parent : _parents)
+        {
+            // Invalidate parent caches so they rebuild on next direct access.
+            parent->_NameMapCache = nullptr;
+            parent->_ResolvedKeyToActionMapCache = nullptr;
+            parent->_GlobalHotkeysCache = nullptr;
+            parent->_AllCommandsCache = nullptr;
+            parent->_ResolveScancodeBindings(layout);
+        }
+    }
+
     com_ptr<ActionMap> ActionMap::Copy() const
     {
         auto actionMap{ make_self<ActionMap>() };

--- a/src/cascadia/TerminalSettingsModel/ActionMap.h
+++ b/src/cascadia/TerminalSettingsModel/ActionMap.h
@@ -96,6 +96,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         void DeleteUserCommand(const winrt::hstring& cmdID);
         void AddSendInputAction(winrt::hstring name, winrt::hstring input, const Control::KeyChord keys);
         void UpdateCommandID(const Model::Command& cmd, winrt::hstring newID);
+        void NotifyKeyboardLayoutChanged();
 
         Windows::Foundation::Collections::IVector<Model::Command> ExpandedCommands();
         void ExpandCommands(const Windows::Foundation::Collections::IVectorView<Model::Profile>& profiles,
@@ -111,6 +112,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         std::optional<Model::Command> _GetActionByKeyChordInternal(const Control::KeyChord& keys) const;
 
         void _RefreshKeyBindingCaches();
+        void _ResolveScancodeBindings(HKL layout);
         void _PopulateAvailableActionsWithStandardCommands(std::unordered_map<hstring, Model::ActionAndArgs>& availableActions, std::unordered_set<InternalActionID>& visitedActionIDs) const;
         void _PopulateNameMapWithSpecialCommands(std::unordered_map<hstring, Model::Command>& nameMap) const;
         void _PopulateNameMapWithStandardCommands(std::unordered_map<hstring, Model::Command>& nameMap) const;

--- a/src/cascadia/TerminalSettingsModel/ActionMap.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionMap.idl
@@ -45,5 +45,6 @@ namespace Microsoft.Terminal.Settings.Model
         void AddKeyBinding(Microsoft.Terminal.Control.KeyChord keys, String cmdID);
         void RegisterKeyBinding(Microsoft.Terminal.Control.KeyChord keys, ActionAndArgs action);
         void AddSendInputAction(String name, String input, Microsoft.Terminal.Control.KeyChord keys);
+        void NotifyKeyboardLayoutChanged();
     }
 }


### PR DESCRIPTION
## Summary

Replace the full `ReloadSettingsThrottled()` call in the `LanguageProfileNotifier` callback with targeted scancode-binding re-resolution. Keyboard layout changes now only update the `sc(nnn)` keybindings that depend on the active layout, preserving font zoom, VT colors, and other runtime state.

## References and Relevant Issues

- Closes #11522
- Supersedes #14498 (closed as stale)

## Detailed Description of the Pull Request / Additional comments

`sc(nnn)` keybindings translate a physical scancode to a virtual key code (VK) via `MapVirtualKeyW` at parse time. This mapping is layout-dependent — `sc(41)` resolves to `` VK_OEM_3 `` (backtick) on US-QWERTY but to a different VK on other layouts. When the user switches layouts, these cached VK codes become stale.

The previous fix called `ReloadSettingsThrottled()` on every layout switch, which correctly re-resolved scancodes but also reset font zoom, VT colors, and all runtime state by reloading `settings.json` from disk.

This PR adds `ActionMap::NotifyKeyboardLayoutChanged()` which:
1. Walks `_KeyMap` for entries with `ScanCode != 0`
2. Re-resolves each scancode's VK via `MapVirtualKeyExW` under the new layout
3. Erases stale entries and reinserts with updated `KeyChord` objects
4. Invalidates `_NameMapCache` and rebuilds all binding caches
5. Recursively processes parent ActionMap layers

The `LanguageProfileNotifier` callback now dispatches to the UI thread and calls this method instead of triggering a full settings reload. Non-scancode bindings (standard VK-based like `ctrl+c`) are unaffected — their VK codes are layout-independent.

### Known limitations (follow-up)

- **OEM punctuation bindings** (`ctrl+;`, `ctrl+[`, etc.) are also layout-dependent via `VkKeyScanW` at parse time, but this PR intentionally scopes to `ScanCode != 0` entries only. Re-resolving all `VkKeyScanW`-based bindings would be a larger behavioral change.
- **Global hotkeys** (`RegisterHotKey`) store the VK at OS registration time. A `win+sc(41)` globalSummon binding's in-process resolution will be updated, but the OS-level hotkey won't be re-registered. Fixing this requires plumbing layout-change notifications into the global hotkey registration path.

| Left (Production Terminal) | Right (Dev - fix) |
|-|-|
| Ctrl++ zoom 3x | Ctrl++ zoom 3x |
| alt+shift (switch layout) | alt+shift (switch layout) |
| Font resets to default ✗ | Font stays zoomed ✓ |

![Animation](https://github.com/user-attachments/assets/6014275a-94a6-444a-ab49-6da9b886344e)

## Validation Steps Performed

1. Ctrl++ to zoom in several levels
2. Switch keyboard layout (EN → EL via Win+Space)
3. Verified font zoom is preserved (previously reset to default)
4. Verified `win+sc(41)` (Quake Mode) works correctly after layout switch
5. Verified OEM keybindings (`Ctrl+,`) still work after layout switch
6. Verified editing `settings.json` still triggers reload via file watcher
7. Compared behavior against production build to confirm fix

## PR Checklist
- [x] Closes #11522
- [ ] Tests added/passed — layout-dependent tests require mocking `GetKeyboardLayout`/`MapVirtualKeyExW` which the test harness doesn't currently support. Manual validation performed above.
- [ ] Documentation updated
- [ ] Schema updated (if necessary)