### PR TITLE
TermControl: Remove the "hairpin" paste handler, consolidate string writers

### DIFF
--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -452,8 +452,11 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_HandlePasteText(const IInspectable& /*sender*/,
                                         const ActionEventArgs& args)
     {
-        _PasteText();
-        args.Handled(true);
+        if (const auto& control{ _GetActiveControl() })
+        {
+            _PasteFromClipboardHandler(control, nullptr);
+            args.Handled(true);
+        }
     }
 
     void TerminalPage::_HandleNewTab(const IInspectable& /*sender*/,

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -185,7 +185,7 @@ namespace winrt::TerminalApp::implementation
         {
             if (const auto termControl{ _senderOrActiveControl(sender) })
             {
-                termControl.SendInput(realArgs.Input());
+                termControl.WriteInputString(realArgs.Input(), WriteInputStringType::Raw);
                 args.Handled(true);
             }
         }

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -3044,14 +3044,15 @@ void Pane::BroadcastChar(const winrt::Microsoft::Terminal::Control::TermControl&
 }
 
 void Pane::BroadcastString(const winrt::Microsoft::Terminal::Control::TermControl& sourceControl,
-                           const winrt::hstring& text)
+                           const winrt::hstring& text,
+                           const winrt::Microsoft::Terminal::Control::WriteInputStringType type)
 {
     WalkTree([&](const auto& pane) {
         if (const auto& termControl{ pane->GetTerminalControl() })
         {
             if (termControl != sourceControl && !termControl.ReadOnly())
             {
-                termControl.RawWriteString(text);
+                termControl.WriteInputString(text, type);
             }
         }
     });

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -3052,7 +3052,7 @@ void Pane::BroadcastString(const winrt::Microsoft::Terminal::Control::TermContro
         {
             if (termControl != sourceControl && !termControl.ReadOnly())
             {
-                termControl.WriteInputString(text, type);
+                termControl.WriteInputStringWithoutBroadcast(text, type);
             }
         }
     });

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -152,7 +152,7 @@ public:
     void EnableBroadcast(bool enabled);
     void BroadcastKey(const winrt::Microsoft::Terminal::Control::TermControl& sourceControl, const WORD vkey, const WORD scanCode, const winrt::Microsoft::Terminal::Core::ControlKeyStates modifiers, const bool keyDown);
     void BroadcastChar(const winrt::Microsoft::Terminal::Control::TermControl& sourceControl, const wchar_t vkey, const WORD scanCode, const winrt::Microsoft::Terminal::Core::ControlKeyStates modifiers);
-    void BroadcastString(const winrt::Microsoft::Terminal::Control::TermControl& sourceControl, const winrt::hstring& text);
+    void BroadcastString(const winrt::Microsoft::Terminal::Control::TermControl& sourceControl, const winrt::hstring& text, const winrt::Microsoft::Terminal::Control::WriteInputStringType type);
 
     void UpdateResources(const PaneResources& resources);
 

--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -2222,7 +2222,8 @@ namespace winrt::TerminalApp::implementation
                 if (tab->_tabStatus.IsInputBroadcastActive())
                 {
                     tab->_rootPane->BroadcastString(sender.try_as<TermControl>(),
-                                                    e.Text());
+                                                    e.Text(),
+                                                    static_cast<winrt::Microsoft::Terminal::Control::WriteInputStringType>(e.Type()));
                 }
             }
         });

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -3058,7 +3058,7 @@ namespace winrt::TerminalApp::implementation
         // This will end up calling ConptyConnection::WriteInput which calls WriteFile which may block for
         // an indefinite amount of time. Avoid freezes and deadlocks by running this on a background thread.
         assert(!dispatcher.HasThreadAccess());
-        eventArgs.HandleClipboardData(text);
+        control.WriteInputString(text, WriteInputStringType::Clipboard);
 
         // GH#18821: If broadcast input is active, paste the same text into all other
         // panes on the tab. We do this here (rather than re-reading the

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2958,7 +2958,7 @@ namespace winrt::TerminalApp::implementation
         // Used to determine whether to emit empty pastes and strip extra whitespace
         const auto anyHasBracketedPaste = control && !control.ReadOnly() && control.BracketedPasteEnabled();
         // Used to determine whether to warn on multi-line paste
-        // If none have bracketed paste, we can short-circuit.
+        // If none lack bracketed paste, we can skip the warning.
         const auto anyHasUnbracketedPaste = !anyHasBracketedPaste;
 
         // GetClipboardData might block for up to 30s for delay-rendered contents.

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2945,9 +2945,7 @@ namespace winrt::TerminalApp::implementation
     // - Sends the text back to the TermControl through the event's
     //   `HandleClipboardData` member function.
     // - Does some of this in a background thread, as to not hang/crash the UI thread.
-    // Arguments:
-    // - eventArgs: the PasteFromClipboard event sent from the TermControl
-    safe_void_coroutine TerminalPage::_PasteFromClipboardHandler(const IInspectable sender, const PasteFromClipboardEventArgs eventArgs)
+    safe_void_coroutine TerminalPage::_PasteFromClipboardHandler(const IInspectable sender, const IInspectable /* args */)
     try
     {
         // The old Win32 clipboard API as used below is somewhere in the order of 300-1000x faster than
@@ -2955,7 +2953,14 @@ namespace winrt::TerminalApp::implementation
         const auto weakThis = get_weak();
         const auto dispatcher = Dispatcher();
         const auto globalSettings = _settings.GlobalSettings();
-        const auto bracketedPaste = eventArgs.BracketedPasteEnabled();
+        const auto control = sender.as<TermControl>();
+        // TODO GH#20164 these were added to ease the transition to broadcast group management; fill them in
+        // Used to determine whether to emit empty pastes and strip extra whitespace
+        const auto anyHasBracketedPaste = control && !control.ReadOnly() && control.BracketedPasteEnabled();
+        // Used to determine whether to warn on multi-line paste
+        // If none have bracketed paste, we can short-circuit.
+        const auto anyHasUnbracketedPaste = !anyHasBracketedPaste;
+
         // GetClipboardData might block for up to 30s for delay-rendered contents.
         co_await winrt::resume_background();
 
@@ -2965,8 +2970,11 @@ namespace winrt::TerminalApp::implementation
             text = clipboard::read();
         }
 
-        if (!bracketedPaste && globalSettings.TrimPaste())
+        if (!anyHasBracketedPaste && globalSettings.TrimPaste())
         {
+            // Warning - when broadcast is enabled, this will trim the paste for all receivers.
+            // Until we propagate this decision-making elsewhere, this is safer; broadcast will not auto-submit commands in other panes.
+            // Tracked in GH#20164
             text = winrt::hstring{ Utils::TrimPaste(text) };
         }
 
@@ -2974,7 +2982,7 @@ namespace winrt::TerminalApp::implementation
         // Bracketed Paste provides an application a way to know whether the
         // user pasted, even if there was no applicable content on it. This
         // behavior is observed in GNOME Terminal, among others.
-        if (!bracketedPaste && text.empty())
+        if (!anyHasBracketedPaste && text.empty())
         {
             co_return;
         }
@@ -2986,7 +2994,7 @@ namespace winrt::TerminalApp::implementation
             // NOTE that this is unsafe, because a shell that doesn't support bracketed paste
             // will allow an attacker to enable the mode, not realize that, and then accept
             // the paste as if it was a series of legitimate commands. See GH#13014.
-            warnMultiLine = !bracketedPaste;
+            warnMultiLine = anyHasUnbracketedPaste;
             break;
         case WarnAboutMultiLinePaste::Always:
             warnMultiLine = true;
@@ -3052,8 +3060,6 @@ namespace winrt::TerminalApp::implementation
 
             co_await winrt::resume_background();
         }
-
-        const auto control = sender.as<TermControl>();
 
         // This will end up calling ConptyConnection::WriteInput which calls WriteFile which may block for
         // an indefinite amount of time. Avoid freezes and deadlocks by running this on a background thread.
@@ -3433,16 +3439,6 @@ namespace winrt::TerminalApp::implementation
                 { plain.data(), plain.size() },
                 { reinterpret_cast<const char*>(html.data()), html.size() },
                 { reinterpret_cast<const char*>(rtf.data()), rtf.size() });
-        }
-    }
-
-    // Method Description:
-    // - Paste text from the Windows Clipboard to the focused terminal
-    void TerminalPage::_PasteText()
-    {
-        if (const auto& control{ _GetActiveControl() })
-        {
-            control.PasteTextFromClipboard();
         }
     }
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -3075,7 +3075,7 @@ namespace winrt::TerminalApp::implementation
                         {
                             if (control.ContentId() != sourceId && !control.ReadOnly())
                             {
-                                control.RawWriteString(text);
+                                control.WriteInputString(text, WriteInputStringType::Clipboard);
                             }
                         }
                     });

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2956,8 +2956,6 @@ namespace winrt::TerminalApp::implementation
         const auto dispatcher = Dispatcher();
         const auto globalSettings = _settings.GlobalSettings();
         const auto bracketedPaste = eventArgs.BracketedPasteEnabled();
-        const auto sourceId = sender.try_as<ControlInteractivity>().Id();
-
         // GetClipboardData might block for up to 30s for delay-rendered contents.
         co_await winrt::resume_background();
 
@@ -3055,6 +3053,8 @@ namespace winrt::TerminalApp::implementation
             co_await winrt::resume_background();
         }
 
+        const auto control = sender.as<TermControl>();
+
         // This will end up calling ConptyConnection::WriteInput which calls WriteFile which may block for
         // an indefinite amount of time. Avoid freezes and deadlocks by running this on a background thread.
         assert(!dispatcher.HasThreadAccess());
@@ -3071,11 +3071,11 @@ namespace winrt::TerminalApp::implementation
                 if (tab->TabStatus().IsInputBroadcastActive())
                 {
                     tab->GetRootPane()->WalkTree([&](auto&& pane) {
-                        if (const auto control = pane->GetTerminalControl())
+                        if (const auto nextControl = pane->GetTerminalControl())
                         {
-                            if (control.ContentId() != sourceId && !control.ReadOnly())
+                            if (nextControl.ContentId() != control.ContentId() && !nextControl.ReadOnly())
                             {
-                                control.WriteInputString(text, WriteInputStringType::Clipboard);
+                                nextControl.WriteInputString(text, WriteInputStringType::Clipboard);
                             }
                         }
                     });

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -3065,29 +3065,6 @@ namespace winrt::TerminalApp::implementation
         // an indefinite amount of time. Avoid freezes and deadlocks by running this on a background thread.
         assert(!dispatcher.HasThreadAccess());
         control.WriteInputString(text, WriteInputStringType::Clipboard);
-
-        // GH#18821: If broadcast input is active, paste the same text into all other
-        // panes on the tab. We do this here (rather than re-reading the
-        // clipboard per-pane) so that only one paste warning is shown.
-        co_await wil::resume_foreground(dispatcher);
-        if (const auto strongThis = weakThis.get())
-        {
-            if (const auto& tab{ strongThis->_GetFocusedTabImpl() })
-            {
-                if (tab->TabStatus().IsInputBroadcastActive())
-                {
-                    tab->GetRootPane()->WalkTree([&](auto&& pane) {
-                        if (const auto nextControl = pane->GetTerminalControl())
-                        {
-                            if (nextControl.ContentId() != control.ContentId() && !nextControl.ReadOnly())
-                            {
-                                nextControl.WriteInputString(text, WriteInputStringType::Clipboard);
-                            }
-                        }
-                    });
-                }
-            }
-        }
     }
     CATCH_LOG();
 

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -420,7 +420,7 @@ namespace winrt::TerminalApp::implementation
         void _SetAcceleratorForMenuItem(Windows::UI::Xaml::Controls::MenuFlyoutItem& menuItem, const winrt::Microsoft::Terminal::Control::KeyChord& keyChord);
 
         safe_void_coroutine _PasteFromClipboardHandler(const IInspectable sender,
-                                                       const Microsoft::Terminal::Control::PasteFromClipboardEventArgs eventArgs);
+                                                       const IInspectable eventArgs);
 
         safe_void_coroutine _OpenHyperlinkHandler(const IInspectable sender, const Microsoft::Terminal::Control::OpenHyperlinkEventArgs eventArgs);
         static bool _IsUriSupported(const winrt::Windows::Foundation::Uri& parsedUri);

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -498,7 +498,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - wstr: the string of characters to write to the terminal connection.
     // Return Value:
     // - <none>
-    void ControlCore::SendInput(const std::wstring_view wstr)
+    void ControlCore::_sendInput(const std::wstring_view wstr)
     {
         if (wstr.empty())
         {
@@ -554,7 +554,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         }
         if (out)
         {
-            SendInput(*out);
+            _sendInput(*out);
             return true;
         }
         return false;
@@ -712,7 +712,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         }
         if (out)
         {
-            SendInput(*out);
+            _sendInput(*out);
             return true;
         }
         return false;
@@ -731,7 +731,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         }
         if (out)
         {
-            SendInput(*out);
+            _sendInput(*out);
             return true;
         }
         return false;
@@ -1451,24 +1451,34 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // Method Description:
     // - Pre-process text pasted (presumably from the clipboard)
     //   before sending it over the terminal's connection.
-    void ControlCore::PasteText(const winrt::hstring& hstr)
+    void ControlCore::WriteInputString(const std::wstring_view& str, WriteInputStringType type)
     {
-        using namespace ::Microsoft::Console::Utils;
-
-        auto filtered = FilterStringForPaste(hstr, CarriageReturnNewline | ControlCodes);
-        if (BracketedPasteEnabled())
+        switch (type)
         {
-            filtered.insert(0, L"\x1b[200~");
-            filtered.append(L"\x1b[201~");
+        case WriteInputStringType::Clipboard:
+        {
+            using namespace ::Microsoft::Console::Utils;
+
+            auto filtered = FilterStringForPaste(str, CarriageReturnNewline | ControlCodes);
+            if (BracketedPasteEnabled())
+            {
+                filtered.insert(0, L"\x1b[200~");
+                filtered.append(L"\x1b[201~");
+            }
+
+            // It's important to not hold the terminal lock while calling this function as sending the data may take a long time.
+            _sendInput(filtered);
+
+            const auto lock = _terminal->LockForWriting();
+            _terminal->ClearSelection();
+            _updateSelectionUI();
+            _terminal->TrySnapOnInput();
+            return;
         }
-
-        // It's important to not hold the terminal lock while calling this function as sending the data may take a long time.
-        SendInput(filtered);
-
-        const auto lock = _terminal->LockForWriting();
-        _terminal->ClearSelection();
-        _updateSelectionUI();
-        _terminal->TrySnapOnInput();
+        case WriteInputStringType::Raw:
+            _sendInput(str);
+            return;
+        }
     }
 
     FontInfo ControlCore::GetFont() const
@@ -2197,7 +2207,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                     // Sending input requires that we're unlocked, because
                     // writing the input pipe may block indefinitely.
                     const auto suspension = _terminal->SuspendLock();
-                    SendInput(buffer);
+                    _sendInput(buffer);
                 }
             }
         }

--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -122,8 +122,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         til::color ForegroundColor() const;
         til::color BackgroundColor() const;
 
-        void SendInput(std::wstring_view wstr);
-        void PasteText(const winrt::hstring& hstr);
+        void WriteInputString(const std::wstring_view& str, WriteInputStringType type);
         bool CopySelectionToClipboard(bool singleLine, bool withControlSequences, const CopyFormat formats);
         void SelectAll();
         void ClearSelection();
@@ -320,6 +319,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         void _handleControlC();
         void _sendInputToConnection(std::wstring_view wstr);
+        void _sendInput(std::wstring_view wstr);
 
 #pragma region TerminalCoreCallbacks
         void _terminalWarningBell();

--- a/src/cascadia/TerminalControl/ControlCore.idl
+++ b/src/cascadia/TerminalControl/ControlCore.idl
@@ -68,6 +68,14 @@ namespace Microsoft.Terminal.Control
         Boolean SearchRegexInvalid;
     };
 
+    enum WriteInputStringType
+    {
+        // Text which is to be passed through unmodified.
+        Raw,
+        // Text which is to be treated as clipboard input, stripped and formatted according to the application's wishes.
+        Clipboard,
+    };
+
     [default_interface] runtimeclass SelectionColor
     {
         SelectionColor();
@@ -128,8 +136,7 @@ namespace Microsoft.Terminal.Control
         Boolean SendCharEvent(Char ch,
                               Int16 scanCode,
                               Microsoft.Terminal.Core.ControlKeyStates modifiers);
-        void SendInput(String text);
-        void PasteText(String text);
+        void WriteInputString(String text, WriteInputStringType type);
         void SelectAll();
         void ClearSelection();
         Boolean ToggleBlockSelection();

--- a/src/cascadia/TerminalControl/ControlInteractivity.cpp
+++ b/src/cascadia/TerminalControl/ControlInteractivity.cpp
@@ -242,10 +242,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - Initiate a paste operation.
     void ControlInteractivity::RequestPasteTextFromClipboard()
     {
-        auto args = winrt::make<PasteFromClipboardEventArgs>(_core->BracketedPasteEnabled());
-
         // send paste event up to TermApp
-        PasteFromClipboard.raise(*this, std::move(args));
+        PasteFromClipboard.raise(*this, nullptr);
     }
 
     void ControlInteractivity::PointerPressed(const uint32_t /*pointerId*/,

--- a/src/cascadia/TerminalControl/ControlInteractivity.cpp
+++ b/src/cascadia/TerminalControl/ControlInteractivity.cpp
@@ -244,7 +244,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     {
         auto args = winrt::make<PasteFromClipboardEventArgs>(
             [core = _core](const winrt::hstring& wstr) {
-                core->PasteText(wstr);
+                core->WriteInputString(wstr, WriteInputStringType::Clipboard);
             },
             _core->BracketedPasteEnabled());
 

--- a/src/cascadia/TerminalControl/ControlInteractivity.cpp
+++ b/src/cascadia/TerminalControl/ControlInteractivity.cpp
@@ -242,11 +242,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - Initiate a paste operation.
     void ControlInteractivity::RequestPasteTextFromClipboard()
     {
-        auto args = winrt::make<PasteFromClipboardEventArgs>(
-            [core = _core](const winrt::hstring& wstr) {
-                core->WriteInputString(wstr, WriteInputStringType::Clipboard);
-            },
-            _core->BracketedPasteEnabled());
+        auto args = winrt::make<PasteFromClipboardEventArgs>(_core->BracketedPasteEnabled());
 
         // send paste event up to TermApp
         PasteFromClipboard.raise(*this, std::move(args));

--- a/src/cascadia/TerminalControl/ControlInteractivity.h
+++ b/src/cascadia/TerminalControl/ControlInteractivity.h
@@ -92,7 +92,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void AttachToNewControl();
 
         til::typed_event<IInspectable, Control::OpenHyperlinkEventArgs> OpenHyperlink;
-        til::typed_event<IInspectable, Control::PasteFromClipboardEventArgs> PasteFromClipboard;
+        til::typed_event<IInspectable, IInspectable> PasteFromClipboard;
         til::typed_event<IInspectable, Control::ScrollPositionChangedArgs> ScrollPositionChanged;
         til::typed_event<IInspectable, Control::ContextMenuRequestedEventArgs> ContextMenuRequested;
 

--- a/src/cascadia/TerminalControl/ControlInteractivity.idl
+++ b/src/cascadia/TerminalControl/ControlInteractivity.idl
@@ -68,7 +68,7 @@ namespace Microsoft.Terminal.Control
 
         event Windows.Foundation.TypedEventHandler<Object, OpenHyperlinkEventArgs> OpenHyperlink;
         event Windows.Foundation.TypedEventHandler<Object, ScrollPositionChangedArgs> ScrollPositionChanged;
-        event Windows.Foundation.TypedEventHandler<Object, PasteFromClipboardEventArgs> PasteFromClipboard;
+        event Windows.Foundation.TypedEventHandler<Object, Object> PasteFromClipboard;
 
         event Windows.Foundation.TypedEventHandler<Object, Object> Closed;
 

--- a/src/cascadia/TerminalControl/EventArgs.cpp
+++ b/src/cascadia/TerminalControl/EventArgs.cpp
@@ -7,7 +7,6 @@
 #include "TitleChangedEventArgs.g.cpp"
 #include "ContextMenuRequestedEventArgs.g.cpp"
 #include "WriteToClipboardEventArgs.g.cpp"
-#include "PasteFromClipboardEventArgs.g.cpp"
 #include "OpenHyperlinkEventArgs.g.cpp"
 #include "NoticeEventArgs.g.cpp"
 #include "ScrollPositionChangedArgs.g.cpp"

--- a/src/cascadia/TerminalControl/EventArgs.h
+++ b/src/cascadia/TerminalControl/EventArgs.h
@@ -86,19 +86,10 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     struct PasteFromClipboardEventArgs : public PasteFromClipboardEventArgsT<PasteFromClipboardEventArgs>
     {
     public:
-        PasteFromClipboardEventArgs(std::function<void(const hstring&)> clipboardDataHandler, bool bracketedPasteEnabled) :
-            m_clipboardDataHandler(clipboardDataHandler),
+        PasteFromClipboardEventArgs(bool bracketedPasteEnabled) :
             _BracketedPasteEnabled{ bracketedPasteEnabled } {}
 
-        void HandleClipboardData(hstring value)
-        {
-            m_clipboardDataHandler(value);
-        };
-
         WINRT_PROPERTY(bool, BracketedPasteEnabled, false);
-
-    private:
-        std::function<void(const hstring&)> m_clipboardDataHandler;
     };
 
     struct OpenHyperlinkEventArgs : public OpenHyperlinkEventArgsT<OpenHyperlinkEventArgs>

--- a/src/cascadia/TerminalControl/EventArgs.h
+++ b/src/cascadia/TerminalControl/EventArgs.h
@@ -235,10 +235,11 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     struct StringSentEventArgs : public StringSentEventArgsT<StringSentEventArgs>
     {
     public:
-        StringSentEventArgs(const winrt::hstring& text) :
-            _Text(text) {}
+        StringSentEventArgs(const winrt::hstring& text, uint32_t type) :
+            _Text(text), _Type(type) {}
 
         WINRT_PROPERTY(winrt::hstring, Text);
+        WINRT_PROPERTY(uint32_t, Type);
     };
 
     struct SearchMissingCommandEventArgs : public SearchMissingCommandEventArgsT<SearchMissingCommandEventArgs>

--- a/src/cascadia/TerminalControl/EventArgs.h
+++ b/src/cascadia/TerminalControl/EventArgs.h
@@ -7,7 +7,6 @@
 #include "TitleChangedEventArgs.g.h"
 #include "ContextMenuRequestedEventArgs.g.h"
 #include "WriteToClipboardEventArgs.g.h"
-#include "PasteFromClipboardEventArgs.g.h"
 #include "OpenHyperlinkEventArgs.g.h"
 #include "NoticeEventArgs.g.h"
 #include "ScrollPositionChangedArgs.g.h"
@@ -81,15 +80,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         winrt::hstring _plain;
         std::string _html;
         std::string _rtf;
-    };
-
-    struct PasteFromClipboardEventArgs : public PasteFromClipboardEventArgsT<PasteFromClipboardEventArgs>
-    {
-    public:
-        PasteFromClipboardEventArgs(bool bracketedPasteEnabled) :
-            _BracketedPasteEnabled{ bracketedPasteEnabled } {}
-
-        WINRT_PROPERTY(bool, BracketedPasteEnabled, false);
     };
 
     struct OpenHyperlinkEventArgs : public OpenHyperlinkEventArgsT<OpenHyperlinkEventArgs>

--- a/src/cascadia/TerminalControl/EventArgs.idl
+++ b/src/cascadia/TerminalControl/EventArgs.idl
@@ -70,7 +70,6 @@ namespace Microsoft.Terminal.Control
 
     runtimeclass PasteFromClipboardEventArgs
     {
-        void HandleClipboardData(String data);
         Boolean BracketedPasteEnabled { get; };
     }
 

--- a/src/cascadia/TerminalControl/EventArgs.idl
+++ b/src/cascadia/TerminalControl/EventArgs.idl
@@ -68,11 +68,6 @@ namespace Microsoft.Terminal.Control
         byte[] Rtf { get; }; // UTF-8, as required by "Rich Text Format"
     }
 
-    runtimeclass PasteFromClipboardEventArgs
-    {
-        Boolean BracketedPasteEnabled { get; };
-    }
-
     runtimeclass OpenHyperlinkEventArgs
     {
         OpenHyperlinkEventArgs(String uri);

--- a/src/cascadia/TerminalControl/EventArgs.idl
+++ b/src/cascadia/TerminalControl/EventArgs.idl
@@ -152,6 +152,7 @@ namespace Microsoft.Terminal.Control
     runtimeclass StringSentEventArgs
     {
         String Text { get; };
+        UInt32 Type { get; }; // We cannot forward-declare WriteInputStringType, and as of GH#20164 this whole event is getting deleted anyway.
     }
 
     runtimeclass SearchMissingCommandEventArgs

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -238,7 +238,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         {
             return;
         }
-        core->SendInput(text);
+        core->WriteInputString(text, WriteInputStringType::Raw);
     }
 
     ::Microsoft::Console::Render::Renderer* TsfDataProvider::GetRenderer()
@@ -912,7 +912,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - wstr: the string of characters to write to the terminal connection.
     // Return Value:
     // - <none>
-    void TermControl::SendInput(const winrt::hstring& wstr)
+    void TermControl::WriteInputString(const winrt::hstring& wstr, WriteInputStringType type)
     {
         // Dismiss any previewed input.
         PreviewInput(hstring{});
@@ -920,10 +920,10 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // only broadcast if there's an actual listener. Saves the overhead of some object creation.
         if (StringSent)
         {
-            StringSent.raise(*this, winrt::make<StringSentEventArgs>(wstr));
+            StringSent.raise(*this, winrt::make<StringSentEventArgs>(wstr, static_cast<uint32_t>(type)));
         }
 
-        RawWriteString(wstr);
+        _core.WriteInputString(wstr, type);
     }
     void TermControl::ClearBuffer(Control::ClearBufferType clearType)
     {
@@ -1524,11 +1524,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         return _core.SendCharEvent(character, scanCode, modifiers);
     }
 
-    void TermControl::RawWriteString(const winrt::hstring& text)
-    {
-        _core.SendInput(text);
-    }
-
     // Method Description:
     // - Manually handles key events for certain keys that can't be passed to us
     //   normally. Namely, the keys we're concerned with are F7 down and Alt up.
@@ -1675,7 +1670,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                 // If it encounters a string that isn't, cppwinrt will abort().
                 // It should already be null-terminated, but let's make sure to not crash.
                 buf[buf_len] = L'\0';
-                _core.SendInput(std::wstring_view{ &buf[0], buf_len });
+                _core.WriteInputString(std::wstring_view{ &buf[0], buf_len }, WriteInputStringType::Raw);
             }
 
             s = {};
@@ -3240,9 +3235,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // only broadcast if there's an actual listener. Saves the overhead of some object creation.
         if (StringSent)
         {
-            StringSent.raise(*this, winrt::make<StringSentEventArgs>(text));
+            StringSent.raise(*this, winrt::make<StringSentEventArgs>(text, static_cast<uint32_t>(WriteInputStringType::Raw)));
         }
-        _core.PasteText(text);
+        _core.WriteInputString(text, WriteInputStringType::Raw);
     }
 
     // Method Description:

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -914,17 +914,23 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - <none>
     void TermControl::WriteInputString(const winrt::hstring& wstr, WriteInputStringType type)
     {
-        // Dismiss any previewed input.
-        PreviewInput(hstring{});
+        WriteInputStringWithoutBroadcast(wstr, type);
 
         // only broadcast if there's an actual listener. Saves the overhead of some object creation.
         if (StringSent)
         {
             StringSent.raise(*this, winrt::make<StringSentEventArgs>(wstr, static_cast<uint32_t>(type)));
         }
+    }
+
+    void TermControl::WriteInputStringWithoutBroadcast(const winrt::hstring& wstr, WriteInputStringType type)
+    {
+        // Dismiss any previewed input.
+        PreviewInput(hstring{});
 
         _core.WriteInputString(wstr, type);
     }
+
     void TermControl::ClearBuffer(Control::ClearBufferType clearType)
     {
         _core.ClearBuffer(clearType);
@@ -3097,7 +3103,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                 auto link{ co_await e.DataView().GetApplicationLinkAsync() };
                 if (const auto strong = weak.get())
                 {
-                    _pasteTextWithBroadcast(link.AbsoluteUri());
+                    WriteInputString(link.AbsoluteUri(), WriteInputStringType::Clipboard);
                 }
             }
             CATCH_LOG();
@@ -3109,7 +3115,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                 auto link{ co_await e.DataView().GetWebLinkAsync() };
                 if (const auto strong = weak.get())
                 {
-                    _pasteTextWithBroadcast(link.AbsoluteUri());
+                    WriteInputString(link.AbsoluteUri(), WriteInputStringType::Clipboard);
                 }
             }
             CATCH_LOG();
@@ -3121,7 +3127,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                 auto text{ co_await e.DataView().GetTextAsync() };
                 if (const auto strong = weak.get())
                 {
-                    _pasteTextWithBroadcast(text);
+                    WriteInputString(text, WriteInputStringType::Clipboard);
                 }
             }
             CATCH_LOG();
@@ -3219,25 +3225,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                     }
                 }
 
-                _pasteTextWithBroadcast(winrt::hstring{ allPathsString });
+                WriteInputString(winrt::hstring{ allPathsString }, WriteInputStringType::Clipboard);
             }
         }
-    }
-
-    // Method Description:
-    // - Paste this text, and raise a StringSent, to potentially broadcast this
-    //   text to other controls in the app. For certain interactions, like
-    //   drag/dropping a file, we want to act like we "pasted" the text (even if
-    //   the text didn't come from the clipboard). This lets those interactions
-    //   broadcast as well.
-    void TermControl::_pasteTextWithBroadcast(const winrt::hstring& text)
-    {
-        // only broadcast if there's an actual listener. Saves the overhead of some object creation.
-        if (StringSent)
-        {
-            StringSent.raise(*this, winrt::make<StringSentEventArgs>(text, static_cast<uint32_t>(WriteInputStringType::Raw)));
-        }
-        _core.WriteInputString(text, WriteInputStringType::Raw);
     }
 
     // Method Description:

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -126,6 +126,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         winrt::Windows::Foundation::Size GetFontSize() const;
 
         void WriteInputString(const winrt::hstring& wstr, WriteInputStringType type);
+        void WriteInputStringWithoutBroadcast(const winrt::hstring& wstr, WriteInputStringType type);
         void ClearBuffer(Control::ClearBufferType clearType);
 
         void ToggleShaderEffects();
@@ -427,8 +428,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         winrt::Windows::Foundation::Point _toPosInDips(const Core::Point terminalCellPos);
         void _throttledUpdateScrollbar(const ScrollBarUpdate& update);
-
-        void _pasteTextWithBroadcast(const winrt::hstring& text);
 
         void _contextMenuHandler(IInspectable sender, Control::ContextMenuRequestedEventArgs args);
         void _showContextMenuAt(const winrt::Windows::Foundation::Point& controlRelativePos);

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -125,7 +125,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void ResetFontSize();
         winrt::Windows::Foundation::Size GetFontSize() const;
 
-        void SendInput(const winrt::hstring& input);
+        void WriteInputString(const winrt::hstring& wstr, WriteInputStringType type);
         void ClearBuffer(Control::ClearBufferType clearType);
 
         void ToggleShaderEffects();
@@ -179,7 +179,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         bool RawWriteKeyEvent(const WORD vkey, const WORD scanCode, const winrt::Microsoft::Terminal::Core::ControlKeyStates modifiers, const bool keyDown);
         bool RawWriteChar(const wchar_t character, const WORD scanCode, const winrt::Microsoft::Terminal::Core::ControlKeyStates modifiers);
-        void RawWriteString(const winrt::hstring& text);
 
         void ShowContextMenu();
         bool OpenQuickFixMenu();

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -228,7 +228,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         BUBBLED_FORWARDED_TYPED_EVENT(CompletionsChanged,       IInspectable, Control::CompletionsChangedEventArgs);
         BUBBLED_FORWARDED_TYPED_EVENT(RestartTerminalRequested, IInspectable, IInspectable);
         BUBBLED_FORWARDED_TYPED_EVENT(WriteToClipboard,         IInspectable, Control::WriteToClipboardEventArgs);
-        BUBBLED_FORWARDED_TYPED_EVENT(PasteFromClipboard,       IInspectable, Control::PasteFromClipboardEventArgs);
+        BUBBLED_FORWARDED_TYPED_EVENT(PasteFromClipboard,       IInspectable, IInspectable);
 
         // clang-format on
 

--- a/src/cascadia/TerminalControl/TermControl.idl
+++ b/src/cascadia/TerminalControl/TermControl.idl
@@ -64,7 +64,7 @@ namespace Microsoft.Terminal.Control
 
         event Windows.Foundation.TypedEventHandler<Object, TitleChangedEventArgs> TitleChanged;
         event Windows.Foundation.TypedEventHandler<Object, WriteToClipboardEventArgs> WriteToClipboard;
-        event Windows.Foundation.TypedEventHandler<Object, PasteFromClipboardEventArgs> PasteFromClipboard;
+        event Windows.Foundation.TypedEventHandler<Object, Object> PasteFromClipboard;
         event Windows.Foundation.TypedEventHandler<Object, OpenHyperlinkEventArgs> OpenHyperlink;
         event Windows.Foundation.TypedEventHandler<Object, Object> SetTaskbarProgress;
         event Windows.Foundation.TypedEventHandler<Object, NoticeEventArgs> RaiseNotice;

--- a/src/cascadia/TerminalControl/TermControl.idl
+++ b/src/cascadia/TerminalControl/TermControl.idl
@@ -127,10 +127,9 @@ namespace Microsoft.Terminal.Control
         void ResetFontSize();
 
         void ToggleShaderEffects();
-        void SendInput(String input);
         Boolean RawWriteKeyEvent(UInt16 vkey, UInt16 scanCode, Microsoft.Terminal.Core.ControlKeyStates modifiers, Boolean keyDown);
         Boolean RawWriteChar(Char character, UInt16 scanCode, Microsoft.Terminal.Core.ControlKeyStates modifiers);
-        void RawWriteString(String text);
+        void WriteInputString(String text, WriteInputStringType type);
 
         void BellLightOn();
 

--- a/src/cascadia/TerminalControl/TermControl.idl
+++ b/src/cascadia/TerminalControl/TermControl.idl
@@ -130,6 +130,9 @@ namespace Microsoft.Terminal.Control
         Boolean RawWriteKeyEvent(UInt16 vkey, UInt16 scanCode, Microsoft.Terminal.Core.ControlKeyStates modifiers, Boolean keyDown);
         Boolean RawWriteChar(Char character, UInt16 scanCode, Microsoft.Terminal.Core.ControlKeyStates modifiers);
         void WriteInputString(String text, WriteInputStringType type);
+        // This is a stopgap until GH#20164 removes StringSent
+        // It prevents us from entering an infinite broadcast loop
+        void WriteInputStringWithoutBroadcast(String text, WriteInputStringType type);
 
         void BellLightOn();
 

--- a/src/cascadia/inc/cppwinrt_utils.h
+++ b/src/cascadia/inc/cppwinrt_utils.h
@@ -153,9 +153,9 @@ public:                                                                         
 //    _core.TitleChanged({ get_weak(), &TermControl::_bubbleTitleChanged });
 #define BUBBLED_FORWARDED_TYPED_EVENT(name, sender, args) \
     TYPED_EVENT(name, sender, args)                       \
-    void _bubble##name(const sender& s, const args& a)    \
+    void _bubble##name(const sender&, const args& a)      \
     {                                                     \
-        _##name##Handlers(s, a);                          \
+        _##name##Handlers(*this, a);                      \
     }
 
 // Use this macro to quick implement both the getter and setter for a property.


### PR DESCRIPTION
This pull request rewrites how TermControl takes input from the outside world in a number of ways.

First, it introduces a new API called `WriteInputString`, which replaces both `SendInput` and `PasteText`. Those functions all had terrible and confusing names and semantics, but all boiled down to some internal implementation details around what was stripped where and how we added the bracketed paste sequence for clipboard content.

(For now, there is a duplicate `WriteInputStringWithoutBroadcast` which skips some of the loopy callback machinery; it is removed in #20165.)

Then, it removes the entire `PasteFromClipboardEventArgs` and its "callback" machinery for requesting a paste-if-you-would-just-please-call-me-back from the hosting application.

The connection is now 1:1: a control raises `PasteRequested`, and the host calls `WriteInputString(..., Clipboard)` to complete the transaction.

This also necessitated changing how we compute whether a paste would have been bracketed for the purpose of displaying warning dialogs and emitting empty paste packets. Now we check the control that originated the event (which required us to change how bubbled events report their sender.)

It might seem like I left weird stubs laying around.

In the future:

1. `StringSent` can be totally removed, as paste _content_ handling is already part of the app layer and drag/drop handling will be soon.
2. `anyHasBracketedPaste` (and `anyHasUnbracketedPaste`) will grow to check every control in the "broadcast group" so that we warn appropriately when a paste will touch multiple controls in different encodings.

These changes allow us to localize paste encoding behavior to the control (rather than e.g. firing `StringSent` with a bracketed paste sequence to be consumed by a control that has bracketed paste turned off) and improve broadcast without weaving new and expensive event handlers up and down through the stack.

While doing this, I noticed that TSF composition doesn't get broadcasted... lol.