### PR TITLE
Fix Settings tab color mismatch with Settings page background

### DIFF
--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -192,7 +192,7 @@
                                             ResourceKey="TabViewBackground" />
 
                             <SolidColorBrush x:Key="SettingsUiTabBrush"
-                                             Color="#0c0c0c" />
+                                             Color="#282828" />
 
                             <SolidColorBrush x:Key="BroadcastPaneBorderColor"
                                              Color="{StaticResource SystemAccentColorDark2}" />
@@ -211,7 +211,7 @@
                                             ResourceKey="TabViewBackground" />
 
                             <SolidColorBrush x:Key="SettingsUiTabBrush"
-                                             Color="#ffffff" />
+                                             Color="#F9F9F9" />
 
                             <SolidColorBrush x:Key="BroadcastPaneBorderColor"
                                              Color="{StaticResource SystemAccentColorLight2}" />
@@ -234,7 +234,7 @@
                                             ResourceKey="SystemColorButtonFaceColorBrush" />
 
                             <StaticResource x:Key="SettingsUiTabBrush"
-                                            ResourceKey="SystemControlBackgroundBaseLowBrush" />
+                                            ResourceKey="SystemColorWindowBrush" />
 
                             <SolidColorBrush x:Key="BroadcastPaneBorderColor"
                                              Color="{StaticResource SystemColorHighlightColor}" />


### PR DESCRIPTION
## Summary

Fixes #19873

The Settings tab color (`SettingsUiTabBrush`) was out of sync with the Settings page background (`SettingsPageBackground`), causing a visible mismatch - the tab appeared black while the page was dark gray.

## Changes

Aligned `SettingsUiTabBrush` in `App.xaml` to match `SettingsPageBackground` from `MainPage.xaml`:

| Theme | Before (tab) | After (tab) | Matches page |
|---|---|---|---|
| **Dark** | `#0c0c0c` | `#282828` | Yes |
| **Light** | `#ffffff` | `#F9F9F9` | Yes |
| **HighContrast** | `SystemControlBackgroundBaseLowBrush` | `SystemColorWindowBrush` | Yes |

<img width="2191" height="182" alt="image" src="https://github.com/user-attachments/assets/a368ee3b-9612-41e3-a385-b68b99d4e064" />

## Validation

- Built and deployed locally as Windows Terminal Dev
- Verified Settings tab and page backgrounds match in Dark and Light themes
- No impact on other tab colors or theming