### PR TITLE
avoid committing rows just to figure out rendition, blink and cursor

### DIFF
--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -219,6 +219,17 @@ til::CoordType TextBuffer::_estimateOffsetOfLastCommittedRow() const noexcept
     return std::max(0, gsl::narrow_cast<til::CoordType>(lastRowOffset - 2));
 }
 
+bool TextBuffer::_isRowCommitted(til::CoordType y) const noexcept
+{
+    auto offset = (_firstRow + y + 1 /* account for the scratch row */) % _height;
+    if (offset < 0)
+    {
+        offset += _height;
+    }
+    const auto row = _buffer.get() + _bufferRowStride * offset;
+    return row < _commitWatermark;
+}
+
 // Retrieves a row from the buffer by its offset from the first row of the text buffer
 // (what corresponds to the top row of the screen buffer).
 const ROW& TextBuffer::GetRowByOffset(const til::CoordType index) const
@@ -934,6 +945,10 @@ void TextBuffer::ResetLineRenditionRange(const til::CoordType startRow, const ti
 
 LineRendition TextBuffer::GetLineRendition(const til::CoordType row) const
 {
+    if (!_isRowCommitted(row)) [[unlikely]]
+    {
+        return LineRendition::SingleWidth;
+    }
     return GetRowByOffset(row).GetLineRendition();
 }
 
@@ -3511,4 +3526,35 @@ void TextBuffer::ManuallyMarkRowAsPrompt(til::CoordType y)
     {
         attr.SetMarkAttributes(MarkKind::Prompt);
     }
+}
+
+// This is an optimization used by the renderer to avoid scheduling a timer if not necessary;
+// unlike the renderer, we know the committed range of our own buffer.
+bool TextBuffer::ContainsBlinkAttributeInRegion(const Microsoft::Console::Types::Viewport& region) const
+{
+    const auto top = region.Top();
+    auto bottom = std::min(region.BottomInclusive(), _estimateOffsetOfLastCommittedRow());
+
+    for (auto row = top; row < bottom; ++row)
+    {
+        const auto& r = GetRowByOffset(row);
+        for (const auto& attr : r.Attributes())
+        {
+            if (attr.IsBlinking())
+            {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+bool TextBuffer::IsGlyphDoubleWidthAt(const til::point at) const
+{
+    if (!_isRowCommitted(at.y)) [[unlikely]]
+    {
+        return false;
+    }
+    return _getRow(at.y).DbcsAttrAt(at.x) != DbcsAttribute::Single;
 }

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -310,6 +310,9 @@ public:
     void SetScrollbarData(ScrollbarData mark, til::CoordType y);
     void ManuallyMarkRowAsPrompt(til::CoordType y);
 
+    bool ContainsBlinkAttributeInRegion(const Microsoft::Console::Types::Viewport& region) const;
+    bool IsGlyphDoubleWidthAt(const til::point at) const;
+
 private:
     void _reserve(til::size screenBufferSize, const TextAttribute& defaultAttributes);
     void _commit(const std::byte* row);
@@ -319,6 +322,7 @@ private:
     ROW& _getRowByOffsetDirect(size_t offset);
     ROW& _getRow(til::CoordType y) const;
     til::CoordType _estimateOffsetOfLastCommittedRow() const noexcept;
+    bool _isRowCommitted(til::CoordType y) const noexcept;
 
     void _SetFirstRowIndex(const til::CoordType FirstRowIndex) noexcept;
     void _ExpandTextRow(til::inclusive_rect& selectionRow) const;

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -789,22 +789,8 @@ bool Renderer::_CheckViewportAndScroll()
 void Renderer::_scheduleRenditionBlink()
 {
     const auto& buffer = _pData->GetTextBuffer();
-    bool blinkUsed = false;
+    const auto blinkUsed = buffer.ContainsBlinkAttributeInRegion(_viewport);
 
-    for (auto row = _viewport.Top(); row < _viewport.BottomExclusive(); ++row)
-    {
-        const auto& r = buffer.GetRowByOffset(row);
-        for (const auto& attr : r.Attributes())
-        {
-            if (attr.IsBlinking())
-            {
-                blinkUsed = true;
-                goto why_does_cpp_not_have_labeled_loops;
-            }
-        }
-    }
-
-why_does_cpp_not_have_labeled_loops:
     if (blinkUsed != IsTimerRunning(_renditionBlinker))
     {
         if (blinkUsed)
@@ -1530,7 +1516,7 @@ void Renderer::_updateCursorInfo()
     _currentCursorOptions.lineRendition = lineRendition;
     _currentCursorOptions.ulCursorHeightPercent = cursorHeight;
     _currentCursorOptions.cursorPixelWidth = _pData->GetCursorPixelWidth();
-    _currentCursorOptions.fIsDoubleWidth = buffer.GetRowByOffset(cursorPosition.y).DbcsAttrAt(cursorPosition.x) != DbcsAttribute::Single;
+    _currentCursorOptions.fIsDoubleWidth = buffer.IsGlyphDoubleWidthAt(cursorPosition);
     _currentCursorOptions.cursorType = cursor.GetType();
     _currentCursorOptions.fUseColor = useColor;
     _currentCursorOptions.cursorColor = cursorColor;


### PR DESCRIPTION
We have been looking at a set of conhost crashes due to low-memory conditions. I've observed that they all happen during the first pass of rendering, before there's even an engine set up, when we try to estimate whether there are any blink attributes. I also found that we'll commit the buffer to check the cursor's double-width status and whether it's on a double-width-rendition line.

Uncommitted rows _never_ contain a blinker, are never double-width and never contain DBCS.

We can't necessarily avoid committing an empty buffer _forever,_ but this at least moves the first commit until after the renderer truly starts.

This prevents us from committing an empty buffer for headless console apps (!)