### PR TITLE
Path translation setting: use 🡒 instead of ->

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -2611,19 +2611,19 @@
   </data>
   <data name="Profile_PathTranslationStyleWsl.Content" xml:space="preserve">
     <value>WSL (C:\ 🡒 /mnt/c)</value>
-    <comment>{Locked="WSL","C:\","/mnt/c","🡒"} An option to choose from for the "path translation" setting.</comment>
+    <comment>{Locked="WSL","C:\","/mnt/c"} An option to choose from for the "path translation" setting.</comment>
   </data>
   <data name="Profile_PathTranslationStyleCygwin.Content" xml:space="preserve">
     <value>Cygwin (C:\ 🡒 /cygdrive/c)</value>
-    <comment>{Locked="Cygwin","C:\","/cygdrive/c","🡒"} An option to choose from for the "path translation" setting.</comment>
+    <comment>{Locked="Cygwin","C:\","/cygdrive/c"} An option to choose from for the "path translation" setting.</comment>
   </data>
   <data name="Profile_PathTranslationStyleMsys2.Content" xml:space="preserve">
     <value>MSYS2 (C:\ 🡒 /c)</value>
-    <comment>{Locked="MSYS2","C:\","/c","🡒"} An option to choose from for the "path translation" setting.</comment>
+    <comment>{Locked="MSYS2","C:\","/c"} An option to choose from for the "path translation" setting.</comment>
   </data>
   <data name="Profile_PathTranslationStyleMinGW.Content" xml:space="preserve">
     <value>MinGW (C:\ 🡒 C:/)</value>
-    <comment>{Locked="MinGW","C:\","C:/","🡒"} An option to choose from for the "path translation" setting.</comment>
+    <comment>{Locked="MinGW","C:\","C:/"} An option to choose from for the "path translation" setting.</comment>
   </data>
   <data name="Profile_Delete_Orphaned.Header" xml:space="preserve">
     <value>Profile no longer detected</value>


### PR DESCRIPTION
It looks better, as decided by committee.