### PR TITLE
TerminalControl fix: Invalidate hovered hyperlink on scroll

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -244,6 +244,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             [weakThis = get_weak()](const auto& update) {
                 if (auto core{ weakThis.get() }; core && !core->_IsClosing())
                 {
+                    // GH#20219: re-evaluate if we're hovering over a hyperlink after scrolling
+                    core->_refreshHoveredCell();
                     core->ScrollPositionChanged.raise(*core, update);
                 }
             });
@@ -746,6 +748,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             _terminal->UserScrollViewport(viewTop);
         }
 
+        // GH#20219: re-evaluate if we're hovering over a hyperlink after scrolling
+        _refreshHoveredCell();
+
         const auto shared = _shared.lock_shared();
         if (shared->outputIdle)
         {
@@ -835,6 +840,16 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void ControlCore::ClearHoveredCell()
     {
         _updateHoveredCell(std::nullopt);
+    }
+
+    void ControlCore::_refreshHoveredCell()
+    {
+        if (_lastHoveredCell)
+        {
+            const auto cell = *_lastHoveredCell;
+            _lastHoveredCell.reset();
+            _updateHoveredCell(cell);
+        }
     }
 
     void ControlCore::_updateHoveredCell(const std::optional<til::point> terminalPosition)

--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -351,6 +351,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void _connectionOutputHandler(winrt::array_view<const char16_t> str);
         void _connectionStateChangedHandler(const TerminalConnection::ITerminalConnection&, const Windows::Foundation::IInspectable&);
         void _updateHoveredCell(const std::optional<til::point> terminalPosition);
+        void _refreshHoveredCell();
         void _setOpacity(const float opacity, const bool focused = true);
 
         bool _isBackgroundTransparent();

--- a/src/cascadia/TerminalControl/ControlInteractivity.cpp
+++ b/src/cascadia/TerminalControl/ControlInteractivity.cpp
@@ -635,6 +635,14 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // ScrollPositionChanged event to update the scrollbar
         UpdateScrollbar(newValue);
 
+        // GH#20219: Re-evaluate the hovered hyperlink after scrolling. The
+        // viewport shift may have changed which logical buffer cell sits under
+        // the stationary cursor, so we must invalidate the cached hover state
+        // and re-query at the same pixel position.
+        _core->ClearHoveredCell();
+        const auto terminalPosition = _getTerminalPosition(til::point{ pixelPosition }, false);
+        _core->SetHoveredCell(terminalPosition.to_core_point());
+
         if (isLeftButtonPressed)
         {
             // If user is mouse selecting and scrolls, they then point at new

--- a/src/cascadia/TerminalControl/ControlInteractivity.cpp
+++ b/src/cascadia/TerminalControl/ControlInteractivity.cpp
@@ -635,14 +635,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // ScrollPositionChanged event to update the scrollbar
         UpdateScrollbar(newValue);
 
-        // GH#20219: Re-evaluate the hovered hyperlink after scrolling. The
-        // viewport shift may have changed which logical buffer cell sits under
-        // the stationary cursor, so we must invalidate the cached hover state
-        // and re-query at the same pixel position.
-        _core->ClearHoveredCell();
-        const auto terminalPosition = _getTerminalPosition(til::point{ pixelPosition }, false);
-        _core->SetHoveredCell(terminalPosition.to_core_point());
-
         if (isLeftButtonPressed)
         {
             // If user is mouse selecting and scrolls, they then point at new


### PR DESCRIPTION
## Summary of the Pull Request
Invalidate the cached hovered hyperlink state after scrolling, so the hover underline is re-evaluated when the viewport shifts under a stationary cursor.

## Detailed Description of the Pull Request / Additional comments
When the user scrolls with the mouse wheel without moving the cursor,  `_mouseScrollHandler` calls `UpdateScrollbar` which shifts the viewport, but `_lastHoveredCell` was never invalidated. Since the cached viewport coordinates hadn't changed, `_updateHoveredCell` hit its early-return guard and skipped re-querying the buffer entirely. This left the hover underline stuck on a hyperlink that had scrolled away, even when plain text was now under the cursor.

The fix adds `ControlCore::_refreshHoveredCell()` and calls it in `updateScrollBar` for non-user-initiated scrolling and `UserScrollViewport` for user-initiated scrolling. This ensures the hover state always reflects the actual buffer cell under the cursor after a scroll.

## Validation Steps Performed
Manually reproduced the bug as described in #20219, hovered an OSC 8 hyperlink in Windows Terminal, kept the mouse stationary, and scrolled with the mouse wheel. The hover underline visibly persisted on the scrolled-away link.

## PR Checklist
Closes #20219
