### PR TITLE
fix: manual memory management using malloc/free with... in EchoCon.cpp

### DIFF
--- a/samples/ConPTY/EchoCon/EchoCon/EchoCon.cpp
+++ b/samples/ConPTY/EchoCon/EchoCon/EchoCon.cpp
@@ -74,6 +74,7 @@ int main()
                 // Cleanup attribute list
                 DeleteProcThreadAttributeList(startupInfo.lpAttributeList);
                 free(startupInfo.lpAttributeList);
+                startupInfo.lpAttributeList = nullptr;
             }
 
             // Close ConPTY - this will terminate client process if running


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `samples/ConPTY/EchoCon/EchoCon/EchoCon.cpp`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `samples/ConPTY/EchoCon/EchoCon/EchoCon.cpp:76` |

**Description**: Manual memory management using malloc/free without RAII patterns creates opportunities for use-after-free vulnerabilities. In EchoCon.cpp:76, lpAttributeList is freed but the pointer is not nulled, and there's no clear guarantee that it won't be accessed later in error paths. The memallocator.h:25-27 provides a Free() wrapper around free() without any safeguards against double-free or use-after-free conditions. Without examining all code paths, there's potential for the freed memory to be accessed if error handling or cleanup code references these pointers after deallocation.

## Changes
- `samples/ConPTY/EchoCon/EchoCon/EchoCon.cpp`

## Verification
- [ ] Build not verified
- [ ] Scanner re-scan not performed
- [ ] LLM code review not performed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
