### PR TITLE
Remove Debug|x64 deploy entry from OpenConsole.slnx

### DIFF
--- a/OpenConsole.slnx
+++ b/OpenConsole.slnx
@@ -648,7 +648,6 @@
       <Build Solution="Fuzzing|x64" Project="false" />
       <Build Solution="Fuzzing|x86" Project="false" />
       <Deploy Solution="Debug|ARM64" />
-      <Deploy Solution="Debug|x64" />
       <Deploy Solution="Debug|x86" />
       <Deploy Solution="Release|ARM64" />
       <Deploy Solution="Release|x64" />


### PR DESCRIPTION
## Summary of the Pull Request
This PR removes the `Debug|x64` deploy entry from `OpenConsole.slnx`.

## References and Relevant Issues
N/A

## Detailed Description of the Pull Request / Additional comments
Removed `<Deploy Solution="Debug|x64" />` from `OpenConsole.slnx`.

## Validation Steps Performed
- Reviewed the staged diff locally

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Schema updated (if necessary)