### PR TITLE
Replace Bold with SemiBold; clean up new-tab tooltip typography

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.xaml
+++ b/src/cascadia/TerminalApp/CommandPalette.xaml
@@ -344,7 +344,7 @@
                 <TextBlock x:Name="_parentCommandText"
                            Padding="16,4"
                            VerticalAlignment="Center"
-                           FontStyle="Italic"
+                           FontWeight="SemiBold"
                            Text="{x:Bind ParentCommandName, Mode=OneWay}" />
             </StackPanel>
 
@@ -358,8 +358,8 @@
 
                 <ScrollViewer MaxHeight="200"
                               VerticalScrollBarVisibility="Auto">
-                    <TextBlock FontStyle="Italic"
-                               Text="{x:Bind ParsedCommandLineText, Mode=OneWay}"
+                    <TextBlock Text="{x:Bind ParsedCommandLineText, Mode=OneWay}"
+                               TextAlignment="Left"
                                TextWrapping="Wrap" />
                 </ScrollViewer>
             </Border>
@@ -371,7 +371,6 @@
                     Visibility="Collapsed">
                 <TextBlock Padding="12,0"
                            VerticalAlignment="Center"
-                           FontStyle="Italic"
                            Text="{x:Bind NoMatchesText, Mode=OneWay}" />
             </Border>
 

--- a/src/cascadia/TerminalApp/HighlightedTextControl.cpp
+++ b/src/cascadia/TerminalApp/HighlightedTextControl.cpp
@@ -152,8 +152,8 @@ namespace winrt::TerminalApp::implementation
                     }
                     else
                     {
-                        // Default style: bold
-                        run.FontWeight(FontWeights::Bold());
+                        // Default style: semibold
+                        run.FontWeight(FontWeights::SemiBold());
                     }
                     inlinesCollection.Append(run);
 

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -443,13 +443,13 @@
     <value>Open a new tab</value>
   </data>
   <data name="NewPaneRun.Text" xml:space="preserve">
-    <value>Alt+Click to split the current window</value>
+    <value>Alt + Click to split the current window</value>
   </data>
   <data name="NewWindowRun.Text" xml:space="preserve">
-    <value>Shift+Click to open a new window</value>
+    <value>Shift + Click to open a new window</value>
   </data>
   <data name="ElevatedRun.Text" xml:space="preserve">
-    <value>Ctrl+Click to open as administrator</value>
+    <value>Ctrl + Click to open as administrator</value>
   </data>
   <data name="WindowCloseButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Close</value>

--- a/src/cascadia/TerminalApp/SuggestionsControl.xaml
+++ b/src/cascadia/TerminalApp/SuggestionsControl.xaml
@@ -167,7 +167,7 @@
                 <TextBlock x:Name="_parentCommandText"
                            Padding="16,4"
                            VerticalAlignment="Center"
-                           FontStyle="Italic"
+                           FontWeight="SemiBold"
                            Text="{x:Bind ParentCommandName, Mode=OneWay}" />
             </StackPanel>
 
@@ -179,7 +179,6 @@
                     Visibility="Collapsed">
                 <TextBlock Padding="12,0"
                            VerticalAlignment="Center"
-                           FontStyle="Italic"
                            Text="{x:Bind NoMatchesText, Mode=OneWay}" />
             </Border>
 

--- a/src/cascadia/TerminalApp/SuggestionsControl.xaml
+++ b/src/cascadia/TerminalApp/SuggestionsControl.xaml
@@ -228,7 +228,7 @@
                         Visibility="Collapsed">
                 <TextBlock x:Name="_descriptionTitle"
                            FontSize="14"
-                           FontWeight="Bold"
+                           FontWeight="SemiBold"
                            IsTextSelectionEnabled="True"
                            TextWrapping="WrapWholeWords">
                     <TextBlock.ContextFlyout>

--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -235,14 +235,14 @@ namespace winrt::TerminalApp::implementation
 
         auto textBlock = WUX::Controls::TextBlock{};
         textBlock.TextWrapping(WUX::TextWrapping::Wrap);
-        textBlock.TextAlignment(WUX::TextAlignment::Center);
+        textBlock.TextAlignment(WUX::TextAlignment::Left);
         textBlock.Inlines().Append(titleRun);
 
         if (!_keyChord.empty())
         {
             auto keyChordRun = WUX::Documents::Run();
             keyChordRun.Text(_keyChord);
-            keyChordRun.FontStyle(winrt::Windows::UI::Text::FontStyle::Italic);
+            textBlock.Inlines().Append(WUX::Documents::LineBreak{});
             textBlock.Inlines().Append(WUX::Documents::LineBreak{});
             textBlock.Inlines().Append(keyChordRun);
         }

--- a/src/cascadia/TerminalApp/TabRowControl.xaml
+++ b/src/cascadia/TerminalApp/TabRowControl.xaml
@@ -71,11 +71,9 @@
                     <ToolTipService.ToolTip>
                         <ToolTip Placement="Mouse">
                             <TextBlock TextWrapping="Wrap">
-                                <Run x:Uid="NewTabRun" /> <LineBreak />
-                                <Run x:Uid="NewPaneRun"
-                                     FontStyle="Italic" /> <LineBreak />
-                                <Run x:Uid="NewWindowRun"
-                                     FontStyle="Italic" />
+                                <Run x:Uid="NewTabRun" /> <LineBreak /><LineBreak />
+                                <Run x:Uid="NewPaneRun" /> <LineBreak />
+                                <Run x:Uid="NewWindowRun" />
                             </TextBlock>
                         </ToolTip>
                     </ToolTipService.ToolTip>

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1295,16 +1295,14 @@ namespace winrt::TerminalApp::implementation
         newTabRun.Text(RS_(L"NewTabRun/Text"));
         auto newPaneRun = WUX::Documents::Run();
         newPaneRun.Text(RS_(L"NewPaneRun/Text"));
-        newPaneRun.FontStyle(FontStyle::Italic);
         auto newWindowRun = WUX::Documents::Run();
         newWindowRun.Text(RS_(L"NewWindowRun/Text"));
-        newWindowRun.FontStyle(FontStyle::Italic);
         auto elevatedRun = WUX::Documents::Run();
         elevatedRun.Text(RS_(L"ElevatedRun/Text"));
-        elevatedRun.FontStyle(FontStyle::Italic);
 
         auto textBlock = WUX::Controls::TextBlock{};
         textBlock.Inlines().Append(newTabRun);
+        textBlock.Inlines().Append(WUX::Documents::LineBreak{});
         textBlock.Inlines().Append(WUX::Documents::LineBreak{});
         textBlock.Inlines().Append(newPaneRun);
         textBlock.Inlines().Append(WUX::Documents::LineBreak{});

--- a/src/cascadia/TerminalSettingsEditor/ActionsViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ActionsViewModel.cpp
@@ -1334,7 +1334,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             const auto conflictingCmdName{ conflictingCmd.Name() };
             TextBlock conflictingCommandNameTB{};
             conflictingCommandNameTB.Text(fmt::format(L"\"{}\"", conflictingCmdName.empty() ? RS_(L"Actions_UnnamedCommandName") : conflictingCmdName));
-            conflictingCommandNameTB.FontStyle(Windows::UI::Text::FontStyle::Italic);
 
             TextBlock confirmationQuestionTB{};
             confirmationQuestionTB.Text(RS_(L"Actions_RenameConflictConfirmationQuestion"));

--- a/src/cascadia/TerminalSettingsEditor/Extensions.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Extensions.xaml
@@ -19,12 +19,6 @@
                 <ResourceDictionary Source="CommonResources.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
-            <Style x:Key="ItalicDisclaimerStyle"
-                   BasedOn="{StaticResource DisclaimerStyle}"
-                   TargetType="TextBlock">
-                <Setter Property="FontStyle" Value="Italic" />
-            </Style>
-
             <Style x:Key="CodeBlockStyle"
                    TargetType="TextBlock">
                 <Setter Property="FontFamily" Value="Cascadia Mono, Consolas" />

--- a/src/cascadia/TerminalSettingsEditor/NewTabMenu.xaml
+++ b/src/cascadia/TerminalSettingsEditor/NewTabMenu.xaml
@@ -121,7 +121,7 @@
                                 Style="{StaticResource NewTabMenuEntryControlsWrapper}">
                     <TextBlock x:Uid="NewTabMenuEntry_Separator"
                                VerticalAlignment="Center"
-                               FontStyle="Italic" />
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                 </ContentControl>
             </DataTemplate>
 
@@ -201,7 +201,7 @@
                                 DataContext="{Binding Mode=OneWay}"
                                 Style="{StaticResource NewTabMenuEntryControlsWrapper}">
                     <TextBlock VerticalAlignment="Center"
-                               FontStyle="Italic"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                Text="{x:Bind DisplayText, Mode=OneWay}" />
                 </ContentControl>
             </DataTemplate>
@@ -213,7 +213,7 @@
                                 Style="{StaticResource NewTabMenuEntryControlsWrapper}">
                     <TextBlock x:Uid="NewTabMenuEntry_RemainingProfiles"
                                VerticalAlignment="Center"
-                               FontStyle="Italic" />
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                 </ContentControl>
             </DataTemplate>
 


### PR DESCRIPTION
## Summary

A first pass at the issues raised in #20228 around non-Fluent `Bold` / `Italic` typography in TerminalApp.

Closes: #20228

## Changes

### Bold → SemiBold
Replace `FontWeight=Bold` with `SemiBold` (matches Fluent's `BodyStrong` style):

- `SuggestionsControl.xaml` — the description title shown above a suggestion's body.
- `TerminalPage.cpp` — the default-profile entry in the new-tab dropdown flyout.
- `HighlightedTextControl.cpp` — fallback run style used to render matched characters (e.g. in the Command Palette / snippets list).

### New-tab `+` button + per-profile dropdown tooltip
- Remove `FontStyle=Italic` from the shortcut-hint runs in both tooltips (`TabRowControl.xaml` and the dropdown tooltip built in `TerminalPage.cpp`).
- Insert a blank line between the title (`Open a new tab`) and the shortcut hints.
- Add spaces around `+` in the en-US shortcut strings:
  - `Alt + Click to split the current window`
  - `Shift + Click to open a new window`
  - `Ctrl + Click to open as administrator`

Other locales will be updated by the localization team.

## Validation

- Hover the new-tab `+` button → tooltip has the new layout/spacing, no italics.
- Open the new-tab dropdown, hover a profile → tooltip likewise has the new layout/spacing, no italics. The default profile still stands out via SemiBold (was Bold).
- Open the Command Palette, type to filter → matched character runs render as SemiBold.
- Run `showSuggestions` on a snippet/task with a description → the description title is SemiBold.


Before:
<img width="220" height="82" alt="image" src="https://github.com/user-attachments/assets/973494d4-a618-419d-b798-29a96b591971" />


After:
<img width="256" height="108" alt="image" src="https://github.com/user-attachments/assets/ac6dd4e9-321e-4efb-b859-2e228fe7e14c" />

---

Before:

<img width="309" height="103" alt="image" src="https://github.com/user-attachments/assets/779c1dcf-f9a8-4e11-a72c-31aa140cd1c1" />

After:

<img width="257" height="131" alt="image" src="https://github.com/user-attachments/assets/0ee28a05-e99b-4ace-b25e-3315fc06d427" />

---

Before:
<img width="242" height="124" alt="image" src="https://github.com/user-attachments/assets/89b3840f-27bb-4c31-a88d-1e87f8a33d7e" />

After:

---

Before:
<img width="353" height="212" alt="image" src="https://github.com/user-attachments/assets/8183b7bc-25e4-4c02-b615-d3ef884fd25c" />

After:
<img width="383" height="305" alt="image" src="https://github.com/user-attachments/assets/63002785-1c4f-4c4b-b1b5-b64dd625412a" />
