### PR TITLE
Preview the selected tab in `tabSearch` too

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -224,7 +224,7 @@ namespace winrt::TerminalApp::implementation
     {
         const auto selectedCommand = _filteredActionsView().SelectedItem();
         const auto filteredCommand{ selectedCommand.try_as<winrt::TerminalApp::FilteredCommand>() };
-        if (_currentMode == CommandPaletteMode::TabSwitchMode)
+        if (_currentMode == CommandPaletteMode::TabSwitchMode || _currentMode == CommandPaletteMode::TabSearchMode)
         {
             _switchToTab(filteredCommand);
         }


### PR DESCRIPTION
Currently when you use the cmdpal in tabswitcher mode, we "preview" switching to that tab. We don't do that for `tabSearch` mode though.

Fixing that was half a line of code. Now we do.

Closes #20233
