### PR TITLE
Fix CascadiaPackage platform mapping in OpenConsole.slnx

### DIFF
--- a/OpenConsole.slnx
+++ b/OpenConsole.slnx
@@ -454,7 +454,8 @@
       <BuildType Solution="AuditMode|x64" Project="Release" />
       <BuildType Solution="AuditMode|x86" Project="Release" />
       <BuildType Solution="Fuzzing|*" Project="Debug" />
-      <Platform Solution="*|Any CPU" Project="x86" />
+      <Platform Solution="*|Any CPU" Project="Win32" />
+      <Platform Solution="*|x86" Project="Win32" />
       <Build Solution="*|Any CPU" Project="false" />
       <Build Solution="AuditMode|ARM64" Project="false" />
       <Build Solution="AuditMode|x64" Project="false" />
@@ -1058,3 +1059,4 @@
     </Project>
   </Folder>
 </Solution>
+


### PR DESCRIPTION
Map '*|Any CPU' to 'Win32' (not 'x86') to match the project's actual configuration names (Debug|Win32, Release|Win32). Also add an explicit '*|x86 -> Win32' mapping so solution platform x86 resolves correctly.

Fixes VS warning: solution specifies a project configuration that does not exist for CascadiaPackage.wapproj.

## Summary of the Pull Request

## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
