### PR TITLE
Making sure the starting title is prioritized if set and that it only set once on start.

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -1508,7 +1508,11 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     hstring ControlCore::Title()
     {
         const auto lock = _terminal->LockForReading();
-        return hstring{ _terminal->GetConsoleTitle() };
+
+        const auto startingTitle = _terminal->GetStartingTitle();
+
+        // startingTitle always gets prioritized if it was set.
+        return hstring{ !startingTitle.empty() ? startingTitle : _terminal->GetConsoleTitle() };
     }
 
     hstring ControlCore::WorkingDirectory() const

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -1508,11 +1508,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     hstring ControlCore::Title()
     {
         const auto lock = _terminal->LockForReading();
-
-        const auto startingTitle = _terminal->GetStartingTitle();
-
-        // startingTitle always gets prioritized if it was set.
-        return hstring{ !startingTitle.empty() ? startingTitle : _terminal->GetConsoleTitle() };
+        return hstring{ _terminal->GetConsoleTitle() };
     }
 
     hstring ControlCore::WorkingDirectory() const

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -98,11 +98,18 @@ void Terminal::UpdateSettings(ICoreSettings settings)
     _answerbackMessage = settings.AnswerbackMessage();
     _wordDelimiters = settings.WordDelimiters();
     _suppressApplicationTitle = settings.SuppressApplicationTitle();
-    _startingTitle = settings.StartingTitle();
     _trimBlockSelection = settings.TrimBlockSelection();
     _autoMarkPrompts = settings.AutoMarkPrompts();
     _rainbowSuggestions = settings.RainbowSuggestions();
     _clipboardOperationsAllowed = settings.AllowVtClipboardWrite();
+
+    if (!_initialUpdateWasDone)
+    {
+        //Starting title can only be set once on start, it should never update.
+        _startingTitle = settings.StartingTitle();
+        _initialUpdateWasDone = true;
+    }
+
 
     if (_stateMachine)
     {
@@ -1260,6 +1267,15 @@ const size_t Microsoft::Terminal::Core::Terminal::GetTaskbarState() const noexce
 const size_t Microsoft::Terminal::Core::Terminal::GetTaskbarProgress() const noexcept
 {
     return _taskbarProgress;
+}
+
+// Method Description:
+// - Gets the starting title value
+// Return Value:
+// - The starting title
+std::wstring Terminal::GetStartingTitle() const
+{
+    return _startingTitle;
 }
 
 void Microsoft::Terminal::Core::Terminal::CompletionsChangedCallback(std::function<void(std::wstring_view, unsigned int)> pfn) noexcept

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -110,7 +110,6 @@ void Terminal::UpdateSettings(ICoreSettings settings)
         _initialUpdateWasDone = true;
     }
 
-
     if (_stateMachine)
     {
         SetOptionalFeatures(settings);
@@ -1267,15 +1266,6 @@ const size_t Microsoft::Terminal::Core::Terminal::GetTaskbarState() const noexce
 const size_t Microsoft::Terminal::Core::Terminal::GetTaskbarProgress() const noexcept
 {
     return _taskbarProgress;
-}
-
-// Method Description:
-// - Gets the starting title value
-// Return Value:
-// - The starting title
-std::wstring Terminal::GetStartingTitle() const
-{
-    return _startingTitle;
 }
 
 void Microsoft::Terminal::Core::Terminal::CompletionsChangedCallback(std::function<void(std::wstring_view, unsigned int)> pfn) noexcept

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -243,8 +243,6 @@ public:
 
     const std::optional<til::color> GetTabColor() const;
 
-    std::wstring GetStartingTitle() const;
-
     const size_t GetTaskbarState() const noexcept;
     const size_t GetTaskbarProgress() const noexcept;
 

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -243,6 +243,8 @@ public:
 
     const std::optional<til::color> GetTabColor() const;
 
+    std::wstring GetStartingTitle() const;
+
     const size_t GetTaskbarState() const noexcept;
     const size_t GetTaskbarProgress() const noexcept;
 
@@ -370,6 +372,7 @@ private:
     bool _trimBlockSelection = true;
     bool _autoMarkPrompts = false;
     bool _rainbowSuggestions = false;
+    bool _initialUpdateWasDone = false;
 
     size_t _taskbarState = 0;
     size_t _taskbarProgress = 0;


### PR DESCRIPTION
## Summary of the Pull Request
I've tried to fix the bug by doing two things:
1. ~~Updating ControlCore.cpp to use the startingTitle value if it was set.~~
2. Modifying `Terminal.cpp` to only get the value of `settings.StartingTitle()` once, presumably on first setting load during creation of the terminal. Future updates of the settings should not affect the startingTitle value.

## Validation Steps Performed
1. Tests seem to pass. 
2. `--title` command-line option and `Tab title` seem to work fine.
3. Apps can still change the title if the `Suppress title changes` is not set.

## PR Checklist
- [ ] Closes #19340 