### PR TITLE
Add screen reader announcement for opening/closing navigation pane

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -381,6 +381,28 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _setThemeOnPopups(SettingsSearchBox(), requestedTheme);
     }
 
+    void MainPage::_AnnounceNavPaneState(bool opened)
+    {
+        if (const auto automationPeer{ Automation::Peers::FrameworkElementAutomationPeer::FromElement(SettingsNav()) })
+        {
+            automationPeer.RaiseNotificationEvent(
+                Automation::Peers::AutomationNotificationKind::ActionCompleted,
+                Automation::Peers::AutomationNotificationProcessing::MostRecent,
+                opened ? RS_(L"Nav_PaneOpenedAnnouncement") : RS_(L"Nav_PaneClosedAnnouncement"),
+                L"SettingsNavPaneState");
+        }
+    }
+
+    void MainPage::SettingsNav_PaneOpened(const MUX::Controls::NavigationView&, const IInspectable&)
+    {
+        _AnnounceNavPaneState(true);
+    }
+
+    void MainPage::SettingsNav_PaneClosed(const MUX::Controls::NavigationView&, const IInspectable&)
+    {
+        _AnnounceNavPaneState(false);
+    }
+
     // Function Description:
     // - Called when NavigationView items are invoked. Navigates to the corresponding page.
     // Arguments:

--- a/src/cascadia/TerminalSettingsEditor/MainPage.h
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.h
@@ -56,6 +56,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         void SettingsNav_Loaded(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
         void SettingsNav_ItemInvoked(const Microsoft::UI::Xaml::Controls::NavigationView& sender, const Microsoft::UI::Xaml::Controls::NavigationViewItemInvokedEventArgs& args);
+        void SettingsNav_PaneOpened(const Microsoft::UI::Xaml::Controls::NavigationView& sender, const Windows::Foundation::IInspectable& args);
+        void SettingsNav_PaneClosed(const Microsoft::UI::Xaml::Controls::NavigationView& sender, const Windows::Foundation::IInspectable& args);
         void SaveButton_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
         void ResetButton_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
         void BreadcrumbBar_ItemClicked(const Microsoft::UI::Xaml::Controls::BreadcrumbBar& sender, const Microsoft::UI::Xaml::Controls::BreadcrumbBarItemClickedEventArgs& args);
@@ -99,6 +101,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void _NavigateToProfileHandler(const IInspectable& sender, winrt::guid profileGuid);
         void _NavigateToColorSchemeHandler(const IInspectable& sender, const IInspectable& args);
         Microsoft::UI::Xaml::Controls::NavigationViewItem _FindProfileNavItem(winrt::guid profileGuid) const;
+
+        void _AnnounceNavPaneState(bool opened);
 
         void _UpdateBackgroundForMica();
         void _MoveXamlParsedNavItemsIntoItemSource();

--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -68,6 +68,8 @@
                          IsSettingsVisible="False"
                          ItemInvoked="SettingsNav_ItemInvoked"
                          Loaded="SettingsNav_Loaded"
+                         PaneClosed="SettingsNav_PaneClosed"
+                         PaneOpened="SettingsNav_PaneOpened"
                          TabFocusNavigation="Cycle">
         <muxc:NavigationView.Resources>
             <ResourceDictionary>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -669,6 +669,14 @@
     <value>Startup</value>
     <comment>Header for the "startup" menu item. This navigates to a page that lets you see and modify settings related to the app's launch experience (i.e. screen position, mode, etc.)</comment>
   </data>
+  <data name="Nav_PaneOpenedAnnouncement" xml:space="preserve">
+    <value>Navigation pane opened</value>
+    <comment>Screen reader announcement made when the user activates the toggle button that opens the settings navigation pane.</comment>
+  </data>
+  <data name="Nav_PaneClosedAnnouncement" xml:space="preserve">
+    <value>Navigation pane closed</value>
+    <comment>Screen reader announcement made when the user activates the toggle button that closes the settings navigation pane.</comment>
+  </data>
   <data name="Nav_OpenJSON.Content" xml:space="preserve">
     <value>Open JSON file</value>
     <comment>Header for a menu item. This opens the JSON file that is used to log the app's settings.</comment>


### PR DESCRIPTION
## Summary of the Pull Request
Adds a manual event handler for `PaneOpened`/`PaneClosed` on the navigation view in the settings UI. After catching the event, we raise a UIA notification event to force the attached screen reader to read out "Navigation pane opened/closed" appropriately. This experience aligns with WinUI and the text is localized appropriately.

## Validation Steps Performed
✅ Narrator announces "Navigation pane opened/closed" appropriately (aligns with WinUI 3 gallery experience)

## PR Checklist
Closes #19687 
📝 NOTE: the associated issue is currently affecting our accessibility score