### PR TITLE
vpack: actually, we have to use a 3-segment version number

### DIFF
--- a/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
@@ -211,7 +211,7 @@ extends:
                   ob_createvpack_verbose: true
                   ob_createvpack_vpackdirectory: '$(JobOutputDirectory)\vpack'
                   ob_createvpack_versionAs: string
-                  ob_createvpack_version: '$(XES_APPXMANIFESTVERSION)'
+                  ob_createvpack_version: '$(XES_PACKAGEVERSIONNUMBER)'
                   ob_updateOSManifest_gitcheckinConfigPath: '$(Build.SourcesDirectory)\build\config\GitCheckin.json'
                   # We're skipping the 'fetch' part of the OneBranch rules, but that doesn't mean
                   # that it doesn't expect to have downloaded a manifest directly to some 'destination'


### PR DESCRIPTION
Our last build failed because it tried to pass "10621.0" off as a uint64. I didn't know it had to be a single number... so let's use the 3-component equivalent (which would have been 1.24.260303001)