### PR TITLE
Revert "Implement OSC 7 for setting the CWD (#20019)"

### DIFF
--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -1475,7 +1475,7 @@ namespace winrt::TerminalApp::implementation
                                       WI_IsAnyFlagSet(source, SuggestionsSource::CommandHistory | SuggestionsSource::QuickFixes);
         if (const auto& control{ _GetActiveControl() })
         {
-            currentWorkingDirectory = control.WorkingDirectory();
+            currentWorkingDirectory = control.CurrentWorkingDirectory();
 
             if (shouldGetContext)
             {

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1600,7 +1600,8 @@ namespace winrt::TerminalApp::implementation
 
             // Replace the Starting directory with the CWD, if given
             const auto workingDirectory = control.WorkingDirectory();
-            if (Utils::IsValidDirectory(workingDirectory.c_str()))
+            const auto validWorkingDirectory = !workingDirectory.empty();
+            if (validWorkingDirectory)
             {
                 controlSettings.DefaultSettings()->StartingDirectory(workingDirectory);
             }
@@ -3558,7 +3559,8 @@ namespace winrt::TerminalApp::implementation
                 profile = GetClosestProfileForDuplicationOfProfile(profile);
                 controlSettings = Settings::TerminalSettings::CreateWithProfile(_settings, profile);
                 const auto workingDirectory = tabImpl->GetActiveTerminalControl().WorkingDirectory();
-                if (Utils::IsValidDirectory(workingDirectory.c_str()))
+                const auto validWorkingDirectory = !workingDirectory.empty();
+                if (validWorkingDirectory)
                 {
                     controlSettings.DefaultSettings()->StartingDirectory(workingDirectory);
                 }

--- a/src/cascadia/TerminalApp/TerminalPaneContent.cpp
+++ b/src/cascadia/TerminalApp/TerminalPaneContent.cpp
@@ -102,7 +102,7 @@ namespace winrt::TerminalApp::implementation
 
         args.Profile(::Microsoft::Console::Utils::GuidToString(_profile.Guid()));
         // If we know the user's working directory use it instead of the profile.
-        if (const auto dir = _control.WorkingDirectory(); ::Microsoft::Console::Utils::IsValidDirectory(dir.c_str()))
+        if (const auto dir = _control.WorkingDirectory(); !dir.empty())
         {
             args.StartingDirectory(dir);
         }

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -2426,6 +2426,11 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         return *context;
     }
 
+    winrt::hstring ControlCore::CurrentWorkingDirectory() const
+    {
+        return winrt::hstring{ _terminal->GetWorkingDirectory() };
+    }
+
     bool ControlCore::QuickFixesAvailable() const noexcept
     {
         return _cachedQuickFixes && _cachedQuickFixes.Size() > 0;

--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -191,6 +191,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         void ContextMenuSelectCommand();
         void ContextMenuSelectOutput();
+
+        winrt::hstring CurrentWorkingDirectory() const;
 #pragma endregion
 
 #pragma region ITerminalInput

--- a/src/cascadia/TerminalControl/ICoreState.idl
+++ b/src/cascadia/TerminalControl/ICoreState.idl
@@ -60,5 +60,7 @@ namespace Microsoft.Terminal.Control
         void SelectOutput(Boolean goUp);
         IVector<ScrollMark> ScrollMarks { get; };
 
+        String CurrentWorkingDirectory { get; };
+
     };
 }

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -3733,6 +3733,10 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     {
         return _core.CommandHistory();
     }
+    winrt::hstring TermControl::CurrentWorkingDirectory() const
+    {
+        return _core.CurrentWorkingDirectory();
+    }
 
     void TermControl::UpdateWinGetSuggestions(Windows::Foundation::Collections::IVector<hstring> suggestions)
     {

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -117,6 +117,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void ScrollToMark(const Control::ScrollToMarkDirection& direction);
         void SelectCommand(const bool goUp);
         void SelectOutput(const bool goUp);
+
+        winrt::hstring CurrentWorkingDirectory() const;
 #pragma endregion
 
         void ScrollViewport(int viewTop);

--- a/src/terminal/adapter/ITermDispatch.hpp
+++ b/src/terminal/adapter/ITermDispatch.hpp
@@ -82,7 +82,6 @@ public:
     virtual void BackIndex() = 0; // DECBI
     virtual void ForwardIndex() = 0; // DECFI
     virtual void SetWindowTitle(std::wstring_view title) = 0; // DECSWT, OscWindowTitle
-    virtual void SetCurrentWorkingDirectory(const std::wstring_view uri) = 0; // OSC 7
     virtual void HorizontalTabSet() = 0; // HTS
     virtual void ForwardTab(const VTInt numTabs) = 0; // CHT, HT
     virtual void BackwardsTab(const VTInt numTabs) = 0; // CBT
@@ -157,9 +156,13 @@ public:
     virtual void EndHyperlink() = 0;
 
     virtual void DoConEmuAction(const std::wstring_view string) = 0;
+
     virtual void DoITerm2Action(const std::wstring_view string) = 0;
+
     virtual void DoFinalTermAction(const std::wstring_view string) = 0;
+
     virtual void DoVsCodeAction(const std::wstring_view string) = 0;
+
     virtual void DoWTAction(const std::wstring_view string) = 0;
 
     virtual StringHandler DefineSixelImage(const VTInt macroParameter,

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -2615,27 +2615,6 @@ void AdaptDispatch::SetWindowTitle(std::wstring_view title)
     _api.SetWindowTitle(title);
 }
 
-// OSC 7 - Set Current Working Directory
-// While ConEmu's OSC 9;9 works well for native Windows paths,
-// OSC 7 uses file URIs, which may not always work.
-void AdaptDispatch::SetCurrentWorkingDirectory(std::wstring_view uri)
-{
-    // Ensure that the URI has a null terminator.
-    std::wstring path{ uri };
-
-    // PathCreateFromUrlW supports writing to the input pointer,
-    // and the resulting path can never be longer than the URI.
-    const auto ptr = path.data();
-    auto len = gsl::narrow<DWORD>(path.size());
-    THROW_IF_FAILED(PathCreateFromUrlW(ptr, ptr, &len, 0));
-    path.resize(len);
-
-    if (til::is_legal_path(path))
-    {
-        _api.SetWorkingDirectory(path);
-    }
-}
-
 //Routine Description:
 // HTS - sets a VT tab stop in the cursor's current column.
 //Arguments:

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -114,7 +114,6 @@ namespace Microsoft::Console::VirtualTerminal
         void BackIndex() override; // DECBI
         void ForwardIndex() override; // DECFI
         void SetWindowTitle(const std::wstring_view title) override; // DECSWT, OSCWindowTitle
-        void SetCurrentWorkingDirectory(std::wstring_view uri) override; // OSC 7
         void HorizontalTabSet() override; // HTS
         void ForwardTab(const VTInt numTabs) override; // CHT, HT
         void BackwardsTab(const VTInt numTabs) override; // CBT

--- a/src/terminal/adapter/precomp.h
+++ b/src/terminal/adapter/precomp.h
@@ -13,8 +13,7 @@ Abstract:
 // This includes support libraries from the CRT, STL, WIL, and GSL
 #include "LibraryIncludes.h"
 
-#include <Shlwapi.h>
-
+#include <cmath>
 #define ENABLE_INTSAFE_SIGNED_FUNCTIONS
 #include <intsafe.h>
 

--- a/src/terminal/adapter/termDispatch.hpp
+++ b/src/terminal/adapter/termDispatch.hpp
@@ -69,7 +69,6 @@ public:
     void BackIndex() override {} // DECBI
     void ForwardIndex() override {} // DECFI
     void SetWindowTitle(std::wstring_view /*title*/) override {} // DECSWT, OscWindowTitle
-    void SetCurrentWorkingDirectory(std::wstring_view /*uri*/) override {} // OSC 7
     void HorizontalTabSet() override {} // HTS
     void ForwardTab(const VTInt /*numTabs*/) override {} // CHT, HT
     void BackwardsTab(const VTInt /*numTabs*/) override {} // CBT

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -865,7 +865,8 @@ bool OutputStateMachineEngine::ActionOscDispatch(const size_t parameter, const s
         break;
     }
     case OscActionCodes::CurrentWorkingDirectory:
-        _dispatch->SetCurrentWorkingDirectory(string);
+        // TODO: Add support for OSC 7 = CWD sequences?
+        // In GH#8214 it was decided that it's a bad idea due to WSL compat.
         break;
     case OscActionCodes::Hyperlink:
     {

--- a/src/types/inc/utils.hpp
+++ b/src/types/inc/utils.hpp
@@ -128,8 +128,6 @@ namespace Microsoft::Console::Utils
 
     const wchar_t* FindActionableControlCharacter(const wchar_t* beg, const size_t len) noexcept;
 
-    bool IsValidDirectory(const wchar_t* path) noexcept;
-
     // Same deal, but in TerminalPage::_evaluatePathForCwd
     std::wstring EvaluateStartingDirectory(std::wstring_view cwd, std::wstring_view startingDirectory);
 

--- a/src/types/utils.cpp
+++ b/src/types/utils.cpp
@@ -1237,19 +1237,6 @@ plainSearch:
     return it;
 }
 
-// Returns true if it's a valid path to a directory.
-bool Utils::IsValidDirectory(const wchar_t* path) noexcept
-{
-    if (path == nullptr || *path == L'\0')
-    {
-        return false;
-    }
-
-    WIN32_FILE_ATTRIBUTE_DATA data;
-    const auto ok = GetFileAttributesExW(path, GetFileExInfoStandard, &data);
-    return ok && (data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
-}
-
 #pragma warning(pop)
 
 std::wstring Utils::EvaluateStartingDirectory(


### PR DESCRIPTION
This reverts commit 7f5185eb063f5ffd9b229b11847c47edba552d3d.

I have some new concerns about the fix in #20094, so I'm considering reverting OSC 7 from 1.25.

Refs #20108 