### PR TITLE
Fix #20049: Enable file drag & drop by fixing forbidden icon issue

### DIFF
--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -9,6 +9,7 @@
 #include <dwmapi.h>
 #include <TerminalThemeHelpers.h>
 #include <CoreWindow.h>
+#include <shellapi.h> 
 
 extern "C" IMAGE_DOS_HEADER __ImageBase;
 
@@ -387,7 +388,9 @@ void IslandWindow::Initialize()
 
     _rootGrid = winrt::Windows::UI::Xaml::Controls::Grid();
     _source.Content(_rootGrid);
-
+    DragAcceptFiles(_window.get(), TRUE);
+    // cspell:ignore MSGFLT_ADD WM_DROPFILES
+    ChangeWindowMessageFilter(WM_DROPFILES, MSGFLT_ADD);
     // initialize the taskbar object
     if (auto taskbar = wil::CoCreateInstanceNoThrow<ITaskbarList3>(CLSID_TaskbarList))
     {


### PR DESCRIPTION
## Summary of the Pull Request
This PR fixes the long-standing issue #20049 where dragging files from the desktop into Windows Terminal shows a forbidden cursor icon, while the native cmd.exe works correctly. After this fix, users can drag files directly into Terminal, and the file path will be inserted normally.

## References and Relevant Issues
Closes #20049

## Detailed Description of the Pull Request / Additional comments
### Root Cause
The Terminal window was not registered as a valid file drop target, and the `WM_DROPFILES` message was blocked by User Interface Privilege Isolation (UIPI), which prevented cross-permission drag-and-drop operations, resulting in a forbidden icon.

### Fix Implementation
1.  Added `DragAcceptFiles(_window.get(), TRUE)` in `IslandWindow::Initialize()` to register the window as a file drop target
2.  Added `ChangeWindowMessageFilter(WM_DROPFILES, MSGFLT_ADD)` to allow `WM_DROPFILES` messages across different permission levels
3.  Added `#include <shellapi.h>` to resolve undefined function errors
4.  Added `// cspell:ignore MSGFLT_ADD WM_DROPFILES` to fix the spelling check false positive

## Validation Steps Performed
- Tested on Windows 10 22H2 (Build 19045.6093), Windows Terminal 1.25.622.0
- Verified that dragging files from desktop to Terminal now works normally, no forbidden icon
- Confirmed that file paths are correctly inserted into cmd/powershell
- Tested with different permission levels (admin/non-admin) to ensure compatibility
- No regression in existing window functionality

## PR Checklist
- [x] Closes #20049
- [x] Tests added/passed (manual validation completed)
- [ ] Documentation updated
- [ ] Schema updated (if necessary)