### PR TITLE
Add --position argument to wt new-tab command

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -936,6 +936,14 @@
             "action": {
               "type": "string",
               "const": "newTab"
+            },
+            "position": {
+              "type": "string",
+              "enum": [
+                "afterLastTab",
+                "afterCurrentTab"
+              ],
+              "description": "Where to place the new tab. When omitted, the global newTabPosition setting is used."
             }
           }
         }

--- a/src/cascadia/LocalTests_TerminalApp/CommandlineTest.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/CommandlineTest.cpp
@@ -51,6 +51,7 @@ namespace TerminalAppLocalTests
 
         TEST_METHOD(ParseBasicCommandlineIntoArgs);
         TEST_METHOD(ParseNewTabCommand);
+        TEST_METHOD(ParseNewTabWithPosition);
         TEST_METHOD(ParseSplitPaneIntoArgs);
         TEST_METHOD(ParseComboCommandlineIntoArgs);
         TEST_METHOD(ParseFocusTabArgs);
@@ -1927,6 +1928,83 @@ namespace TerminalAppLocalTests
                 auto terminalArgs{ myArgs.ContentArgs().try_as<NewTerminalArgs>() };
                 VERIFY_IS_NOT_NULL(terminalArgs);
             }
+        }
+    }
+
+    void CommandlineTest::ParseNewTabWithPosition()
+    {
+        BEGIN_TEST_METHOD_PROPERTIES()
+            TEST_METHOD_PROPERTY(L"Data:useShortForm", L"{false, true}")
+        END_TEST_METHOD_PROPERTIES()
+
+        INIT_TEST_PROPERTY(bool, useShortForm, L"If true, use `nt` instead of `new-tab`");
+        auto subcommand = useShortForm ? L"nt" : L"new-tab";
+
+        {
+            // Parse --position afterCurrentTab
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", subcommand, L"--position", L"afterCurrentTab" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_ARE_EQUAL(1u, appArgs._startupActions.size());
+
+            auto actionAndArgs = appArgs._startupActions.at(0);
+            VERIFY_ARE_EQUAL(ShortcutAction::NewTab, actionAndArgs.Action());
+            VERIFY_IS_NOT_NULL(actionAndArgs.Args());
+            auto myArgs = actionAndArgs.Args().try_as<NewTabArgs>();
+            VERIFY_IS_NOT_NULL(myArgs);
+            VERIFY_IS_NOT_NULL(myArgs.Position());
+            VERIFY_ARE_EQUAL(NewTabPosition::AfterCurrentTab, myArgs.Position().Value());
+        }
+        {
+            // Parse --position afterLastTab
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", subcommand, L"--position", L"afterLastTab" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_ARE_EQUAL(1u, appArgs._startupActions.size());
+
+            auto actionAndArgs = appArgs._startupActions.at(0);
+            VERIFY_ARE_EQUAL(ShortcutAction::NewTab, actionAndArgs.Action());
+            VERIFY_IS_NOT_NULL(actionAndArgs.Args());
+            auto myArgs = actionAndArgs.Args().try_as<NewTabArgs>();
+            VERIFY_IS_NOT_NULL(myArgs);
+            VERIFY_IS_NOT_NULL(myArgs.Position());
+            VERIFY_ARE_EQUAL(NewTabPosition::AfterLastTab, myArgs.Position().Value());
+        }
+        {
+            // Without --position, Position should be null (use global setting)
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", subcommand };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_ARE_EQUAL(1u, appArgs._startupActions.size());
+
+            auto actionAndArgs = appArgs._startupActions.at(0);
+            VERIFY_ARE_EQUAL(ShortcutAction::NewTab, actionAndArgs.Action());
+            VERIFY_IS_NOT_NULL(actionAndArgs.Args());
+            auto myArgs = actionAndArgs.Args().try_as<NewTabArgs>();
+            VERIFY_IS_NOT_NULL(myArgs);
+            VERIFY_IS_NULL(myArgs.Position());
+        }
+        {
+            // Combine --position with --profile
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", subcommand, L"--position", L"afterCurrentTab", L"--profile", L"cmd" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_ARE_EQUAL(1u, appArgs._startupActions.size());
+
+            auto actionAndArgs = appArgs._startupActions.at(0);
+            VERIFY_ARE_EQUAL(ShortcutAction::NewTab, actionAndArgs.Action());
+            VERIFY_IS_NOT_NULL(actionAndArgs.Args());
+            auto myArgs = actionAndArgs.Args().try_as<NewTabArgs>();
+            VERIFY_IS_NOT_NULL(myArgs);
+            VERIFY_IS_NOT_NULL(myArgs.Position());
+            VERIFY_ARE_EQUAL(NewTabPosition::AfterCurrentTab, myArgs.Position().Value());
+            auto terminalArgs{ myArgs.ContentArgs().try_as<NewTerminalArgs>() };
+            VERIFY_IS_NOT_NULL(terminalArgs);
+            VERIFY_ARE_EQUAL(L"cmd", terminalArgs.Profile());
         }
     }
 }

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -472,7 +472,25 @@ namespace winrt::TerminalApp::implementation
                 return;
             }
 
-            LOG_IF_FAILED(_OpenNewTab(realArgs.ContentArgs()));
+            const auto position = realArgs.Position();
+            uint32_t insertPosition = static_cast<uint32_t>(-1);
+            if (position)
+            {
+                if (position.Value() == NewTabPosition::AfterCurrentTab)
+                {
+                    auto currentTabIndex = _GetFocusedTabIndex();
+                    if (currentTabIndex.has_value())
+                    {
+                        insertPosition = currentTabIndex.value() + 1;
+                    }
+                }
+                else
+                {
+                    insertPosition = _tabs.Size();
+                }
+            }
+
+            LOG_IF_FAILED(_OpenNewTab(realArgs.ContentArgs(), insertPosition));
             args.Handled(true);
         }
     }

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -226,17 +226,34 @@ void AppCommandlineArgs::_buildNewTabParser()
     auto setupSubcommand = [this](auto& subcommand) {
         _addNewTerminalArgs(subcommand);
 
+        auto* positionOption = subcommand.subcommand->add_option("--position",
+                                                                 _tabPosition,
+                                                                 RS_A(L"CmdTabPositionArgDesc"));
+
         // When ParseCommand is called, if this subcommand was provided, this
         // callback function will be triggered on the same thread. We can be sure
         // that `this` will still be safe - this function just lets us know this
         // command was parsed.
-        subcommand.subcommand->callback([&, this]() {
+        subcommand.subcommand->callback([&, positionOption, this]() {
             // Build the NewTab action from the values we've parsed on the commandline.
             ActionAndArgs newTabAction{};
             newTabAction.Action(ShortcutAction::NewTab);
             // _getNewTerminalArgs MUST be called before parsing any other options,
             // as it might clear those options while finding the commandline
             NewTabArgs args{ _getNewTerminalArgs(subcommand) };
+
+            if (*positionOption)
+            {
+                if (_tabPosition == "afterCurrentTab")
+                {
+                    args.Position(NewTabPosition::AfterCurrentTab);
+                }
+                else if (_tabPosition == "afterLastTab")
+                {
+                    args.Position(NewTabPosition::AfterLastTab);
+                }
+            }
+
             newTabAction.Args(args);
             _startupActions.push_back(newTabAction);
         });
@@ -798,6 +815,7 @@ void AppCommandlineArgs::_resetStateToDefault()
     _commandline.clear();
     _suppressApplicationTitle = false;
     _appendCommandLineOption = false;
+    _tabPosition.clear();
 
     _splitVertical = false;
     _splitHorizontal = false;

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.h
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.h
@@ -102,6 +102,7 @@ private:
     std::string _startingTitle;
     std::string _startingTabColor;
     std::string _startingColorScheme;
+    std::string _tabPosition;
     bool _suppressApplicationTitle{ false };
     bool _inheritEnvironment{ false };
 
@@ -126,6 +127,7 @@ private:
     std::string _saveInputName;
     std::string _keyChordOption;
     // Are you adding more args here? Make sure to reset them in _resetStateToDefault
+    // Note: _tabPosition is reset in _resetStateToDefault too.
 
     const Commandline* _currentCommandline{ nullptr };
     std::optional<winrt::Microsoft::Terminal::Settings::Model::LaunchMode> _launchMode{ std::nullopt };

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -381,6 +381,10 @@
   <data name="CmdTabColorArgDesc" xml:space="preserve">
     <value>Open the tab with the specified color, in #rrggbb format</value>
   </data>
+  <data name="CmdTabPositionArgDesc" xml:space="preserve">
+    <value>Position to place the new tab at. Accepts "afterLastTab" or "afterCurrentTab"</value>
+    <comment>{Locked="\"afterLastTab\""}{Locked="\"afterCurrentTab\""}</comment>
+  </data>
   <data name="CmdSuppressApplicationTitleDesc" xml:space="preserve">
     <value>Open the tab with tabTitle overriding default title and suppressing title change messages from the application</value>
     <comment>{Locked="\"tabTitle\""}</comment>

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -61,7 +61,7 @@ namespace winrt::TerminalApp::implementation
     // - existingConnection: An optional connection that is already established to a PTY
     //   for this tab to host instead of creating one.
     //   If not defined, the tab will create the connection.
-    HRESULT TerminalPage::_OpenNewTab(const INewContentArgs& newContentArgs)
+    HRESULT TerminalPage::_OpenNewTab(const INewContentArgs& newContentArgs, uint32_t insertPosition)
     try
     {
         if (const auto& newTerminalArgs{ newContentArgs.try_as<NewTerminalArgs>() })
@@ -87,7 +87,7 @@ namespace winrt::TerminalApp::implementation
 
         // This call to _MakePane won't return nullptr, we already checked that
         // case above with the _maybeElevate call.
-        _CreateNewTabFromPane(_MakePane(newContentArgs, nullptr));
+        _CreateNewTabFromPane(_MakePane(newContentArgs, nullptr), insertPosition);
         return S_OK;
     }
     CATCH_RETURN();

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -314,7 +314,7 @@ namespace winrt::TerminalApp::implementation
         winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem _CreateNewTabFlyoutAction(const winrt::hstring& actionId, const winrt::hstring& iconPathOverride);
 
         void _OpenNewTabDropdown();
-        HRESULT _OpenNewTab(const Microsoft::Terminal::Settings::Model::INewContentArgs& newContentArgs);
+        HRESULT _OpenNewTab(const Microsoft::Terminal::Settings::Model::INewContentArgs& newContentArgs, uint32_t insertPosition = static_cast<uint32_t>(-1));
         TerminalApp::Tab _CreateNewTabFromPane(std::shared_ptr<Pane> pane, uint32_t insertPosition = -1);
 
         std::wstring _evaluatePathForCwd(std::wstring_view path);

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -592,6 +592,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         NewTabArgs(const Model::INewContentArgs& terminalArgs) :
             _ContentArgs{ terminalArgs } {};
         WINRT_PROPERTY(Model::INewContentArgs, ContentArgs, nullptr);
+        WINRT_PROPERTY(Windows::Foundation::IReference<Model::NewTabPosition>, Position, nullptr);
 
     public:
         hstring GenerateName() const { return GenerateName(GetLibraryResourceLoader().ResourceContext()); }
@@ -602,16 +603,19 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             auto otherAsUs = other.try_as<NewTabArgs>();
             if (otherAsUs)
             {
-                return otherAsUs->_ContentArgs.Equals(_ContentArgs);
+                return otherAsUs->_ContentArgs.Equals(_ContentArgs) &&
+                       otherAsUs->_Position == _Position;
             }
             return false;
         }
+        static constexpr std::string_view PositionKey{ "position" };
         static FromJsonResult FromJson(const Json::Value& json)
         {
             // LOAD BEARING: Not using make_self here _will_ break you in the future!
             auto args = winrt::make_self<NewTabArgs>();
             auto [content, warnings] = ContentArgsFromJson(json);
             args->_ContentArgs = content;
+            JsonUtils::GetValueForKey(json, PositionKey, args->_Position);
             return { *args, warnings };
         }
         static Json::Value ToJson(const IActionArgs& val)
@@ -621,18 +625,22 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                 return {};
             }
             const auto args{ get_self<NewTabArgs>(val) };
-            return ContentArgsToJson(args->_ContentArgs);
+            auto json = ContentArgsToJson(args->_ContentArgs);
+            JsonUtils::SetValueForKey(json, PositionKey, args->_Position);
+            return json;
         }
         IActionArgs Copy() const
         {
             auto copy{ winrt::make_self<NewTabArgs>() };
             copy->_ContentArgs = _ContentArgs.Copy();
+            copy->_Position = _Position;
             return *copy;
         }
         size_t Hash() const
         {
             til::hasher h;
             h.write(ContentArgs());
+            h.write(Position());
             return h.finalize();
         }
         winrt::Windows::Foundation::Collections::IVectorView<ArgDescriptor> GetArgDescriptors()

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -125,6 +125,12 @@ namespace Microsoft.Terminal.Settings.Model
         Disabled,
     };
 
+    enum NewTabPosition
+    {
+        AfterLastTab,
+        AfterCurrentTab,
+    };
+
     enum DesktopBehavior
     {
         Any,
@@ -215,6 +221,7 @@ namespace Microsoft.Terminal.Settings.Model
     {
         NewTabArgs(INewContentArgs contentArgs);
         INewContentArgs ContentArgs { get; };
+        Windows.Foundation.IReference<NewTabPosition> Position;
     };
 
     [default_interface] runtimeclass MovePaneArgs : IActionArgs, IActionArgsDescriptorAccess

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
@@ -44,12 +44,6 @@ namespace Microsoft.Terminal.Settings.Model
         PersistedLayoutAndContent,
     };
 
-    enum NewTabPosition
-    {
-        AfterLastTab,
-        AfterCurrentTab,
-    };
-
     [default_interface] runtimeclass GlobalAppSettings {
         Guid DefaultProfile;
 


### PR DESCRIPTION
## Summary of the Pull Request

Adds a `--position` argument to the `wt new-tab` subcommand, allowing users to control where new tabs are inserted without changing the global `newTabPosition` setting.

This addresses #14687.

## References and Relevant Issues

Closes #14687

## Detailed Description of the Pull Request / Additional comments

### Changes:

- **ActionArgs.idl / ActionArgs.h**: Added `Position` property (`IReference<NewTabPosition>`) to `NewTabArgs`, with full JSON serialization, equality, copy, and hash support.
- **GlobalAppSettings.idl / ActionArgs.idl**: Moved `NewTabPosition` enum from `GlobalAppSettings.idl` to `ActionArgs.idl` to avoid circular IDL import dependencies. The enum remains accessible to `GlobalAppSettings` through the transitive import chain.
- **AppCommandlineArgs.h/.cpp**: Registered `--position` CLI option in `_buildNewTabParser()`, accepting `afterCurrentTab` and `afterLastTab` string values.
- **AppActionHandlers.cpp**: Modified `_HandleNewTab` to extract the position from `NewTabArgs`, calculate the insert index, and pass it to `_OpenNewTab`.
- **TerminalPage.h / TabManagement.cpp**: Updated `_OpenNewTab` signature to accept an `insertPosition` parameter, forwarded to `_CreateNewTabFromPane`.
- **Resources.resw**: Added `CmdTabPositionArgDesc` localization resource string.
- **profiles.schema.json**: Added `position` property to `NewTabAction` schema.
- **CommandlineTest.cpp**: Added `ParseNewTabWithPosition` test method with 4 test cases.

### Usage:

```powershell
# Open a new tab after the current tab
wt new-tab --position afterCurrentTab

# Open a new tab at the end (default)
wt new-tab --position afterLastTab

# Combined with other arguments
wt new-tab --position afterCurrentTab --profile cmd
```

## Validation Steps Performed

- [x] Code compiles without errors (x64 Debug)
- [x] All modified files verified for correctness
- [x] Unit test `ParseNewTabWithPosition` added with 4 test cases
- [x] JSON schema updated