### PR TITLE
Add \--headless\ CLI flag to start WT without opening a window

### DIFF
--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -183,6 +183,11 @@ void AppCommandlineArgs::_buildParser()
     maximized->excludes(fullscreen);
     focus->excludes(fullscreen);
 
+    auto headlessCallback = [this](int64_t /*count*/) {
+        _headless = true;
+    };
+    _app.add_flag_function("--headless", headlessCallback, RS_A(L"CmdHeadlessDesc"));
+
     auto positionCallback = [this](std::string string) {
         _position = LaunchPositionFromString(string);
     };
@@ -1002,6 +1007,14 @@ bool AppCommandlineArgs::ShouldExitEarly() const noexcept
 // - <none>
 void AppCommandlineArgs::ValidateStartupCommands()
 {
+    // If launched with --headless and no other subcommands/commandlines were
+    // provided, there's nothing to start — the process will wait silently in
+    // the background until the user summons it (e.g. via globalSummon/quakeMode).
+    if (_headless && _startupActions.empty())
+    {
+        return;
+    }
+
     // If we only have a single x-save command, then set our target to the
     // current terminal window. This will prevent us from spawning a new
     // window just to save the commandline.
@@ -1046,6 +1059,11 @@ std::optional<winrt::Microsoft::Terminal::Settings::Model::LaunchPosition> AppCo
 std::optional<til::size> AppCommandlineArgs::GetSize() const noexcept
 {
     return _size;
+}
+
+bool AppCommandlineArgs::IsHeadless() const noexcept
+{
+    return _headless;
 }
 
 // Method Description:
@@ -1169,6 +1187,7 @@ void AppCommandlineArgs::FullResetState()
 
     _currentCommandline = nullptr;
     _launchMode = std::nullopt;
+    _headless = false;
     _startupActions.clear();
     _exitMessage = "";
     _shouldExitEarly = false;

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.h
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.h
@@ -42,6 +42,7 @@ public:
     std::optional<winrt::Microsoft::Terminal::Settings::Model::LaunchMode> GetLaunchMode() const noexcept;
     std::optional<winrt::Microsoft::Terminal::Settings::Model::LaunchPosition> GetPosition() const noexcept;
     std::optional<til::size> GetSize() const noexcept;
+    bool IsHeadless() const noexcept;
 
     int ParseArgs(const winrt::Microsoft::Terminal::Settings::Model::ExecuteCommandlineArgs& args);
     void DisableHelpInExitMessage();
@@ -129,6 +130,7 @@ private:
 
     const Commandline* _currentCommandline{ nullptr };
     std::optional<winrt::Microsoft::Terminal::Settings::Model::LaunchMode> _launchMode{ std::nullopt };
+    bool _headless{ false };
     std::optional<winrt::Microsoft::Terminal::Settings::Model::LaunchPosition> _position{ std::nullopt };
     std::optional<til::size> _size{ std::nullopt };
     std::vector<winrt::Microsoft::Terminal::Settings::Model::ActionAndArgs> _startupActions;

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -272,6 +272,42 @@ namespace winrt::TerminalApp::implementation
         return _hasSettingsStartupActions;
     }
 
+    // Method Description:
+    // - Parses the given commandline and returns true if it contains a top-level
+    //   --headless flag with no other subcommands. This is used by WindowEmperor
+    //   to decide whether to suppress window creation at startup.
+    // Arguments:
+    // - commandLine: the full commandline string (as from GetCommandLineW())
+    // Return Value:
+    // - true if --headless was provided and no window-creating subcommands were given
+    bool AppLogic::IsHeadlessCommandline(winrt::hstring const& commandLine) const
+    {
+        if (commandLine.empty())
+        {
+            return false;
+        }
+
+        int argc = 0;
+        LPWSTR* argv = CommandLineToArgvW(commandLine.c_str(), &argc);
+        if (!argv || argc <= 0)
+        {
+            return false;
+        }
+        const auto freeArgv = wil::scope_exit([argv] { LocalFree(argv); });
+
+        std::vector<winrt::hstring> args;
+        args.reserve(argc);
+        for (int i = 0; i < argc; i++)
+        {
+            args.emplace_back(argv[i]);
+        }
+
+        AppCommandlineArgs tempArgs;
+        tempArgs.ParseArgs(winrt::array_view<const winrt::hstring>{ args });
+        tempArgs.ValidateStartupCommands();
+        return tempArgs.IsHeadless() && tempArgs.GetStartupActions().empty();
+    }
+
     // Call this function after loading your _settings.
     // It handles any CPU intensive settings updates (like updating the Jumplist)
     // which should thus only occur if the settings file actually changed.

--- a/src/cascadia/TerminalApp/AppLogic.h
+++ b/src/cascadia/TerminalApp/AppLogic.h
@@ -40,6 +40,7 @@ namespace winrt::TerminalApp::implementation
         void NotifyRootInitialized();
 
         bool HasSettingsStartupActions() const noexcept;
+        bool IsHeadlessCommandline(winrt::hstring const& commandLine) const;
 
         Microsoft::Terminal::Settings::Model::CascadiaSettings Settings() const noexcept;
 

--- a/src/cascadia/TerminalApp/AppLogic.idl
+++ b/src/cascadia/TerminalApp/AppLogic.idl
@@ -24,6 +24,11 @@ namespace TerminalApp
 
         Boolean HasSettingsStartupActions();
 
+        // Returns true if the given commandline contains a top-level --headless flag
+        // with no other subcommands, indicating the process should start without
+        // opening any window.
+        Boolean IsHeadlessCommandline(String commandLine);
+
         void ReloadSettings();
         void ReloadSettingsThrottled();
         Microsoft.Terminal.Settings.Model.CascadiaSettings Settings { get; };

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -402,6 +402,9 @@
   <data name="CmdFullscreenDesc" xml:space="preserve">
     <value>Launch the window in fullscreen mode</value>
   </data>
+  <data name="CmdHeadlessDesc" xml:space="preserve">
+    <value>Start without opening a window, staying alive in the background for global hotkeys (e.g. quake mode)</value>
+  </data>
   <data name="CmdMoveFocusDesc" xml:space="preserve">
     <value>Move focus to the adjacent pane in the specified direction</value>
   </data>

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -414,19 +414,28 @@ void WindowEmperor::HandleCommandlineArgs(int nCmdShow)
         const auto cwd = wil::GetCurrentDirectoryW<std::wstring>();
         const auto showCmd = gsl::narrow_cast<uint32_t>(nCmdShow);
 
-        // Restore persisted windows.
-        const auto state = ApplicationState::SharedInstance();
-        const auto layouts = state.PersistedWindowLayouts();
-        if (layouts && layouts.Size() > 0)
-        {
-            _needsPersistenceCleanup = true;
+        // Check whether the user launched with --headless (and no other subcommands)
+        // before restoring any persisted layouts. A headless launch should silently
+        // stay alive in the background so that global hotkeys (e.g. quake mode) work
+        // immediately, without ever opening a window.
+        _launchHeadless = _app.Logic().IsHeadlessCommandline(GetCommandLineW());
 
-            uint32_t startIdx = 0;
-            for (const auto layout : layouts)
+        // Restore persisted windows (skipped for headless launches).
+        if (!_launchHeadless)
+        {
+            const auto state = ApplicationState::SharedInstance();
+            const auto layouts = state.PersistedWindowLayouts();
+            if (layouts && layouts.Size() > 0)
             {
-                hstring args[] = { L"wt", L"-w", L"new", L"-s", winrt::to_hstring(startIdx) };
-                _dispatchCommandlineCommon(args, cwd, env, showCmd);
-                startIdx += 1;
+                _needsPersistenceCleanup = true;
+
+                uint32_t startIdx = 0;
+                for (const auto layout : layouts)
+                {
+                    hstring args[] = { L"wt", L"-w", L"new", L"-s", winrt::to_hstring(startIdx) };
+                    _dispatchCommandlineCommon(args, cwd, env, showCmd);
+                    startIdx += 1;
+                }
             }
         }
 
@@ -438,6 +447,13 @@ void WindowEmperor::HandleCommandlineArgs(int nCmdShow)
             //
             // TODO: Here we could start a timer and exit after, say, 5 seconds
             // if no windows are created. But that's a minor concern.
+        }
+        else if (_launchHeadless)
+        {
+            // Pure headless launch: don't create any window. The process stays alive
+            // waiting for the user to summon it via a global hotkey (e.g. Win+`).
+            // _postQuitMessageIfNeeded() won't exit because _launchHeadless is set.
+            _postQuitMessageIfNeeded();
         }
         else
         {
@@ -868,6 +884,7 @@ void WindowEmperor::_postQuitMessageIfNeeded() const
     if (
         _messageBoxCount <= 0 &&
         _windowCount <= 0 &&
+        !_launchHeadless &&
         !_app.Logic().Settings().GlobalSettings().AllowHeadless())
     {
         PostQuitMessage(0);

--- a/src/cascadia/WindowsTerminal/WindowEmperor.h
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.h
@@ -79,6 +79,7 @@ private:
     bool _notificationIconShown = false;
     bool _skipPersistence = false;
     bool _needsPersistenceCleanup = false;
+    bool _launchHeadless = false;
     SafeDispatcherTimer _persistStateTimer;
     std::optional<bool> _currentSystemThemeIsDark;
     int32_t _windowCount = 0;


### PR DESCRIPTION
## Summary

Closes #9996

Adds a new top-level \--headless\ flag that allows Windows Terminal to start silently in the background without creating any visible window. This is primarily intended for use at login (via startup tasks or Task Scheduler) combined with \globalSummon\ / quake mode, so that Win+\ works immediately on first press without a Terminal window flashing open at login.

## Behavior (design 2B)

- \wt --headless\ → process starts, **no window opens**, no persisted layouts are restored, process stays alive waiting for a global hotkey
- \wt --headless new-tab\ → \--headless\ is a top-level flag but since a subcommand is present, it is executed normally (window created as requested)
- When all windows are later closed, the process stays alive — same as \compatibility.allowHeadless: true\ in settings

## Implementation

| Layer | Change |
|---|---|
| \AppCommandlineArgs.h/.cpp\ | New \--headless\ top-level flag (no short form to avoid conflict with split-pane's \-H\/\--horizontal\). \ValidateStartupCommands()\ skips the default new-tab injection when headless+no-subcommands. \FullResetState()\ resets \_headless\. |
| \AppLogic.idl/.h/.cpp\ | New WinRT method \IsHeadlessCommandline(String)\ that parses a raw commandline and returns \	rue\ iff \--headless\ is set with no user-requested startup actions. |
| \WindowEmperor.h/.cpp\ | Calls \IsHeadlessCommandline()\ early in \HandleCommandlineArgs()\, before restoring persisted layouts. When true: skips layout restore, skips window creation, keeps process alive via \_launchHeadless\ checked in \_postQuitMessageIfNeeded()\. |
| \Resources.resw\ | Added \CmdHeadlessDesc\ localization string. |

## Testing

- \wt --headless\ → no window, process stays alive (verify via Task Manager or \	asklist\)
- Win+\ after headless launch → quake window opens instantly
- \wt --headless new-tab\ → opens a new tab window normally
- \wt --headless ;\ → edge case, treated same as with a subcommand
- Existing \llowHeadless\ behavior unchanged

## Known limitations

- If WT is **already running** and the user calls \wt --headless\, the single-instance handoff sends the args to the existing instance which will call \CreateNewWindow\ (no headless behavior in that path). This is acceptable for the MVP since the primary use case is startup when WT is not yet running.
- \startOnUserLogin: headless\ (closes #13630) is a follow-up — requires detecting startup task activation kind.

---

cc @zadjii-msft (you [explicitly invited community PRs](https://github.com/microsoft/terminal/issues/9996#issuecomment-2825163738) for this — here it is! 🎉)