### PR TITLE
conhost: Unlock the console while tearing down during coniosrv focus evt

### DIFF
--- a/src/interactivity/onecore/ConIoSrvComm.cpp
+++ b/src/interactivity/onecore/ConIoSrvComm.cpp
@@ -444,7 +444,15 @@ VOID ConIoSrvComm::HandleFocusEvent(const CIS_EVENT* const Event)
                 // TODO: MSFT: 11833883 - Determine action when wait on paint operation via
                 //       DirectX on OneCoreUAP times out while switching console
                 //       applications.
+
+                UnlockConsole();
+                // Teardown may need to wait for an entire frame to finish, but it will not be
+                // able to do so while we are holding the console lock. Relinquish the lock
+                // for as long as it takes to quiesce the render thread, and then take it back
+                // afterwards. This is globally safe because ConIoSrv will not process any other
+                // requests while the focus event is outstanding.
                 Renderer->TriggerTeardown();
+                LockConsole();
 
                 // Relinquish control of the graphics device (only one
                 // DirectX application may control the device at any one


### PR DESCRIPTION
With the rendering thread changes in #18632 and #19330, we strengthened a requirement that render shutdown be done outside of the console lock. This works on all platforms except OneCore, where ConIoSrv manages the focus of multiple console windows and we need to explicitly order the handling of tearing down and relinquishing device resources.

The old code (before #18632) used to wait for a whole second before giving up.

Instead, let's just unlock the console to let the final frame drain out.

I created a synthetic repro: start two cmd sessions with a lot of rendering load (`cmdd start cmd /c dir /s c:\`), and then run `cmdd date /t` in a tight loop while tabbing between the console windows.

Before this fix, it hangs within a couple tens of date invocations. With this fix, it does not hang at all.

Fixes MSFT-61354695