### PR TITLE
"fix(TerminalControl): invalidate hovered hyperlink on scroll

### DIFF
--- a/src/cascadia/TerminalControl/ControlInteractivity.cpp
+++ b/src/cascadia/TerminalControl/ControlInteractivity.cpp
@@ -635,6 +635,14 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // ScrollPositionChanged event to update the scrollbar
         UpdateScrollbar(newValue);
 
+        // GH#20219: Re-evaluate the hovered hyperlink after scrolling. The
+        // viewport shift may have changed which logical buffer cell sits under
+        // the stationary cursor, so we must invalidate the cached hover state
+        // and re-query at the same pixel position.
+        _core->ClearHoveredCell();
+        const auto terminalPosition = _getTerminalPosition(til::point{ pixelPosition }, false);
+        _core->SetHoveredCell(terminalPosition.to_core_point());
+
         if (isLeftButtonPressed)
         {
             // If user is mouse selecting and scrolls, they then point at new


### PR DESCRIPTION
## Summary of the Pull Request
Invalidate the cached hovered hyperlink state after mouse-wheel scrolling, so the hover underline is re-evaluated when the viewport shifts under a stationary cursor.

## References and Relevant Issues
Closes #20219

## Detailed Description of the Pull Request / Additional comments
When the user scrolls with the mouse wheel without moving the cursor,  `_mouseScrollHandler` calls `UpdateScrollbar` which shifts the viewport, but `_lastHoveredCell` was never invalidated. Since the cached viewport coordinates hadn't changed, `_updateHoveredCell` hit its early-return guard and skipped re-querying the buffer entirely. This left the hover underline stuck on a hyperlink that had scrolled away, even when plain text was now under the cursor.

The fix calls `ClearHoveredCell` immediately after `UpdateScrollbar` to bust the cache, then re-queries at the same pixel position via `SetHoveredCell`. This ensures the hover state always reflects the actual buffer cell under the cursor after a scroll.

## Validation Steps Performed
Manually reproduced the bug as described in #20219, hovered an OSC 8 hyperlink in Windows Terminal, kept the mouse stationary, and scrolled with the mouse wheel. The hover underline visibly persisted on the scrolled-away link. The fix has not been validated with a local build due to build environment constraints, but the change is minimal and targeted.

## PR Checklist
- [x] Closes #20219
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
