### PR TITLE
Suppress the invalid media error in Stable

### DIFF
--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -647,9 +647,12 @@ void CascadiaSettings::_validateMediaResources()
 
     _globals->ResolveMediaResources(mediaResourceResolver);
 
-    if (_foundInvalidUserResources)
+    if (Feature_WarnOnInvalidSettingsMediaResources::IsEnabled())
     {
-        _warnings.Append(SettingsLoadWarnings::InvalidMediaResource);
+        if (_foundInvalidUserResources)
+        {
+            _warnings.Append(SettingsLoadWarnings::InvalidMediaResource);
+        }
     }
 }
 

--- a/src/features.xml
+++ b/src/features.xml
@@ -187,4 +187,11 @@
         <alwaysDisabledReleaseTokens/>
     </feature>
 
+    <feature>
+        <name>Feature_WarnOnInvalidSettingsMediaResources</name>
+	<description>Controls whether Terminal should display a warning dialog when icon, backgroundImage, shader, etc. could not be found.</description>
+        <stage>AlwaysEnabled</stage>
+        <alwaysDisabledReleaseTokens/>
+    </feature>
+
 </featureStaging>


### PR DESCRIPTION
It's creating a lot of noise for folks, and it is not particularly _helpful_ since it does not specify a location or even name which resource failed to load or parse.

On stable, let's just silently ignore them.

Refs #19964