### PR TITLE
OS-15022958: conhost: onboard our RI-TPs for other internal Windows editions

### DIFF
--- a/src/buffer/out/ut_textbuffer/UTextAdapterTests.cpp
+++ b/src/buffer/out/ut_textbuffer/UTextAdapterTests.cpp
@@ -34,6 +34,16 @@ class UTextAdapterTests
 {
     TEST_CLASS(UTextAdapterTests);
 
+    TEST_CLASS_SETUP(ClassSetup)
+    {
+        wil::unique_hmodule icu{ LoadLibraryExW(L"icu.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32) };
+        if (!icu)
+        {
+            WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped, L"ICU is not present");
+        }
+        return true;
+    }
+
     TEST_METHOD(Unicode)
     {
         DummyRenderer renderer;

--- a/src/buffer/out/ut_textbuffer/sources
+++ b/src/buffer/out/ut_textbuffer/sources
@@ -26,6 +26,9 @@ TARGETLIBS = \
     $(CONSOLE_OBJ_PATH)\types\lib\$(O)\ConTypes.lib \
     $(TARGETLIBS) \
 
+DELAYLOAD = \
+    icu.dll \
+
 # -------------------------------------
 # Localization
 # -------------------------------------

--- a/src/host/ft_host/testmd.definition
+++ b/src/host/ft_host/testmd.definition
@@ -40,6 +40,12 @@
       "Execution": {
         "AdditionalParameter": "/select:\"@IsPerfTest=true\""
       }
+    },
+    {
+      "Name": "NoAppPlatform",
+      "Execution": {
+        "AdditionalParameter": "/select:\"not(@Name='PolicyTests::*')\""
+      }
     }
   ]
 }

--- a/src/host/ut_host/SearchTests.cpp
+++ b/src/host/ut_host/SearchTests.cpp
@@ -18,10 +18,17 @@ class SearchTests
 {
     TEST_CLASS(SearchTests);
 
-    CommonState* m_state;
+    CommonState* m_state{ nullptr };
 
     TEST_CLASS_SETUP(ClassSetup)
     {
+        wil::unique_hmodule icu{ LoadLibraryExW(L"icu.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32) };
+        if (!icu)
+        {
+            Log::Result(TestResults::Skipped, L"ICU is not present");
+            return true;
+        }
+
         m_state = new CommonState();
         m_state->PrepareGlobalScreenBuffer();
         return true;
@@ -29,8 +36,11 @@ class SearchTests
 
     TEST_CLASS_CLEANUP(ClassCleanup)
     {
-        m_state->CleanupGlobalScreenBuffer();
-        delete m_state;
+        if (m_state)
+        {
+            m_state->CleanupGlobalScreenBuffer();
+            delete m_state;
+        }
         return true;
     }
 

--- a/src/testlist/Microsoft.Console.TestLab.Desktop.testlist
+++ b/src/testlist/Microsoft.Console.TestLab.Desktop.testlist
@@ -2,5 +2,8 @@
   "$schema": "http://universaltest/schema/testlist-2.json",
   "Testlists": [
         { "FilePath": "Microsoft.Console.Tests.testlist" }
-    ]
+    ],
+  "TestMDs" :  [
+    { "FilePath": "Microsoft.Console.Host.FeatureTests.testmd" }
+  ]
 }

--- a/src/testlist/Microsoft.Console.TestLab.OneCoreUap.testlist
+++ b/src/testlist/Microsoft.Console.TestLab.OneCoreUap.testlist
@@ -2,5 +2,8 @@
   "$schema": "http://universaltest/schema/testlist-2.json",
   "Testlists": [
         { "FilePath": "Microsoft.Console.Tests.testlist" }
-    ]
+    ],
+  "TestMDs" :  [
+    { "FilePath": "Microsoft.Console.Host.FeatureTests.testmd" }
+  ]
 }

--- a/src/testlist/Microsoft.Console.TestLab.Win3.testlist
+++ b/src/testlist/Microsoft.Console.TestLab.Win3.testlist
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://universaltest/schema/testlist-3.json",
+  "Testlists": [
+    {
+      "FilePath": "Microsoft.Console.Tests.testlist"
+    }
+  ],
+  "TestMDs": [
+    {
+      "FilePath": "Microsoft.Console.Host.FeatureTests.testmd",
+      "Profile": "NoAppPlatform"
+    }
+  ]
+}

--- a/src/testlist/Microsoft.Console.Tests.testlist
+++ b/src/testlist/Microsoft.Console.Tests.testlist
@@ -3,7 +3,6 @@
   "TestMDs" :  [
     { "FilePath": "Microsoft.Console.Host.UnitTests.testmd" },
     { "FilePath": "Microsoft.Console.TextBuffer.UnitTests.testmd" },
-    { "FilePath": "Microsoft.Console.Host.FeatureTests.testmd" },
     { "FilePath": "Microsoft.Console.VirtualTerminal.Adapter.UnitTests.testmd" },
     { "FilePath": "Microsoft.Console.VirtualTerminal.Parser.UnitTests.testmd" },
     { "FilePath": "Microsoft.Console.Conpty.UnitTests.testmd" },

--- a/src/testlist/sources
+++ b/src/testlist/sources
@@ -8,6 +8,7 @@ TESTLIST_SOURCES=\
     Microsoft.Console.TestLab.Desktop.testlist \
     Microsoft.Console.TestLab.OneCoreUap.testlist \
     Microsoft.Console.TestLab.Performance.testlist \
+    Microsoft.Console.TestLab.Win3.testlist \
 
 TESTLIST_REFERENCE_DIRS=\
     $(OBJ_PATH)\..\interactivity\win32\ut_interactivity_win32\$O \

--- a/src/types/ut_types/sources
+++ b/src/types/ut_types/sources
@@ -28,6 +28,9 @@ TARGETLIBS = \
     $(ONECORE_EXTERNAL_SDK_LIB_PATH)\ntdll.lib \
     $(TARGETLIBS) \
 
+DELAYLOAD = \
+    icu.dll \
+
 # -------------------------------------
 # Localization
 # -------------------------------------

--- a/src/winconpty/ft_pty/ConPtyTests.cpp
+++ b/src/winconpty/ft_pty/ConPtyTests.cpp
@@ -39,7 +39,8 @@ static Pipes createPipes()
     VERIFY_IS_TRUE(SetHandleInformation(p.our.out.get(), HANDLE_FLAG_INHERIT, 0));
 
     // ConPTY requests a DA1 report on startup. Emulate the response from the terminal.
-    WriteFile(p.our.in.get(), "\x1b[?61c", 6, nullptr, nullptr);
+    DWORD written{};
+    WriteFile(p.our.in.get(), "\x1b[?61c", 6, &written, nullptr);
 
     return p;
 }
@@ -125,6 +126,7 @@ static HRESULT AttachPseudoConsole(HPCON hPC, std::wstring command, PROCESS_INFO
 
     STARTUPINFOEXW siEx{};
     siEx.StartupInfo.cb = sizeof(STARTUPINFOEXW);
+    siEx.StartupInfo.dwFlags = STARTF_USESTDHANDLES; // we will leave the handles empty to ensure none are inherited.
     siEx.lpAttributeList = reinterpret_cast<PPROC_THREAD_ATTRIBUTE_LIST>(buffer.get());
 
     RETURN_IF_WIN32_BOOL_FALSE(InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, &size));


### PR DESCRIPTION
This required the following changes:
- Delayloading ICU in all of our tests, and skipping tests where it could not be loaded
- Adding a new test group which skips the PolicyTests, which cannot be run on some editions which have no app platform.

In addition, instead of onboarding new failing test passes, this pull request finally repairs the broken ConPTY tests (which diverged from the OSS implementation and had to be re-en-verged)

Closes MSFT-61409507
Reflected from OS PR !15022958