### PR TITLE
Add UI checkbox for url configuration 

### DIFF
--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -702,6 +702,9 @@
   <data name="UnsafeUrlConfirmAllowAction" xml:space="preserve">
     <value>Open anyway</value>
   </data>
+  <data name="RememberUriSchemeCheckBox.Content" xml:space="preserve">
+    <value>Always allow links with this scheme</value>
+  </data>
   <data name="SettingsTab" xml:space="preserve">
     <value>Settings</value>
   </data>

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -3218,9 +3218,8 @@ namespace winrt::TerminalApp::implementation
                         CouldNotOpenUriReason().Text(RS_(L"UnsafeUrlConfirmText"));
                         UnopenedUri().Text(uriString);
 
-                        // Get the checkbox and make it visible for unsafe URL warnings only
-                        const auto stackPanel = unopenedUriDialog.Content().as<StackPanel>();
-                        const auto checkbox = stackPanel.Children().GetAt(1).as<CheckBox>();
+                        // Get the checkbox directly by its x:Name and make it visible for unsafe URL warnings only
+                        const auto checkbox = RememberUriSchemeCheckBox();
                         checkbox.IsChecked(false);
                         checkbox.Visibility(Visibility::Visible);
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -3218,9 +3218,51 @@ namespace winrt::TerminalApp::implementation
                         CouldNotOpenUriReason().Text(RS_(L"UnsafeUrlConfirmText"));
                         UnopenedUri().Text(uriString);
 
+                        // Get the checkbox and make it visible for unsafe URL warnings only
+                        const auto stackPanel = unopenedUriDialog.Content().as<StackPanel>();
+                        const auto checkbox = stackPanel.Children().GetAt(1).as<CheckBox>();
+                        checkbox.IsChecked(false);
+                        checkbox.Visibility(Visibility::Visible);
+
                         // Show the dialog
                         auto result = co_await presenter.ShowDialog(unopenedUriDialog);
+
+                        // Hide the checkbox again after dialog closes (for other use cases)
+                        checkbox.Visibility(Visibility::Collapsed);
+
                         shouldLaunch = result == ContentDialogResult::Secondary;
+
+                        // If the user clicked "Open anyway" AND checked the box, save the scheme
+                        if (shouldLaunch && checkbox.IsChecked().Value())
+                        {
+                            const auto scheme = parsed.SchemeName();
+
+                            // Get the current list of safe schemes (or create a new one)
+                            auto safeSchemes = _settings.GlobalSettings().SafeUriSchemes();
+                            if (!safeSchemes)
+                            {
+                                safeSchemes = winrt::single_threaded_vector<winrt::hstring>();
+                            }
+
+                            // Check if the scheme is already in the list
+                            bool schemeExists = false;
+                            for (const auto& existingScheme : safeSchemes)
+                            {
+                                if (til::equals_insensitive_ascii(scheme, existingScheme))
+                                {
+                                    schemeExists = true;
+                                    break;
+                                }
+                            }
+
+                            // Add the scheme if it's not already there
+                            if (!schemeExists)
+                            {
+                                safeSchemes.Append(scheme);
+                                _settings.GlobalSettings().SafeUriSchemes(safeSchemes);
+                                _settings.WriteSettingsToDisk();
+                            }
+                        }
                     }
                 }
 

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -144,15 +144,21 @@
                        Grid.Row="2"
                        x:Load="False"
                        DefaultButton="Close">
-            <TextBlock IsTextSelectionEnabled="True"
-                       TextWrapping="WrapWholeWords">
-                <TextBlock.ContextFlyout>
-                    <mtu:TextMenuFlyout />
-                </TextBlock.ContextFlyout>
-                <Run x:Name="CouldNotOpenUriReason" /> <LineBreak /> <LineBreak />
-                <Run x:Name="UnopenedUri"
-                     FontFamily="Cascadia Mono" />
-            </TextBlock>
+            <StackPanel>
+                <TextBlock IsTextSelectionEnabled="True"
+                           TextWrapping="WrapWholeWords">
+                    <TextBlock.ContextFlyout>
+                        <mtu:TextMenuFlyout />
+                    </TextBlock.ContextFlyout>
+                    <Run x:Name="CouldNotOpenUriReason" /> <LineBreak /> <LineBreak />
+                    <Run x:Name="UnopenedUri"
+                         FontFamily="Cascadia Mono" />
+                </TextBlock>
+                <CheckBox x:Name="RememberUriSchemeCheckBox"
+                          x:Uid="RememberUriSchemeCheckBox"
+                          Margin="0,16,0,0"
+                          Visibility="Collapsed" />
+            </StackPanel>
         </ContentDialog>
 
         <local:CommandPalette x:Name="CommandPaletteElement"


### PR DESCRIPTION
## Summary of the Pull Request

This PR adds a checkbox to the unsafe URL warning dialog that allows users to easily trust a link. When a user checks the box and clicks **"Open anyway"**, the URL scheme is automatically saved to the `safeUriSchemes` list in their `settings.json`.

---

## References and Relevant Issues

- Completes the UI checkbox suggestion requested by @DHowett in #20191.
- Direct follow-up to PR #20207 (which added the backend `safeUriSchemes` logic).

---

## Detailed Description of the Pull Request / Additional Comments

The backend for this feature was successfully added in #20207, but it lacked a user interface. This PR connects the UI to that backend logic.

### Files Modified

### `TerminalPage.xaml`
- Added the checkbox inside the `UriErrorDialog` using a `StackPanel`.

### `TerminalPage.cpp`
- Added the logic to:
  - Extract the URI scheme.
  - Save it to `_settings.GlobalSettings().SafeUriSchemes()` if the checkbox is checked.

### `Resources.resw` (en-US)
- Added the translation string for the checkbox text.

> A working video demonstrating the feature has been attached in the PR thread.

https://github.com/user-attachments/assets/adbf3f73-7ad0-41a4-97b1-e24abb909f30


---

## Validation Steps Performed

- Built and deployed the app locally.
- Generated a `vscode://` hyperlink in the terminal using an OSC 8 escape sequence.
- Clicked the link, checked the new checkbox, and selected **"Open anyway"**.
- Verified that `"vscode"` was automatically written to the `safeUriSchemes` array in `settings.json`.
- Clicked the `vscode://` link a second time and verified that the warning dialog was completely bypassed.

---

## PR Checklist

- [x] Closes #20191
- [x] Tests added/passed
- [ ] Documentation updated
- [ ] Schema updated (if necessary)
