### PR TITLE
build: inject the github client secret in the 1ESPT pipeline as well

### DIFF
--- a/build/pipelines/templates-v2/pipeline-1espt-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-1espt-full-release-build.yml
@@ -121,6 +121,10 @@ extends:
 
                 - template: ./build/pipelines/templates-v2/steps-install-terrapin.yml@self
 
+                - template: ./build/pipelines/templates-v2/steps-inject-secrets.yml@self
+                  parameters:
+                    githubClientSecret: $(GithubClientSecret)
+
                 - task: UniversalPackages@0
                   displayName: Download terminal-internal Universal Package
                   inputs:


### PR DESCRIPTION
I missed this when I ported the build pipeline over.

Closes #20198 