### PR TITLE
Normalize commandline in media resource tests

### DIFF
--- a/src/cascadia/UnitTests_SettingsModel/MediaResourceTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/MediaResourceTests.cpp
@@ -105,9 +105,10 @@ namespace SettingsModelUnitTests
         TEST_METHOD(RealResolverUrlCases);
         TEST_METHOD(RealResolverUNCCases);
 
-        static constexpr std::wstring_view pingCommandline{ LR"(C:\Windows\System32\PING.EXE)" }; // Normalized by Profile (this is the casing that Windows stores on disk)
-        static constexpr std::wstring_view overrideCommandline{ LR"(C:\Windows\System32\cscript.exe)" };
-        static constexpr std::wstring_view cmdCommandline{ LR"(C:\Windows\System32\cmd.exe)" }; // The default commandline for a profile
+        // These are normalized by NormalizeCommandLine, which resolves to the on-disk casing.
+        // They must be computed at runtime because the casing varies between machines.
+        static inline const std::wstring overrideCommandline{ implementation::Profile::NormalizeCommandLine(LR"(C:\Windows\System32\cscript.exe)") };
+        static inline const std::wstring cmdCommandline{ implementation::Profile::NormalizeCommandLine(LR"(C:\Windows\System32\cmd.exe)") }; // The default commandline for a profile
         static constexpr std::wstring_view fragmentBasePath1{ LR"(C:\Windows\Media)" };
 
     private:

--- a/src/cascadia/UnitTests_SettingsModel/MediaResourceTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/MediaResourceTests.cpp
@@ -106,9 +106,20 @@ namespace SettingsModelUnitTests
         TEST_METHOD(RealResolverUNCCases);
 
         // These are normalized by NormalizeCommandLine, which resolves to the on-disk casing.
-        // They must be computed at runtime because the casing varies between machines.
-        static inline const std::wstring overrideCommandline{ implementation::Profile::NormalizeCommandLine(LR"(C:\Windows\System32\cscript.exe)") };
-        static inline const std::wstring cmdCommandline{ implementation::Profile::NormalizeCommandLine(LR"(C:\Windows\System32\cmd.exe)") }; // The default commandline for a profile
+        // They must be computed lazily (not at static init) because on x86 the test class
+        // disables WoW64 filesystem redirection in TEST_CLASS_SETUP, and static init runs
+        // before that, which causes System32 paths to resolve to SysWOW64.
+        // They are used in test cases where media paths fall back to profile command lines.
+        static const std::wstring& overrideCommandline()
+        {
+            static const std::wstring value{ implementation::Profile::NormalizeCommandLine(LR"(C:\Windows\System32\cscript.exe)") };
+            return value;
+        }
+        static const std::wstring& cmdCommandline()
+        {
+            static const std::wstring value{ implementation::Profile::NormalizeCommandLine(LR"(C:\Windows\System32\cmd.exe)") };
+            return value;
+        }
         static constexpr std::wstring_view fragmentBasePath1{ LR"(C:\Windows\Media)" };
 
     private:
@@ -825,7 +836,7 @@ namespace SettingsModelUnitTests
         auto profile{ settings->GetProfileByName(L"Base") };
         auto icon{ profile.Icon() };
         VERIFY_IS_TRUE(icon.Ok()); // Profile with commandline always has an icon
-        VERIFY_ARE_EQUAL(cmdCommandline, icon.Resolved());
+        VERIFY_ARE_EQUAL(cmdCommandline(), icon.Resolved());
     }
 
     // The invalid resource came from the profile itself, which has its own commandline.
@@ -860,7 +871,7 @@ namespace SettingsModelUnitTests
         auto profile{ settings->GetProfileByName(L"ProfileSpecifiesInvalidIconAndCommandline") };
         auto icon{ profile.Icon() };
         VERIFY_IS_TRUE(icon.Ok()); // Profile with commandline always has an icon
-        VERIFY_ARE_EQUAL(overrideCommandline, icon.Resolved());
+        VERIFY_ARE_EQUAL(overrideCommandline(), icon.Resolved());
     }
 
     // The invalid resource came from the profile itself, where the commandline is the default value (profile.commandline default value is CMD.exe)
@@ -893,7 +904,7 @@ namespace SettingsModelUnitTests
         auto profile{ settings->GetProfileByName(L"ProfileSpecifiesInvalidIconAndNoCommandline") };
         auto icon{ profile.Icon() };
         VERIFY_IS_TRUE(icon.Ok());
-        VERIFY_ARE_EQUAL(cmdCommandline, icon.Resolved());
+        VERIFY_ARE_EQUAL(cmdCommandline(), icon.Resolved());
     }
 
     // The invalid resource came from the Defaults profile, where the commandline falls back to the default value of CMD.exe (PROFILE COMMANDLINE IGNORED)
@@ -926,7 +937,7 @@ namespace SettingsModelUnitTests
         auto profile{ settings->GetProfileByName(L"ProfileInheritsInvalidIconAndHasCommandline") };
         auto icon{ profile.Icon() };
         VERIFY_IS_TRUE(icon.Ok());
-        VERIFY_ARE_EQUAL(cmdCommandline, icon.Resolved());
+        VERIFY_ARE_EQUAL(cmdCommandline(), icon.Resolved());
     }
 
     // The invalid resource came from the Defaults profile, which has the default command line of CMD.exe (PROFILE COMMANDLINE MISSING)
@@ -958,7 +969,7 @@ namespace SettingsModelUnitTests
         auto profile{ settings->GetProfileByName(L"ProfileInheritsInvalidIconAndHasNoCommandline") };
         auto icon{ profile.Icon() };
         VERIFY_IS_TRUE(icon.Ok());
-        VERIFY_ARE_EQUAL(cmdCommandline, icon.Resolved());
+        VERIFY_ARE_EQUAL(cmdCommandline(), icon.Resolved());
     }
 
     // The invalid resource came from the profile itself, which has its own commandline.
@@ -993,7 +1004,7 @@ namespace SettingsModelUnitTests
         auto profile{ settings->GetProfileByName(L"ProfileSpecifiesNullIcon") };
         auto icon{ profile.Icon() };
         VERIFY_IS_TRUE(icon.Ok()); // Profile with commandline always has an icon
-        VERIFY_ARE_EQUAL(overrideCommandline, icon.Resolved());
+        VERIFY_ARE_EQUAL(overrideCommandline(), icon.Resolved());
     }
 
     // The invalid resource came from the profile itself, where the commandline falls back to the default value of CMD.exe
@@ -1026,7 +1037,7 @@ namespace SettingsModelUnitTests
         auto profile{ settings->GetProfileByName(L"ProfileSpecifiesNullIconAndHasNoCommandline") };
         auto icon{ profile.Icon() };
         VERIFY_IS_TRUE(icon.Ok()); // Profile with commandline always has an icon
-        VERIFY_ARE_EQUAL(cmdCommandline, icon.Resolved());
+        VERIFY_ARE_EQUAL(cmdCommandline(), icon.Resolved());
     }
 
     // A profile replaces the bell sounds (2) in the base settings; all bell sounds retained

--- a/src/cascadia/UnitTests_SettingsModel/MediaResourceTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/MediaResourceTests.cpp
@@ -106,20 +106,9 @@ namespace SettingsModelUnitTests
         TEST_METHOD(RealResolverUNCCases);
 
         // These are normalized by NormalizeCommandLine, which resolves to the on-disk casing.
-        // They must be computed lazily (not at static init) because on x86 the test class
-        // disables WoW64 filesystem redirection in TEST_CLASS_SETUP, and static init runs
-        // before that, which causes System32 paths to resolve to SysWOW64.
         // They are used in test cases where media paths fall back to profile command lines.
-        static const std::wstring& overrideCommandline()
-        {
-            static const std::wstring value{ implementation::Profile::NormalizeCommandLine(LR"(C:\Windows\System32\cscript.exe)") };
-            return value;
-        }
-        static const std::wstring& cmdCommandline()
-        {
-            static const std::wstring value{ implementation::Profile::NormalizeCommandLine(LR"(C:\Windows\System32\cmd.exe)") };
-            return value;
-        }
+        static inline std::wstring overrideCommandline;
+        static inline std::wstring cmdCommandline;
         static constexpr std::wstring_view fragmentBasePath1{ LR"(C:\Windows\Media)" };
 
     private:
@@ -230,6 +219,9 @@ namespace SettingsModelUnitTests
         // Some of our tests use paths under system32. Just don't redirect them.
         Wow64DisableWow64FsRedirection(&redirectionFlag);
 #endif
+        // Normalize these AFTER the call above so that we get the correctly redirected paths.
+        overrideCommandline = implementation::Profile::NormalizeCommandLine(LR"(C:\Windows\System32\cscript.exe)");
+        cmdCommandline = implementation::Profile::NormalizeCommandLine(LR"(C:\Windows\System32\cmd.exe)");
         return true;
     }
 
@@ -836,7 +828,7 @@ namespace SettingsModelUnitTests
         auto profile{ settings->GetProfileByName(L"Base") };
         auto icon{ profile.Icon() };
         VERIFY_IS_TRUE(icon.Ok()); // Profile with commandline always has an icon
-        VERIFY_ARE_EQUAL(cmdCommandline(), icon.Resolved());
+        VERIFY_ARE_EQUAL(cmdCommandline, icon.Resolved());
     }
 
     // The invalid resource came from the profile itself, which has its own commandline.
@@ -871,7 +863,7 @@ namespace SettingsModelUnitTests
         auto profile{ settings->GetProfileByName(L"ProfileSpecifiesInvalidIconAndCommandline") };
         auto icon{ profile.Icon() };
         VERIFY_IS_TRUE(icon.Ok()); // Profile with commandline always has an icon
-        VERIFY_ARE_EQUAL(overrideCommandline(), icon.Resolved());
+        VERIFY_ARE_EQUAL(overrideCommandline, icon.Resolved());
     }
 
     // The invalid resource came from the profile itself, where the commandline is the default value (profile.commandline default value is CMD.exe)
@@ -904,7 +896,7 @@ namespace SettingsModelUnitTests
         auto profile{ settings->GetProfileByName(L"ProfileSpecifiesInvalidIconAndNoCommandline") };
         auto icon{ profile.Icon() };
         VERIFY_IS_TRUE(icon.Ok());
-        VERIFY_ARE_EQUAL(cmdCommandline(), icon.Resolved());
+        VERIFY_ARE_EQUAL(cmdCommandline, icon.Resolved());
     }
 
     // The invalid resource came from the Defaults profile, where the commandline falls back to the default value of CMD.exe (PROFILE COMMANDLINE IGNORED)
@@ -937,7 +929,7 @@ namespace SettingsModelUnitTests
         auto profile{ settings->GetProfileByName(L"ProfileInheritsInvalidIconAndHasCommandline") };
         auto icon{ profile.Icon() };
         VERIFY_IS_TRUE(icon.Ok());
-        VERIFY_ARE_EQUAL(cmdCommandline(), icon.Resolved());
+        VERIFY_ARE_EQUAL(cmdCommandline, icon.Resolved());
     }
 
     // The invalid resource came from the Defaults profile, which has the default command line of CMD.exe (PROFILE COMMANDLINE MISSING)
@@ -969,7 +961,7 @@ namespace SettingsModelUnitTests
         auto profile{ settings->GetProfileByName(L"ProfileInheritsInvalidIconAndHasNoCommandline") };
         auto icon{ profile.Icon() };
         VERIFY_IS_TRUE(icon.Ok());
-        VERIFY_ARE_EQUAL(cmdCommandline(), icon.Resolved());
+        VERIFY_ARE_EQUAL(cmdCommandline, icon.Resolved());
     }
 
     // The invalid resource came from the profile itself, which has its own commandline.
@@ -1004,7 +996,7 @@ namespace SettingsModelUnitTests
         auto profile{ settings->GetProfileByName(L"ProfileSpecifiesNullIcon") };
         auto icon{ profile.Icon() };
         VERIFY_IS_TRUE(icon.Ok()); // Profile with commandline always has an icon
-        VERIFY_ARE_EQUAL(overrideCommandline(), icon.Resolved());
+        VERIFY_ARE_EQUAL(overrideCommandline, icon.Resolved());
     }
 
     // The invalid resource came from the profile itself, where the commandline falls back to the default value of CMD.exe
@@ -1037,7 +1029,7 @@ namespace SettingsModelUnitTests
         auto profile{ settings->GetProfileByName(L"ProfileSpecifiesNullIconAndHasNoCommandline") };
         auto icon{ profile.Icon() };
         VERIFY_IS_TRUE(icon.Ok()); // Profile with commandline always has an icon
-        VERIFY_ARE_EQUAL(cmdCommandline(), icon.Resolved());
+        VERIFY_ARE_EQUAL(cmdCommandline, icon.Resolved());
     }
 
     // A profile replaces the bell sounds (2) in the base settings; all bell sounds retained


### PR DESCRIPTION
## Summary of the Pull Request
Some of the Media Resource tests were failing on my machine. Turns out that it's because my machine uses `C:\WINDOWS` instead of `C:\Windows`.

This PR fixes those tests by calling `Profile::NormalizeCommandline()` on a few impacted strings. This also makes them loaded after enabling filesystem redirection in `TEST_CLASS_SETUP` so that we resolve to the correct path expected by x86.

Admittedly, I'm not the biggest fan of using that to fix the tests, but it's better than the alternative which is a case-insensitive string comparison. Also, the tests are testing fallback behavior, so this doesn't really impact that. It just makes the tests more consistently reliable.

This also removes the unused `pingCommandline` variable.

## Validation Steps Performed
✅ Tests pass