### PR TITLE
Only set startingTitle once, clear up title fallback handling

### DIFF
--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -98,7 +98,6 @@ void Terminal::UpdateSettings(ICoreSettings settings)
     _answerbackMessage = settings.AnswerbackMessage();
     _wordDelimiters = settings.WordDelimiters();
     _suppressApplicationTitle = settings.SuppressApplicationTitle();
-    _startingTitle = settings.StartingTitle();
     _trimBlockSelection = settings.TrimBlockSelection();
     _autoMarkPrompts = settings.AutoMarkPrompts();
     _rainbowSuggestions = settings.RainbowSuggestions();
@@ -123,6 +122,11 @@ void Terminal::UpdateSettings(ICoreSettings settings)
 
     // Save the changes made above and in UpdateAppearance as the new default render settings.
     GetRenderSettings().SaveDefaultSettings();
+
+    if (!_startingTitle)
+    {
+        _startingTitle = settings.StartingTitle();
+    }
 
     if (!_startingTabColor && settings.StartingTabColor())
     {

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -349,7 +349,7 @@ private:
     ::Microsoft::Console::VirtualTerminal::TerminalInput _terminalInput;
 
     std::optional<std::wstring> _title;
-    std::wstring _startingTitle;
+    std::optional<std::wstring> _startingTitle;
     std::optional<til::color> _startingTabColor;
 
     std::vector<til::point_span> _searchHighlights;

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -91,8 +91,12 @@ void Terminal::SetWindowTitle(const std::wstring_view title)
     _assertLocked();
     if (!_suppressApplicationTitle)
     {
-        _title.emplace(title.empty() ? _startingTitle : title);
-        _pfnTitleChanged(_title.value());
+        _title.reset();
+        if (!title.empty())
+        {
+            _title.emplace(title);
+        }
+        _pfnTitleChanged(GetConsoleTitle());
     }
 }
 

--- a/src/cascadia/TerminalCore/terminalrenderdata.cpp
+++ b/src/cascadia/TerminalCore/terminalrenderdata.cpp
@@ -184,11 +184,18 @@ void Terminal::SelectNewRegion(const til::point coordStart, const til::point coo
 std::wstring_view Terminal::GetConsoleTitle() const noexcept
 {
     _assertLocked();
-    if (_title.has_value())
+
+    if (_title)
     {
         return *_title;
     }
-    return _startingTitle;
+
+    if (_startingTitle)
+    {
+        return *_startingTitle;
+    }
+
+    return {};
 }
 
 // Method Description:


### PR DESCRIPTION
This commit ensures that we only set the starting title once when we open a new terminal pane.

It also consolidates all title selection into Terminal::GetConsoleTitle, which is now used in the TitleChanged event.

TitleChanged no longer stores a separate copy of the starting title if an application attempts to _clear_ the title; that seems like a poorer implementation of what we already had.

This supersedes work in #20204.

Closes #19340
Closes #20204