### PR TITLE
Clear scroll marks when clearing the buffer

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -2338,6 +2338,13 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             }
 
             _terminal->Write(sequence);
+
+            // Clear scroll marks so they don't remain stale in the scrollbar.
+            // The Scrollback case is already handled by the \x1b[3J path (TextBuffer::ClearScrollback).
+            if (clearType != ClearBufferType::Scrollback)
+            {
+                _terminal->ClearAllMarks();
+            }
         }
 
         if (clearType == Control::ClearBufferType::Screen || clearType == Control::ClearBufferType::All)

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -3242,6 +3242,9 @@ void AdaptDispatch::_EraseAll()
 
     // Also reset the line rendition for the erased rows.
     textBuffer.ResetLineRenditionRange(newPageTop, newPageBottom);
+
+    // Clear scroll marks in the erased rows so they don't remain stale in the scrollbar.
+    textBuffer.ClearMarksInRange({ 0, newPageTop }, { pageWidth, newPageBottom });
 }
 
 //Routine Description:


### PR DESCRIPTION
## Summary

Fixes #20086 — Ctrl+Shift+K (Clear Buffer) now clears scroll marks from the scrollbar.

## References and Relevant Issues

- Closes #20086

## Detailed Description

`ControlCore::ClearBuffer()` sends VT escape sequences to clear the buffer. The scrollback path (`\x1b[3J`) already clears marks via `TextBuffer::ClearScrollback`, but the screen-clearing path doesn't touch marks — they persist stale in the scrollbar.

This adds a `ClearAllMarks()` call inside the existing lock block after the VT sequences are written, for both `Screen` and `All` clear types.

## Validation Steps

1. Enable `"showMarksOnScrollbar": true` in profile defaults
2. Open a PowerShell tab, hit Enter ~20 times to generate scroll marks
3. Press Ctrl+Shift+K — marks should disappear
4. Hit Enter again — new marks should appear normally


https://github.com/user-attachments/assets/41dd33af-ee37-42cb-8a03-c81845cd3333


- [x] Closes #20086
- [x] Tests added/passed
- [ ] Documentation updated
- [ ] Schema updated