### PR TITLE
Fix GenerateSettingsIndex using element name instead of x:Name

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Compatibility.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.xaml
@@ -43,7 +43,8 @@
         </local:SettingContainer>
 
         <!--  Ambiguous Width  -->
-        <local:SettingContainer x:Uid="Globals_AmbiguousWidth">
+        <local:SettingContainer x:Name="AmbiguousWidth"
+                                x:Uid="Globals_AmbiguousWidth">
             <ComboBox AutomationProperties.AccessibilityView="Content"
                       ItemTemplate="{StaticResource EnumComboBoxTemplate}"
                       ItemsSource="{x:Bind ViewModel.AmbiguousWidthList}"

--- a/src/cascadia/TerminalSettingsEditor/NewTabMenu.xaml
+++ b/src/cascadia/TerminalSettingsEditor/NewTabMenu.xaml
@@ -329,7 +329,8 @@
             </local:SettingContainer>
 
             <!--  Icon  -->
-            <local:SettingContainer x:Uid="NewTabMenu_CurrentFolderIcon"
+            <local:SettingContainer x:Name="CurrentFolderIcon"
+                                    x:Uid="NewTabMenu_CurrentFolderIcon"
                                     CurrentValueAccessibleName="{x:Bind ViewModel.CurrentFolderLocalizedIcon, Mode=OneWay}"
                                     Style="{StaticResource ExpanderSettingContainerStyleWithComplexPreview}">
                 <local:SettingContainer.CurrentValue>
@@ -497,7 +498,8 @@
             </local:SettingContainer>
 
             <!--  Add Remaining Profiles  -->
-            <local:SettingContainer x:Uid="NewTabMenu_AddRemainingProfiles"
+            <local:SettingContainer x:Name="AddRemainingProfiles"
+                                    x:Uid="NewTabMenu_AddRemainingProfiles"
                                     FontIconGlyph="&#xE902;"
                                     Style="{StaticResource SettingContainerWithIcon}">
                 <Button x:Name="AddRemainingProfilesButton"

--- a/tools/GenerateSettingsIndex.ps1
+++ b/tools/GenerateSettingsIndex.ps1
@@ -207,8 +207,13 @@ foreach ($xamlFile in Get-ChildItem -Path $SourceDir -Filter *.xaml)
             continue
         }
 
-        # Extract Name (prefer x:Name over Name)
-        $name = $null -ne $settingContainer.Name ? $settingContainer.Name : ""
+        # Extract Name via GetAttribute to avoid PowerShell's XML integration
+        # returning the element name (e.g. "local:SettingContainer") when x:Name is absent.
+        $name = $settingContainer.GetAttribute("x:Name")
+        if ([string]::IsNullOrEmpty($name))
+        {
+            $name = ""
+        }
         if ($filename -eq "Appearances.xaml")
         {
             # Profile.Appearance settings need a special prefix for the ElementName.


### PR DESCRIPTION
Use GetAttribute('x:Name') instead of .Name in GenerateSettingsIndex.ps1 to avoid PowerShell's XML integration returning the element tag name (e.g. 'local:SettingContainer') when x:Name is absent.

Also add missing x:Name attributes to:
- Compatibility.xaml: AmbiguousWidth SettingContainer
- NewTabMenu.xaml: AddRemainingProfiles and CurrentFolderIcon containers

## Summary of the Pull Request
Fix GenerateSettingsIndex.ps1 emitting "local:SettingContainer" as the element name in the generated index when a SettingContainer has no x:Name attribute.

## References and Relevant Issues
Per DHowett's comment - the root cause is PowerShell's XML integration: $element.Name returns the XML element tag name (e.g. local:SettingContainer) when no x:Name attribute exists.

## Detailed Description of the Pull Request / Additional comments
Two changes:

- GenerateSettingsIndex.ps1: Replace $settingContainer.Name with $settingContainer.GetAttribute("x:Name"), which correctly returns an empty string when the attribute is absent instead of the element tag name.

- Add missing x:Name attributes to three SettingContainer elements:
    - Compatibility.xaml: AmbiguousWidth (Globals_AmbiguousWidth)
    - NewTabMenu.xaml: AddRemainingProfiles (NewTabMenu_AddRemainingProfiles)
    - NewTabMenu.xaml: CurrentFolderIcon (NewTabMenu_CurrentFolderIcon)
    - This fixes four incorrect IndexEntry lines in the generated output that previously contained L"local:SettingContainer" as the element name.

## Validation Steps Performed
Ran GenerateSettingsIndex.ps1 before and after - confirmed the four incorrect entries with L"local:SettingContainer" are now generated with the correct x:Name values (or empty string where appropriate).

## PR Checklist
Closes #19929
