### PR TITLE
Reinstate the (apparently) load-bearing empty bracketed paste

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2972,7 +2972,11 @@ namespace winrt::TerminalApp::implementation
             text = winrt::hstring{ Utils::TrimPaste(text) };
         }
 
-        if (text.empty())
+        // LOAD BEARING: Send an empty bracketed paste even if the clipboard was empty.
+        // Bracketed Paste provides an application a way to know whether the
+        // user pasted, even if there was no applicable content on it. This
+        // behavior is observed in GNOME Terminal, among others.
+        if (!bracketedPaste && text.empty())
         {
             co_return;
         }


### PR DESCRIPTION
Some applications have come to rely on an "empty" bracketed paste packet to indicate that the clipboard was _requested,_ but not sent. Some agentic CLI tools use this to guess whether the clipboard contained e.g. an image or otherwise unserializable data.

Apparently, gnome-terminal and VS Code do this; others as well (I tested xterm, konsole, gnome-terminal and I can't remember which ones did and which ones did not.)

Refs #19517