### PR TITLE
Always use the cls shim for cmd/pwsh

### DIFF
--- a/src/host/_output.cpp
+++ b/src/host/_output.cpp
@@ -400,20 +400,16 @@ static FillConsoleResult FillConsoleImpl(SCREEN_INFORMATION& screenInfo, FillCon
         // See FillConsoleOutputCharacterWImpl and its identical code.
         if (enablePowershellShim)
         {
-            auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
-            if (const auto writer = gci.GetVtWriterForBuffer(&OutContext))
-            {
-                const auto currentBufferDimensions{ OutContext.GetBufferSize().Dimensions() };
-                const auto wroteWholeBuffer = lengthToWrite == (currentBufferDimensions.area<size_t>());
-                const auto startedAtOrigin = startingCoordinate == til::point{ 0, 0 };
-                const auto wroteSpaces = attribute == (FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED);
+            const auto currentBufferDimensions{ OutContext.GetBufferSize().Dimensions() };
+            const auto wroteWholeBuffer = lengthToWrite == (currentBufferDimensions.area<size_t>());
+            const auto startedAtOrigin = startingCoordinate == til::point{ 0, 0 };
+            const auto wroteSpaces = attribute == (FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED);
 
-                if (wroteWholeBuffer && startedAtOrigin && wroteSpaces)
-                {
-                    // PowerShell has previously called FillConsoleOutputCharacterW() which triggered a call to WriteClearScreen().
-                    cellsModified = lengthToWrite;
-                    return S_OK;
-                }
+            if (wroteWholeBuffer && startedAtOrigin && wroteSpaces)
+            {
+                // PowerShell has previously called FillConsoleOutputCharacterW() which triggered a call to WriteClearScreen().
+                cellsModified = lengthToWrite;
+                return S_OK;
             }
         }
 
@@ -457,21 +453,23 @@ static FillConsoleResult FillConsoleImpl(SCREEN_INFORMATION& screenInfo, FillCon
         // their entire buffer will be cleared as well.
         if (enablePowershellShim)
         {
-            auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
-            if (auto writer = gci.GetVtWriterForBuffer(&OutContext))
-            {
-                const auto currentBufferDimensions{ OutContext.GetBufferSize().Dimensions() };
-                const auto wroteWholeBuffer = lengthToWrite == (currentBufferDimensions.area<size_t>());
-                const auto startedAtOrigin = startingCoordinate == til::point{ 0, 0 };
-                const auto wroteSpaces = character == UNICODE_SPACE;
+            const auto currentBufferDimensions{ OutContext.GetBufferSize().Dimensions() };
+            const auto wroteWholeBuffer = lengthToWrite == (currentBufferDimensions.area<size_t>());
+            const auto startedAtOrigin = startingCoordinate == til::point{ 0, 0 };
+            const auto wroteSpaces = character == UNICODE_SPACE;
 
-                if (wroteWholeBuffer && startedAtOrigin && wroteSpaces)
+            if (wroteWholeBuffer && startedAtOrigin && wroteSpaces)
+            {
+                WriteClearScreen(OutContext);
+
+                auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
+                if (auto writer = gci.GetVtWriterForBuffer(&OutContext))
                 {
-                    WriteClearScreen(OutContext);
                     writer.Submit();
-                    cellsModified = lengthToWrite;
-                    return S_OK;
                 }
+
+                cellsModified = lengthToWrite;
+                return S_OK;
             }
         }
 

--- a/src/host/getset.cpp
+++ b/src/host/getset.cpp
@@ -982,23 +982,20 @@ void ApiRoutines::GetLargestConsoleWindowSizeImpl(const SCREEN_INFORMATION& cont
         // A null character will get translated to whitespace.
         fillCharacter = Microsoft::Console::VirtualTerminal::VtIo::SanitizeUCS2(fillCharacter);
 
-        if (writer)
+        // GH#3126 - This is a shim for cmd's `cls` function. In the
+        // legacy console, `cls` is supposed to clear the entire buffer.
+        // We always use a VT sequence, even if ConPTY isn't used, because those are faster nowadays.
+        if (enableCmdShim &&
+            source.left <= 0 && source.top <= 0 &&
+            source.right >= bufferSize.RightInclusive() && source.bottom >= bufferSize.BottomInclusive() &&
+            target.x == 0 && target.y <= -bufferSize.BottomExclusive() &&
+            !clip &&
+            fillCharacter == UNICODE_SPACE && fillAttribute == buffer.GetAttributes().GetLegacyAttributes())
         {
-            // GH#3126 - This is a shim for cmd's `cls` function. In the
-            // legacy console, `cls` is supposed to clear the entire buffer.
-            // We always use a VT sequence, even if ConPTY isn't used, because those are faster nowadays.
-            if (enableCmdShim &&
-                source.left <= 0 && source.top <= 0 &&
-                source.right >= bufferSize.RightInclusive() && source.bottom >= bufferSize.BottomInclusive() &&
-                target.x == 0 && target.y <= -bufferSize.BottomExclusive() &&
-                !clip &&
-                fillCharacter == UNICODE_SPACE && fillAttribute == buffer.GetAttributes().GetLegacyAttributes())
-            {
-                WriteClearScreen(context);
-                writer.Submit();
-                return S_OK;
-            }
-
+            WriteClearScreen(context);
+        }
+        else if (writer)
+        {
             const auto clipViewport = clip ? Viewport::FromInclusive(*clip).Clamp(bufferSize) : bufferSize;
             const auto sourceViewport = Viewport::FromInclusive(source);
             const auto fillViewport = sourceViewport.Clamp(clipViewport);
@@ -1084,13 +1081,16 @@ void ApiRoutines::GetLargestConsoleWindowSizeImpl(const SCREEN_INFORMATION& cont
                 RETURN_IF_FAILED(WriteConsoleOutputWImplHelper(context, fill, w, fillViewport, writtenViewport));
                 RETURN_IF_FAILED(WriteConsoleOutputWImplHelper(context, backup, w, Viewport::FromDimensions(target, readViewport.Dimensions()).Clamp(clipViewport), writtenViewport));
             }
-
-            writer.Submit();
         }
         else
         {
             TextAttribute useThisAttr(fillAttribute);
             ScrollRegion(buffer, source, clip, target, fillCharacter, useThisAttr);
+        }
+
+        if (writer)
+        {
+            writer.Submit();
         }
 
         return S_OK;


### PR DESCRIPTION
This improves performance and avoids a memory spike on `cls`.

## Validation Steps Performed
* `cls` clears ✅
* RSS doesn't spike ✅