### PR TITLE
Fix MSB4019 error in ConPTY nupkg

### DIFF
--- a/src/winconpty/package/native/Microsoft.Windows.Console.ConPTY.props
+++ b/src/winconpty/package/native/Microsoft.Windows.Console.ConPTY.props
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildThisProjectDirectory)\..\Microsoft.Windows.Console.ConPTY.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\Microsoft.Windows.Console.ConPTY.props" />
 </Project>


### PR DESCRIPTION
## Summary of the Pull Request
This PR fixes the following error that occurs when attempting to use the `Microsoft.Windows.Console.ConPTY` nupkg in a Visual C++ project:
```
MSB4019: The imported project "C:\Microsoft.Windows.Console.ConPTY.props" was not found. Confirm that the expression in the Import declaration "$(MSBuildThisProjectDirectory)\..\Microsoft.Windows.Console.ConPTY.props", which evaluated to "\..\Microsoft.Windows.Console.ConPTY.props", is correct, and that the file exists on disk.
```

## References and Relevant Issues
(None)

## Detailed Description of the Pull Request / Additional comments
Based on the [list of reserved and well-known properties](https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-reserved-and-well-known-properties?view=visualstudio), the property `MSBuildThisProjectDirectory` does not appear to exist. This PR replaces it with the correct property, `MSBuildThisFileDirectory`.

## Validation Steps Performed
Verified that after applying this fix and packaging, the MSB4019 error no longer occurs. (Note: A different error now appears, but I will file a separate issue for that shortly.)

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
