### PR TITLE
Add send-input command with delayed enter and optional activation

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -1108,6 +1108,12 @@
               "type": "string",
               "default": "",
               "description": "The text input to feed into the shell. ANSI escape sequences may be used. Escape codes like \\x1b must be written as \\u001b."
+            },
+            "enterDelayMs": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "description": "Delay the trailing Enter key by the given number of milliseconds when the input should be submitted after a short pause."
             }
           }
         }

--- a/src/cascadia/LocalTests_TerminalApp/CommandlineTest.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/CommandlineTest.cpp
@@ -58,6 +58,7 @@ namespace TerminalAppLocalTests
         TEST_METHOD(ParseSwapPaneArgs);
         TEST_METHOD(ParseArgumentsWithParsingTerminators);
         TEST_METHOD(ParseFocusPaneArgs);
+        TEST_METHOD(ParseSendInputArgs);
 
         TEST_METHOD(ParseNoCommandIsNewTab);
 
@@ -1460,6 +1461,106 @@ namespace TerminalAppLocalTests
                 VERIFY_IS_NOT_NULL(myArgs);
                 VERIFY_ARE_EQUAL(1u, myArgs.Id());
             }
+        }
+    }
+
+    void CommandlineTest::ParseSendInputArgs()
+    {
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"send-input" };
+
+            Log::Comment(NoThrowString().Format(
+                L"send-input without any text should fail."));
+            _buildCommandlinesExpectFailureHelper(appArgs, 1u, rawCommands);
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"send-input", L"hello", L"world" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_ARE_EQUAL(2u, appArgs._startupActions.size());
+            VERIFY_ARE_EQUAL(ShortcutAction::NewTab, appArgs._startupActions.at(0).Action());
+
+            const auto actionAndArgs = appArgs._startupActions.at(1);
+            VERIFY_ARE_EQUAL(ShortcutAction::SendInput, actionAndArgs.Action());
+            VERIFY_IS_NOT_NULL(actionAndArgs.Args());
+
+            const auto myArgs = actionAndArgs.Args().try_as<SendInputArgs>();
+            VERIFY_IS_NOT_NULL(myArgs);
+            VERIFY_ARE_EQUAL(L"hello world", myArgs.Input());
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"send-input", L"--enter", L"echo", L"ready" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_ARE_EQUAL(2u, appArgs._startupActions.size());
+            VERIFY_ARE_EQUAL(ShortcutAction::NewTab, appArgs._startupActions.at(0).Action());
+
+            const auto actionAndArgs = appArgs._startupActions.at(1);
+            VERIFY_ARE_EQUAL(ShortcutAction::SendInput, actionAndArgs.Action());
+            VERIFY_IS_NOT_NULL(actionAndArgs.Args());
+
+            const auto myArgs = actionAndArgs.Args().try_as<SendInputArgs>();
+            VERIFY_IS_NOT_NULL(myArgs);
+            VERIFY_ARE_EQUAL(L"echo ready\r", myArgs.Input());
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"send-input", L"--escape", L"\\u001b[A" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_ARE_EQUAL(2u, appArgs._startupActions.size());
+            VERIFY_ARE_EQUAL(ShortcutAction::NewTab, appArgs._startupActions.at(0).Action());
+
+            const auto actionAndArgs = appArgs._startupActions.at(1);
+            VERIFY_ARE_EQUAL(ShortcutAction::SendInput, actionAndArgs.Action());
+            VERIFY_IS_NOT_NULL(actionAndArgs.Args());
+
+            const auto myArgs = actionAndArgs.Args().try_as<SendInputArgs>();
+            VERIFY_IS_NOT_NULL(myArgs);
+            VERIFY_ARE_EQUAL(winrt::hstring{ L"\u001b[A" }, myArgs.Input());
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"-w", L"0", L"send-input", L"hello", L"world" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_ARE_EQUAL(1u, appArgs._startupActions.size());
+
+            const auto actionAndArgs = appArgs._startupActions.at(0);
+            VERIFY_ARE_EQUAL(ShortcutAction::SendInput, actionAndArgs.Action());
+            VERIFY_ARE_EQUAL(std::string{ "0" }, std::string{ appArgs.GetTargetWindow() });
+            VERIFY_IS_NOT_NULL(actionAndArgs.Args());
+
+            const auto myArgs = actionAndArgs.Args().try_as<SendInputArgs>();
+            VERIFY_IS_NOT_NULL(myArgs);
+            VERIFY_ARE_EQUAL(L"hello world", myArgs.Input());
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"-w", L"0", L"focus-tab", L"-t", L"2", L";", L"send-input", L"hello" };
+            _buildCommandlinesHelper(appArgs, 2u, rawCommands);
+
+            VERIFY_ARE_EQUAL(2u, appArgs._startupActions.size());
+            VERIFY_ARE_EQUAL(std::string{ "0" }, std::string{ appArgs.GetTargetWindow() });
+
+            const auto focusAction = appArgs._startupActions.at(0);
+            VERIFY_ARE_EQUAL(ShortcutAction::SwitchToTab, focusAction.Action());
+            VERIFY_IS_NOT_NULL(focusAction.Args());
+
+            const auto focusArgs = focusAction.Args().try_as<SwitchToTabArgs>();
+            VERIFY_IS_NOT_NULL(focusArgs);
+            VERIFY_ARE_EQUAL(2u, focusArgs.TabIndex());
+
+            const auto sendInputAction = appArgs._startupActions.at(1);
+            VERIFY_ARE_EQUAL(ShortcutAction::SendInput, sendInputAction.Action());
+            VERIFY_IS_NOT_NULL(sendInputAction.Args());
+
+            const auto sendInputArgs = sendInputAction.Args().try_as<SendInputArgs>();
+            VERIFY_IS_NOT_NULL(sendInputArgs);
+            VERIFY_ARE_EQUAL(L"hello", sendInputArgs.Input());
         }
     }
 

--- a/src/cascadia/LocalTests_TerminalApp/CommandlineTest.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/CommandlineTest.cpp
@@ -1481,6 +1481,24 @@ namespace TerminalAppLocalTests
 
             VERIFY_ARE_EQUAL(2u, appArgs._startupActions.size());
             VERIFY_ARE_EQUAL(ShortcutAction::NewTab, appArgs._startupActions.at(0).Action());
+            VERIFY_IS_TRUE(appArgs.ShouldActivateWindow());
+
+            const auto actionAndArgs = appArgs._startupActions.at(1);
+            VERIFY_ARE_EQUAL(ShortcutAction::SendInput, actionAndArgs.Action());
+            VERIFY_IS_NOT_NULL(actionAndArgs.Args());
+
+            const auto myArgs = actionAndArgs.Args().try_as<SendInputArgs>();
+            VERIFY_IS_NOT_NULL(myArgs);
+            VERIFY_ARE_EQUAL(L"hello world", myArgs.Input());
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"send-input", L"--activate", L"hello", L"world" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_ARE_EQUAL(2u, appArgs._startupActions.size());
+            VERIFY_ARE_EQUAL(ShortcutAction::NewTab, appArgs._startupActions.at(0).Action());
+            VERIFY_IS_TRUE(appArgs.ShouldActivateWindow());
 
             const auto actionAndArgs = appArgs._startupActions.at(1);
             VERIFY_ARE_EQUAL(ShortcutAction::SendInput, actionAndArgs.Action());
@@ -1497,6 +1515,7 @@ namespace TerminalAppLocalTests
 
             VERIFY_ARE_EQUAL(2u, appArgs._startupActions.size());
             VERIFY_ARE_EQUAL(ShortcutAction::NewTab, appArgs._startupActions.at(0).Action());
+            VERIFY_IS_TRUE(appArgs.ShouldActivateWindow());
 
             const auto actionAndArgs = appArgs._startupActions.at(1);
             VERIFY_ARE_EQUAL(ShortcutAction::SendInput, actionAndArgs.Action());
@@ -1522,6 +1541,7 @@ namespace TerminalAppLocalTests
 
             VERIFY_ARE_EQUAL(2u, appArgs._startupActions.size());
             VERIFY_ARE_EQUAL(ShortcutAction::NewTab, appArgs._startupActions.at(0).Action());
+            VERIFY_IS_TRUE(appArgs.ShouldActivateWindow());
 
             const auto actionAndArgs = appArgs._startupActions.at(1);
             VERIFY_ARE_EQUAL(ShortcutAction::SendInput, actionAndArgs.Action());
@@ -1539,6 +1559,7 @@ namespace TerminalAppLocalTests
 
             VERIFY_ARE_EQUAL(2u, appArgs._startupActions.size());
             VERIFY_ARE_EQUAL(ShortcutAction::NewTab, appArgs._startupActions.at(0).Action());
+            VERIFY_IS_TRUE(appArgs.ShouldActivateWindow());
 
             const auto actionAndArgs = appArgs._startupActions.at(1);
             VERIFY_ARE_EQUAL(ShortcutAction::SendInput, actionAndArgs.Action());
@@ -1556,6 +1577,7 @@ namespace TerminalAppLocalTests
 
             VERIFY_ARE_EQUAL(2u, appArgs._startupActions.size());
             VERIFY_ARE_EQUAL(ShortcutAction::NewTab, appArgs._startupActions.at(0).Action());
+            VERIFY_IS_TRUE(appArgs.ShouldActivateWindow());
 
             const auto actionAndArgs = appArgs._startupActions.at(1);
             VERIFY_ARE_EQUAL(ShortcutAction::SendInput, actionAndArgs.Action());
@@ -1567,10 +1589,29 @@ namespace TerminalAppLocalTests
         }
         {
             AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"send-input", L"--escape", L"--enter", L"--enter-delay-ms", L"75", L"\\u001b[A" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_ARE_EQUAL(2u, appArgs._startupActions.size());
+            VERIFY_ARE_EQUAL(ShortcutAction::NewTab, appArgs._startupActions.at(0).Action());
+            VERIFY_IS_TRUE(appArgs.ShouldActivateWindow());
+
+            const auto actionAndArgs = appArgs._startupActions.at(1);
+            VERIFY_ARE_EQUAL(ShortcutAction::SendInput, actionAndArgs.Action());
+            VERIFY_IS_NOT_NULL(actionAndArgs.Args());
+
+            const auto myArgs = actionAndArgs.Args().try_as<SendInputArgs>();
+            VERIFY_IS_NOT_NULL(myArgs);
+            VERIFY_ARE_EQUAL(winrt::hstring{ L"\u001b[A" }, myArgs.Input());
+            VERIFY_ARE_EQUAL(75u, myArgs.EnterDelayMs());
+        }
+        {
+            AppCommandlineArgs appArgs{};
             std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"-w", L"0", L"send-input", L"hello", L"world" };
             _buildCommandlinesHelper(appArgs, 1u, rawCommands);
 
             VERIFY_ARE_EQUAL(1u, appArgs._startupActions.size());
+            VERIFY_IS_FALSE(appArgs.ShouldActivateWindow());
 
             const auto actionAndArgs = appArgs._startupActions.at(0);
             VERIFY_ARE_EQUAL(ShortcutAction::SendInput, actionAndArgs.Action());
@@ -1583,11 +1624,61 @@ namespace TerminalAppLocalTests
         }
         {
             AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"-w", L"0", L"send-input", L"--activate", L"hello", L"world" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_ARE_EQUAL(1u, appArgs._startupActions.size());
+            VERIFY_IS_TRUE(appArgs.ShouldActivateWindow());
+
+            const auto actionAndArgs = appArgs._startupActions.at(0);
+            VERIFY_ARE_EQUAL(ShortcutAction::SendInput, actionAndArgs.Action());
+            VERIFY_ARE_EQUAL(std::string{ "0" }, std::string{ appArgs.GetTargetWindow() });
+            VERIFY_IS_NOT_NULL(actionAndArgs.Args());
+
+            const auto myArgs = actionAndArgs.Args().try_as<SendInputArgs>();
+            VERIFY_IS_NOT_NULL(myArgs);
+            VERIFY_ARE_EQUAL(L"hello world", myArgs.Input());
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"-w", L"codexfresh", L"send-input", L"hello", L"world" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_ARE_EQUAL(1u, appArgs._startupActions.size());
+            VERIFY_IS_FALSE(appArgs.ShouldActivateWindow());
+
+            const auto actionAndArgs = appArgs._startupActions.at(0);
+            VERIFY_ARE_EQUAL(ShortcutAction::SendInput, actionAndArgs.Action());
+            VERIFY_ARE_EQUAL(std::string{ "codexfresh" }, std::string{ appArgs.GetTargetWindow() });
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"-w", L"last", L"send-input", L"hello" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_ARE_EQUAL(1u, appArgs._startupActions.size());
+            VERIFY_IS_FALSE(appArgs.ShouldActivateWindow());
+            VERIFY_ARE_EQUAL(std::string{ "last" }, std::string{ appArgs.GetTargetWindow() });
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"-w", L"new", L"send-input", L"hello" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_ARE_EQUAL(2u, appArgs._startupActions.size());
+            VERIFY_IS_TRUE(appArgs.ShouldActivateWindow());
+            VERIFY_ARE_EQUAL(std::string{ "new" }, std::string{ appArgs.GetTargetWindow() });
+            VERIFY_ARE_EQUAL(ShortcutAction::NewTab, appArgs._startupActions.at(0).Action());
+            VERIFY_ARE_EQUAL(ShortcutAction::SendInput, appArgs._startupActions.at(1).Action());
+        }
+        {
+            AppCommandlineArgs appArgs{};
             std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"-w", L"0", L"focus-tab", L"-t", L"2", L";", L"send-input", L"hello" };
             _buildCommandlinesHelper(appArgs, 2u, rawCommands);
 
             VERIFY_ARE_EQUAL(2u, appArgs._startupActions.size());
             VERIFY_ARE_EQUAL(std::string{ "0" }, std::string{ appArgs.GetTargetWindow() });
+            VERIFY_IS_FALSE(appArgs.ShouldActivateWindow());
 
             const auto focusAction = appArgs._startupActions.at(0);
             VERIFY_ARE_EQUAL(ShortcutAction::SwitchToTab, focusAction.Action());
@@ -1604,6 +1695,131 @@ namespace TerminalAppLocalTests
             const auto sendInputArgs = sendInputAction.Args().try_as<SendInputArgs>();
             VERIFY_IS_NOT_NULL(sendInputArgs);
             VERIFY_ARE_EQUAL(L"hello", sendInputArgs.Input());
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"-w", L"0", L"focus-tab", L"-t", L"2", L";", L"send-input", L"--activate", L"hello" };
+            _buildCommandlinesHelper(appArgs, 2u, rawCommands);
+
+            VERIFY_ARE_EQUAL(2u, appArgs._startupActions.size());
+            VERIFY_ARE_EQUAL(std::string{ "0" }, std::string{ appArgs.GetTargetWindow() });
+            VERIFY_IS_TRUE(appArgs.ShouldActivateWindow());
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"-w", L"0", L"new-tab", L";", L"send-input", L"hello" };
+            _buildCommandlinesHelper(appArgs, 2u, rawCommands);
+
+            VERIFY_ARE_EQUAL(2u, appArgs._startupActions.size());
+            VERIFY_ARE_EQUAL(std::string{ "0" }, std::string{ appArgs.GetTargetWindow() });
+            VERIFY_IS_TRUE(appArgs.ShouldActivateWindow());
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"-w", L"0", L"new-tab", L";", L"send-input", L"--activate", L"hello" };
+            _buildCommandlinesHelper(appArgs, 2u, rawCommands);
+
+            VERIFY_ARE_EQUAL(2u, appArgs._startupActions.size());
+            VERIFY_ARE_EQUAL(std::string{ "0" }, std::string{ appArgs.GetTargetWindow() });
+            VERIFY_IS_TRUE(appArgs.ShouldActivateWindow());
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"-w", L"0", L"split-pane", L";", L"send-input", L"hello" };
+            _buildCommandlinesHelper(appArgs, 2u, rawCommands);
+
+            VERIFY_ARE_EQUAL(2u, appArgs._startupActions.size());
+            VERIFY_ARE_EQUAL(std::string{ "0" }, std::string{ appArgs.GetTargetWindow() });
+            VERIFY_IS_TRUE(appArgs.ShouldActivateWindow());
+        }
+        {
+            CommandlineArgs remotingArgs{};
+            const std::array<hstring, 5> rawCommands{ L"wt.exe", L"-w", L"0", L"send-input", L"hello" };
+            remotingArgs.Commandline(rawCommands);
+
+            VERIFY_ARE_EQUAL(0, remotingArgs.ExitCode());
+            VERIFY_ARE_EQUAL(winrt::hstring{ L"0" }, remotingArgs.TargetWindow());
+            VERIFY_IS_FALSE(remotingArgs.ActivateWindow());
+        }
+        {
+            CommandlineArgs remotingArgs{};
+            const std::array<hstring, 7> rawCommands{ L"wt.exe", L"-w", L"0", L"new-tab", L";", L"send-input", L"hello" };
+            remotingArgs.Commandline(rawCommands);
+
+            VERIFY_ARE_EQUAL(0, remotingArgs.ExitCode());
+            VERIFY_ARE_EQUAL(winrt::hstring{ L"0" }, remotingArgs.TargetWindow());
+            VERIFY_IS_TRUE(remotingArgs.ActivateWindow());
+        }
+        {
+            CommandlineArgs remotingArgs{};
+            const std::array<hstring, 5> rawCommands{ L"wt.exe", L"-w", L"codexfresh", L"send-input", L"hello" };
+            remotingArgs.Commandline(rawCommands);
+
+            VERIFY_ARE_EQUAL(0, remotingArgs.ExitCode());
+            VERIFY_ARE_EQUAL(winrt::hstring{ L"codexfresh" }, remotingArgs.TargetWindow());
+            VERIFY_IS_FALSE(remotingArgs.ActivateWindow());
+        }
+        {
+            CommandlineArgs remotingArgs{};
+            const std::array<hstring, 5> backgroundCommands{ L"wt.exe", L"-w", L"0", L"send-input", L"hello" };
+            remotingArgs.Commandline(backgroundCommands);
+
+            VERIFY_ARE_EQUAL(0, remotingArgs.ExitCode());
+            VERIFY_IS_FALSE(remotingArgs.ActivateWindow());
+
+            const std::array<hstring, 6> activatedCommands{ L"wt.exe", L"-w", L"0", L"send-input", L"--activate", L"hello" };
+            remotingArgs.Commandline(activatedCommands);
+
+            VERIFY_ARE_EQUAL(0, remotingArgs.ExitCode());
+            VERIFY_IS_TRUE(remotingArgs.ActivateWindow());
+        }
+        {
+            CommandlineArgs remotingArgs{};
+            const std::array<hstring, 5> rawCommands{ L"wt.exe", L"-w", L"last", L"send-input", L"hello" };
+            remotingArgs.Commandline(rawCommands);
+
+            VERIFY_ARE_EQUAL(0, remotingArgs.ExitCode());
+            VERIFY_ARE_EQUAL(winrt::hstring{ L"last" }, remotingArgs.TargetWindow());
+            VERIFY_IS_FALSE(remotingArgs.ActivateWindow());
+        }
+        {
+            CommandlineArgs remotingArgs{};
+            const std::array<hstring, 5> rawCommands{ L"wt.exe", L"-w", L"new", L"send-input", L"hello" };
+            remotingArgs.Commandline(rawCommands);
+
+            VERIFY_ARE_EQUAL(0, remotingArgs.ExitCode());
+            VERIFY_ARE_EQUAL(winrt::hstring{ L"new" }, remotingArgs.TargetWindow());
+            VERIFY_IS_TRUE(remotingArgs.ActivateWindow());
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"-w", L"codexfresh", L"send-input", L"hello" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_ARE_EQUAL(1u, appArgs._startupActions.size());
+            VERIFY_IS_FALSE(appArgs.ShouldActivateWindow());
+
+            appArgs.RetargetToNewWindow();
+            appArgs.ValidateStartupCommands();
+
+            VERIFY_IS_TRUE(appArgs.ShouldActivateWindow());
+            VERIFY_ARE_EQUAL(2u, appArgs._startupActions.size());
+            VERIFY_ARE_EQUAL(ShortcutAction::NewTab, appArgs._startupActions.at(0).Action());
+            VERIFY_ARE_EQUAL(ShortcutAction::SendInput, appArgs._startupActions.at(1).Action());
+            VERIFY_ARE_EQUAL(std::string_view{}, appArgs.GetTargetWindow());
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"-w", L"0", L"send-input", L"--", L"/quit" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_ARE_EQUAL(1u, appArgs._startupActions.size());
+            VERIFY_IS_FALSE(appArgs.ShouldActivateWindow());
+
+            const auto actionAndArgs = appArgs._startupActions.at(0);
+            const auto myArgs = actionAndArgs.Args().try_as<SendInputArgs>();
+            VERIFY_IS_NOT_NULL(myArgs);
+            VERIFY_ARE_EQUAL(L"/quit", myArgs.Input());
         }
     }
 

--- a/src/cascadia/LocalTests_TerminalApp/CommandlineTest.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/CommandlineTest.cpp
@@ -1641,7 +1641,7 @@ namespace TerminalAppLocalTests
         }
         {
             AppCommandlineArgs appArgs{};
-            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"-w", L"codexfresh", L"send-input", L"hello", L"world" };
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"-w", L"namedWindow", L"send-input", L"hello", L"world" };
             _buildCommandlinesHelper(appArgs, 1u, rawCommands);
 
             VERIFY_ARE_EQUAL(1u, appArgs._startupActions.size());
@@ -1649,7 +1649,7 @@ namespace TerminalAppLocalTests
 
             const auto actionAndArgs = appArgs._startupActions.at(0);
             VERIFY_ARE_EQUAL(ShortcutAction::SendInput, actionAndArgs.Action());
-            VERIFY_ARE_EQUAL(std::string{ "codexfresh" }, std::string{ appArgs.GetTargetWindow() });
+            VERIFY_ARE_EQUAL(std::string{ "namedWindow" }, std::string{ appArgs.GetTargetWindow() });
         }
         {
             AppCommandlineArgs appArgs{};
@@ -1728,9 +1728,12 @@ namespace TerminalAppLocalTests
             std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"-w", L"0", L"split-pane", L";", L"send-input", L"hello" };
             _buildCommandlinesHelper(appArgs, 2u, rawCommands);
 
-            VERIFY_ARE_EQUAL(2u, appArgs._startupActions.size());
+            VERIFY_ARE_EQUAL(3u, appArgs._startupActions.size());
             VERIFY_ARE_EQUAL(std::string{ "0" }, std::string{ appArgs.GetTargetWindow() });
             VERIFY_IS_TRUE(appArgs.ShouldActivateWindow());
+            VERIFY_ARE_EQUAL(ShortcutAction::NewTab, appArgs._startupActions.at(0).Action());
+            VERIFY_ARE_EQUAL(ShortcutAction::SplitPane, appArgs._startupActions.at(1).Action());
+            VERIFY_ARE_EQUAL(ShortcutAction::SendInput, appArgs._startupActions.at(2).Action());
         }
         {
             CommandlineArgs remotingArgs{};
@@ -1752,11 +1755,11 @@ namespace TerminalAppLocalTests
         }
         {
             CommandlineArgs remotingArgs{};
-            const std::array<hstring, 5> rawCommands{ L"wt.exe", L"-w", L"codexfresh", L"send-input", L"hello" };
+            const std::array<hstring, 5> rawCommands{ L"wt.exe", L"-w", L"namedWindow", L"send-input", L"hello" };
             remotingArgs.Commandline(rawCommands);
 
             VERIFY_ARE_EQUAL(0, remotingArgs.ExitCode());
-            VERIFY_ARE_EQUAL(winrt::hstring{ L"codexfresh" }, remotingArgs.TargetWindow());
+            VERIFY_ARE_EQUAL(winrt::hstring{ L"namedWindow" }, remotingArgs.TargetWindow());
             VERIFY_IS_FALSE(remotingArgs.ActivateWindow());
         }
         {
@@ -1793,7 +1796,7 @@ namespace TerminalAppLocalTests
         }
         {
             AppCommandlineArgs appArgs{};
-            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"-w", L"codexfresh", L"send-input", L"hello" };
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"-w", L"namedWindow", L"send-input", L"hello" };
             _buildCommandlinesHelper(appArgs, 1u, rawCommands);
 
             VERIFY_ARE_EQUAL(1u, appArgs._startupActions.size());

--- a/src/cascadia/LocalTests_TerminalApp/CommandlineTest.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/CommandlineTest.cpp
@@ -1505,6 +1505,49 @@ namespace TerminalAppLocalTests
             const auto myArgs = actionAndArgs.Args().try_as<SendInputArgs>();
             VERIFY_IS_NOT_NULL(myArgs);
             VERIFY_ARE_EQUAL(L"echo ready\r", myArgs.Input());
+            VERIFY_ARE_EQUAL(0u, myArgs.EnterDelayMs());
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"send-input", L"--enter-delay-ms", L"75", L"echo", L"ready" };
+
+            Log::Comment(NoThrowString().Format(
+                L"send-input --enter-delay-ms without --enter should fail."));
+            _buildCommandlinesExpectFailureHelper(appArgs, 1u, rawCommands);
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"send-input", L"--enter", L"--enter-delay-ms", L"75", L"echo", L"ready" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_ARE_EQUAL(2u, appArgs._startupActions.size());
+            VERIFY_ARE_EQUAL(ShortcutAction::NewTab, appArgs._startupActions.at(0).Action());
+
+            const auto actionAndArgs = appArgs._startupActions.at(1);
+            VERIFY_ARE_EQUAL(ShortcutAction::SendInput, actionAndArgs.Action());
+            VERIFY_IS_NOT_NULL(actionAndArgs.Args());
+
+            const auto myArgs = actionAndArgs.Args().try_as<SendInputArgs>();
+            VERIFY_IS_NOT_NULL(myArgs);
+            VERIFY_ARE_EQUAL(L"echo ready", myArgs.Input());
+            VERIFY_ARE_EQUAL(75u, myArgs.EnterDelayMs());
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"send-input", L"--enter", L"--enter-delay-ms", L"0", L"echo", L"ready" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_ARE_EQUAL(2u, appArgs._startupActions.size());
+            VERIFY_ARE_EQUAL(ShortcutAction::NewTab, appArgs._startupActions.at(0).Action());
+
+            const auto actionAndArgs = appArgs._startupActions.at(1);
+            VERIFY_ARE_EQUAL(ShortcutAction::SendInput, actionAndArgs.Action());
+            VERIFY_IS_NOT_NULL(actionAndArgs.Args());
+
+            const auto myArgs = actionAndArgs.Args().try_as<SendInputArgs>();
+            VERIFY_IS_NOT_NULL(myArgs);
+            VERIFY_ARE_EQUAL(L"echo ready\r", myArgs.Input());
+            VERIFY_ARE_EQUAL(0u, myArgs.EnterDelayMs());
         }
         {
             AppCommandlineArgs appArgs{};

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -31,6 +31,22 @@ namespace winrt
 
 namespace winrt::TerminalApp::implementation
 {
+    namespace
+    {
+        safe_void_coroutine _SendInputEnterAfterDelay(winrt::weak_ref<TermControl> weakControl, const CoreDispatcher dispatcher, const uint32_t enterDelayMs)
+        {
+            co_await winrt::resume_after(std::chrono::milliseconds{ enterDelayMs });
+            co_await wil::resume_foreground(dispatcher);
+
+            if (const auto termControl{ weakControl.get() })
+            {
+                // Delayed Enter is intentionally a second injection so clients can
+                // observe the text payload before submit.
+                termControl.SendInput(L"\r");
+            }
+        }
+    }
+
     TermControl TerminalPage::_senderOrActiveControl(const IInspectable& sender)
     {
         if (sender)
@@ -186,6 +202,10 @@ namespace winrt::TerminalApp::implementation
             if (const auto termControl{ _senderOrActiveControl(sender) })
             {
                 termControl.SendInput(realArgs.Input());
+                if (realArgs.EnterDelayMs() > 0)
+                {
+                    _SendInputEnterAfterDelay(winrt::weak_ref<TermControl>{ termControl }, termControl.Dispatcher(), realArgs.EnterDelayMs());
+                }
                 args.Handled(true);
             }
         }

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -582,12 +582,17 @@ void AppCommandlineArgs::_buildSendInputParser()
 {
     _sendInputCommand = _app.add_subcommand("send-input", RS_A(L"CmdSendInputDesc"));
 
+    auto* enterOpt = _sendInputCommand->add_flag("--enter",
+                                                 _sendInputEnter,
+                                                 RS_A(L"CmdSendInputEnterDesc"));
     _sendInputCommand->add_flag("--escape",
                                 _sendInputEscapes,
                                 RS_A(L"CmdSendInputEscapeDesc"));
-    _sendInputCommand->add_flag("--enter",
-                                _sendInputEnter,
-                                RS_A(L"CmdSendInputEnterDesc"));
+    auto* enterDelayOpt = _sendInputCommand->add_option("--enter-delay-ms",
+                                                        _sendInputEnterDelayMs,
+                                                        RS_A(L"CmdSendInputEnterDelayDesc"));
+    enterDelayOpt->check(CLI::NonNegativeNumber);
+    enterDelayOpt->needs(enterOpt);
     auto* inputOpt = _sendInputCommand->add_option("input,",
                                                    _sendInputText,
                                                    RS_A(L"CmdSendInputArgDesc"));
@@ -602,12 +607,19 @@ void AppCommandlineArgs::_buildSendInputParser()
         auto input = _sendInputEscapes ? _decodeEscapedInput(rawInput) :
                                          winrt::to_hstring(rawInput);
 
-        if (_sendInputEnter)
+        if (_sendInputEnter && _sendInputEnterDelayMs == 0)
         {
             input = input + L"\r";
         }
 
-        sendInputAction.Args(SendInputArgs{ input });
+        if (_sendInputEnterDelayMs > 0)
+        {
+            sendInputAction.Args(SendInputArgs{ input, _sendInputEnterDelayMs });
+        }
+        else
+        {
+            sendInputAction.Args(SendInputArgs{ input });
+        }
         _startupActions.push_back(std::move(sendInputAction));
     });
 }
@@ -892,6 +904,7 @@ void AppCommandlineArgs::_resetStateToDefault()
     _sendInputText.clear();
     _sendInputEscapes = false;
     _sendInputEnter = false;
+    _sendInputEnterDelayMs = 0;
     _loadPersistedLayoutIdx = -1;
 
     // DON'T clear _launchMode here! This will get called once for every

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -582,6 +582,9 @@ void AppCommandlineArgs::_buildSendInputParser()
 {
     _sendInputCommand = _app.add_subcommand("send-input", RS_A(L"CmdSendInputDesc"));
 
+    _sendInputCommand->add_flag("--activate",
+                                _sendInputActivate,
+                                RS_A(L"CmdSendInputActivateDesc"));
     auto* enterOpt = _sendInputCommand->add_flag("--enter",
                                                  _sendInputEnter,
                                                  RS_A(L"CmdSendInputEnterDesc"));
@@ -600,6 +603,8 @@ void AppCommandlineArgs::_buildSendInputParser()
     _sendInputCommand->positionals_at_end(true);
 
     _sendInputCommand->callback([&, this]() {
+        _sendInputActivateRequested = _sendInputActivateRequested || _sendInputActivate;
+
         ActionAndArgs sendInputAction{};
         sendInputAction.Action(ShortcutAction::SendInput);
 
@@ -905,12 +910,15 @@ void AppCommandlineArgs::_resetStateToDefault()
     _sendInputEscapes = false;
     _sendInputEnter = false;
     _sendInputEnterDelayMs = 0;
+    _sendInputActivate = false;
     _loadPersistedLayoutIdx = -1;
 
     // DON'T clear _launchMode here! This will get called once for every
     // subcommand, so we don't want `wt -F new-tab ; split-pane` clearing out
     // the "global" fullscreen flag (-F).
     // Same with _windowTarget, _position and _size.
+    // Don't clear _sendInputActivateRequested here either.
+    // It is commandline-wide state, not per-subcommand state.
 }
 
 // Function Description:
@@ -1132,7 +1140,7 @@ bool AppCommandlineArgs::_targetsExistingWindow() const noexcept
         return *opt >= 0;
     }
 
-    return _windowTarget == "last";
+    return _windowTarget != "new";
 }
 
 bool AppCommandlineArgs::_canTargetExistingWindowWithoutNewTab() const noexcept
@@ -1302,6 +1310,7 @@ void AppCommandlineArgs::FullResetState()
     _startupActions.clear();
     _exitMessage = "";
     _shouldExitEarly = false;
+    _sendInputActivateRequested = false;
 
     _windowTarget = {};
 }
@@ -1309,4 +1318,44 @@ void AppCommandlineArgs::FullResetState()
 std::string_view AppCommandlineArgs::GetTargetWindow() const noexcept
 {
     return _windowTarget;
+}
+
+bool AppCommandlineArgs::ShouldActivateWindow() const noexcept
+{
+    if (!_targetsExistingWindow())
+    {
+        return true;
+    }
+
+    if (_sendInputActivateRequested)
+    {
+        return true;
+    }
+
+    auto hasSendInput = false;
+
+    for (const auto& actionAndArgs : _startupActions)
+    {
+        switch (actionAndArgs.Action())
+        {
+        case ShortcutAction::SendInput:
+            hasSendInput = true;
+            break;
+        case ShortcutAction::SwitchToTab:
+        case ShortcutAction::NextTab:
+        case ShortcutAction::PrevTab:
+        case ShortcutAction::MoveFocus:
+        case ShortcutAction::FocusPane:
+            break;
+        default:
+            return true;
+        }
+    }
+
+    return !hasSendInput;
+}
+
+void AppCommandlineArgs::RetargetToNewWindow() noexcept
+{
+    _windowTarget.clear();
 }

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -5,12 +5,52 @@
 #include "AppCommandlineArgs.h"
 #include "../types/inc/utils.hpp"
 #include "TerminalSettingsModel/ModelSerializationHelpers.h"
+#include <json/json.h>
 
 using namespace winrt::Microsoft::Terminal::Settings::Model;
 using namespace TerminalApp;
 
 // Either a ; at the start of a line, or a ; preceded by any non-\ char.
 const std::wregex AppCommandlineArgs::_commandDelimiterRegex{ LR"(^;|[^\\];)" };
+
+namespace
+{
+    std::string _joinInputSegments(const std::vector<std::string>& inputSegments)
+    {
+        std::string joinedInput;
+
+        for (const auto& segment : inputSegments)
+        {
+            if (!joinedInput.empty())
+            {
+                joinedInput.push_back(' ');
+            }
+
+            joinedInput.append(segment);
+        }
+
+        return joinedInput;
+    }
+
+    winrt::hstring _decodeEscapedInput(const std::string& rawInput)
+    {
+        std::string jsonString;
+        jsonString.reserve(rawInput.size() + 2);
+        jsonString.push_back('"');
+        jsonString.append(rawInput);
+        jsonString.push_back('"');
+
+        std::string errs;
+        std::unique_ptr<Json::CharReader> reader{ Json::CharReaderBuilder{}.newCharReader() };
+        Json::Value root;
+        if (reader->parse(jsonString.data(), jsonString.data() + jsonString.size(), &root, &errs) && root.isString())
+        {
+            return winrt::hstring{ til::u8u16(root.asString()) };
+        }
+
+        return winrt::to_hstring(rawInput);
+    }
+}
 
 AppCommandlineArgs::AppCommandlineArgs()
 {
@@ -208,6 +248,7 @@ void AppCommandlineArgs::_buildParser()
     _buildMovePaneParser();
     _buildSwapPaneParser();
     _buildFocusPaneParser();
+    _buildSendInputParser();
     _buildSaveSnippetParser();
 }
 
@@ -537,6 +578,40 @@ void AppCommandlineArgs::_buildFocusPaneParser()
     setupSubcommand(_focusPaneShort);
 }
 
+void AppCommandlineArgs::_buildSendInputParser()
+{
+    _sendInputCommand = _app.add_subcommand("send-input", RS_A(L"CmdSendInputDesc"));
+
+    _sendInputCommand->add_flag("--escape",
+                                _sendInputEscapes,
+                                RS_A(L"CmdSendInputEscapeDesc"));
+    _sendInputCommand->add_flag("--enter",
+                                _sendInputEnter,
+                                RS_A(L"CmdSendInputEnterDesc"));
+    auto* inputOpt = _sendInputCommand->add_option("input,",
+                                                   _sendInputText,
+                                                   RS_A(L"CmdSendInputArgDesc"));
+    inputOpt->required();
+    _sendInputCommand->positionals_at_end(true);
+
+    _sendInputCommand->callback([&, this]() {
+        ActionAndArgs sendInputAction{};
+        sendInputAction.Action(ShortcutAction::SendInput);
+
+        const auto rawInput = _joinInputSegments(_sendInputText);
+        auto input = _sendInputEscapes ? _decodeEscapedInput(rawInput) :
+                                         winrt::to_hstring(rawInput);
+
+        if (_sendInputEnter)
+        {
+            input = input + L"\r";
+        }
+
+        sendInputAction.Args(SendInputArgs{ input });
+        _startupActions.push_back(std::move(sendInputAction));
+    });
+}
+
 void AppCommandlineArgs::_buildSaveSnippetParser()
 {
     _saveCommand = _app.add_subcommand("x-save", RS_A(L"SaveSnippetDesc"));
@@ -775,6 +850,7 @@ bool AppCommandlineArgs::_noCommandsProvided()
              *_swapPaneCommand ||
              *_focusPaneCommand ||
              *_focusPaneShort ||
+             *_sendInputCommand ||
              *_newPaneShort.subcommand ||
              *_newPaneCommand.subcommand ||
              *_saveCommand);
@@ -813,6 +889,9 @@ void AppCommandlineArgs::_resetStateToDefault()
     _swapPaneDirection = FocusDirection::None;
 
     _focusPaneTarget = -1;
+    _sendInputText.clear();
+    _sendInputEscapes = false;
+    _sendInputEnter = false;
     _loadPersistedLayoutIdx = -1;
 
     // DON'T clear _launchMode here! This will get called once for every
@@ -1016,7 +1095,8 @@ void AppCommandlineArgs::ValidateStartupCommands()
     // (also, we don't need to do this if the only action is a x-save)
     else if (_startupActions.empty() ||
              (_startupActions.front().Action() != ShortcutAction::NewTab &&
-              _startupActions.front().Action() != ShortcutAction::SaveSnippet))
+              _startupActions.front().Action() != ShortcutAction::SaveSnippet &&
+              !_canTargetExistingWindowWithoutNewTab()))
     {
         // Build the NewTab action from the values we've parsed on the commandline.
         NewTerminalArgs newTerminalArgs{};
@@ -1026,6 +1106,43 @@ void AppCommandlineArgs::ValidateStartupCommands()
         _startupActions.insert(_startupActions.begin(), 1, newTabAction);
     }
 }
+
+bool AppCommandlineArgs::_targetsExistingWindow() const noexcept
+{
+    if (_windowTarget.empty())
+    {
+        return false;
+    }
+
+    if (const auto opt = til::parse_signed<int64_t>(_windowTarget, 10))
+    {
+        return *opt >= 0;
+    }
+
+    return _windowTarget == "last";
+}
+
+bool AppCommandlineArgs::_canTargetExistingWindowWithoutNewTab() const noexcept
+{
+    if (!_targetsExistingWindow() || _startupActions.empty())
+    {
+        return false;
+    }
+
+    switch (_startupActions.front().Action())
+    {
+    case ShortcutAction::SwitchToTab:
+    case ShortcutAction::NextTab:
+    case ShortcutAction::PrevTab:
+    case ShortcutAction::MoveFocus:
+    case ShortcutAction::FocusPane:
+    case ShortcutAction::SendInput:
+        return true;
+    default:
+        return false;
+    }
+}
+
 std::optional<uint32_t> AppCommandlineArgs::GetPersistedLayoutIdx() const noexcept
 {
     return _loadPersistedLayoutIdx >= 0 ?

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.h
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.h
@@ -48,6 +48,8 @@ public:
     void FullResetState();
 
     std::string_view GetTargetWindow() const noexcept;
+    bool ShouldActivateWindow() const noexcept;
+    void RetargetToNewWindow() noexcept;
 
 private:
     static const std::wregex _commandDelimiterRegex;
@@ -128,6 +130,7 @@ private:
     bool _sendInputEscapes{ false };
     bool _sendInputEnter{ false };
     uint32_t _sendInputEnterDelayMs{ 0 };
+    bool _sendInputActivate{ false };
     std::string _saveInputName;
     std::string _keyChordOption;
     // Are you adding more args here? Make sure to reset them in _resetStateToDefault
@@ -139,6 +142,7 @@ private:
     std::vector<winrt::Microsoft::Terminal::Settings::Model::ActionAndArgs> _startupActions;
     std::string _exitMessage;
     bool _shouldExitEarly{ false };
+    bool _sendInputActivateRequested{ false };
 
     int _loadPersistedLayoutIdx{};
     std::string _windowTarget{};

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.h
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.h
@@ -92,6 +92,7 @@ private:
     CLI::App* _swapPaneCommand;
     CLI::App* _focusPaneCommand;
     CLI::App* _focusPaneShort;
+    CLI::App* _sendInputCommand;
     CLI::App* _saveCommand;
 
     // Are you adding a new sub-command? Make sure to update _noCommandsProvided!
@@ -123,6 +124,9 @@ private:
     bool _focusPrevTab{ false };
 
     int _focusPaneTarget{ -1 };
+    std::vector<std::string> _sendInputText;
+    bool _sendInputEscapes{ false };
+    bool _sendInputEnter{ false };
     std::string _saveInputName;
     std::string _keyChordOption;
     // Are you adding more args here? Make sure to reset them in _resetStateToDefault
@@ -150,6 +154,9 @@ private:
     void _buildMovePaneParser();
     void _buildSwapPaneParser();
     void _buildFocusPaneParser();
+    void _buildSendInputParser();
+    bool _targetsExistingWindow() const noexcept;
+    bool _canTargetExistingWindowWithoutNewTab() const noexcept;
     bool _noCommandsProvided();
     void _resetStateToDefault();
     int _handleExit(const CLI::App& command, const CLI::Error& e);

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.h
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.h
@@ -127,6 +127,7 @@ private:
     std::vector<std::string> _sendInputText;
     bool _sendInputEscapes{ false };
     bool _sendInputEnter{ false };
+    uint32_t _sendInputEnterDelayMs{ 0 };
     std::string _saveInputName;
     std::string _keyChordOption;
     // Are you adding more args here? Make sure to reset them in _resetStateToDefault

--- a/src/cascadia/TerminalApp/Remoting.cpp
+++ b/src/cascadia/TerminalApp/Remoting.cpp
@@ -40,9 +40,20 @@ namespace winrt::TerminalApp::implementation
         return winrt::to_hstring(_parsed.GetTargetWindow());
     }
 
+    bool CommandlineArgs::ActivateWindow() const noexcept
+    {
+        return _parsed.ShouldActivateWindow();
+    }
+
+    void CommandlineArgs::RetargetToNewWindow() noexcept
+    {
+        _parsed.RetargetToNewWindow();
+    }
+
     void CommandlineArgs::Commandline(const winrt::array_view<const winrt::hstring>& value)
     {
         _args = { value.begin(), value.end() };
+        _parsed.FullResetState();
         _parseResult = _parsed.ParseArgs(_args);
     }
 

--- a/src/cascadia/TerminalApp/Remoting.h
+++ b/src/cascadia/TerminalApp/Remoting.h
@@ -20,6 +20,8 @@ namespace winrt::TerminalApp::implementation
         int32_t ExitCode() const noexcept;
         winrt::hstring ExitMessage() const;
         winrt::hstring TargetWindow() const;
+        bool ActivateWindow() const noexcept;
+        void RetargetToNewWindow() noexcept;
 
         til::property<winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection> Connection;
         void Commandline(const winrt::array_view<const winrt::hstring>& value);

--- a/src/cascadia/TerminalApp/Remoting.idl
+++ b/src/cascadia/TerminalApp/Remoting.idl
@@ -10,6 +10,8 @@ namespace TerminalApp
         Int32 ExitCode { get; };
         String ExitMessage { get; };
         String TargetWindow { get; };
+        Boolean ActivateWindow { get; };
+        void RetargetToNewWindow();
 
         Microsoft.Terminal.TerminalConnection.ITerminalConnection Connection;
         String[] Commandline;

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -348,6 +348,18 @@
   <data name="CmdFocusPaneTargetArgDesc" xml:space="preserve">
     <value>Focus the pane at the given index</value>
   </data>
+  <data name="CmdSendInputDesc" xml:space="preserve">
+    <value>Send input to the active pane</value>
+  </data>
+  <data name="CmdSendInputArgDesc" xml:space="preserve">
+    <value>The text to send to the active pane</value>
+  </data>
+  <data name="CmdSendInputEscapeDesc" xml:space="preserve">
+    <value>Interpret the input using JSON-style escape sequences</value>
+  </data>
+  <data name="CmdSendInputEnterDesc" xml:space="preserve">
+    <value>Append a carriage return to the input</value>
+  </data>
   <data name="CmdProfileArgDesc" xml:space="preserve">
     <value>Open with the given profile. Accepts either the name or GUID of a profile</value>
   </data>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -360,6 +360,9 @@
   <data name="CmdSendInputEnterDesc" xml:space="preserve">
     <value>Append a carriage return to the input</value>
   </data>
+  <data name="CmdSendInputEnterDelayDesc" xml:space="preserve">
+    <value>When used with --enter, delay the carriage return by the given number of milliseconds</value>
+  </data>
   <data name="CmdProfileArgDesc" xml:space="preserve">
     <value>Open with the given profile. Accepts either the name or GUID of a profile</value>
   </data>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -357,6 +357,9 @@
   <data name="CmdSendInputEscapeDesc" xml:space="preserve">
     <value>Interpret the input using JSON-style escape sequences</value>
   </data>
+  <data name="CmdSendInputActivateDesc" xml:space="preserve">
+    <value>Bring the target window to the foreground before executing the commandline</value>
+  </data>
   <data name="CmdSendInputEnterDesc" xml:space="preserve">
     <value>Append a carriage return to the input</value>
   </data>

--- a/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
@@ -78,6 +78,7 @@ static constexpr std::string_view DisplayWorkingDirectoryKey{ "debugTerminalCwd"
 static constexpr std::string_view SearchForTextKey{ "searchWeb" };
 static constexpr std::string_view GlobalSummonKey{ "globalSummon" };
 static constexpr std::string_view QuakeModeKey{ "quakeMode" };
+
 static constexpr std::string_view FocusPaneKey{ "focusPane" };
 static constexpr std::string_view OpenSystemMenuKey{ "openSystemMenu" };
 static constexpr std::string_view ExportBufferKey{ "exportBuffer" };
@@ -110,6 +111,25 @@ static constexpr std::string_view UnboundKey{ "unbound" };
 namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 {
     using namespace ::Microsoft::Terminal::Settings::Model;
+
+    static uint64_t _GeneratedArgsHash(const ShortcutAction action, const IActionArgs& args)
+    {
+        if (action == ShortcutAction::SendInput)
+        {
+            if (const auto sendInputArgs = args.try_as<winrt::Microsoft::Terminal::Settings::Model::SendInputArgs>())
+            {
+                til::hasher h;
+                h.write(sendInputArgs.Input());
+                if (sendInputArgs.EnterDelayMs() > 0)
+                {
+                    h.write(sendInputArgs.EnterDelayMs());
+                }
+                return h.finalize();
+            }
+        }
+
+        return args.Hash();
+    }
 
     using ParseActionFunction = FromJsonResult (*)(const Json::Value&);
     using SerializeActionFunction = Json::Value (*)(const IActionArgs&);
@@ -379,7 +399,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                 // 2. convert it to a hex string
                 // there is a _tiny_ chance of collision because of the truncate but unlikely for
                 // the number of commands a user is expected to have
-                const auto argsHash32 = static_cast<uint32_t>(_Args.Hash() & 0xFFFFFFFF);
+                const auto argsHash32 = static_cast<uint32_t>(_GeneratedArgsHash(_Action, _Args) & 0xFFFFFFFF);
                 // {0:X} formats the truncated hash to an uppercase hex string
                 fmt::format_to(std::back_inserter(result), FMT_COMPILE(L".{:X}"), argsHash32);
             }

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -930,7 +930,11 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             }
             Json::Value json{ Json::ValueType::objectValue };
             const auto args{ get_self<SendInputArgs>(val) };
-            SEND_INPUT_ARGS(TO_JSON_ARGS);
+            JsonUtils::SetValueForKey(json, "input", args->_Input);
+            if (args->EnterDelayMs() > 0)
+            {
+                JsonUtils::SetValueForKey(json, "enterDelayMs", args->_EnterDelayMs);
+            }
             return json;
         }
         IActionArgs Copy() const
@@ -943,12 +947,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         {
             til::hasher h;
             h.write(Input());
-            // Preserve legacy generated IDs for sendInput actions that don't
-            // opt into delayed Enter behavior.
-            if (EnterDelayMs() > 0)
-            {
-                h.write(EnterDelayMs());
-            }
+            h.write(EnterDelayMs());
             return h.finalize();
         }
     };

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -138,7 +138,8 @@ protected:                                                                  \
 
 ////////////////////////////////////////////////////////////////////////////////
 #define SEND_INPUT_ARGS(X) \
-    X(winrt::hstring, Input, "input", args->Input().empty(), ArgTypeHint::None, L"")
+    X(winrt::hstring, Input, "input", args->Input().empty(), ArgTypeHint::None, L"") \
+    X(uint32_t, EnterDelayMs, "enterDelayMs", false, ArgTypeHint::None, 0u)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define OPEN_SETTINGS_ARGS(X) \
@@ -892,7 +893,65 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
     ACTION_ARGS_STRUCT(AdjustFontSizeArgs, ADJUST_FONT_SIZE_ARGS);
 
-    ACTION_ARGS_STRUCT(SendInputArgs, SEND_INPUT_ARGS);
+    struct SendInputArgs : public SendInputArgsT<SendInputArgs>
+    {
+        PARTIAL_ACTION_ARG_BODY(SendInputArgs, SEND_INPUT_ARGS);
+
+        SendInputArgs(const winrt::hstring& input) :
+            SendInputArgs(input, 0u) {}
+
+    public:
+        hstring GenerateName() const
+        {
+            return GenerateName(GetLibraryResourceLoader().ResourceContext());
+        }
+        hstring GenerateName(const winrt::Windows::ApplicationModel::Resources::Core::ResourceContext& context) const;
+        bool Equals(const IActionArgs& other)
+        {
+            auto otherAsUs = other.try_as<SendInputArgs>();
+            if (otherAsUs)
+            {
+                return otherAsUs->_Input == _Input &&
+                       otherAsUs->_EnterDelayMs == _EnterDelayMs;
+            }
+            return false;
+        }
+        static FromJsonResult FromJson(const Json::Value& json)
+        {
+            auto args = winrt::make_self<SendInputArgs>();
+            SEND_INPUT_ARGS(FROM_JSON_ARGS);
+            return { *args, {} };
+        }
+        static Json::Value ToJson(const IActionArgs& val)
+        {
+            if (!val)
+            {
+                return {};
+            }
+            Json::Value json{ Json::ValueType::objectValue };
+            const auto args{ get_self<SendInputArgs>(val) };
+            SEND_INPUT_ARGS(TO_JSON_ARGS);
+            return json;
+        }
+        IActionArgs Copy() const
+        {
+            auto copy{ winrt::make_self<SendInputArgs>() };
+            SEND_INPUT_ARGS(COPY_ARGS);
+            return *copy;
+        }
+        size_t Hash() const
+        {
+            til::hasher h;
+            h.write(Input());
+            // Preserve legacy generated IDs for sendInput actions that don't
+            // opt into delayed Enter behavior.
+            if (EnterDelayMs() > 0)
+            {
+                h.write(EnterDelayMs());
+            }
+            return h.finalize();
+        }
+    };
 
     ACTION_ARGS_STRUCT(OpenSettingsArgs, OPEN_SETTINGS_ARGS);
 

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -255,8 +255,10 @@ namespace Microsoft.Terminal.Settings.Model
     [default_interface] runtimeclass SendInputArgs : IActionArgs, IActionArgsDescriptorAccess
     {
         SendInputArgs(String input);
+        SendInputArgs(String input, UInt32 enterDelayMs);
 
         String Input { get; };
+        UInt32 EnterDelayMs { get; };
     };
 
     [default_interface] runtimeclass SplitPaneArgs : IActionArgs, IActionArgsDescriptorAccess

--- a/src/cascadia/TerminalSettingsModel/ActionMap.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionMap.cpp
@@ -1114,7 +1114,11 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
             const auto inArgs{ command.ActionAndArgs().Args().try_as<Model::SendInputArgs>() };
             const auto inputString{ inArgs ? inArgs.Input() : L"" };
-            auto args = winrt::make_self<SendInputArgs>(til::hstring_format(FMT_COMPILE(L"{:\x7f^{}}{}"), L"", numBackspaces, inputString));
+            const auto delayedEnterMs{ inArgs ? inArgs.EnterDelayMs() : 0u };
+            const auto rewrittenInput = til::hstring_format(FMT_COMPILE(L"{:\x7f^{}}{}"), L"", numBackspaces, inputString);
+            auto args = delayedEnterMs > 0 ?
+                            winrt::make_self<SendInputArgs>(rewrittenInput, delayedEnterMs) :
+                            winrt::make_self<SendInputArgs>(rewrittenInput);
             Model::ActionAndArgs actionAndArgs{ ShortcutAction::SendInput, *args };
 
             auto copy = cmdImpl->Copy();

--- a/src/cascadia/TerminalSettingsModel/ActionMap.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionMap.cpp
@@ -60,6 +60,23 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         return hasher.finalize();
     }
 
+    static bool _ActionAndArgsSemanticallyEqual(const Model::ActionAndArgs& lhs, const Model::ActionAndArgs& rhs)
+    {
+        if (lhs.Action() != rhs.Action())
+        {
+            return false;
+        }
+
+        const auto lhsArgs = lhs.Args();
+        const auto rhsArgs = rhs.Args();
+        if (!lhsArgs || !rhsArgs)
+        {
+            return !lhsArgs && !rhsArgs;
+        }
+
+        return lhsArgs.Equals(rhsArgs);
+    }
+
     winrt::hstring ActionArgFactory::GetNameForAction(Model::ShortcutAction action)
     {
         return GetNameForAction(action, GetLibraryResourceLoader().ResourceContext());
@@ -1218,7 +1235,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             if (const auto foundCmd{ _GetActionByID(newID) })
             {
                 const auto foundCmdActionAndArgs = foundCmd.ActionAndArgs();
-                if (foundCmdActionAndArgs != cmd.ActionAndArgs())
+                if (!_ActionAndArgsSemanticallyEqual(foundCmdActionAndArgs, cmd.ActionAndArgs()))
                 {
                     // we found a command that has the same ID as this one, but that command has different ActionAndArgs
                     // this means that foundCommand's action and/or args have been changed since its ID was generated,

--- a/src/cascadia/TerminalSettingsModel/ActionMap.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionMap.cpp
@@ -67,8 +67,19 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             return false;
         }
 
-        const auto lhsArgs = lhs.Args();
-        const auto rhsArgs = rhs.Args();
+        const auto action = lhs.Action();
+        auto lhsArgs = lhs.Args();
+        auto rhsArgs = rhs.Args();
+
+        if (!lhsArgs)
+        {
+            lhsArgs = ActionArgFactory::GetEmptyArgsForAction(action);
+        }
+        if (!rhsArgs)
+        {
+            rhsArgs = ActionArgFactory::GetEmptyArgsForAction(action);
+        }
+
         if (!lhsArgs || !rhsArgs)
         {
             return !lhsArgs && !rhsArgs;

--- a/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
@@ -853,6 +853,9 @@
   <data name="InputActionArgumentLocalized" xml:space="preserve">
     <value>Input</value>
   </data>
+  <data name="EnterDelayMsActionArgumentLocalized" xml:space="preserve">
+    <value>Enter delay (ms)</value>
+  </data>
   <data name="TargetActionArgumentLocalized" xml:space="preserve">
     <value>Target</value>
   </data>

--- a/src/cascadia/UnitTests_SettingsModel/KeyBindingsTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/KeyBindingsTests.cpp
@@ -27,6 +27,7 @@ namespace SettingsModelUnitTests
         TEST_METHOD(ManyKeysSameAction);
         TEST_METHOD(LayerKeybindings);
         TEST_METHOD(HashDeduplication);
+        TEST_METHOD(DefaultArgSemanticDeduplication);
         TEST_METHOD(SendInputZeroDelayDeduplication);
         TEST_METHOD(SendInputDelayedEnterStaysDistinct);
         TEST_METHOD(HashContentArgs);
@@ -162,6 +163,26 @@ namespace SettingsModelUnitTests
         actionMap->LayerJson(VerifyParseSucceeded(R"([ { "command": "splitPane", "keys": ["ctrl+c"] } ])"), OriginTag::User);
         actionMap->LayerJson(VerifyParseSucceeded(R"([ { "command": "splitPane", "keys": ["ctrl+c"] } ])"), OriginTag::User);
         VERIFY_ARE_EQUAL(1u, actionMap->_ActionMap.size());
+    }
+
+    void KeyBindingsTests::DefaultArgSemanticDeduplication()
+    {
+        const auto actionMap = winrt::make_self<implementation::ActionMap>();
+        actionMap->LayerJson(VerifyParseSucceeded(R"([ { "command": "splitPane", "keys": ["ctrl+c"] } ])"), OriginTag::User);
+        actionMap->LayerJson(VerifyParseSucceeded(R"([ { "command": { "action": "splitPane" }, "keys": ["ctrl+shift+c"] } ])"), OriginTag::User);
+
+        VERIFY_ARE_EQUAL(1u, actionMap->_ActionMap.size());
+        VERIFY_ARE_EQUAL(2u, actionMap->_KeyMap.size());
+
+        KeyChord ctrlC{ VirtualKeyModifiers::Control, static_cast<int32_t>('C'), 0 };
+        KeyChord ctrlShiftC{ VirtualKeyModifiers::Control | VirtualKeyModifiers::Shift, static_cast<int32_t>('C'), 0 };
+
+        const auto cmd1 = actionMap->GetActionByKeyChord(ctrlC);
+        const auto cmd2 = actionMap->GetActionByKeyChord(ctrlShiftC);
+
+        VERIFY_IS_NOT_NULL(cmd1);
+        VERIFY_IS_NOT_NULL(cmd2);
+        VERIFY_ARE_EQUAL(cmd1.ID(), cmd2.ID());
     }
 
     void KeyBindingsTests::SendInputZeroDelayDeduplication()

--- a/src/cascadia/UnitTests_SettingsModel/KeyBindingsTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/KeyBindingsTests.cpp
@@ -27,6 +27,8 @@ namespace SettingsModelUnitTests
         TEST_METHOD(ManyKeysSameAction);
         TEST_METHOD(LayerKeybindings);
         TEST_METHOD(HashDeduplication);
+        TEST_METHOD(SendInputZeroDelayDeduplication);
+        TEST_METHOD(SendInputDelayedEnterStaysDistinct);
         TEST_METHOD(HashContentArgs);
         TEST_METHOD(UnbindKeybindings);
         TEST_METHOD(LayerScancodeKeybindings);
@@ -160,6 +162,46 @@ namespace SettingsModelUnitTests
         actionMap->LayerJson(VerifyParseSucceeded(R"([ { "command": "splitPane", "keys": ["ctrl+c"] } ])"), OriginTag::User);
         actionMap->LayerJson(VerifyParseSucceeded(R"([ { "command": "splitPane", "keys": ["ctrl+c"] } ])"), OriginTag::User);
         VERIFY_ARE_EQUAL(1u, actionMap->_ActionMap.size());
+    }
+
+    void KeyBindingsTests::SendInputZeroDelayDeduplication()
+    {
+        const auto actionMap = winrt::make_self<implementation::ActionMap>();
+        actionMap->LayerJson(VerifyParseSucceeded(R"([ { "command": { "action": "sendInput", "input": "just some input" }, "keys": ["ctrl+c"] } ])"), OriginTag::User);
+        actionMap->LayerJson(VerifyParseSucceeded(R"([ { "command": { "action": "sendInput", "input": "just some input", "enterDelayMs": 0 }, "keys": ["ctrl+shift+c"] } ])"), OriginTag::User);
+
+        VERIFY_ARE_EQUAL(1u, actionMap->_ActionMap.size());
+        VERIFY_ARE_EQUAL(2u, actionMap->_KeyMap.size());
+
+        KeyChord ctrlC{ VirtualKeyModifiers::Control, static_cast<int32_t>('C'), 0 };
+        KeyChord ctrlShiftC{ VirtualKeyModifiers::Control | VirtualKeyModifiers::Shift, static_cast<int32_t>('C'), 0 };
+
+        const auto cmd1 = actionMap->GetActionByKeyChord(ctrlC);
+        const auto cmd2 = actionMap->GetActionByKeyChord(ctrlShiftC);
+
+        VERIFY_IS_NOT_NULL(cmd1);
+        VERIFY_IS_NOT_NULL(cmd2);
+        VERIFY_ARE_EQUAL(cmd1.ID(), cmd2.ID());
+    }
+
+    void KeyBindingsTests::SendInputDelayedEnterStaysDistinct()
+    {
+        const auto actionMap = winrt::make_self<implementation::ActionMap>();
+        actionMap->LayerJson(VerifyParseSucceeded(R"([ { "command": { "action": "sendInput", "input": "just some input" }, "keys": ["ctrl+c"] } ])"), OriginTag::User);
+        actionMap->LayerJson(VerifyParseSucceeded(R"([ { "command": { "action": "sendInput", "input": "just some input", "enterDelayMs": 75 }, "keys": ["ctrl+shift+c"] } ])"), OriginTag::User);
+
+        VERIFY_ARE_EQUAL(2u, actionMap->_ActionMap.size());
+        VERIFY_ARE_EQUAL(2u, actionMap->_KeyMap.size());
+
+        KeyChord ctrlC{ VirtualKeyModifiers::Control, static_cast<int32_t>('C'), 0 };
+        KeyChord ctrlShiftC{ VirtualKeyModifiers::Control | VirtualKeyModifiers::Shift, static_cast<int32_t>('C'), 0 };
+
+        const auto cmd1 = actionMap->GetActionByKeyChord(ctrlC);
+        const auto cmd2 = actionMap->GetActionByKeyChord(ctrlShiftC);
+
+        VERIFY_IS_NOT_NULL(cmd1);
+        VERIFY_IS_NOT_NULL(cmd2);
+        VERIFY_ARE_NOT_EQUAL(cmd1.ID(), cmd2.ID());
     }
 
     void KeyBindingsTests::HashContentArgs()

--- a/src/cascadia/UnitTests_SettingsModel/SerializationTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/SerializationTests.cpp
@@ -53,6 +53,7 @@ namespace SettingsModelUnitTests
         TEST_METHOD(RoundtripGenerateActionID);
         TEST_METHOD(SendInputZeroDelayPreservesGeneratedActionID);
         TEST_METHOD(SendInputDelayedEnterGetsDistinctGeneratedActionID);
+        TEST_METHOD(RoundtripSendInputEnterDelay);
         TEST_METHOD(NoGeneratedIDsForIterableAndNestedCommands);
         TEST_METHOD(GeneratedActionIDsEqualForIdenticalCommands);
         TEST_METHOD(RoundtripLegacyToModernActions);
@@ -1004,6 +1005,7 @@ namespace SettingsModelUnitTests
 
         std::string_view expectedID{ R"(User.sendInput.)" SEND_INPUT_ARCH_SPECIFIC_ACTION_HASH };
 
+        VERIFY_IS_NOT_NULL(sendInputCmd);
         VERIFY_ARE_EQUAL(sendInputCmd.ID(), winrt::to_hstring(expectedID));
     }
 
@@ -1046,6 +1048,8 @@ namespace SettingsModelUnitTests
         const auto legacySendInputCmd = legacySettings->ActionMap().GetActionByKeyChord(KeyChord{ true, false, true, false, 87, 0 });
         const auto explicitZeroDelaySendInputCmd = explicitZeroDelaySettings->ActionMap().GetActionByKeyChord(KeyChord{ true, false, true, false, 87, 0 });
 
+        VERIFY_IS_NOT_NULL(legacySendInputCmd);
+        VERIFY_IS_NOT_NULL(explicitZeroDelaySendInputCmd);
         VERIFY_ARE_EQUAL(legacySendInputCmd.ID(), explicitZeroDelaySendInputCmd.ID());
     }
 
@@ -1087,11 +1091,49 @@ namespace SettingsModelUnitTests
 
         const auto legacySendInputCmd = legacySettings->ActionMap().GetActionByKeyChord(KeyChord{ true, false, true, false, 87, 0 });
         const auto delayedEnterSendInputCmd = delayedEnterSettings->ActionMap().GetActionByKeyChord(KeyChord{ true, false, true, false, 87, 0 });
-        const auto delayedArgs = delayedEnterSendInputCmd.ActionAndArgs().Args().try_as<SendInputArgs>();
 
+        VERIFY_IS_NOT_NULL(legacySendInputCmd);
+        VERIFY_IS_NOT_NULL(delayedEnterSendInputCmd);
+        const auto delayedArgs = delayedEnterSendInputCmd.ActionAndArgs().Args().try_as<SendInputArgs>();
         VERIFY_IS_NOT_NULL(delayedArgs);
         VERIFY_ARE_NOT_EQUAL(legacySendInputCmd.ID(), delayedEnterSendInputCmd.ID());
         VERIFY_ARE_EQUAL(75u, delayedArgs.EnterDelayMs());
+    }
+
+    void SerializationTests::RoundtripSendInputEnterDelay()
+    {
+        static constexpr std::string_view delayedEnterSettingsJson{ R"(
+        {
+            "actions": [
+                {
+                    "name": "foo",
+                    "command": { "action": "sendInput", "input": "just some input", "enterDelayMs": 75 },
+                    "keys": "ctrl+shift+w"
+                }
+            ]
+        })" };
+
+        implementation::SettingsLoader loader{ delayedEnterSettingsJson, implementation::LoadStringResource(IDR_DEFAULTS) };
+        loader.MergeInboxIntoUserSettings();
+        loader.FinalizeLayering();
+        loader.FixupUserSettings();
+        const auto settings = winrt::make_self<implementation::CascadiaSettings>(std::move(loader));
+
+        const auto oldResult{ settings->ToJson() };
+
+        implementation::SettingsLoader roundtripLoader{ toString(oldResult), implementation::LoadStringResource(IDR_DEFAULTS) };
+        roundtripLoader.MergeInboxIntoUserSettings();
+        roundtripLoader.FinalizeLayering();
+        roundtripLoader.FixupUserSettings();
+        const auto roundtripSettings = winrt::make_self<implementation::CascadiaSettings>(std::move(roundtripLoader));
+        const auto newResult{ roundtripSettings->ToJson() };
+        const auto sendInputCmd = roundtripSettings->ActionMap().GetActionByKeyChord(KeyChord{ true, false, true, false, 87, 0 });
+
+        VERIFY_IS_NOT_NULL(sendInputCmd);
+        const auto delayedArgs = sendInputCmd.ActionAndArgs().Args().try_as<SendInputArgs>();
+        VERIFY_IS_NOT_NULL(delayedArgs);
+        VERIFY_ARE_EQUAL(75u, delayedArgs.EnterDelayMs());
+        VERIFY_ARE_EQUAL(toString(newResult), toString(oldResult));
     }
 
     void SerializationTests::NoGeneratedIDsForIterableAndNestedCommands()
@@ -1171,7 +1213,9 @@ namespace SettingsModelUnitTests
         const auto sendInputCmd1 = settings1->ActionMap().GetActionByKeyChord(KeyChord{ true, false, true, false, 87, 0 });
         const auto sendInputCmd2 = settings2->ActionMap().GetActionByKeyChord(KeyChord{ true, false, true, false, 87, 0 });
 
-        VERIFY_ARE_EQUAL(sendInputCmd1.ID(), sendInputCmd1.ID());
+        VERIFY_IS_NOT_NULL(sendInputCmd1);
+        VERIFY_IS_NOT_NULL(sendInputCmd2);
+        VERIFY_ARE_EQUAL(sendInputCmd1.ID(), sendInputCmd2.ID());
     }
 
     void SerializationTests::RoundtripLegacyToModernActions()

--- a/src/cascadia/UnitTests_SettingsModel/SerializationTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/SerializationTests.cpp
@@ -51,6 +51,8 @@ namespace SettingsModelUnitTests
         TEST_METHOD(RoundtripUserDeletedColorSchemeCollision);
 
         TEST_METHOD(RoundtripGenerateActionID);
+        TEST_METHOD(SendInputZeroDelayPreservesGeneratedActionID);
+        TEST_METHOD(SendInputDelayedEnterGetsDistinctGeneratedActionID);
         TEST_METHOD(NoGeneratedIDsForIterableAndNestedCommands);
         TEST_METHOD(GeneratedActionIDsEqualForIdenticalCommands);
         TEST_METHOD(RoundtripLegacyToModernActions);
@@ -1003,6 +1005,93 @@ namespace SettingsModelUnitTests
         std::string_view expectedID{ R"(User.sendInput.)" SEND_INPUT_ARCH_SPECIFIC_ACTION_HASH };
 
         VERIFY_ARE_EQUAL(sendInputCmd.ID(), winrt::to_hstring(expectedID));
+    }
+
+    void SerializationTests::SendInputZeroDelayPreservesGeneratedActionID()
+    {
+        static constexpr std::string_view legacySettingsJson{ R"(
+        {
+            "actions": [
+                {
+                    "name": "foo",
+                    "command": { "action": "sendInput", "input": "just some input" },
+                    "keys": "ctrl+shift+w"
+                }
+            ]
+        })" };
+
+        static constexpr std::string_view explicitZeroDelaySettingsJson{ R"(
+        {
+            "actions": [
+                {
+                    "name": "foo",
+                    "command": { "action": "sendInput", "input": "just some input", "enterDelayMs": 0 },
+                    "keys": "ctrl+shift+w"
+                }
+            ]
+        })" };
+
+        implementation::SettingsLoader legacyLoader{ legacySettingsJson, implementation::LoadStringResource(IDR_DEFAULTS) };
+        legacyLoader.MergeInboxIntoUserSettings();
+        legacyLoader.FinalizeLayering();
+        legacyLoader.FixupUserSettings();
+        const auto legacySettings = winrt::make_self<implementation::CascadiaSettings>(std::move(legacyLoader));
+
+        implementation::SettingsLoader explicitZeroDelayLoader{ explicitZeroDelaySettingsJson, implementation::LoadStringResource(IDR_DEFAULTS) };
+        explicitZeroDelayLoader.MergeInboxIntoUserSettings();
+        explicitZeroDelayLoader.FinalizeLayering();
+        explicitZeroDelayLoader.FixupUserSettings();
+        const auto explicitZeroDelaySettings = winrt::make_self<implementation::CascadiaSettings>(std::move(explicitZeroDelayLoader));
+
+        const auto legacySendInputCmd = legacySettings->ActionMap().GetActionByKeyChord(KeyChord{ true, false, true, false, 87, 0 });
+        const auto explicitZeroDelaySendInputCmd = explicitZeroDelaySettings->ActionMap().GetActionByKeyChord(KeyChord{ true, false, true, false, 87, 0 });
+
+        VERIFY_ARE_EQUAL(legacySendInputCmd.ID(), explicitZeroDelaySendInputCmd.ID());
+    }
+
+    void SerializationTests::SendInputDelayedEnterGetsDistinctGeneratedActionID()
+    {
+        static constexpr std::string_view legacySettingsJson{ R"(
+        {
+            "actions": [
+                {
+                    "name": "foo",
+                    "command": { "action": "sendInput", "input": "just some input" },
+                    "keys": "ctrl+shift+w"
+                }
+            ]
+        })" };
+
+        static constexpr std::string_view delayedEnterSettingsJson{ R"(
+        {
+            "actions": [
+                {
+                    "name": "foo",
+                    "command": { "action": "sendInput", "input": "just some input", "enterDelayMs": 75 },
+                    "keys": "ctrl+shift+w"
+                }
+            ]
+        })" };
+
+        implementation::SettingsLoader legacyLoader{ legacySettingsJson, implementation::LoadStringResource(IDR_DEFAULTS) };
+        legacyLoader.MergeInboxIntoUserSettings();
+        legacyLoader.FinalizeLayering();
+        legacyLoader.FixupUserSettings();
+        const auto legacySettings = winrt::make_self<implementation::CascadiaSettings>(std::move(legacyLoader));
+
+        implementation::SettingsLoader delayedEnterLoader{ delayedEnterSettingsJson, implementation::LoadStringResource(IDR_DEFAULTS) };
+        delayedEnterLoader.MergeInboxIntoUserSettings();
+        delayedEnterLoader.FinalizeLayering();
+        delayedEnterLoader.FixupUserSettings();
+        const auto delayedEnterSettings = winrt::make_self<implementation::CascadiaSettings>(std::move(delayedEnterLoader));
+
+        const auto legacySendInputCmd = legacySettings->ActionMap().GetActionByKeyChord(KeyChord{ true, false, true, false, 87, 0 });
+        const auto delayedEnterSendInputCmd = delayedEnterSettings->ActionMap().GetActionByKeyChord(KeyChord{ true, false, true, false, 87, 0 });
+        const auto delayedArgs = delayedEnterSendInputCmd.ActionAndArgs().Args().try_as<SendInputArgs>();
+
+        VERIFY_IS_NOT_NULL(delayedArgs);
+        VERIFY_ARE_NOT_EQUAL(legacySendInputCmd.ID(), delayedEnterSendInputCmd.ID());
+        VERIFY_ARE_EQUAL(75u, delayedArgs.EnterDelayMs());
     }
 
     void SerializationTests::NoGeneratedIDsForIterableAndNestedCommands()

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -797,14 +797,17 @@ void AppHost::_WindowMouseWheeled(const winrt::Windows::Foundation::Point coord,
 // - <none>
 void AppHost::DispatchCommandline(winrt::TerminalApp::CommandlineArgs args)
 {
-    winrt::TerminalApp::SummonWindowBehavior summonArgs{};
-    summonArgs.MoveToCurrentDesktop(false);
-    summonArgs.DropdownDuration(0);
-    summonArgs.ToMonitor(winrt::TerminalApp::MonitorBehavior::InPlace);
-    summonArgs.ToggleVisibility(false); // Do not toggle, just make visible.
-    // Summon the window whenever we dispatch a commandline to it. This will
-    // make it obvious when a new tab/pane is created in a window.
-    HandleSummon(std::move(summonArgs));
+    if (args.ActivateWindow())
+    {
+        winrt::TerminalApp::SummonWindowBehavior summonArgs{};
+        summonArgs.MoveToCurrentDesktop(false);
+        summonArgs.DropdownDuration(0);
+        summonArgs.ToMonitor(winrt::TerminalApp::MonitorBehavior::InPlace);
+        summonArgs.ToggleVisibility(false); // Do not toggle, just make visible.
+        // Summon the window whenever we dispatch a commandline to it. This will
+        // make it obvious when a new tab/pane is created in a window.
+        HandleSummon(std::move(summonArgs));
+    }
     _windowLogic.ExecuteCommandline(std::move(args));
 }
 

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -676,6 +676,7 @@ void WindowEmperor::_dispatchCommandline(winrt::TerminalApp::CommandlineArgs arg
     }
     else
     {
+        args.RetargetToNewWindow();
         winrt::TerminalApp::WindowRequestedArgs request{ windowId, std::move(args) };
         request.WindowName(std::move(windowName));
         CreateNewWindow(std::move(request));
@@ -729,6 +730,7 @@ safe_void_coroutine WindowEmperor::_dispatchCommandlineCurrentDesktop(winrt::Ter
     }
     else
     {
+        args.RetargetToNewWindow();
         CreateNewWindow(winrt::TerminalApp::WindowRequestedArgs{ 0, std::move(args) });
     }
 }


### PR DESCRIPTION
## Summary

This adds a new `wt send-input` command for sending text to the active pane.

Included in this change:
- `send-input <input...>`
- `--enter`
- `--enter-delay-ms <ms>`
- `--activate`

Behavior notes:
- `send-input` targeting an existing window stays in the background by default
- `send-input --activate` opts back into the normal summon/foreground behavior
- focus-helper chains like `focus-tab ; send-input` stay background by default
- structural chains like `new-tab ; send-input` and `split-pane ; send-input` preserve existing activation behavior

## Examples

```powershell
wt -w 0 send-input "hello"
wt -w 0 send-input --enter "echo ready"
wt -w 0 send-input --enter --enter-delay-ms 200 "Please reply exactly with TEST_OK."
wt -w 0 send-input --activate "hello"
wt -w 0 focus-tab -t 1 ; send-input --enter "echo TAB2_OK"
```

## Implementation Notes

- Reuses the existing `SendInput` action path
- Allows targeting existing windows without implicitly prepending `new-tab` for automation-style send/focus flows
- Preserves existing activation behavior for non-send structural command chains
- Keeps generated action IDs stable for zero-delay/default-args cases

## Validation

Built successfully:
- `SettingsModel.UnitTests.vcxproj`
- `TerminalApp.LocalTests.vcxproj`

Focused tests passed:
- `SettingsModelUnitTests::KeyBindingsTests::HashDeduplication`
- `SettingsModelUnitTests::KeyBindingsTests::DefaultArgSemanticDeduplication`
- `SettingsModelUnitTests::KeyBindingsTests::SendInputZeroDelayDeduplication`
- `SettingsModelUnitTests::KeyBindingsTests::SendInputDelayedEnterStaysDistinct`
- `TerminalAppLocalTests::CommandlineTest::ParseSendInputArgs`

Manual smoke also passed against a side-by-side patched Terminal Dev package:
- background `send-input`
- `--activate`
- `focus-tab ; send-input`
- Codex prompt submission using `--enter --enter-delay-ms`