### PR TITLE
f/llm: propagate newer Terminal internal package version to 1espt

### DIFF
--- a/build/pipelines/templates-v2/pipeline-1espt-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-1espt-full-release-build.yml
@@ -41,7 +41,7 @@ parameters:
     default: true
   - name: terminalInternalPackageVersion
     type: string
-    default: '0.0.8'
+    default: '0.0.9'
 
   - name: publishSymbolsToPublic
     type: boolean


### PR DESCRIPTION
Build fails without it.