### PR TITLE
Tab menu: show "restart" + maintain items' enable state

### DIFF
--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -875,10 +875,10 @@
     <value>If set, the command will be appended to the profile's default command instead of replacing it.</value>
   </data>
   <data name="RestartConnectionText" xml:space="preserve">
-    <value>Restart connection</value>
+    <value>Restart session</value>
   </data>
   <data name="RestartConnectionToolTip" xml:space="preserve">
-    <value>Restart the active pane connection</value>
+    <value>Restart the active pane session</value>
   </data>
   <data name="SnippetPaneTitle.Text" xml:space="preserve">
     <value>Snippets</value>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -878,7 +878,7 @@
     <value>Restart session</value>
   </data>
   <data name="RestartConnectionToolTip" xml:space="preserve">
-    <value>Restart the active pane session</value>
+    <value>Restart the session in the active pane</value>
   </data>
   <data name="SnippetPaneTitle.Text" xml:space="preserve">
     <value>Snippets</value>

--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -35,7 +35,6 @@ namespace winrt::TerminalApp::implementation
         _activePane = nullptr;
 
         _closePaneMenuItem.Visibility(WUX::Visibility::Collapsed);
-        _restartConnectionMenuItem.Visibility(WUX::Visibility::Collapsed);
 
         auto firstId = _nextPaneId;
 
@@ -86,6 +85,7 @@ namespace winrt::TerminalApp::implementation
 
         _MakeTabViewItem();
         _CreateContextMenu();
+        _UpdateMenuItemEnablement();
 
         _headerControl.TabStatus(_tabStatus);
 
@@ -1271,13 +1271,6 @@ namespace winrt::TerminalApp::implementation
 
             _tabStatus.IsConnectionClosed(isClosed);
         }
-
-        if (_activePane)
-        {
-            _restartConnectionMenuItem.Visibility(_activePane->IsConnectionClosed() ?
-                                                      WUX::Visibility::Visible :
-                                                      WUX::Visibility::Collapsed);
-        }
     }
 
     void Tab::_RestartActivePaneConnection()
@@ -1348,6 +1341,22 @@ namespace winrt::TerminalApp::implementation
                 }
             });
         }
+
+        _UpdateMenuItemEnablement();
+    }
+
+    void Tab::_UpdateMenuItemEnablement()
+    {
+        // Terminal-specific menu items
+        const auto content = _activePane ? _activePane->GetContent() : nullptr;
+        const auto isTerm = content && content.try_as<winrt::TerminalApp::TerminalPaneContent>() != nullptr;
+        _duplicateTabMenuItem.IsEnabled(isTerm);
+        _exportTabMenuItem.IsEnabled(isTerm);
+        _findMenuItem.IsEnabled(isTerm);
+        _restartConnectionMenuItem.IsEnabled(isTerm);
+
+        // Snippets Pane can technically be split
+        _splitTabMenuItem.IsEnabled(isTerm || (content && content.try_as<winrt::TerminalApp::SnippetsPaneContent>() != nullptr));
     }
 
     // Method Description:
@@ -1652,7 +1661,7 @@ namespace winrt::TerminalApp::implementation
             Automation::AutomationProperties::SetHelpText(renameTabMenuItem, renameTabToolTip);
         }
 
-        Controls::MenuFlyoutItem duplicateTabMenuItem;
+        Controls::MenuFlyoutItem duplicateTabMenuItem = _duplicateTabMenuItem;
         {
             // "Duplicate tab"
             Controls::FontIcon duplicateTabSymbol;
@@ -1669,7 +1678,7 @@ namespace winrt::TerminalApp::implementation
             Automation::AutomationProperties::SetHelpText(duplicateTabMenuItem, duplicateTabToolTip);
         }
 
-        Controls::MenuFlyoutItem splitTabMenuItem;
+        Controls::MenuFlyoutItem splitTabMenuItem = _splitTabMenuItem;
         {
             // "Split tab"
             Controls::FontIcon splitTabSymbol;
@@ -1698,7 +1707,7 @@ namespace winrt::TerminalApp::implementation
             Automation::AutomationProperties::SetHelpText(closePaneMenuItem, closePaneToolTip);
         }
 
-        Controls::MenuFlyoutItem exportTabMenuItem;
+        Controls::MenuFlyoutItem exportTabMenuItem = _exportTabMenuItem;
         {
             // "Export tab"
             Controls::FontIcon exportTabSymbol;
@@ -1715,7 +1724,7 @@ namespace winrt::TerminalApp::implementation
             Automation::AutomationProperties::SetHelpText(exportTabMenuItem, exportTabToolTip);
         }
 
-        Controls::MenuFlyoutItem findMenuItem;
+        Controls::MenuFlyoutItem findMenuItem = _findMenuItem;
         {
             // "Find"
             Controls::FontIcon findSymbol;

--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -1254,7 +1254,7 @@ namespace winrt::TerminalApp::implementation
 
     // Method Description:
     // - Set an indicator on the tab if any pane is in a closed connection state.
-    // - Show/hide the Restart Connection context menu entry depending on active pane's state.
+    // - Show/hide the Restart Session context menu entry depending on active pane's state.
     // Arguments:
     // - <none>
     // Return Value:
@@ -1737,7 +1737,7 @@ namespace winrt::TerminalApp::implementation
         }
 
         {
-            // "Restart connection"
+            // "Restart session"
             Controls::FontIcon restartConnectionSymbol;
             restartConnectionSymbol.FontFamily(Media::FontFamily{ L"Segoe Fluent Icons, Segoe MDL2 Assets" });
             restartConnectionSymbol.Glyph(L"\xE72C");

--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -85,7 +85,7 @@ namespace winrt::TerminalApp::implementation
 
         _MakeTabViewItem();
         _CreateContextMenu();
-        _UpdateMenuItemEnablement();
+        _UpdateMenuItemStates();
 
         _headerControl.TabStatus(_tabStatus);
 
@@ -1342,10 +1342,10 @@ namespace winrt::TerminalApp::implementation
             });
         }
 
-        _UpdateMenuItemEnablement();
+        _UpdateMenuItemStates();
     }
 
-    void Tab::_UpdateMenuItemEnablement()
+    void Tab::_UpdateMenuItemStates()
     {
         // Terminal-specific menu items
         const auto content = _activePane ? _activePane->GetContent() : nullptr;
@@ -1661,106 +1661,100 @@ namespace winrt::TerminalApp::implementation
             Automation::AutomationProperties::SetHelpText(renameTabMenuItem, renameTabToolTip);
         }
 
-        Controls::MenuFlyoutItem duplicateTabMenuItem = _duplicateTabMenuItem;
         {
             // "Duplicate tab"
             Controls::FontIcon duplicateTabSymbol;
             duplicateTabSymbol.FontFamily(Media::FontFamily{ L"Segoe Fluent Icons, Segoe MDL2 Assets" });
             duplicateTabSymbol.Glyph(L"\xF5ED");
 
-            duplicateTabMenuItem.Click({ get_weak(), &Tab::_duplicateTabClicked });
-            duplicateTabMenuItem.Text(RS_(L"DuplicateTabText"));
-            duplicateTabMenuItem.Icon(duplicateTabSymbol);
+            _duplicateTabMenuItem.Click({ get_weak(), &Tab::_duplicateTabClicked });
+            _duplicateTabMenuItem.Text(RS_(L"DuplicateTabText"));
+            _duplicateTabMenuItem.Icon(duplicateTabSymbol);
 
             const auto duplicateTabToolTip = RS_(L"DuplicateTabToolTip");
 
-            WUX::Controls::ToolTipService::SetToolTip(duplicateTabMenuItem, box_value(duplicateTabToolTip));
-            Automation::AutomationProperties::SetHelpText(duplicateTabMenuItem, duplicateTabToolTip);
+            WUX::Controls::ToolTipService::SetToolTip(_duplicateTabMenuItem, box_value(duplicateTabToolTip));
+            Automation::AutomationProperties::SetHelpText(_duplicateTabMenuItem, duplicateTabToolTip);
         }
 
-        Controls::MenuFlyoutItem splitTabMenuItem = _splitTabMenuItem;
         {
             // "Split tab"
             Controls::FontIcon splitTabSymbol;
             splitTabSymbol.FontFamily(Media::FontFamily{ L"Segoe Fluent Icons, Segoe MDL2 Assets" });
             splitTabSymbol.Glyph(L"\xF246"); // ViewDashboard
 
-            splitTabMenuItem.Click({ get_weak(), &Tab::_splitTabClicked });
-            splitTabMenuItem.Text(RS_(L"SplitTabText"));
-            splitTabMenuItem.Icon(splitTabSymbol);
+            _splitTabMenuItem.Click({ get_weak(), &Tab::_splitTabClicked });
+            _splitTabMenuItem.Text(RS_(L"SplitTabText"));
+            _splitTabMenuItem.Icon(splitTabSymbol);
 
             const auto splitTabToolTip = RS_(L"SplitTabToolTip");
 
-            WUX::Controls::ToolTipService::SetToolTip(splitTabMenuItem, box_value(splitTabToolTip));
-            Automation::AutomationProperties::SetHelpText(splitTabMenuItem, splitTabToolTip);
+            WUX::Controls::ToolTipService::SetToolTip(_splitTabMenuItem, box_value(splitTabToolTip));
+            Automation::AutomationProperties::SetHelpText(_splitTabMenuItem, splitTabToolTip);
         }
 
-        Controls::MenuFlyoutItem closePaneMenuItem = _closePaneMenuItem;
         {
             // "Close pane"
-            closePaneMenuItem.Click({ get_weak(), &Tab::_closePaneClicked });
-            closePaneMenuItem.Text(RS_(L"ClosePaneText"));
+            _closePaneMenuItem.Click({ get_weak(), &Tab::_closePaneClicked });
+            _closePaneMenuItem.Text(RS_(L"ClosePaneText"));
 
             const auto closePaneToolTip = RS_(L"ClosePaneToolTip");
 
-            WUX::Controls::ToolTipService::SetToolTip(closePaneMenuItem, box_value(closePaneToolTip));
-            Automation::AutomationProperties::SetHelpText(closePaneMenuItem, closePaneToolTip);
+            WUX::Controls::ToolTipService::SetToolTip(_closePaneMenuItem, box_value(closePaneToolTip));
+            Automation::AutomationProperties::SetHelpText(_closePaneMenuItem, closePaneToolTip);
         }
 
-        Controls::MenuFlyoutItem exportTabMenuItem = _exportTabMenuItem;
         {
             // "Export tab"
             Controls::FontIcon exportTabSymbol;
             exportTabSymbol.FontFamily(Media::FontFamily{ L"Segoe Fluent Icons, Segoe MDL2 Assets" });
             exportTabSymbol.Glyph(L"\xE74E"); // Save
 
-            exportTabMenuItem.Click({ get_weak(), &Tab::_exportTextClicked });
-            exportTabMenuItem.Text(RS_(L"ExportTabText"));
-            exportTabMenuItem.Icon(exportTabSymbol);
+            _exportTabMenuItem.Click({ get_weak(), &Tab::_exportTextClicked });
+            _exportTabMenuItem.Text(RS_(L"ExportTabText"));
+            _exportTabMenuItem.Icon(exportTabSymbol);
 
             const auto exportTabToolTip = RS_(L"ExportTabToolTip");
 
-            WUX::Controls::ToolTipService::SetToolTip(exportTabMenuItem, box_value(exportTabToolTip));
-            Automation::AutomationProperties::SetHelpText(exportTabMenuItem, exportTabToolTip);
+            WUX::Controls::ToolTipService::SetToolTip(_exportTabMenuItem, box_value(exportTabToolTip));
+            Automation::AutomationProperties::SetHelpText(_exportTabMenuItem, exportTabToolTip);
         }
 
-        Controls::MenuFlyoutItem findMenuItem = _findMenuItem;
         {
             // "Find"
             Controls::FontIcon findSymbol;
             findSymbol.FontFamily(Media::FontFamily{ L"Segoe Fluent Icons, Segoe MDL2 Assets" });
             findSymbol.Glyph(L"\xF78B"); // SearchMedium
 
-            findMenuItem.Click({ get_weak(), &Tab::_findClicked });
-            findMenuItem.Text(RS_(L"FindText"));
-            findMenuItem.Icon(findSymbol);
+            _findMenuItem.Click({ get_weak(), &Tab::_findClicked });
+            _findMenuItem.Text(RS_(L"FindText"));
+            _findMenuItem.Icon(findSymbol);
 
             const auto findToolTip = RS_(L"FindToolTip");
 
-            WUX::Controls::ToolTipService::SetToolTip(findMenuItem, box_value(findToolTip));
-            Automation::AutomationProperties::SetHelpText(findMenuItem, findToolTip);
+            WUX::Controls::ToolTipService::SetToolTip(_findMenuItem, box_value(findToolTip));
+            Automation::AutomationProperties::SetHelpText(_findMenuItem, findToolTip);
         }
 
-        Controls::MenuFlyoutItem restartConnectionMenuItem = _restartConnectionMenuItem;
         {
             // "Restart connection"
             Controls::FontIcon restartConnectionSymbol;
             restartConnectionSymbol.FontFamily(Media::FontFamily{ L"Segoe Fluent Icons, Segoe MDL2 Assets" });
             restartConnectionSymbol.Glyph(L"\xE72C");
 
-            restartConnectionMenuItem.Click([weakThis](auto&&, auto&&) {
+            _restartConnectionMenuItem.Click([weakThis](auto&&, auto&&) {
                 if (auto tab{ weakThis.get() })
                 {
                     tab->_RestartActivePaneConnection();
                 }
             });
-            restartConnectionMenuItem.Text(RS_(L"RestartConnectionText"));
-            restartConnectionMenuItem.Icon(restartConnectionSymbol);
+            _restartConnectionMenuItem.Text(RS_(L"RestartConnectionText"));
+            _restartConnectionMenuItem.Icon(restartConnectionSymbol);
 
             const auto restartConnectionToolTip = RS_(L"RestartConnectionToolTip");
 
-            WUX::Controls::ToolTipService::SetToolTip(restartConnectionMenuItem, box_value(restartConnectionToolTip));
-            Automation::AutomationProperties::SetHelpText(restartConnectionMenuItem, restartConnectionToolTip);
+            WUX::Controls::ToolTipService::SetToolTip(_restartConnectionMenuItem, box_value(restartConnectionToolTip));
+            Automation::AutomationProperties::SetHelpText(_restartConnectionMenuItem, restartConnectionToolTip);
         }
 
         // Build the menu
@@ -1768,16 +1762,16 @@ namespace winrt::TerminalApp::implementation
         Controls::MenuFlyoutSeparator menuSeparator;
         contextMenuFlyout.Items().Append(chooseColorMenuItem);
         contextMenuFlyout.Items().Append(renameTabMenuItem);
-        contextMenuFlyout.Items().Append(duplicateTabMenuItem);
-        contextMenuFlyout.Items().Append(splitTabMenuItem);
+        contextMenuFlyout.Items().Append(_duplicateTabMenuItem);
+        contextMenuFlyout.Items().Append(_splitTabMenuItem);
         _AppendMoveMenuItems(contextMenuFlyout);
-        contextMenuFlyout.Items().Append(exportTabMenuItem);
-        contextMenuFlyout.Items().Append(findMenuItem);
-        contextMenuFlyout.Items().Append(restartConnectionMenuItem);
+        contextMenuFlyout.Items().Append(_exportTabMenuItem);
+        contextMenuFlyout.Items().Append(_findMenuItem);
+        contextMenuFlyout.Items().Append(_restartConnectionMenuItem);
         contextMenuFlyout.Items().Append(menuSeparator);
 
         auto closeSubMenu = _AppendCloseMenuItems(contextMenuFlyout);
-        closeSubMenu.Items().Append(closePaneMenuItem);
+        closeSubMenu.Items().Append(_closePaneMenuItem);
 
         // GH#5750 - When the context menu is dismissed with ESC, toss the focus
         // back to our control.

--- a/src/cascadia/TerminalApp/Tab.h
+++ b/src/cascadia/TerminalApp/Tab.h
@@ -140,11 +140,17 @@ namespace winrt::TerminalApp::implementation
         static constexpr double HeaderRenameBoxWidthTitleLength{ std::numeric_limits<double>::infinity() };
 
         winrt::Windows::UI::Xaml::FocusState _focusState{ winrt::Windows::UI::Xaml::FocusState::Unfocused };
-        winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem _closeOtherTabsMenuItem{};
-        winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem _closeTabsAfterMenuItem{};
+        winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem _duplicateTabMenuItem{};
+        winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem _splitTabMenuItem{};
         winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem _moveToNewWindowMenuItem{};
         winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem _moveRightMenuItem{};
         winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem _moveLeftMenuItem{};
+        winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem _exportTabMenuItem{};
+        winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem _findMenuItem{};
+        winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem _restartConnectionMenuItem{};
+        winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem _closeOtherTabsMenuItem{};
+        winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem _closeTabsAfterMenuItem{};
+        winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem _closePaneMenuItem{};
         winrt::TerminalApp::ShortcutActionDispatch _dispatch;
         Microsoft::Terminal::Settings::Model::IActionMapView _actionMap{ nullptr };
         winrt::hstring _keyChord{};
@@ -158,9 +164,6 @@ namespace winrt::TerminalApp::implementation
         std::shared_ptr<Pane> _rootPane{ nullptr };
         std::shared_ptr<Pane> _activePane{ nullptr };
         std::shared_ptr<Pane> _zoomedPane{ nullptr };
-
-        Windows::UI::Xaml::Controls::MenuFlyoutItem _closePaneMenuItem;
-        Windows::UI::Xaml::Controls::MenuFlyoutItem _restartConnectionMenuItem;
 
         winrt::Microsoft::Terminal::Settings::Model::IconStyle _lastIconStyle;
         winrt::hstring _lastIconPath{};
@@ -220,6 +223,7 @@ namespace winrt::TerminalApp::implementation
         void _AttachEventHandlersToPane(std::shared_ptr<Pane> pane);
 
         void _UpdateActivePane(std::shared_ptr<Pane> pane);
+        void _UpdateMenuItemEnablement();
 
         winrt::hstring _GetActiveTitle() const;
 
@@ -229,8 +233,6 @@ namespace winrt::TerminalApp::implementation
 
         void _UpdateConnectionClosedState();
         void _RestartActivePaneConnection();
-
-        void _DuplicateTab();
 
         winrt::Windows::UI::Xaml::Media::Brush _BackgroundBrush();
 

--- a/src/cascadia/TerminalApp/Tab.h
+++ b/src/cascadia/TerminalApp/Tab.h
@@ -223,7 +223,7 @@ namespace winrt::TerminalApp::implementation
         void _AttachEventHandlersToPane(std::shared_ptr<Pane> pane);
 
         void _UpdateActivePane(std::shared_ptr<Pane> pane);
-        void _UpdateMenuItemEnablement();
+        void _UpdateMenuItemStates();
 
         winrt::hstring _GetActiveTitle() const;
 

--- a/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
@@ -702,7 +702,7 @@
     <comment>When enabled, input will go to all panes in this tab simultaneously</comment>
   </data>
   <data name="RestartConnectionKey" xml:space="preserve">
-    <value>Restart connection</value>
+    <value>Restart session</value>
   </data>
   <data name="OpenScratchpadKey" xml:space="preserve">
     <value>Open scratchpad</value>


### PR DESCRIPTION
## Summary of the Pull Request
Changes how/when we display the "restart connection" item in the tab's context menu. Now, we always display it, but it's disabled if we're not in a terminal tab.

Applies similar enable/disable logic to the rest of the menu items. Previous to this, they just wouldn't do anything (which is fair, they didn't make any sense).

## Validation Steps Performed
Check tab's menu in following scenarios:
✅ terminal pane
✅ settings tab
✅ snippets pane

Closes #18891