### PR TITLE
Support random color scheme selection

### DIFF
--- a/src/cascadia/TerminalSettingsAppAdapterLib/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettingsAppAdapterLib/TerminalSettings.cpp
@@ -6,6 +6,8 @@
 #include "winrt/Windows.UI.ViewManagement.h"
 #include "../../types/inc/colorTable.hpp"
 
+#include <random>
+
 using namespace winrt::Microsoft::Terminal::Control;
 using namespace winrt::Microsoft::Terminal::Settings;
 using namespace Microsoft::Console::Utils;
@@ -211,16 +213,61 @@ namespace winrt::Microsoft::Terminal::Settings
                                  winrt::Windows::UI::Xaml::ElementTheme::Light;
         }
 
+        // GH#9422: The special "_random" token causes us to randomly select
+        // a color scheme from the set of available schemes each time a new
+        // tab or pane is created.
+        static constexpr std::wstring_view RandomSchemeToken{ L"_random" };
+
+        // Helper to pick a random scheme from the available schemes map.
+        const auto pickRandomScheme = [&]() -> Model::ColorScheme {
+            const auto size = schemes.Size();
+            if (size == 0)
+            {
+                return nullptr;
+            }
+            // Use a random_device for non-deterministic seeding so each
+            // tab gets a truly random color scheme.
+            std::random_device rd;
+            std::mt19937 gen(rd());
+            std::uniform_int_distribution<uint32_t> dist(0, size - 1);
+            const auto index = dist(gen);
+
+            uint32_t i = 0;
+            for (const auto& [name, scheme] : schemes)
+            {
+                if (i == index)
+                {
+                    return scheme;
+                }
+                ++i;
+            }
+            return nullptr;
+        };
+
         switch (requestedTheme)
         {
         case winrt::Windows::UI::Xaml::ElementTheme::Light:
-            if (const auto scheme = schemes.TryLookup(appearance.LightColorSchemeName()))
+            if (appearance.LightColorSchemeName() == RandomSchemeToken)
+            {
+                if (const auto scheme = pickRandomScheme())
+                {
+                    ApplyColorScheme(scheme);
+                }
+            }
+            else if (const auto scheme = schemes.TryLookup(appearance.LightColorSchemeName()))
             {
                 ApplyColorScheme(scheme);
             }
             break;
         case winrt::Windows::UI::Xaml::ElementTheme::Dark:
-            if (const auto scheme = schemes.TryLookup(appearance.DarkColorSchemeName()))
+            if (appearance.DarkColorSchemeName() == RandomSchemeToken)
+            {
+                if (const auto scheme = pickRandomScheme())
+                {
+                    ApplyColorScheme(scheme);
+                }
+            }
+            else if (const auto scheme = schemes.TryLookup(appearance.DarkColorSchemeName()))
             {
                 ApplyColorScheme(scheme);
             }

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -23,6 +23,10 @@ using namespace winrt::Microsoft::Terminal::Control;
 using namespace winrt::Windows::Foundation::Collections;
 using namespace Microsoft::Console;
 
+// The special token used to indicate that a random color scheme should be
+// selected each time a new tab or pane is created. GH#9422
+static constexpr std::wstring_view RandomSchemeToken{ L"_random" };
+
 // Creating a child of a profile requires us to copy certain
 // required attributes. This method handles those attributes.
 //
@@ -466,13 +470,20 @@ void CascadiaSettings::_validateAllSchemesExist()
     {
         for (const auto& appearance : std::array{ profile.DefaultAppearance(), profile.UnfocusedAppearance() })
         {
-            if (appearance && !colorSchemes.HasKey(appearance.DarkColorSchemeName()))
+            // GH#9422: Don't clear the color scheme name if it's set to
+            // "_random" - that's a special token that will be resolved
+            // at runtime to a randomly chosen scheme.
+            if (appearance &&
+                appearance.DarkColorSchemeName() != RandomSchemeToken &&
+                !colorSchemes.HasKey(appearance.DarkColorSchemeName()))
             {
                 // Clear the user set dark color scheme. We'll just fallback instead.
                 appearance.ClearDarkColorSchemeName();
                 foundInvalidDarkScheme = true;
             }
-            if (appearance && !colorSchemes.HasKey(appearance.LightColorSchemeName()))
+            if (appearance &&
+                appearance.LightColorSchemeName() != RandomSchemeToken &&
+                !colorSchemes.HasKey(appearance.LightColorSchemeName()))
             {
                 // Clear the user set light color scheme. We'll just fallback instead.
                 appearance.ClearLightColorSchemeName();

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -471,8 +471,8 @@ void CascadiaSettings::_validateAllSchemesExist()
         for (const auto& appearance : std::array{ profile.DefaultAppearance(), profile.UnfocusedAppearance() })
         {
             // GH#9422: Don't clear the color scheme name if it's set to
-            // "_random" - that's a special token that will be resolved
-            // at runtime to a randomly chosen scheme.
+            // "_random". This special token is handled during runtime
+            // resolution to pick a random scheme from available ones.
             if (appearance &&
                 appearance.DarkColorSchemeName() != RandomSchemeToken &&
                 !colorSchemes.HasKey(appearance.DarkColorSchemeName()))


### PR DESCRIPTION
## Summary

Closes #9422

Introduces a special `_random` keyword for the `colorScheme` setting. When `colorScheme` is set to `"_random"` in `settings.json`, a randomly chosen color scheme from the available schemes is applied each time a new tab or pane is created.

This is inspired by Oh-My-Zsh's random theme feature, as suggested in the original issue.

### Usage

In `settings.json`, set:
```json
"colorScheme": "_random"
```

Each new tab will now open with a randomly selected color scheme.

### Changes

**`CascadiaSettings.cpp`**
- Added `RandomSchemeToken` constant (`L"_random"`)
- Modified `_validateAllSchemesExist()` to skip validation when the scheme name is `_random`, preventing the `UnknownColorScheme` warning that blocked the previous attempt at this feature

**`TerminalSettings.cpp`**
- Modified `_ApplyAppearanceSettings()` to detect the `_random` token and resolve it to a randomly selected scheme from the available color schemes map
- Uses `std::random_device` + `std::mt19937` for proper random selection

### Design Decisions

- Used `_random` (with underscore prefix) as the token per @zadjii-msft's suggestion that it should be "something slightly more obscure than just `random`"
- Random selection happens per-tab (each new tab gets a freshly random scheme), matching the issue's request
- Both dark and light color scheme names support the `_random` token independently

### Testing

- This is my first contribution to the project. I'm working on macOS and relying on CI for build verification.
- Manual test: Set `"colorScheme": "_random"`, open multiple tabs, verify each gets a different random scheme and no warnings appear.