### PR TITLE
Fix Kitty disambiguation for extended function keys

### DIFF
--- a/src/terminal/adapter/ut_adapter/kittyKeyboardProtocol.cpp
+++ b/src/terminal/adapter/ut_adapter/kittyKeyboardProtocol.cpp
@@ -292,6 +292,28 @@ class KittyKeyboardProtocolTests
         VERIFY_ARE_EQUAL(TerminalInput::MakeOutput(L"\x1b[97;2:2u"), process(input, true, 'A', 0x1E, L'A', SHIFT_PRESSED));
     }
 
+    TEST_METHOD(PushDisambiguateReportsExtendedFunctionKeys)
+    {
+        auto input = TerminalInput{};
+        input.PushKittyFlags(D);
+
+        VERIFY_ARE_EQUAL(TerminalInput::MakeOutput(L"\x1b[57376u"), process(input, true, VK_F13, 0x64, 0, 0));
+        VERIFY_ARE_EQUAL(TerminalInput::MakeOutput(L"\x1b[57377u"), process(input, true, VK_F14, 0x65, 0, 0));
+        VERIFY_ARE_EQUAL(TerminalInput::MakeOutput(L"\x1b[57378u"), process(input, true, VK_F15, 0x66, 0, 0));
+        VERIFY_ARE_EQUAL(TerminalInput::MakeOutput(L"\x1b[57379u"), process(input, true, VK_F16, 0x67, 0, 0));
+        VERIFY_ARE_EQUAL(TerminalInput::MakeOutput(L"\x1b[57380u"), process(input, true, VK_F17, 0x68, 0, 0));
+        VERIFY_ARE_EQUAL(TerminalInput::MakeOutput(L"\x1b[57381u"), process(input, true, VK_F18, 0x69, 0, 0));
+        VERIFY_ARE_EQUAL(TerminalInput::MakeOutput(L"\x1b[57382u"), process(input, true, VK_F19, 0x6A, 0, 0));
+        VERIFY_ARE_EQUAL(TerminalInput::MakeOutput(L"\x1b[57383u"), process(input, true, VK_F20, 0x6B, 0, 0));
+        VERIFY_ARE_EQUAL(TerminalInput::MakeOutput(L"\x1b[57384u"), process(input, true, VK_F21, 0x6C, 0, 0));
+        VERIFY_ARE_EQUAL(TerminalInput::MakeOutput(L"\x1b[57385u"), process(input, true, VK_F22, 0x6D, 0, 0));
+        VERIFY_ARE_EQUAL(TerminalInput::MakeOutput(L"\x1b[57386u"), process(input, true, VK_F23, 0x6E, 0, 0));
+        VERIFY_ARE_EQUAL(TerminalInput::MakeOutput(L"\x1b[57387u"), process(input, true, VK_F24, 0x76, 0, 0));
+
+        VERIFY_ARE_EQUAL(TerminalInput::MakeOutput(L"\x1b[15~"), process(input, true, VK_F5, 0x3F, 0, 0));
+        VERIFY_ARE_EQUAL(TerminalInput::MakeOutput(L"\x1b[24~"), process(input, true, VK_F12, 0x58, 0, 0));
+    }
+
     TEST_METHOD(KeyRepeatResetOnDifferentKey)
     {
         auto input = createInput(E | K);

--- a/src/terminal/input/terminalInput.cpp
+++ b/src/terminal/input/terminalInput.cpp
@@ -530,6 +530,8 @@ bool TerminalInput::_encodeKitty(KeyboardHelper& kbd, EncodingHelper& enc, const
         // KKP> Additionally, all non text keypad keys will be reported [...] with CSI u encoding, [...].
 
         constexpr uint32_t ESCAPE = 27;
+        constexpr uint32_t F13 = 57376;
+        constexpr uint32_t F24 = 57387;
         constexpr uint32_t KP_0 = 57399; // The lowest keypad key
         constexpr uint32_t KP_BEGIN = 57427; // and the highest one
 
@@ -537,6 +539,7 @@ bool TerminalInput::_encodeKitty(KeyboardHelper& kbd, EncodingHelper& enc, const
         {
             if (functionalKeyCode == ESCAPE ||
                 (functionalKeyCode <= 127 && enc.csiModifier != 0) ||
+                (functionalKeyCode >= F13 && functionalKeyCode <= F24) ||
                 (functionalKeyCode >= KP_0 && functionalKeyCode <= KP_BEGIN))
             {
                 enc.csiUnicodeKeyCode = functionalKeyCode;


### PR DESCRIPTION
## Summary

Fixes #20243.

When Kitty keyboard disambiguation mode is enabled with `ESC[>1u`, extended function keys `F13` through `F24` were still falling through to the legacy DECFNK path.

That caused keys such as `F13` through `F20` to emit sequences like:

- `F13 -> ESC[25~`
- `F14 -> ESC[26~`
- `F15 -> ESC[28~`
- `F18 -> ESC[32~`
- `F19 -> ESC[33~`
- `F20 -> ESC[34~`

Instead, Kitty protocol expects these keys to emit CSI-u sequences:

- `F13 -> ESC[57376u`
- ...
- `F24 -> ESC[57387u`

This updates the disambiguation path to promote the existing Kitty extended function-key range before the legacy function-key encoding handles it.

## Tests

- Added regression coverage for `PushKittyFlags(D)` / disambiguation mode.
- Verified `F13` through `F24` emit Kitty CSI-u sequences.
- Verified lower legacy function keys such as `F5` and `F12` still emit their existing legacy sequences.
- `git diff --check` passes.

I attempted the targeted Adapter unit test build locally, but my Visual Studio install is missing the C++ targets:

```text
Microsoft.Cpp.Default.props was not found
```