### PR TITLE
Fix rounding error for word selection

### DIFF
--- a/src/cascadia/TerminalControl/ControlInteractivity.cpp
+++ b/src/cascadia/TerminalControl/ControlInteractivity.cpp
@@ -309,8 +309,10 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             const auto isOnOriginalPosition = _lastMouseClickPosNoSelection == pixelPosition;
 
             // Rounded coordinates for text selection.
-            // Don't round in VT mouse mode; cell-level precision matters more
-            const auto round = !_core->IsVtMouseModeEnabled();
+            // Don't round in VT mouse mode; cell-level precision matters more.
+            // Only round for single-click: for double/triple-click, rounding
+            // can push the position to the next cell, selecting the wrong word.
+            const auto round = multiClickMapper == 1 && !_core->IsVtMouseModeEnabled();
             _core->LeftClickOnTerminal(_getTerminalPosition(til::point{ pixelPosition }, round),
                                        multiClickMapper,
                                        altEnabled,


### PR DESCRIPTION
## Summary of the Pull Request
Dustin reported this bug to me. Thankfully it was an easy fix.

## References and Relevant Issues
Bug from implementing #5099

## Validation Steps Performed
Double-click ____ of right-most cell of a word selects the current word
✅ right-half
✅ left-half