### PR TITLE
Fix: Prevent Enter key leaking to terminal during Command Palette actions

### DIFF
--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -1200,24 +1200,24 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_HandleExportBuffer(const IInspectable& sender,
                                            const ActionEventArgs& args)
     {
+        if (args)
+        {
+            args.Handled(true);
+        }
+
         if (const auto activeTab{ _senderOrFocusedTab(sender) })
         {
+            winrt::hstring path;
+
             if (args)
             {
                 if (const auto& realArgs = args.ActionArgs().try_as<ExportBufferArgs>())
                 {
-                    _ExportTab(*activeTab, realArgs.Path());
-                    args.Handled(true);
-                    return;
+                    path = realArgs.Path();
                 }
             }
 
-            // If we didn't have args, or the args weren't ExportBufferArgs (somehow)
-            _ExportTab(*activeTab, L"");
-            if (args)
-            {
-                args.Handled(true);
-            }
+            _ExportTab(*activeTab, path);
         }
     }
 

--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -332,8 +332,8 @@ namespace winrt::TerminalApp::implementation
 
             const auto selectedCommand = _filteredActionsView().SelectedItem();
             const auto filteredCommand = selectedCommand.try_as<winrt::TerminalApp::FilteredCommand>();
-            _dispatchCommand(filteredCommand);
             e.Handled(true);
+            _dispatchCommand(filteredCommand);
         }
         else if (key == VirtualKey::Escape)
         {
@@ -795,7 +795,19 @@ namespace winrt::TerminalApp::implementation
                     // All other actions can just be dispatched.
                     if (command.ActionAndArgs().Action() != ShortcutAction::ToggleCommandPalette)
                     {
-                        DispatchCommandRequested.raise(*this, command);
+                        if (command.ActionAndArgs().Action() == ShortcutAction::ExportBuffer)
+                        {
+                            Dispatcher().RunAsync(CoreDispatcherPriority::Low, [weak = get_weak(), command]() {
+                                if (auto self{ weak.get() })
+                                {
+                                    self->DispatchCommandRequested.raise(*self, command);
+                                }
+                            });
+                        }
+                        else
+                        {
+                            DispatchCommandRequested.raise(*this, command);
+                        }
                     }
 
                     TraceLoggingWrite(


### PR DESCRIPTION
## Summary of the Pull Request

This PR addresses the issue reported in #20188, where triggering the "Export Text" action from the Command Palette would result in a phantom `Enter` key press being sent to the active terminal session.

The original implementation marked the event as handled (`args.Handled(true)`) only after invoking the `_ExportTab` function. When no predefined file path is provided (the default behavior in the Command Palette), `_ExportTab` triggers a modal Windows dialog (`FileSavePicker`). This system dialog captures the UI focus immediately.

## The Problem

Because the focus shifted before the event was marked as handled, the WinUI event routing system allowed the residual `Enter` keystroke to "leak" into the terminal control that regained focus in the background.

This behavior might stem from an early design focus on single-window control architectures, as seen in previous discussions like: https://github.com/microsoft/terminal/pull/6635

## Solution 

1. **Early Neutralization:** Moved `args.Handled(true);` to the very beginning of the `_HandleExportBuffer` method. This ensures the `Enter` event is consumed by the Command Palette while it still holds focus, preventing any further propagation.

2. **Flow Refactoring:** Refactored the method to utilize a single execution path for `_ExportTab`. The method now prepares the path string and executes the call once, improving code readability and ensuring consistent behavior regardless of whether a path argument is provided.

## Validation Steps Performed

### Before

<img width="634" alt="before" src="https://github.com/user-attachments/assets/31fa75dc-8e15-432c-802a-4ac0bb788321" />

### After

<img width="634" alt="after" src="https://github.com/user-attachments/assets/b0a321fc-3b48-43ee-af1b-b20beb3376dc" />

## PR Checklist

- [x] Closes #20188
- [x] Tests passed (Manual validation and successful compilation)
- [ ] Documentation updated
- [ ] Schema updated (if necessary)