### PR TITLE
Implement 5s timeout for ConPTY handoff embedding.

### DIFF
--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -268,7 +268,7 @@ void WindowEmperor::CreateNewWindow(winrt::TerminalApp::WindowRequestedArgs args
 
     auto host = std::make_shared<AppHost>(this, _app.Logic(), std::move(args));
     host->Initialize();
-
+    _handoffTimeoutTimer.Stop();
     _windowCount += 1;
     _windows.emplace_back(std::move(host));
 
@@ -600,9 +600,12 @@ void WindowEmperor::HandleCommandlineArgs(int nCmdShow)
         if (args.size() == 2 && args[1] == L"-Embedding")
         {
             // We were launched for ConPTY handoff. We have no windows and also don't want to exit.
-            //
-            // TODO: Here we could start a timer and exit after, say, 5 seconds
-            // if no windows are created. But that's a minor concern.
+            // But if we don't receive any handoff within a reasonable timeout, we should exit.
+            _handoffTimeoutTimer.Interval(5s);
+            _handoffTimeoutTimer.Tick([this](auto&&, auto&&) {
+                _postQuitMessageIfNeeded();
+            });
+            _handoffTimeoutTimer.Start();
         }
         else
         {

--- a/src/cascadia/WindowsTerminal/WindowEmperor.h
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.h
@@ -96,6 +96,7 @@ private:
     bool _skipPersistence = false;
     bool _needsPersistenceCleanup = false;
     SafeDispatcherTimer _persistStateTimer;
+    SafeDispatcherTimer _handoffTimeoutTimer;
     std::optional<bool> _currentSystemThemeIsDark;
     int32_t _windowCount = 0;
     int32_t _messageBoxCount = 0;


### PR DESCRIPTION
Add a timer in WindowEmperor to automatically exit after 5 seconds if no windows are created during a ConPTY handoff. The timer is cancelled as soon as a new window is created. This prevents the process from staying alive indefinitely if a handoff fails or is never received.

## Summary of the Pull Request
I've implemented a 5-second timeout for the ConPTY handoff embedding in the Windows Terminal.
1. Added a `SafeDispatcherTimer _handoffTimeoutTimer;` member to the `WindowEmperor` class.
2. In `HandleCommandlineArgs`, when the application is launched with the `-Embedding` flag (ConPTY handoff), the timer is started with a 5-second interval.
3. If the timer ticks (indicating no window was created within 5 seconds), it calls `_postQuitMessageIfNeeded()` to attempt an application exit.
4. In `CreateNewWindow`, the timer is explicitly stopped to ensure that the application doesn't exit if a window is successfully created.

The implementation follows the existing codebase patterns using `SafeDispatcherTimer` and `_postQuitMessageIfNeeded`
## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
