### PR TITLE
AtlasEngine: Enable RTL text shaping via bidi analysis (#20156)

### DIFF
--- a/src/renderer/atlas/AtlasEngine.cpp
+++ b/src/renderer/atlas/AtlasEngine.cpp
@@ -824,6 +824,19 @@ void AtlasEngine::_flushBufferLine()
     // This would seriously blow us up otherwise.
     Expects(_api.bufferLineColumn.size() == _api.bufferLine.size() + 1);
 
+    // Run bidi + script analysis once over the whole line so downstream segmenters
+    // (font fallback, complexity) can clamp at the resulting boundaries. This guarantees
+    // every range handed to _mapComplex is uniform in direction and script.
+    _api.analysisResults.clear();
+    _api.bidiResults.clear();
+    {
+        const auto totalLen = gsl::narrow<UINT32>(_api.bufferLine.size());
+        TextAnalysisSource analysisSource{ _p.userLocaleName.c_str(), _api.bufferLine.data(), totalLen };
+        TextAnalysisSink analysisSink{ _api.analysisResults, _api.bidiResults };
+        THROW_IF_FAILED(_p.textAnalyzer->AnalyzeScript(&analysisSource, 0, totalLen, &analysisSink));
+        THROW_IF_FAILED(_p.textAnalyzer->AnalyzeBidi(&analysisSource, 0, totalLen, &analysisSink));
+    }
+
     const auto builtinGlyphs = _p.s->font->builtinGlyphs;
     const auto beg = _api.bufferLine.data();
     const auto len = _api.bufferLine.size();
@@ -869,15 +882,45 @@ void AtlasEngine::_flushBufferLine()
     }
 }
 
+// Returns the smallest position strictly greater than `pos` that ends either a script
+// analysis run or a bidi run, or end-of-line if none. Used by segmenters to keep each
+// chunk uniform in script and direction.
+u32 AtlasEngine::_nextAnalysisBoundary(u32 pos) const noexcept
+{
+    auto next = gsl::narrow_cast<u32>(_api.bufferLine.size());
+    for (const auto& a : _api.analysisResults)
+    {
+        const auto end = a.textPosition + a.textLength;
+        if (end > pos && end < next)
+        {
+            next = end;
+        }
+    }
+    for (const auto& b : _api.bidiResults)
+    {
+        const auto end = b.textPosition + b.textLength;
+        if (end > pos && end < next)
+        {
+            next = end;
+        }
+    }
+    return next;
+}
+
 void AtlasEngine::_mapRegularText(size_t offBeg, size_t offEnd)
 {
     auto& row = *_p.rows[_api.lastPaintBufferLineCoord.y];
 
     for (u32 idx = gsl::narrow_cast<u32>(offBeg), mappedEnd = 0; idx < offEnd; idx = mappedEnd)
     {
+        // Clamp at the next script/bidi boundary so each chunk is uniform in direction
+        // and script. Font fallback and complexity analysis stay within these bounds.
+        const auto boundary = _nextAnalysisBoundary(idx);
+        const auto segEnd = std::min(gsl::narrow_cast<u32>(offEnd), boundary);
+
         u32 mappedLength = 0;
         wil::com_ptr<IDWriteFontFace2> mappedFontFace;
-        _mapCharacters(_api.bufferLine.data() + idx, gsl::narrow_cast<u32>(offEnd - idx), &mappedLength, mappedFontFace.addressof());
+        _mapCharacters(_api.bufferLine.data() + idx, segEnd - idx, &mappedLength, mappedFontFace.addressof());
         mappedEnd = idx + mappedLength;
 
         if (!mappedFontFace)
@@ -1031,220 +1074,212 @@ void AtlasEngine::_mapCharacters(const wchar_t* text, const u32 textLength, u32*
 
 void AtlasEngine::_mapComplex(IDWriteFontFace2* mappedFontFace, u32 idx, u32 length, ShapedRow& row)
 {
-    _api.analysisResults.clear();
-    _api.bidiResults.clear();
-
-    TextAnalysisSource analysisSource{ _p.userLocaleName.c_str(), _api.bufferLine.data(), gsl::narrow<UINT32>(_api.bufferLine.size()) };
-    TextAnalysisSink analysisSink{ _api.analysisResults, _api.bidiResults };
-    THROW_IF_FAILED(_p.textAnalyzer->AnalyzeScript(&analysisSource, idx, length, &analysisSink));
-    THROW_IF_FAILED(_p.textAnalyzer->AnalyzeBidi(&analysisSource, idx, length, &analysisSink));
-
+    // _flushBufferLine ran AnalyzeScript+AnalyzeBidi on the full line, and _mapRegularText
+    // clamps every segment to those boundaries, so [idx, idx+length) lies entirely inside
+    // a single script run AND a single bidi run.
+    static constexpr DWRITE_SCRIPT_ANALYSIS defaultAnalysis{};
+    const DWRITE_SCRIPT_ANALYSIS* scriptAnalysis = &defaultAnalysis;
     for (const auto& a : _api.analysisResults)
     {
-        // Determine if this script run is RTL by intersecting with bidi runs.
-        // If all overlapping bidi runs agree on direction → use that.
-        // If mixed (RTL+LTR within the same script run) → fall back to LTR.
-        int direction = -1;
-        for (const auto& b : _api.bidiResults)
+        if (a.textPosition <= idx && idx < a.textPosition + a.textLength)
         {
-            if (b.textPosition + b.textLength <= a.textPosition) continue;
-            if (b.textPosition >= a.textPosition + a.textLength) continue;
-            const int bdir = (b.resolvedLevel % 2 != 0) ? 1 : 0;
-            if (direction == -1)
-                direction = bdir;
-            else if (direction != bdir)
-            {
-                direction = 0;
-                break;
-            }
+            scriptAnalysis = &a.analysis;
+            break;
         }
-        const BOOL isRTL = (direction == 1);
+    }
 
-        u32 actualGlyphCount = 0;
+    BOOL isRTL = FALSE;
+    for (const auto& b : _api.bidiResults)
+    {
+        if (b.textPosition <= idx && idx < b.textPosition + b.textLength)
+        {
+            isRTL = (b.resolvedLevel & 1) ? TRUE : FALSE;
+            break;
+        }
+    }
+
+    u32 actualGlyphCount = 0;
 
 #pragma warning(push)
 #pragma warning(disable : 26494) // Variable '...' is uninitialized. Always initialize an object (type.5).
-        // None of these variables need to be initialized.
-        // features/featureRangeLengths are marked _In_reads_opt_(featureRanges).
-        // featureRanges is only > 0 when we also initialize all these variables.
-        DWRITE_TYPOGRAPHIC_FEATURES feature;
-        const DWRITE_TYPOGRAPHIC_FEATURES* features;
-        u32 featureRangeLengths;
+    // None of these variables need to be initialized.
+    // features/featureRangeLengths are marked _In_reads_opt_(featureRanges).
+    // featureRanges is only > 0 when we also initialize all these variables.
+    DWRITE_TYPOGRAPHIC_FEATURES feature;
+    const DWRITE_TYPOGRAPHIC_FEATURES* features;
+    u32 featureRangeLengths;
 #pragma warning(pop)
-        u32 featureRanges = 0;
+    u32 featureRanges = 0;
 
-        if (!_p.s->font->fontFeatures.empty())
-        {
-            // Direct2D, why is this mutable?         Why?
+    if (!_p.s->font->fontFeatures.empty())
+    {
+        // Direct2D, why is this mutable?         Why?
 #pragma warning(suppress : 26492) // Don't use const_cast to cast away const or volatile (type.3).
-            feature.features = const_cast<DWRITE_FONT_FEATURE*>(_p.s->font->fontFeatures.data());
-            feature.featureCount = gsl::narrow_cast<u32>(_p.s->font->fontFeatures.size());
-            features = &feature;
-            featureRangeLengths = a.textLength;
-            featureRanges = 1;
-        }
+        feature.features = const_cast<DWRITE_FONT_FEATURE*>(_p.s->font->fontFeatures.data());
+        feature.featureCount = gsl::narrow_cast<u32>(_p.s->font->fontFeatures.size());
+        features = &feature;
+        featureRangeLengths = length;
+        featureRanges = 1;
+    }
 
-        if (_api.clusterMap.size() <= a.textLength)
-        {
-            _api.clusterMap = Buffer<u16>{ static_cast<size_t>(a.textLength) + 1 };
-            _api.textProps = Buffer<DWRITE_SHAPING_TEXT_PROPERTIES>{ a.textLength };
-        }
+    if (_api.clusterMap.size() <= length)
+    {
+        _api.clusterMap = Buffer<u16>{ static_cast<size_t>(length) + 1 };
+        _api.textProps = Buffer<DWRITE_SHAPING_TEXT_PROPERTIES>{ length };
+    }
 
-        for (auto retry = 0;;)
-        {
-            const auto hr = _p.textAnalyzer->GetGlyphs(
-                /* textString          */ _api.bufferLine.data() + a.textPosition,
-                /* textLength          */ a.textLength,
-                /* fontFace            */ mappedFontFace,
-                /* isSideways          */ false,
-                /* isRightToLeft       */ isRTL,
-                /* scriptAnalysis      */ &a.analysis,
-                /* localeName          */ _p.userLocaleName.c_str(),
-                /* numberSubstitution  */ nullptr,
-                /* features            */ &features,
-                /* featureRangeLengths */ &featureRangeLengths,
-                /* featureRanges       */ featureRanges,
-                /* maxGlyphCount       */ gsl::narrow_cast<u32>(_api.glyphIndices.size()),
-                /* clusterMap          */ _api.clusterMap.data(),
-                /* textProps           */ _api.textProps.data(),
-                /* glyphIndices        */ _api.glyphIndices.data(),
-                /* glyphProps          */ _api.glyphProps.data(),
-                /* actualGlyphCount    */ &actualGlyphCount);
-
-            if (hr == HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER) && ++retry < 8)
-            {
-                // Grow factor 1.5x.
-                auto size = _api.glyphIndices.size();
-                size = size + (size >> 1);
-                // Overflow check.
-                Expects(size > _api.glyphIndices.size());
-                _api.glyphIndices = Buffer<u16>{ size };
-                _api.glyphProps = Buffer<DWRITE_SHAPING_GLYPH_PROPERTIES>{ size };
-                continue;
-            }
-
-            THROW_IF_FAILED(hr);
-            break;
-        }
-
-        if (_api.glyphAdvances.size() < actualGlyphCount)
-        {
-            // Grow the buffer by at least 1.5x and at least of `actualGlyphCount` items.
-            // The 1.5x growth ensures we don't reallocate every time we need 1 more slot.
-            auto size = _api.glyphAdvances.size();
-            size = size + (size >> 1);
-            size = std::max<size_t>(size, actualGlyphCount);
-            _api.glyphAdvances = Buffer<f32>{ size };
-            _api.glyphOffsets = Buffer<DWRITE_GLYPH_OFFSET>{ size };
-        }
-
-        THROW_IF_FAILED(_p.textAnalyzer->GetGlyphPlacements(
-            /* textString          */ _api.bufferLine.data() + a.textPosition,
-            /* clusterMap          */ _api.clusterMap.data(),
-            /* textProps           */ _api.textProps.data(),
-            /* textLength          */ a.textLength,
-            /* glyphIndices        */ _api.glyphIndices.data(),
-            /* glyphProps          */ _api.glyphProps.data(),
-            /* glyphCount          */ actualGlyphCount,
+    for (auto retry = 0;;)
+    {
+        const auto hr = _p.textAnalyzer->GetGlyphs(
+            /* textString          */ _api.bufferLine.data() + idx,
+            /* textLength          */ length,
             /* fontFace            */ mappedFontFace,
-            /* fontEmSize          */ _p.s->font->fontSize,
             /* isSideways          */ false,
             /* isRightToLeft       */ isRTL,
-            /* scriptAnalysis      */ &a.analysis,
+            /* scriptAnalysis      */ scriptAnalysis,
             /* localeName          */ _p.userLocaleName.c_str(),
+            /* numberSubstitution  */ nullptr,
             /* features            */ &features,
             /* featureRangeLengths */ &featureRangeLengths,
             /* featureRanges       */ featureRanges,
-            /* glyphAdvances       */ _api.glyphAdvances.data(),
-            /* glyphOffsets        */ _api.glyphOffsets.data()));
+            /* maxGlyphCount       */ gsl::narrow_cast<u32>(_api.glyphIndices.size()),
+            /* clusterMap          */ _api.clusterMap.data(),
+            /* textProps           */ _api.textProps.data(),
+            /* glyphIndices        */ _api.glyphIndices.data(),
+            /* glyphProps          */ _api.glyphProps.data(),
+            /* actualGlyphCount    */ &actualGlyphCount);
 
-        _api.clusterMap[a.textLength] = gsl::narrow_cast<u16>(actualGlyphCount);
-
-        // For RTL runs, DirectWrite returns glyphs in right-to-left visual order
-        // with advances going right-to-left. Reverse to LTR order so backends draw
-        // glyphs correctly without per-direction logic.
-        if (isRTL)
+        if (hr == HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER) && ++retry < 8)
         {
-            const auto N = actualGlyphCount;
-
-            std::reverse(_api.glyphIndices.data(), _api.glyphIndices.data() + N);
-            if (N > 1)
-            {
-                std::reverse(_api.glyphAdvances.data(), _api.glyphAdvances.data() + N - 1);
-            }
-            std::reverse(_api.glyphOffsets.data(), _api.glyphOffsets.data() + N);
-            for (size_t i = 0; i < N; ++i)
-            {
-                _api.glyphOffsets[i].advanceOffset = -_api.glyphOffsets[i].advanceOffset;
-            }
-
-            // Build row output directly. The normal column loop below assumes ascending
-            // clusterMap values and LTR column ordering, both of which fail for RTL.
-            const auto shift = gsl::narrow_cast<u8>(row.lineRendition != LineRendition::SingleWidth);
-            const auto rowColors = _p.foregroundBitmap.begin() + _p.colorBitmapRowStride * _api.lastPaintBufferLineCoord.y;
-
-            // Compute total expected advance for the RTL run and adjust last glyph.
-            const auto colStart = _api.bufferLineColumn[a.textPosition];
-            const auto colEnd = _api.bufferLineColumn[a.textPosition + a.textLength];
-            const auto expectedTotal = static_cast<f32>((colEnd - colStart) * _p.s->font->cellSize.x);
-            f32 actualTotal = 0;
-            for (size_t i = 0; i < N; ++i)
-                actualTotal += _api.glyphAdvances[i];
-            if (N > 0)
-                _api.glyphAdvances[N - 1] += expectedTotal - actualTotal;
-
-            // After reversal, LTR glyph i corresponds to text position (textLength - 1 - i)
-            // in the RTL range, due to 1:1 clusterMap mapping before reversal.
-            for (size_t i = 0; i < N; ++i)
-            {
-                const auto textIdx = a.textPosition + a.textLength - 1 - i;
-                const auto col = _api.bufferLineColumn[textIdx];
-                row.colors.emplace_back(rowColors[static_cast<size_t>(col) << shift]);
-            }
-
-            row.glyphIndices.insert(row.glyphIndices.end(), _api.glyphIndices.begin(), _api.glyphIndices.begin() + N);
-            row.glyphAdvances.insert(row.glyphAdvances.end(), _api.glyphAdvances.begin(), _api.glyphAdvances.begin() + N);
-            row.glyphOffsets.insert(row.glyphOffsets.end(), _api.glyphOffsets.begin(), _api.glyphOffsets.begin() + N);
-
-            // RTL run fully handled. Skip the normal column loop below.
+            // Grow factor 1.5x.
+            auto size = _api.glyphIndices.size();
+            size = size + (size >> 1);
+            // Overflow check.
+            Expects(size > _api.glyphIndices.size());
+            _api.glyphIndices = Buffer<u16>{ size };
+            _api.glyphProps = Buffer<DWRITE_SHAPING_GLYPH_PROPERTIES>{ size };
             continue;
         }
 
-        const auto shift = gsl::narrow_cast<u8>(row.lineRendition != LineRendition::SingleWidth);
-        const auto colors = _p.foregroundBitmap.begin() + _p.colorBitmapRowStride * _api.lastPaintBufferLineCoord.y;
-        auto prevCluster = _api.clusterMap[0];
-        size_t beg = 0;
+        THROW_IF_FAILED(hr);
+        break;
+    }
 
-        for (size_t i = 1; i <= a.textLength; ++i)
+    if (_api.glyphAdvances.size() < actualGlyphCount)
+    {
+        // Grow the buffer by at least 1.5x and at least of `actualGlyphCount` items.
+        // The 1.5x growth ensures we don't reallocate every time we need 1 more slot.
+        auto size = _api.glyphAdvances.size();
+        size = size + (size >> 1);
+        size = std::max<size_t>(size, actualGlyphCount);
+        _api.glyphAdvances = Buffer<f32>{ size };
+        _api.glyphOffsets = Buffer<DWRITE_GLYPH_OFFSET>{ size };
+    }
+
+    THROW_IF_FAILED(_p.textAnalyzer->GetGlyphPlacements(
+        /* textString          */ _api.bufferLine.data() + idx,
+        /* clusterMap          */ _api.clusterMap.data(),
+        /* textProps           */ _api.textProps.data(),
+        /* textLength          */ length,
+        /* glyphIndices        */ _api.glyphIndices.data(),
+        /* glyphProps          */ _api.glyphProps.data(),
+        /* glyphCount          */ actualGlyphCount,
+        /* fontFace            */ mappedFontFace,
+        /* fontEmSize          */ _p.s->font->fontSize,
+        /* isSideways          */ false,
+        /* isRightToLeft       */ isRTL,
+        /* scriptAnalysis      */ scriptAnalysis,
+        /* localeName          */ _p.userLocaleName.c_str(),
+        /* features            */ &features,
+        /* featureRangeLengths */ &featureRangeLengths,
+        /* featureRanges       */ featureRanges,
+        /* glyphAdvances       */ _api.glyphAdvances.data(),
+        /* glyphOffsets        */ _api.glyphOffsets.data()));
+
+    _api.clusterMap[length] = gsl::narrow_cast<u16>(actualGlyphCount);
+
+    // For RTL runs, DirectWrite returns glyphs in right-to-left visual order
+    // with advances going right-to-left. Reverse to LTR order so backends draw
+    // glyphs correctly without per-direction logic.
+    if (isRTL)
+    {
+        const auto N = actualGlyphCount;
+
+        std::reverse(_api.glyphIndices.data(), _api.glyphIndices.data() + N);
+        if (N > 1)
         {
-            const auto nextCluster = _api.clusterMap[i];
-            if (prevCluster == nextCluster)
-            {
-                continue;
-            }
-
-            const size_t col1 = _api.bufferLineColumn[a.textPosition + beg];
-            const size_t col2 = _api.bufferLineColumn[a.textPosition + i];
-            const auto fg = colors[col1 << shift];
-
-            const auto expectedAdvance = (col2 - col1) * _p.s->font->cellSize.x;
-            f32 actualAdvance = 0;
-            for (auto j = prevCluster; j < nextCluster; ++j)
-            {
-                actualAdvance += _api.glyphAdvances[j];
-            }
-            _api.glyphAdvances[nextCluster - 1] += expectedAdvance - actualAdvance;
-
-            row.colors.insert(row.colors.end(), nextCluster - prevCluster, fg);
-
-            prevCluster = nextCluster;
-            beg = i;
+            std::reverse(_api.glyphAdvances.data(), _api.glyphAdvances.data() + N - 1);
+        }
+        std::reverse(_api.glyphOffsets.data(), _api.glyphOffsets.data() + N);
+        for (size_t i = 0; i < N; ++i)
+        {
+            _api.glyphOffsets[i].advanceOffset = -_api.glyphOffsets[i].advanceOffset;
         }
 
-        row.glyphIndices.insert(row.glyphIndices.end(), _api.glyphIndices.begin(), _api.glyphIndices.begin() + actualGlyphCount);
-        row.glyphAdvances.insert(row.glyphAdvances.end(), _api.glyphAdvances.begin(), _api.glyphAdvances.begin() + actualGlyphCount);
-        row.glyphOffsets.insert(row.glyphOffsets.end(), _api.glyphOffsets.begin(), _api.glyphOffsets.begin() + actualGlyphCount);
+        // Build row output directly. The normal column loop below assumes ascending
+        // clusterMap values and LTR column ordering, both of which fail for RTL.
+        const auto shift = gsl::narrow_cast<u8>(row.lineRendition != LineRendition::SingleWidth);
+        const auto rowColors = _p.foregroundBitmap.begin() + _p.colorBitmapRowStride * _api.lastPaintBufferLineCoord.y;
+
+        // Compute total expected advance for the RTL run and adjust last glyph.
+        const auto colStart = _api.bufferLineColumn[idx];
+        const auto colEnd = _api.bufferLineColumn[idx + length];
+        const auto expectedTotal = static_cast<f32>((colEnd - colStart) * _p.s->font->cellSize.x);
+        f32 actualTotal = 0;
+        for (size_t i = 0; i < N; ++i)
+            actualTotal += _api.glyphAdvances[i];
+        if (N > 0)
+            _api.glyphAdvances[N - 1] += expectedTotal - actualTotal;
+
+        // After reversal, LTR glyph i corresponds to text position (length - 1 - i)
+        // in the RTL range, due to 1:1 clusterMap mapping before reversal.
+        for (size_t i = 0; i < N; ++i)
+        {
+            const auto textIdx = idx + length - 1 - i;
+            const auto col = _api.bufferLineColumn[textIdx];
+            row.colors.emplace_back(rowColors[static_cast<size_t>(col) << shift]);
+        }
+
+        row.glyphIndices.insert(row.glyphIndices.end(), _api.glyphIndices.begin(), _api.glyphIndices.begin() + N);
+        row.glyphAdvances.insert(row.glyphAdvances.end(), _api.glyphAdvances.begin(), _api.glyphAdvances.begin() + N);
+        row.glyphOffsets.insert(row.glyphOffsets.end(), _api.glyphOffsets.begin(), _api.glyphOffsets.begin() + N);
+        return;
     }
+
+    const auto shift = gsl::narrow_cast<u8>(row.lineRendition != LineRendition::SingleWidth);
+    const auto colors = _p.foregroundBitmap.begin() + _p.colorBitmapRowStride * _api.lastPaintBufferLineCoord.y;
+    auto prevCluster = _api.clusterMap[0];
+    size_t beg = 0;
+
+    for (size_t i = 1; i <= length; ++i)
+    {
+        const auto nextCluster = _api.clusterMap[i];
+        if (prevCluster == nextCluster)
+        {
+            continue;
+        }
+
+        const size_t col1 = _api.bufferLineColumn[idx + beg];
+        const size_t col2 = _api.bufferLineColumn[idx + i];
+        const auto fg = colors[col1 << shift];
+
+        const auto expectedAdvance = (col2 - col1) * _p.s->font->cellSize.x;
+        f32 actualAdvance = 0;
+        for (auto j = prevCluster; j < nextCluster; ++j)
+        {
+            actualAdvance += _api.glyphAdvances[j];
+        }
+        _api.glyphAdvances[nextCluster - 1] += expectedAdvance - actualAdvance;
+
+        row.colors.insert(row.colors.end(), nextCluster - prevCluster, fg);
+
+        prevCluster = nextCluster;
+        beg = i;
+    }
+
+    row.glyphIndices.insert(row.glyphIndices.end(), _api.glyphIndices.begin(), _api.glyphIndices.begin() + actualGlyphCount);
+    row.glyphAdvances.insert(row.glyphAdvances.end(), _api.glyphAdvances.begin(), _api.glyphAdvances.begin() + actualGlyphCount);
+    row.glyphOffsets.insert(row.glyphOffsets.end(), _api.glyphOffsets.begin(), _api.glyphOffsets.begin() + actualGlyphCount);
 }
 
 void AtlasEngine::_mapReplacementCharacter(u32 from, u32 to, ShapedRow& row)

--- a/src/renderer/atlas/AtlasEngine.cpp
+++ b/src/renderer/atlas/AtlasEngine.cpp
@@ -1032,13 +1032,34 @@ void AtlasEngine::_mapCharacters(const wchar_t* text, const u32 textLength, u32*
 void AtlasEngine::_mapComplex(IDWriteFontFace2* mappedFontFace, u32 idx, u32 length, ShapedRow& row)
 {
     _api.analysisResults.clear();
+    _api.bidiResults.clear();
 
     TextAnalysisSource analysisSource{ _p.userLocaleName.c_str(), _api.bufferLine.data(), gsl::narrow<UINT32>(_api.bufferLine.size()) };
-    TextAnalysisSink analysisSink{ _api.analysisResults };
+    TextAnalysisSink analysisSink{ _api.analysisResults, _api.bidiResults };
     THROW_IF_FAILED(_p.textAnalyzer->AnalyzeScript(&analysisSource, idx, length, &analysisSink));
+    THROW_IF_FAILED(_p.textAnalyzer->AnalyzeBidi(&analysisSource, idx, length, &analysisSink));
 
     for (const auto& a : _api.analysisResults)
     {
+        // Determine if this script run is RTL by intersecting with bidi runs.
+        // If all overlapping bidi runs agree on direction → use that.
+        // If mixed (RTL+LTR within the same script run) → fall back to LTR.
+        int direction = -1;
+        for (const auto& b : _api.bidiResults)
+        {
+            if (b.textPosition + b.textLength <= a.textPosition) continue;
+            if (b.textPosition >= a.textPosition + a.textLength) continue;
+            const int bdir = (b.resolvedLevel % 2 != 0) ? 1 : 0;
+            if (direction == -1)
+                direction = bdir;
+            else if (direction != bdir)
+            {
+                direction = 0;
+                break;
+            }
+        }
+        const BOOL isRTL = (direction == 1);
+
         u32 actualGlyphCount = 0;
 
 #pragma warning(push)
@@ -1076,7 +1097,7 @@ void AtlasEngine::_mapComplex(IDWriteFontFace2* mappedFontFace, u32 idx, u32 len
                 /* textLength          */ a.textLength,
                 /* fontFace            */ mappedFontFace,
                 /* isSideways          */ false,
-                /* isRightToLeft       */ 0,
+                /* isRightToLeft       */ isRTL,
                 /* scriptAnalysis      */ &a.analysis,
                 /* localeName          */ _p.userLocaleName.c_str(),
                 /* numberSubstitution  */ nullptr,
@@ -1128,7 +1149,7 @@ void AtlasEngine::_mapComplex(IDWriteFontFace2* mappedFontFace, u32 idx, u32 len
             /* fontFace            */ mappedFontFace,
             /* fontEmSize          */ _p.s->font->fontSize,
             /* isSideways          */ false,
-            /* isRightToLeft       */ 0,
+            /* isRightToLeft       */ isRTL,
             /* scriptAnalysis      */ &a.analysis,
             /* localeName          */ _p.userLocaleName.c_str(),
             /* features            */ &features,
@@ -1138,6 +1159,56 @@ void AtlasEngine::_mapComplex(IDWriteFontFace2* mappedFontFace, u32 idx, u32 len
             /* glyphOffsets        */ _api.glyphOffsets.data()));
 
         _api.clusterMap[a.textLength] = gsl::narrow_cast<u16>(actualGlyphCount);
+
+        // For RTL runs, DirectWrite returns glyphs in right-to-left visual order
+        // with advances going right-to-left. Reverse to LTR order so backends draw
+        // glyphs correctly without per-direction logic.
+        if (isRTL)
+        {
+            const auto N = actualGlyphCount;
+
+            std::reverse(_api.glyphIndices.data(), _api.glyphIndices.data() + N);
+            if (N > 1)
+            {
+                std::reverse(_api.glyphAdvances.data(), _api.glyphAdvances.data() + N - 1);
+            }
+            std::reverse(_api.glyphOffsets.data(), _api.glyphOffsets.data() + N);
+            for (size_t i = 0; i < N; ++i)
+            {
+                _api.glyphOffsets[i].advanceOffset = -_api.glyphOffsets[i].advanceOffset;
+            }
+
+            // Build row output directly. The normal column loop below assumes ascending
+            // clusterMap values and LTR column ordering, both of which fail for RTL.
+            const auto shift = gsl::narrow_cast<u8>(row.lineRendition != LineRendition::SingleWidth);
+            const auto rowColors = _p.foregroundBitmap.begin() + _p.colorBitmapRowStride * _api.lastPaintBufferLineCoord.y;
+
+            // Compute total expected advance for the RTL run and adjust last glyph.
+            const auto colStart = _api.bufferLineColumn[a.textPosition];
+            const auto colEnd = _api.bufferLineColumn[a.textPosition + a.textLength];
+            const auto expectedTotal = static_cast<f32>((colEnd - colStart) * _p.s->font->cellSize.x);
+            f32 actualTotal = 0;
+            for (size_t i = 0; i < N; ++i)
+                actualTotal += _api.glyphAdvances[i];
+            if (N > 0)
+                _api.glyphAdvances[N - 1] += expectedTotal - actualTotal;
+
+            // After reversal, LTR glyph i corresponds to text position (textLength - 1 - i)
+            // in the RTL range, due to 1:1 clusterMap mapping before reversal.
+            for (size_t i = 0; i < N; ++i)
+            {
+                const auto textIdx = a.textPosition + a.textLength - 1 - i;
+                const auto col = _api.bufferLineColumn[textIdx];
+                row.colors.emplace_back(rowColors[static_cast<size_t>(col) << shift]);
+            }
+
+            row.glyphIndices.insert(row.glyphIndices.end(), _api.glyphIndices.begin(), _api.glyphIndices.begin() + N);
+            row.glyphAdvances.insert(row.glyphAdvances.end(), _api.glyphAdvances.begin(), _api.glyphAdvances.begin() + N);
+            row.glyphOffsets.insert(row.glyphOffsets.end(), _api.glyphOffsets.begin(), _api.glyphOffsets.begin() + N);
+
+            // RTL run fully handled. Skip the normal column loop below.
+            continue;
+        }
 
         const auto shift = gsl::narrow_cast<u8>(row.lineRendition != LineRendition::SingleWidth);
         const auto colors = _p.foregroundBitmap.begin() + _p.colorBitmapRowStride * _api.lastPaintBufferLineCoord.y;

--- a/src/renderer/atlas/AtlasEngine.h
+++ b/src/renderer/atlas/AtlasEngine.h
@@ -144,6 +144,7 @@ namespace Microsoft::Console::Render::Atlas
 
             std::array<Buffer<DWRITE_FONT_AXIS_VALUE>, 4> textFormatAxes;
             std::vector<TextAnalysisSinkResult> analysisResults;
+            std::vector<BidiRun> bidiResults;
             Buffer<u16> clusterMap;
             Buffer<DWRITE_SHAPING_TEXT_PROPERTIES> textProps;
             Buffer<u16> glyphIndices;

--- a/src/renderer/atlas/AtlasEngine.h
+++ b/src/renderer/atlas/AtlasEngine.h
@@ -84,6 +84,7 @@ namespace Microsoft::Console::Render::Atlas
         void _recreateFontDependentResources();
         void _recreateCellCountDependentResources();
         void _flushBufferLine();
+        u32 _nextAnalysisBoundary(u32 pos) const noexcept;
         void _mapRegularText(size_t offBeg, size_t offEnd);
         void _mapBuiltinGlyphs(size_t offBeg, size_t offEnd);
         void _mapCharacters(const wchar_t* text, u32 textLength, u32* mappedLength, IDWriteFontFace2** mappedFontFace) const;

--- a/src/renderer/atlas/DWriteTextAnalysis.cpp
+++ b/src/renderer/atlas/DWriteTextAnalysis.cpp
@@ -104,8 +104,9 @@ HRESULT TextAnalysisSource::GetNumberSubstitution(UINT32 textPosition, UINT32* t
     return E_NOTIMPL;
 }
 
-TextAnalysisSink::TextAnalysisSink(std::vector<TextAnalysisSinkResult>& results) noexcept :
-    _results{ results }
+TextAnalysisSink::TextAnalysisSink(std::vector<TextAnalysisSinkResult>& results, std::vector<BidiRun>& bidiResults) noexcept :
+    _results{ results },
+    _bidiResults{ bidiResults }
 {
 }
 
@@ -167,9 +168,12 @@ HRESULT TextAnalysisSink::SetLineBreakpoints(UINT32 textPosition, UINT32 textLen
 }
 
 HRESULT TextAnalysisSink::SetBidiLevel(UINT32 textPosition, UINT32 textLength, UINT8 explicitLevel, UINT8 resolvedLevel) noexcept
+try
 {
-    return E_NOTIMPL;
+    _bidiResults.emplace_back(textPosition, textLength, resolvedLevel);
+    return S_OK;
 }
+CATCH_RETURN()
 
 HRESULT TextAnalysisSink::SetNumberSubstitution(UINT32 textPosition, UINT32 textLength, IDWriteNumberSubstitution* numberSubstitution) noexcept
 {

--- a/src/renderer/atlas/DWriteTextAnalysis.h
+++ b/src/renderer/atlas/DWriteTextAnalysis.h
@@ -34,7 +34,7 @@ namespace Microsoft::Console::Render::Atlas
 
     struct TextAnalysisSink final : IDWriteTextAnalysisSink
     {
-        TextAnalysisSink(std::vector<TextAnalysisSinkResult>& results) noexcept;
+        TextAnalysisSink(std::vector<TextAnalysisSinkResult>& results, std::vector<BidiRun>& bidiResults) noexcept;
 #ifndef NDEBUG
         ~TextAnalysisSink();
 #endif
@@ -49,6 +49,7 @@ namespace Microsoft::Console::Render::Atlas
 
     private:
         std::vector<TextAnalysisSinkResult>& _results;
+        std::vector<BidiRun>& _bidiResults;
 #ifndef NDEBUG
         ULONG _refCount = 1;
 #endif

--- a/src/renderer/atlas/common.h
+++ b/src/renderer/atlas/common.h
@@ -315,6 +315,13 @@ namespace Microsoft::Console::Render::Atlas
         DWRITE_SCRIPT_ANALYSIS analysis;
     };
 
+    struct BidiRun
+    {
+        u32 textPosition;
+        u32 textLength;
+        u8 resolvedLevel;
+    };
+
     enum class GraphicsAPI
     {
         Automatic,


### PR DESCRIPTION
## Summary of the Pull Request
This fixes Persian/Arabic text rendering in AtlasEngine by enabling DirectWrite's bidirectional (bidi) text analysis and passing the correct isRightToLeft flag to GetGlyphs() and GetGlyphPlacements(). Previously these were hardcoded to 0 (LTR), which prevented Arabic contextual shaping and produced glyphs in reversed order.

## References and Relevant Issues
Closes #20156

## Detailed Description of the Pull Request / Additional comments
Previously, IDWriteTextAnalyzer::GetGlyphs and GetGlyphPlacements were called with isRightToLeft=0 for all text, which prevented DirectWrite from performing Arabic contextual shaping (cursive joining) and produced glyphs in LTR order for RTL text.

This change:
- Calls AnalyzeBidi() to determine text direction per run
- Passes the correct isRightToLeft value to GetGlyphs/GetGlyphPlacements
- Reverses the resulting RTL glyph ordering to LTR for the backends
- Builds ShapedRow directly for RTL runs, bypassing the column loop which assumes ascending clusterMap values

## Validation Steps Performed
- Built and tested on Windows 11 with WindowsTerminalDev app
- Persian text (e.g., سلام) renders with correct RTL ordering and connected letters
- Backspace deletion removes characters from the right (RTL) side
- Mixed LTR/RTL text falls back to LTR direction per run
- Existing tests continue to pass

## PR Checklist
- [x] Closes #20156
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Schema updated (if necessary)
