### PR TITLE
Fix Korean IME overlay hiding characters to the right of cursor

### DIFF
--- a/src/buffer/out/Row.cpp
+++ b/src/buffer/out/Row.cpp
@@ -1143,6 +1143,13 @@ til::CoordType ROW::GetTrailingColumnAtCharOffset(const ptrdiff_t offset) const 
     return _createCharToColumnMapper(offset).GetTrailingColumnAt(offset);
 }
 
+uint16_t ROW::GetCharOffset(til::CoordType col) const noexcept
+{
+    const auto columns = GetReadableColumnCount();
+    const auto colBeg = clamp(col, 0, columns);
+    return _uncheckedCharOffset(gsl::narrow_cast<size_t>(colBeg));
+}
+
 DelimiterClass ROW::DelimiterClassAt(til::CoordType column, const std::wstring_view& wordDelimiters) const noexcept
 {
     const auto col = _clampedColumn(column);

--- a/src/buffer/out/Row.hpp
+++ b/src/buffer/out/Row.hpp
@@ -172,6 +172,7 @@ public:
     std::wstring_view GetText(til::CoordType columnBegin, til::CoordType columnEnd) const noexcept;
     til::CoordType GetLeadingColumnAtCharOffset(ptrdiff_t offset) const noexcept;
     til::CoordType GetTrailingColumnAtCharOffset(ptrdiff_t offset) const noexcept;
+    uint16_t GetCharOffset(til::CoordType col) const noexcept;
     DelimiterClass DelimiterClassAt(til::CoordType column, const std::wstring_view& wordDelimiters) const noexcept;
 
     auto AttrBegin() const noexcept { return _attr.begin(); }

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -1061,109 +1061,7 @@ void Renderer::_PaintBufferOutput(_In_ IRenderEngine* const pEngine)
             ROW* rowBackup = nullptr;
             if (row == compositionRow)
             {
-                auto& scratch = buffer.GetScratchpadRow();
-                scratch.CopyFrom(r);
-                rowBackup = &scratch;
-
-                std::wstring_view text{ activeComposition.text };
-                RowWriteState state{
-                    .columnLimit = r.GetReadableColumnCount(),
-                    .columnEnd = _compositionCache->absoluteOrigin.x,
-                };
-
-                size_t off = 0;
-                for (const auto& range : activeComposition.attributes)
-                {
-                    const auto len = range.len;
-                    auto attr = range.attr;
-
-                    // Use the color at the cursor if TSF didn't specify any explicit color.
-                    if (attr.GetBackground().IsDefault())
-                    {
-                        attr.SetBackground(_compositionCache->baseAttribute.GetBackground());
-                    }
-                    if (attr.GetForeground().IsDefault())
-                    {
-                        attr.SetForeground(_compositionCache->baseAttribute.GetForeground());
-                    }
-
-                    state.text = text.substr(off, len);
-                    state.columnBegin = state.columnEnd;
-                    const_cast<ROW&>(r).ReplaceText(state);
-                    const_cast<ROW&>(r).ReplaceAttributes(state.columnBegin, state.columnEnd, attr);
-                    off += len;
-                }
-
-                // Render the composition as an insertion by copying original
-                // characters from the cursor position to the right of the
-                // composition text, absorbing up to W whitespace columns in the
-                // process. This keeps TUI box borders at their original column
-                // when there is sufficient whitespace padding to the right.
-                //
-                // Algorithm: walk the original row (scratch) from origCursorCol,
-                // skipping up to W whitespace columns ("absorbing" them), and
-                // copying non-whitespace glyphs to r starting at compositionEnd.
-                // When the whitespace budget reaches 0, srcCol == dstCol and the
-                // remaining content in r is already correct, so we stop early.
-                const auto compositionWidth = state.columnEnd - _compositionCache->absoluteOrigin.x;
-                const auto origCursorCol = _compositionCache->absoluteOrigin.x;
-                const auto colLimit = r.GetReadableColumnCount();
-
-                if (compositionWidth > 0 && state.columnEnd < colLimit)
-                {
-                    auto srcCol = origCursorCol;
-                    auto dstCol = state.columnEnd;
-                    auto whitespaceToAbsorb = compositionWidth;
-
-                    while (srcCol < colLimit)
-                    {
-                        // All whitespace absorbed: srcCol == dstCol, r already correct.
-                        if (whitespaceToAbsorb == 0)
-                        {
-                            break;
-                        }
-
-                        const auto glyphEnd = scratch.NavigateToNext(srcCol);
-                        const auto glyphWidth = glyphEnd - srcCol;
-                        const auto glyphText = scratch.GetText(srcCol, glyphEnd);
-
-                        // Absorb half-width (U+0020) or full-width (U+3000) spaces
-                        // only when the budget covers the glyph's full width.
-                        const bool absorb =
-                            whitespaceToAbsorb >= glyphWidth &&
-                            !glyphText.empty() &&
-                            (glyphText[0] == L' ' || glyphText[0] == L'\u3000');
-
-                        if (absorb)
-                        {
-                            whitespaceToAbsorb -= glyphWidth;
-                            srcCol = glyphEnd;
-                        }
-                        else
-                        {
-                            if (dstCol < colLimit)
-                            {
-                                RowCopyTextFromState cs{
-                                    .source = scratch,
-                                    .columnBegin = dstCol,
-                                    .columnLimit = dstCol + glyphWidth,
-                                    .sourceColumnBegin = srcCol,
-                                    .sourceColumnLimit = glyphEnd,
-                                };
-                                const_cast<ROW&>(r).CopyTextFrom(cs);
-
-                                const_cast<ROW&>(r).Attributes().replace(
-                                    gsl::narrow_cast<uint16_t>(dstCol),
-                                    gsl::narrow_cast<uint16_t>(dstCol + glyphWidth),
-                                    scratch.Attributes().slice(
-                                        gsl::narrow_cast<uint16_t>(srcCol),
-                                        gsl::narrow_cast<uint16_t>(glyphEnd)));
-                            }
-                            srcCol = glyphEnd;
-                            dstCol += glyphWidth;
-                        }
-                    }
-                }
+                rowBackup = _PaintBufferOutputComposition(buffer, r, activeComposition);
             }
             const auto restore = wil::scope_exit([&] {
                 if (rowBackup)
@@ -1201,6 +1099,107 @@ void Renderer::_PaintBufferOutput(_In_ IRenderEngine* const pEngine)
             }
         }
     }
+}
+
+ROW* Renderer::_PaintBufferOutputComposition(TextBuffer& buffer, const ROW& r, const Composition& activeComposition)
+{
+    auto& scratch = buffer.GetScratchpadRow();
+    scratch.CopyFrom(r);
+
+    // *Overwrite* the original text with the active composition...
+    til::CoordType compositionEnd = 0;
+    {
+        std::wstring_view text{ activeComposition.text };
+        RowWriteState state{
+            .columnLimit = r.GetReadableColumnCount(),
+            .columnEnd = _compositionCache->absoluteOrigin.x,
+        };
+
+        size_t off = 0;
+        for (const auto& range : activeComposition.attributes)
+        {
+            const auto len = range.len;
+            auto attr = range.attr;
+
+            // Use the color at the cursor if TSF didn't specify any explicit color.
+            if (attr.GetBackground().IsDefault())
+            {
+                attr.SetBackground(_compositionCache->baseAttribute.GetBackground());
+            }
+            if (attr.GetForeground().IsDefault())
+            {
+                attr.SetForeground(_compositionCache->baseAttribute.GetForeground());
+            }
+
+            state.text = text.substr(off, len);
+            state.columnBegin = state.columnEnd;
+            const_cast<ROW&>(r).ReplaceText(state);
+            const_cast<ROW&>(r).ReplaceAttributes(state.columnBegin, state.columnEnd, attr);
+            off += len;
+        }
+
+        compositionEnd = state.columnEnd;
+    }
+
+    // The text we've overwritten may have been crucial to the user,
+    // so copy it back by absorbing available whitespace to the right
+    // and re-inserting the non-whitespace characters instead.
+    const auto compositionWidth = compositionEnd - _compositionCache->absoluteOrigin.x;
+    const auto colLimit = r.GetReadableColumnCount();
+    if (compositionWidth > 0 && compositionEnd < colLimit)
+    {
+        const auto text = scratch.GetText();
+        auto srcCol = _compositionCache->absoluteOrigin.x;
+        auto dstCol = compositionEnd;
+        auto remaining = compositionWidth;
+        size_t i = scratch.GetCharOffset(srcCol);
+
+        while (i < text.size() && dstCol < colLimit)
+        {
+            // Treat whitespace we encounter as a credit towards our composition width.
+            // This loop essentially absorbs the whitespace.
+            while (i < text.size() && til::at(text, i) == L' ' && remaining > 0)
+            {
+                remaining--;
+                srcCol++;
+                i++;
+            }
+            if (remaining <= 0)
+            {
+                break;
+            }
+
+            // Find the end of the non-whitespace span: Our span of text to insert.
+            auto spanEnd = i;
+            while (spanEnd < text.size() && til::at(text, spanEnd) != L' ')
+            {
+                spanEnd++;
+            }
+
+            // Copy the non-whitespace segment from the original text (scratch) back in.
+            RowCopyTextFromState state{
+                .source = scratch,
+                .columnBegin = dstCol,
+                .columnLimit = colLimit,
+                .sourceColumnBegin = srcCol,
+                .sourceColumnLimit = scratch.GetLeadingColumnAtCharOffset(spanEnd),
+            };
+            const_cast<ROW&>(r).CopyTextFrom(state);
+
+            const auto srcBeg = gsl::narrow_cast<uint16_t>(srcCol);
+            const auto srcEnd = gsl::narrow_cast<uint16_t>(state.sourceColumnEnd);
+            const auto attr = scratch.Attributes().slice(srcBeg, srcEnd);
+            const auto dstBeg = gsl::narrow_cast<uint16_t>(dstCol);
+            const auto dstEnd = gsl::narrow_cast<uint16_t>(dstCol + attr.size());
+            const_cast<ROW&>(r).Attributes().replace(dstBeg, dstEnd, attr);
+
+            dstCol = state.columnEnd;
+            srcCol = state.sourceColumnEnd;
+            i = spanEnd;
+        }
+    }
+
+    return &scratch;
 }
 
 static bool _IsAllSpaces(const std::wstring_view v)

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -1090,6 +1090,37 @@ void Renderer::_PaintBufferOutput(_In_ IRenderEngine* const pEngine)
                     const_cast<ROW&>(r).ReplaceAttributes(state.columnBegin, state.columnEnd, attr);
                     off += len;
                 }
+
+                // After writing the composition text, copy the original characters
+                // that were at and after the cursor position into the space to the
+                // right of the composition text. This renders the in-progress
+                // composition as an insertion rather than an overwrite, so that
+                // existing characters to the right of the cursor are not hidden.
+                const auto compositionEnd = state.columnEnd;
+                const auto origCursorCol = _compositionCache->absoluteOrigin.x;
+                const auto colLimit = r.GetReadableColumnCount();
+
+                if (compositionEnd > origCursorCol && compositionEnd < colLimit)
+                {
+                    RowCopyTextFromState copyState{
+                        .source = scratch,
+                        .columnBegin = compositionEnd,
+                        .columnLimit = colLimit,
+                        .sourceColumnBegin = origCursorCol,
+                        .sourceColumnLimit = colLimit,
+                    };
+                    const_cast<ROW&>(r).CopyTextFrom(copyState);
+
+                    const auto srcBeg = gsl::narrow_cast<uint16_t>(origCursorCol);
+                    const auto srcEnd = gsl::narrow_cast<uint16_t>(scratch.GetReadableColumnCount());
+                    const auto dstBeg = gsl::narrow_cast<uint16_t>(compositionEnd);
+                    const auto dstEnd = gsl::narrow_cast<uint16_t>(colLimit);
+                    if (srcBeg < srcEnd && dstBeg < dstEnd)
+                    {
+                        const_cast<ROW&>(r).Attributes().replace(
+                            dstBeg, dstEnd, scratch.Attributes().slice(srcBeg, srcEnd));
+                    }
+                }
             }
             const auto restore = wil::scope_exit([&] {
                 if (rowBackup)

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -1090,37 +1090,6 @@ void Renderer::_PaintBufferOutput(_In_ IRenderEngine* const pEngine)
                     const_cast<ROW&>(r).ReplaceAttributes(state.columnBegin, state.columnEnd, attr);
                     off += len;
                 }
-
-                // After writing the composition text, copy the original characters
-                // that were at and after the cursor position into the space to the
-                // right of the composition text. This renders the in-progress
-                // composition as an insertion rather than an overwrite, so that
-                // existing characters to the right of the cursor are not hidden.
-                const auto compositionEnd = state.columnEnd;
-                const auto origCursorCol = _compositionCache->absoluteOrigin.x;
-                const auto colLimit = r.GetReadableColumnCount();
-
-                if (compositionEnd > origCursorCol && compositionEnd < colLimit)
-                {
-                    RowCopyTextFromState copyState{
-                        .source = scratch,
-                        .columnBegin = compositionEnd,
-                        .columnLimit = colLimit,
-                        .sourceColumnBegin = origCursorCol,
-                        .sourceColumnLimit = colLimit,
-                    };
-                    const_cast<ROW&>(r).CopyTextFrom(copyState);
-
-                    const auto srcBeg = gsl::narrow_cast<uint16_t>(origCursorCol);
-                    const auto srcEnd = gsl::narrow_cast<uint16_t>(scratch.GetReadableColumnCount());
-                    const auto dstBeg = gsl::narrow_cast<uint16_t>(compositionEnd);
-                    const auto dstEnd = gsl::narrow_cast<uint16_t>(colLimit);
-                    if (srcBeg < srcEnd && dstBeg < dstEnd)
-                    {
-                        const_cast<ROW&>(r).Attributes().replace(
-                            dstBeg, dstEnd, scratch.Attributes().slice(srcBeg, srcEnd));
-                    }
-                }
             }
             const auto restore = wil::scope_exit([&] {
                 if (rowBackup)

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -1090,6 +1090,77 @@ void Renderer::_PaintBufferOutput(_In_ IRenderEngine* const pEngine)
                     const_cast<ROW&>(r).ReplaceAttributes(state.columnBegin, state.columnEnd, attr);
                     off += len;
                 }
+
+                // Render the composition as an insertion by copying original
+                // characters from the cursor position to the right of the
+                // composition text, absorbing up to W whitespace columns in the
+                // process. This keeps TUI box borders at their original column
+                // when there is sufficient whitespace padding to the right.
+                //
+                // Algorithm: walk the original row (scratch) from origCursorCol,
+                // skipping up to W whitespace columns ("absorbing" them), and
+                // copying non-whitespace glyphs to r starting at compositionEnd.
+                // When the whitespace budget reaches 0, srcCol == dstCol and the
+                // remaining content in r is already correct, so we stop early.
+                const auto compositionWidth = state.columnEnd - _compositionCache->absoluteOrigin.x;
+                const auto origCursorCol = _compositionCache->absoluteOrigin.x;
+                const auto colLimit = r.GetReadableColumnCount();
+
+                if (compositionWidth > 0 && state.columnEnd < colLimit)
+                {
+                    auto srcCol = origCursorCol;
+                    auto dstCol = state.columnEnd;
+                    auto whitespaceToAbsorb = compositionWidth;
+
+                    while (srcCol < colLimit)
+                    {
+                        // All whitespace absorbed: srcCol == dstCol, r already correct.
+                        if (whitespaceToAbsorb == 0)
+                        {
+                            break;
+                        }
+
+                        const auto glyphEnd = scratch.NavigateToNext(srcCol);
+                        const auto glyphWidth = glyphEnd - srcCol;
+                        const auto glyphText = scratch.GetText(srcCol, glyphEnd);
+
+                        // Absorb half-width (U+0020) or full-width (U+3000) spaces
+                        // only when the budget covers the glyph's full width.
+                        const bool absorb =
+                            whitespaceToAbsorb >= glyphWidth &&
+                            !glyphText.empty() &&
+                            (glyphText[0] == L' ' || glyphText[0] == L'\u3000');
+
+                        if (absorb)
+                        {
+                            whitespaceToAbsorb -= glyphWidth;
+                            srcCol = glyphEnd;
+                        }
+                        else
+                        {
+                            if (dstCol < colLimit)
+                            {
+                                RowCopyTextFromState cs{
+                                    .source = scratch,
+                                    .columnBegin = dstCol,
+                                    .columnLimit = dstCol + glyphWidth,
+                                    .sourceColumnBegin = srcCol,
+                                    .sourceColumnLimit = glyphEnd,
+                                };
+                                const_cast<ROW&>(r).CopyTextFrom(cs);
+
+                                const_cast<ROW&>(r).Attributes().replace(
+                                    gsl::narrow_cast<uint16_t>(dstCol),
+                                    gsl::narrow_cast<uint16_t>(dstCol + glyphWidth),
+                                    scratch.Attributes().slice(
+                                        gsl::narrow_cast<uint16_t>(srcCol),
+                                        gsl::narrow_cast<uint16_t>(glyphEnd)));
+                            }
+                            srcCol = glyphEnd;
+                            dstCol += glyphWidth;
+                        }
+                    }
+                }
             }
             const auto restore = wil::scope_exit([&] {
                 if (rowBackup)

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -121,6 +121,7 @@ namespace Microsoft::Console::Render
         void _scheduleRenditionBlink();
         [[nodiscard]] HRESULT _PaintBackground(_In_ IRenderEngine* const pEngine);
         void _PaintBufferOutput(_In_ IRenderEngine* const pEngine);
+        ROW* _PaintBufferOutputComposition(TextBuffer& buffer, const ROW& r, const Composition& activeComposition);
         void _PaintBufferOutputHelper(_In_ IRenderEngine* const pEngine, TextBufferCellIterator it, const til::point target);
         void _PaintBufferOutputGridLineHelper(_In_ IRenderEngine* const pEngine, const TextAttribute textAttribute, const size_t cchLine, const til::point coordTarget);
         bool _isHoveredHyperlink(const TextAttribute& textAttribute) const noexcept;


### PR DESCRIPTION
This commit fixes a regression in v1.24, where composing Korean text
in-between existing characters causes text to the right to be hidden.
This is problematic for the Korean IME, because it commonly inserts
the composed syllable between existing characters.

The fix compresses (removes/absorbs) available whitespace to the right
of the composition to make space for any existing text. This means
that a composition now virtually acts in insert mode.

Closes #20040
Refs #19738
Refs #20039

## Validation Steps Performed

1. Korean IME: compose `ㄷ` between `가` and `나` → display shows `가ㄷ나`, `나` visible.
2. TUI box (vim prompt with padding): compose inside padded text box → border preserved in place.
3. Composition at end of line (no chars to right): unaffected.
4. English and other IME input: not affected (no active composition row).

Co-authored-by: Leonard Hecker <lhecker@microsoft.com>