### PR TITLE
chore(gitignore): add MacOS specific files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -286,3 +286,6 @@ profiles.json
 
 # MSBuildCache
 /MSBuildCacheLogs/
+
+# MacOS specific files
+.DS_Store


### PR DESCRIPTION
## Summary of the Pull Request
Add macOS Finder metadata files to the ignore list in .gitignore so .DS_Store files are not accidentally committed.

## References and Relevant Issues
None.

## Detailed Description of the Pull Request / Additional comments
This is a repository hygiene-only change. It prevents local macOS metadata from showing up in diffs or being committed, and it does not affect runtime behavior.

## Validation Steps Performed
Reviewed the .gitignore update. No tests were run because this change only updates ignore rules.

## PR Checklist
- [ ] Closes #xxx (n/a)
- [ ] Tests added/passed
- [ ] Documentation updated (if checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx)
- [ ] Schema updated (if necessary)