### PR TITLE
Fix selection markers appearing on scroll

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2512,9 +2512,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         _updateScrollBar->Run(update);
 
-        // if we have a selection, update the position of the markers
-        // (they may have been hidden when the endpoint scrolled out of view)
-        if (_core.HasSelection())
+        // If we have a selection with markers (exposed via selection mode),
+        //   update the position of the markers
+        if (_core.HasSelection() && _core.SelectionMode() >= SelectionInteractionMode::Keyboard)
         {
             _updateSelectionMarkers(nullptr, winrt::make<UpdateSelectionMarkersEventArgs>(false));
         }


### PR DESCRIPTION
## Summary of the Pull Request
Updates the scroll handler to check the selection mode before updating the markers.

Introduced in #19974 

## Validation Steps Performed
`ls` --> create selection --> scroll away and back
✅ keyboard selection: markers are present both times
✅ mouse selection: markers are missing both times