### PR TITLE
Fix a OOB write in SixelParser

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -1,8 +1,8 @@
 aaaaabbb
+ABANDONFONT
 abbcc
 abcc
 abgr
-ABANDONFONT
 ABORTIFHUNG
 ACCESSTOKEN
 acidev
@@ -1157,6 +1157,7 @@ onecoreuuid
 ONECOREWINDOWS
 onehalf
 oneseq
+oom
 openbash
 opencode
 opencon

--- a/src/terminal/adapter/SixelParser.cpp
+++ b/src/terminal/adapter/SixelParser.cpp
@@ -659,10 +659,26 @@ void SixelParser::_initImageBuffer()
 void SixelParser::_resizeImageBuffer(const til::CoordType requiredHeight)
 {
     const auto requiredSize = (_imageCursor.y + requiredHeight) * _imageMaxWidth;
-    if (static_cast<size_t>(requiredSize) > _imageBuffer.size())
+    const auto requiredSizeU = static_cast<size_t>(requiredSize);
+    auto oom = requiredSize < 0;
+
+    if (!oom || requiredSizeU > _imageBuffer.size())
     {
         static constexpr auto transparentPixel = IndexedPixel{ .transparent = true };
-        _imageBuffer.resize(requiredSize, transparentPixel);
+        try
+        {
+            _imageBuffer.resize(requiredSizeU, transparentPixel);
+        }
+        catch (...)
+        {
+            LOG_CAUGHT_EXCEPTION();
+            oom = true;
+        }
+    }
+
+    if (oom)
+    {
+        _imageBuffer = std::vector<IndexedPixel>{};
     }
 }
 
@@ -690,6 +706,14 @@ void SixelParser::_fillImageBackground()
 
 void SixelParser::_fillImageBackground(const int backgroundHeight)
 {
+    // TODO: Ideally we should do bounds checks on all buffer access here.
+    // For now this functions as a viable workaround for GH#20149,
+    // because on allocation failure we clear out the vector.
+    if (_imageBuffer.empty())
+    {
+        return;
+    }
+
     static constexpr auto backgroundPixel = IndexedPixel{};
     const auto backgroundWidth = std::min(_backgroundSize.width, _availablePixelWidth);
     const auto backgroundOffset = _imageCursor.y * _imageMaxWidth;
@@ -736,6 +760,14 @@ void SixelParser::_decreaseFilledBackgroundHeight(const int decreasedHeight) noe
 
 void SixelParser::_writeToImageBuffer(int sixelValue, int repeatCount)
 {
+    // TODO: Ideally we should do bounds checks on all buffer access here.
+    // For now this functions as a viable workaround for GH#20149,
+    // because on allocation failure we clear out the vector.
+    if (_imageBuffer.empty())
+    {
+        return;
+    }
+
     // On terminals that support the raster attributes command (which sets the
     // background size), the background is only drawn when the first sixel value
     // is received. So if we haven't filled it yet, we need to do so now.
@@ -931,6 +963,7 @@ void SixelParser::_maybeFlushImageBuffer(const bool endOfSequence)
                 }
                 else
                 {
+                    // TODO: Here and above in the other advance() call, we should do bounds checks. See GH#20149.
                     std::advance(srcIterator, _imageMaxWidth * _cellSize.height);
                 }
                 rowOffset++;


### PR DESCRIPTION
The `SixelParser` state machine assumes that `_resizeImageBuffer`
succeeded. The state that determines the X/Y size of the buffer
is set outside of the resize function.
This meant that an OOM failure can cause the resize to fail
and the buffer X/Y size variables to be out-of-sync.
A later write in the buffer will then be out of bounds.
Whether that's before or after the buffer address depends
on whether the 32-bit coord multiplication overflows or not.

Closes #20149

## Validation Steps Performed
* Run the repro (super tall sixel), specifically
  in PowerShell 5 (depends on its particular chunking)
* OpenConsole.exe doesn't crash