### PR TITLE
Refactor ConsoleArguments to use in-class initializers and remove redundant = operator (#962)

### DIFF
--- a/src/host/ConsoleArguments.cpp
+++ b/src/host/ConsoleArguments.cpp
@@ -108,49 +108,13 @@ ConsoleArguments::ConsoleArguments(const std::wstring& commandline,
                                    const HANDLE hStdOut) :
     _commandline(commandline),
     _vtInHandle(hStdIn),
-    _vtOutHandle(hStdOut)
+    _vtOutHandle(hStdOut) 
 {
-    _clientCommandline = L"";
-    _headless = false;
-    _runAsComServer = false;
-    _createServerHandle = true;
-    _serverHandle = 0;
-    _signalHandle = 0;
-    _forceV1 = false;
-    _forceNoHandoff = false;
-    _width = 0;
-    _height = 0;
-    _inheritCursor = false;
 }
 
 ConsoleArguments::ConsoleArguments() :
     ConsoleArguments(L"", nullptr, nullptr)
 {
-}
-
-ConsoleArguments& ConsoleArguments::operator=(const ConsoleArguments& other)
-{
-    if (this != &other)
-    {
-        _commandline = other._commandline;
-        _clientCommandline = other._clientCommandline;
-        _vtInHandle = other._vtInHandle;
-        _vtOutHandle = other._vtOutHandle;
-        _headless = other._headless;
-        _textMeasurement = other._textMeasurement;
-        _ambiguousIsWide = other._ambiguousIsWide;
-        _createServerHandle = other._createServerHandle;
-        _serverHandle = other._serverHandle;
-        _signalHandle = other._signalHandle;
-        _forceV1 = other._forceV1;
-        _width = other._width;
-        _height = other._height;
-        _inheritCursor = other._inheritCursor;
-        _runAsComServer = other._runAsComServer;
-        _forceNoHandoff = other._forceNoHandoff;
-    }
-
-    return *this;
 }
 
 // Routine Description:

--- a/src/host/ConsoleArguments.cpp
+++ b/src/host/ConsoleArguments.cpp
@@ -108,7 +108,7 @@ ConsoleArguments::ConsoleArguments(const std::wstring& commandline,
                                    const HANDLE hStdOut) :
     _commandline(commandline),
     _vtInHandle(hStdIn),
-    _vtOutHandle(hStdOut) 
+    _vtOutHandle(hStdOut)
 {
 }
 

--- a/src/host/ConsoleArguments.hpp
+++ b/src/host/ConsoleArguments.hpp
@@ -27,7 +27,7 @@ public:
 
     ConsoleArguments();
 
-    ConsoleArguments& operator=(const ConsoleArguments& other);
+    ConsoleArguments& operator=(const ConsoleArguments& other) = default;
 
     [[nodiscard]] HRESULT ParseCommandline();
 
@@ -114,25 +114,25 @@ private:
 
     std::wstring _clientCommandline;
 
-    HANDLE _vtInHandle;
+    HANDLE _vtInHandle = nullptr;
 
-    HANDLE _vtOutHandle;
+    HANDLE _vtOutHandle = nullptr;
 
     std::wstring _textMeasurement;
     bool _ambiguousIsWide = false;
 
-    bool _forceNoHandoff;
-    bool _forceV1;
-    bool _headless;
+    bool _forceNoHandoff = false;
+    bool _forceV1 = false;
+    bool _headless = false;
 
-    short _width;
-    short _height;
+    short _width = 0;
+    short _height = 0;
 
-    bool _runAsComServer;
-    bool _createServerHandle;
-    DWORD _serverHandle;
-    DWORD _signalHandle;
-    bool _inheritCursor;
+    bool _runAsComServer = false;
+    bool _createServerHandle = true;
+    DWORD _serverHandle = 0;
+    DWORD _signalHandle = 0;
+    bool _inheritCursor = false;
 
     [[nodiscard]] HRESULT _GetClientCommandline(_Inout_ std::vector<std::wstring>& args,
                                                 const size_t index,


### PR DESCRIPTION
## Summary of the Pull Request
This PR refactors the ConsoleArguments class to use in-class member initializers for members with constant or default values, replacing equivalent entries in the constructor initializer list.

This change aligns the class with C++ Core Guidelines C.48 (“Prefer in-class initializers to member initializers in constructors for constant initializers”) while preserving existing behavior.
## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments
src/host/ConsoleArguments.hpp
- Added in-class default member initializers for members previously initialized with constant values.
Examples include:
_headless,
_width,
_height,
_forceV1,
_runAsComServer,
_forceNoHandoff
- make operator= default

src/host/ConsoleArguments.cpp
- Removed redundant constructor member initializers corresponding to the in-class defaults.
- Members that depend on constructor parameters remain in the initializer list.
- Removed =operator as it is no longer needed since the default copy assignment operator performs the exact same now.
## Validation Steps Performed
Manual Verification
- Performed strict code inspection to ensure a one-to-one correspondence between removed constructor initializers and added in-class initializers.