### PR TITLE
IconWUX: let callers set icon size instead of defaulting to 32×32 (#19806)

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1349,8 +1349,8 @@ namespace winrt::TerminalApp::implementation
         }
 
         auto icon = UI::IconPathConverter::IconWUX(iconSource);
-        icon.Width(16);
-        icon.Height(16);
+        icon.Width(32);
+        icon.Height(32);
         Automation::AutomationProperties::SetAccessibilityView(icon, Automation::Peers::AccessibilityView::Raw);
 
         return icon;

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1349,6 +1349,8 @@ namespace winrt::TerminalApp::implementation
         }
 
         auto icon = UI::IconPathConverter::IconWUX(iconSource);
+        icon.Width(16);
+        icon.Height(16);
         Automation::AutomationProperties::SetAccessibilityView(icon, Automation::Peers::AccessibilityView::Raw);
 
         return icon;
@@ -5356,6 +5358,8 @@ namespace winrt::TerminalApp::implementation
             if (!icon.empty())
             {
                 auto iconElement = UI::IconPathConverter::IconWUX(icon);
+                iconElement.Width(16);
+                iconElement.Height(16);
                 Automation::AutomationProperties::SetAccessibilityView(iconElement, Automation::Peers::AccessibilityView::Raw);
                 button.Icon(iconElement);
             }
@@ -5374,6 +5378,8 @@ namespace winrt::TerminalApp::implementation
             if (!icon.empty())
             {
                 auto iconElement = UI::IconPathConverter::IconWUX(icon);
+                iconElement.Width(16);
+                iconElement.Height(16);
                 Automation::AutomationProperties::SetAccessibilityView(iconElement, Automation::Peers::AccessibilityView::Raw);
                 button.Icon(iconElement);
             }
@@ -5394,6 +5400,8 @@ namespace winrt::TerminalApp::implementation
             if (!icon.empty())
             {
                 auto iconElement = UI::IconPathConverter::IconWUX(icon);
+                iconElement.Width(16);
+                iconElement.Height(16);
                 Automation::AutomationProperties::SetAccessibilityView(iconElement, Automation::Peers::AccessibilityView::Raw);
                 button.Icon(iconElement);
             }
@@ -5564,6 +5572,8 @@ namespace winrt::TerminalApp::implementation
             MenuFlyoutItem item{};
 
             auto iconElement = UI::IconPathConverter::IconWUX(L"\ue74c");
+            iconElement.Width(16);
+            iconElement.Height(16);
             Automation::AutomationProperties::SetAccessibilityView(iconElement, Automation::Peers::AccessibilityView::Raw);
             item.Icon(iconElement);
 

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -968,7 +968,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         MUX::Controls::NavigationViewItem profileNavItem;
         profileNavItem.Content(box_value(profile.Name()));
         profileNavItem.Tag(box_value<Editor::ProfileViewModel>(profile));
-        profileNavItem.Icon(UI::IconPathConverter::IconWUX(profile.EvaluatedIcon()));
+        auto profileIcon = UI::IconPathConverter::IconWUX(profile.EvaluatedIcon());
+        profileIcon.Width(16);
+        profileIcon.Height(16);
+        profileNavItem.Icon(profileIcon);
         WUX::Controls::ToolTipService::SetToolTip(profileNavItem, box_value(profile.Name()));
 
         if (profile.Orphaned())
@@ -988,7 +991,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 const auto& tag{ menuItem.Tag().as<Editor::ProfileViewModel>() };
                 if (args.PropertyName() == L"Icon")
                 {
-                    menuItem.Icon(UI::IconPathConverter::IconWUX(tag.EvaluatedIcon()));
+                    auto updatedIcon = UI::IconPathConverter::IconWUX(tag.EvaluatedIcon());
+                    updatedIcon.Width(16);
+                    updatedIcon.Height(16);
+                    menuItem.Icon(updatedIcon);
                 }
                 else if (args.PropertyName() == L"Name")
                 {

--- a/src/cascadia/TerminalSettingsEditor/NewTabMenuViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/NewTabMenuViewModel.cpp
@@ -227,7 +227,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         {
             return nullptr;
         }
-        // IconWUX sets the icon width/height to 32 by default
         auto icon = Microsoft::Terminal::UI::IconPathConverter::IconWUX(_CurrentFolder.Icon());
         icon.Width(16);
         icon.Height(16);

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
@@ -558,7 +558,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     Windows::UI::Xaml::Controls::IconElement ProfileViewModel::IconPreview() const
     {
-        // IconWUX sets the icon width/height to 32 by default
         auto icon = Microsoft::Terminal::UI::IconPathConverter::IconWUX(EvaluatedIcon());
         icon.Width(16);
         icon.Height(16);

--- a/src/cascadia/TerminalSettingsEditor/SearchIndex.cpp
+++ b/src/cascadia/TerminalSettingsEditor/SearchIndex.cpp
@@ -173,13 +173,12 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             }
             else if (const auto extensionPackageVM = navigationArg.try_as<Editor::ExtensionPackageViewModel>())
             {
-                // TODO GH #19806: IconWUX() sets a size on the icon automatically. This is great
-                //   for most icons, but font icons end up being a weird size.
-                // Check if we're using the generic font icon, and, if so, just build it ourselves
-                //   so that it looks right.
                 const auto& extPkgVMIconPath = extensionPackageVM.Icon();
                 if (extPkgVMIconPath == NavTagIconMap[extensionsTag])
                 {
+                    // generic extension icon — build FontIcon directly so FontSize
+                    // matches the other font icons in this list (iconSize, not the
+                    // smaller default from IconWUX)
                     WUX::Controls::FontIcon icon{};
                     icon.FontFamily(Media::FontFamily{ L"Segoe Fluent Icons, Segoe MDL2 Assets" });
                     icon.FontSize(iconSize);

--- a/src/cascadia/UIHelpers/IconPathConverter.cpp
+++ b/src/cascadia/UIHelpers/IconPathConverter.cpp
@@ -331,8 +331,6 @@ namespace winrt::Microsoft::Terminal::UI::implementation
 
         winrt::Microsoft::UI::Xaml::Controls::ImageIcon icon{};
         icon.Source(bitmapSource);
-        icon.Width(32);
-        icon.Height(32);
         return icon;
     }
 }

--- a/src/cascadia/UIHelpers/IconPathConverter.h
+++ b/src/cascadia/UIHelpers/IconPathConverter.h
@@ -8,6 +8,8 @@ namespace winrt::Microsoft::Terminal::UI::implementation
     {
         IconPathConverter() = default;
 
+        // Returns an unsized IconElement — callers are responsible for setting
+        // Width/Height to match their UI context.
         static Windows::UI::Xaml::Controls::IconElement IconWUX(const winrt::hstring& iconPath);
         static Windows::UI::Xaml::Controls::IconSource IconSourceWUX(const winrt::hstring& iconPath);
         static Microsoft::UI::Xaml::Controls::IconSource IconSourceMUX(const winrt::hstring& iconPath, bool convertToGrayscale);


### PR DESCRIPTION
## Summary of the Pull Request

`IconPathConverter::IconWUX()` was hardcoding `Width(32)` / `Height(32)` on every icon it returned. Some call sites were already overriding that to 16×16 with a comment explaining why; others just got stuck with 32×32.

This drops the hardcoded size and has every caller set its own `Width` / `Height` — 16×16 across the board, matching what the overriding callers were already using.

## References and Relevant Issues

Fixes #19806

## Detailed Description of the Pull Request / Additional comments

Callers that were already setting 16×16 — just dropped the stale "IconWUX sets 32 by default" comment:

- `BasePaletteItem.h`
- `ProfileViewModel.cpp`
- `NewTabMenuViewModel.cpp`
- `SearchIndex.cpp`

Callers that previously got 32×32 by default and now set 16×16 themselves:

- `TerminalPage.cpp` — new-tab dropdown, pane context menu, quick-fix menu
- `MainPage.cpp` — profile nav entries

`SearchIndex.cpp` also had a `// TODO GH #19806` comment that's no longer relevant; removed.

## Validation Steps Performed

This is my first contribution to the repo, so I wanted to be thorough. Built locally (VS 2022, Debug x64) and walked through every UI surface that renders icons from these call sites, comparing against the current Store release. Left side of each image is Store, right is this branch.

**New-tab dropdown**

<img width="1914" height="1079" alt="Before and After" src="https://github.com/user-attachments/assets/6d32b6ee-c1a7-41ba-b119-e4664c004eaf" />


**Right-click pane context menu**

<img width="1914" height="1023" alt="Before and After 2" src="https://github.com/user-attachments/assets/6cda2bdb-8510-4e26-b4e9-12f1859dced4" />

**Settings → profile nav**

<img width="1913" height="1007" alt="Before and After 3" src="https://github.com/user-attachments/assets/4222c670-1e39-46ec-89af-f75734edecbe" />


**Profile page icon + left-nav updating after changing the icon**

<img width="1912" height="1008" alt="Before and After 4" src="https://github.com/user-attachments/assets/99f9a8bd-9720-40a1-9dc7-51faec05fc7a" />


**New Tab Menu folder icon** (newer feature than the current Store build — just showing the fork renders it at a sensible size)

<img width="1917" height="1017" alt="Before and After 5" src="https://github.com/user-attachments/assets/b3abaf24-e216-4c2c-8a64-449407fb65f8" />


<img width="1918" height="1008" alt="Before and After 6" src="https://github.com/user-attachments/assets/4f669019-bf95-4121-8028-ab34033dc471" />


**Command palette**

<img width="1913" height="1006" alt="Before and After 7" src="https://github.com/user-attachments/assets/a1b65d1d-6fc0-4db8-83bf-e99e1ce27639" />


**Settings search** (also newer than the Store release)

<img width="1918" height="1016" alt="Before and After 8" src="https://github.com/user-attachments/assets/2de0b1bd-fc7e-415e-9d97-3ca5ceb778ec" />

Couldn't reproduce the quick-fix menu locally — I don't have winget shell integration set up. Same `IconWUX` + explicit 16×16 pattern as the surfaces above.

## PR Checklist

- [x] Closes #19806
- [x] Tests added/passed (visual refactor — verified by walking through each affected surface above)
- [x] Documentation updated (n/a)
- [x] Schema updated (n/a)
---

First contribution to Windows Terminal, it's an honor to put up a patch on a Microsoft open-source project. Thanks in advance for the review.