### PR TITLE
Fix crash when closing scratchpad pane

### DIFF
--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -997,6 +997,17 @@ void Pane::_ContentLostFocusHandler(const winrt::Windows::Foundation::IInspectab
 // - <none>
 void Pane::Close()
 {
+    // GH#20187: Make Close() idempotent. The actual removal of this pane
+    // from the parent's tree is deferred until the close animation in
+    // _CloseChildRoutine completes (~200ms). Without this guard, a second
+    // close request that reaches this same pane during the animation
+    // window (e.g. auto-repeat or rapid double-press of the closePane
+    // keybinding) would re-raise Closed and kick off a redundant close
+    // animation on the parent.
+    if (!_content)
+    {
+        return;
+    }
     _setPaneContent(nullptr);
     // Fire our Closed event to tell our parent that we should be removed.
     Closed.raise(nullptr, nullptr);

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -999,11 +999,10 @@ void Pane::Close()
 {
     // GH#20187: Make Close() idempotent. The actual removal of this pane
     // from the parent's tree is deferred until the close animation in
-    // _CloseChildRoutine completes (~200ms). Without this guard, a second
-    // close request that reaches this same pane during the animation
-    // window (e.g. auto-repeat or rapid double-press of the closePane
-    // keybinding) would re-raise Closed and kick off a redundant close
-    // animation on the parent.
+    // _CloseChildRoutine completes (~200ms). Without this guard, a
+    // second close request that reaches this same pane during the
+    // animation window would re-raise Closed and kick off a redundant
+    // close animation on the parent.
     if (!_content)
     {
         return;

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -93,6 +93,12 @@ public:
     winrt::Windows::UI::Xaml::Controls::Grid GetRootElement();
     winrt::TerminalApp::IPaneContent GetContent() const noexcept { return _IsLeaf() ? _content : nullptr; }
 
+    // GH#20187: True if this is a leaf pane whose content has already been
+    // torn down by Pane::Close() but which has not yet been removed from
+    // its parent (the close animation in _CloseChildRoutine is still
+    // running). Such a "corpse" pane is not safe to operate on.
+    bool IsClosed() const noexcept { return _IsLeaf() && _content == nullptr; }
+
     bool WasLastFocused() const noexcept;
     void UpdateVisuals();
     void ClearActive();

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -781,16 +781,6 @@ namespace winrt::TerminalApp::implementation
     // - pane: the pane to close.
     void TerminalPage::_HandleClosePaneRequested(std::shared_ptr<Pane> pane)
     {
-        // GH#20187: Defensive guard. Callers should already filter out
-        // corpse panes (see _CloseFocusedPane), but in case a future
-        // caller passes a leaf pane whose content has already been torn
-        // down by a prior Pane::Close(), bail before we try to call
-        // GetTerminalArgsForPane on it.
-        if (pane->IsClosed())
-        {
-            return;
-        }
-
         // Build the list of actions to recreate the closed pane,
         // BuildStartupActions returns the "first" pane and the rest of
         // its actions are assuming that first pane has been created first.
@@ -824,13 +814,18 @@ namespace winrt::TerminalApp::implementation
 
             if (const auto pane{ activeTab->GetActivePane() })
             {
-                // GH#20187: When closePane is auto-repeated (or rapidly
-                // re-pressed), the second invocation can arrive while the
-                // parent's close animation is still running and
-                // Tab::_activePane still points at the already-closed
-                // leaf. Detect that "corpse" state here and bail before
-                // we try to call GetTerminalArgsForPane on a leaf whose
-                // content has been torn down.
+                // GH#20187: When the user closes a pane with a keyboard
+                // shortcut, focus moves off the closed pane while keys
+                // are still depressed. The corresponding KeyUp events
+                // arrive at TabRowControl, whose KeyUp is wired to
+                // TerminalPage::_KeyDownHandler (see TerminalPage.xaml).
+                // _KeyDownHandler can't tell it was invoked from KeyUp
+                // and dispatches the close action a second time. By
+                // then the parent's close animation in
+                // _CloseChildRoutine is still running, so
+                // Tab::_activePane still points at the now-closed leaf
+                // ("corpse"). Detect that here and bail before we
+                // dereference its null content in GetTerminalArgsForPane.
                 if (pane->IsClosed())
                 {
                     co_return;

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -781,6 +781,16 @@ namespace winrt::TerminalApp::implementation
     // - pane: the pane to close.
     void TerminalPage::_HandleClosePaneRequested(std::shared_ptr<Pane> pane)
     {
+        // GH#20187: Defensive guard. Callers should already filter out
+        // corpse panes (see _CloseFocusedPane), but in case a future
+        // caller passes a leaf pane whose content has already been torn
+        // down by a prior Pane::Close(), bail before we try to call
+        // GetTerminalArgsForPane on it.
+        if (pane->IsClosed())
+        {
+            return;
+        }
+
         // Build the list of actions to recreate the closed pane,
         // BuildStartupActions returns the "first" pane and the rest of
         // its actions are assuming that first pane has been created first.
@@ -814,6 +824,18 @@ namespace winrt::TerminalApp::implementation
 
             if (const auto pane{ activeTab->GetActivePane() })
             {
+                // GH#20187: When closePane is auto-repeated (or rapidly
+                // re-pressed), the second invocation can arrive while the
+                // parent's close animation is still running and
+                // Tab::_activePane still points at the already-closed
+                // leaf. Detect that "corpse" state here and bail before
+                // we try to call GetTerminalArgsForPane on a leaf whose
+                // content has been torn down.
+                if (pane->IsClosed())
+                {
+                    co_return;
+                }
+
                 const auto weak = get_weak();
 
                 // Check if we should warn before closing a single pane


### PR DESCRIPTION
## Summary of the Pull Request
Fixes a crash when closing a scratchpad pane. The crash would occur in `Pane::GetTerminalArgsForPane()` via a null-pointer exception on `_content` when calling `_content.GetNewTerminalArgs(kind);`.

My root cause analysis revealed that this was happening:
- `Pane::Close()` is synchronously called: `_content` is cleared and `Closed` is raised
- The parent's response (`_CloseChildRoutine`) performs a close animation, _and then_ calls `_CloseChild` to actually mutate the pane tree once the animation is complete.
- During the animation, the closed leaf is in a "corpse" state:
   - still in the pane tree
   - `_isLeaf()` is true
   - `_lastActive` is true
   - pointed at by `Tab::_activePane` in the tab's `Closed` handler
      - NOTE: `_activePane` _only_ updates when a _parent_ of the active pane closes, never when the active pane itself closes
   - `_content` is null
- A second `closePane` is dispatched due to the ctrl+shift+w keypress. This is due to PR #12260 (ugh). This occurs _during_ the animation!
   - `_CloseFocusedPane` calls `activeTab->GetActivePane()` which returns the "corpse" `_activePane`.
   - `_HandleClosePaneRequested` then calls `GetTerminalArgsForPane()`, which dereferences the null `_content`, and the crash occurs.

The minimum fix is:
- add a `Pane::IsClosed()` helper
- `TerminalPage::_CloseFocusedPane`:  return early if pane is closed

The other changes are additional safeguards so that this doesn't happen in the future.

## Validation Steps Performed
✅ Close scratchpad pane with ctrl+shift+w --> no crash!

## PR Checklist
 Closes #20187 