### PR TITLE
Allow tab reordering in elevated windows via pointer-driven drag

### DIFF
--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -170,6 +170,13 @@ namespace winrt::TerminalApp::implementation
         _UpdateTabIcon(*newTabImpl);
 
         tabViewItem.PointerPressed({ this, &TerminalPage::_OnTabPointerPressed });
+        // GH#6661: the OS drag/drop service is unavailable in an elevated session, so the native
+        // TabView reorder is disabled there. Hook PointerMoved to drive reorder ourselves only in
+        // that case (the left-button PointerPressed is consumed by TabViewItem for selection).
+        if (!CanDragDrop())
+        {
+            tabViewItem.PointerMoved({ this, &TerminalPage::_OnTabPointerMoved });
+        }
 
         // When the tab requests close, try to close it (prompt for approval, if required)
         newTabImpl->CloseRequested([weakTab, weakThis{ get_weak() }](auto&& /*s*/, auto&& /*e*/) {
@@ -1061,6 +1068,218 @@ namespace winrt::TerminalApp::implementation
         {
             _HandleCloseTabRequested(tab);
         }
+    }
+
+    // GH#6661: drives custom tab reorder for elevated sessions; only hooked when CanDragDrop() is
+    // false. TabViewItem consumes the left-button PointerPressed for selection, so tracking begins
+    // on the first left-button PointerMoved instead.
+    void TerminalPage::_OnTabPointerMoved(const IInspectable& sender, const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e)
+    {
+        const auto item = sender.try_as<MUX::Controls::TabViewItem>();
+        if (!item)
+        {
+            return;
+        }
+
+        if (!e.GetCurrentPoint(item).Properties().IsLeftButtonPressed())
+        {
+            if (_pointerReorder.item)
+            {
+                _EndPointerReorder();
+            }
+            return;
+        }
+
+        if (_pointerReorder.item != item)
+        {
+            _BeginPointerReorder(item, e);
+        }
+
+        _UpdatePointerReorder(e);
+    }
+
+    void TerminalPage::_BeginPointerReorder(const MUX::Controls::TabViewItem& item,
+                                            const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e)
+    {
+        // Reset any stale tracking from a previous interaction.
+        _EndPointerReorder();
+
+        uint32_t index{};
+        if (!_tabView.TabItems().IndexOf(item, index))
+        {
+            return;
+        }
+
+        _pointerReorder.item = item;
+        _pointerReorder.pointerId = e.Pointer().PointerId();
+        _pointerReorder.originalIndex = index;
+        _pointerReorder.targetIndex = index;
+        _pointerReorder.anchorX = e.GetCurrentPoint(_tabView).Position().X;
+        _pointerReorder.dragging = false;
+
+        // Once we capture the pointer on threshold, releasing it raises PointerCaptureLost; use that to tear down.
+        _pointerReorder.pointerCaptureLost = item.PointerCaptureLost(winrt::auto_revoke,
+                                                                     [weakThis{ get_weak() }](auto&&, auto&&) {
+                                                                         if (const auto page = weakThis.get())
+                                                                         {
+                                                                             page->_EndPointerReorder();
+                                                                         }
+                                                                     });
+    }
+
+    void TerminalPage::_UpdatePointerReorder(const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e)
+    {
+        if (!_pointerReorder.item)
+        {
+            return;
+        }
+        if (e.Pointer().PointerId() != _pointerReorder.pointerId)
+        {
+            return;
+        }
+
+        const auto pointInTabView = e.GetCurrentPoint(_tabView).Position();
+
+        if (!_pointerReorder.dragging)
+        {
+            if (std::abs(pointInTabView.X - _pointerReorder.anchorX) < _pointerReorderThresholdPx)
+            {
+                return;
+            }
+            // Cross the threshold: commit to a drag. Capture the pointer so we keep receiving
+            // events as it travels over sibling tabs.
+            if (!_pointerReorder.item.CapturePointer(e.Pointer()))
+            {
+                _EndPointerReorder();
+                return;
+            }
+            _pointerReorder.dragging = true;
+
+            // Snapshot each tab's natural slot. We don't mutate the collection during the drag,
+            // so these positions stay valid and the dragged tab follows the pointer smoothly.
+            const auto snapshot = _tabView.TabItems();
+            const auto snapshotCount = snapshot.Size();
+
+            // Re-resolve the dragged tab's index against this snapshot so it can't be stale or
+            // index past the geometry we're about to capture (e.g. if a tab closed mid-press).
+            uint32_t originalIndex{};
+            if (!snapshot.IndexOf(_pointerReorder.item, originalIndex))
+            {
+                _EndPointerReorder();
+                return;
+            }
+            _pointerReorder.originalIndex = originalIndex;
+
+            _pointerReorder.naturalLefts.clear();
+            _pointerReorder.naturalWidths.clear();
+            for (uint32_t j = 0; j < snapshotCount; ++j)
+            {
+                const auto t = snapshot.GetAt(j).try_as<MUX::Controls::TabViewItem>();
+                _pointerReorder.naturalLefts.push_back(t ? t.TransformToVisual(_tabView).TransformPoint({ 0.0f, 0.0f }).X : 0.0f);
+                _pointerReorder.naturalWidths.push_back(t ? static_cast<float>(t.ActualWidth()) : 0.0f);
+            }
+            _pointerReorder.naturalLeft = _pointerReorder.naturalLefts[originalIndex];
+            _pointerReorder.draggedWidth = _pointerReorder.naturalWidths[originalIndex];
+            _pointerReorder.grabOffsetX = pointInTabView.X - _pointerReorder.naturalLeft;
+
+            _pointerReorder.dragTransform = Windows::UI::Xaml::Media::TranslateTransform{};
+            _pointerReorder.item.RenderTransform(_pointerReorder.dragTransform);
+            Controls::Canvas::SetZIndex(_pointerReorder.item, 1);
+        }
+
+        // Glue the grabbed point under the pointer, clamped so the tab can't slide past the
+        // first slot's left edge or the last slot's right edge.
+        const double minLeft = _pointerReorder.naturalLefts.front();
+        const double maxLeft = (static_cast<double>(_pointerReorder.naturalLefts.back()) + _pointerReorder.naturalWidths.back()) - _pointerReorder.draggedWidth;
+        const double desiredLeft = pointInTabView.X - _pointerReorder.grabOffsetX;
+        const double clampedLeft = std::clamp(desiredLeft, minLeft, std::max(minLeft, maxLeft));
+        _pointerReorder.dragTransform.X(clampedLeft - _pointerReorder.naturalLeft);
+
+        // The insert index is the number of siblings whose midpoint sits left of the pointer.
+        const auto count = gsl::narrow_cast<uint32_t>(_pointerReorder.naturalLefts.size());
+        uint32_t target = 0;
+        for (uint32_t j = 0; j < count; ++j)
+        {
+            if (j == _pointerReorder.originalIndex)
+            {
+                continue;
+            }
+            const auto midpoint = _pointerReorder.naturalLefts[j] + _pointerReorder.naturalWidths[j] * 0.5f;
+            if (pointInTabView.X > midpoint)
+            {
+                ++target;
+            }
+        }
+        _pointerReorder.targetIndex = target;
+
+        // Slide siblings aside to open a gap at the target slot.
+        const auto live = _tabView.TabItems();
+        for (uint32_t j = 0; j < count && j < live.Size(); ++j)
+        {
+            if (j == _pointerReorder.originalIndex)
+            {
+                continue;
+            }
+            const auto t = live.GetAt(j).try_as<MUX::Controls::TabViewItem>();
+            if (!t)
+            {
+                continue;
+            }
+            double shift = 0.0;
+            if (target > _pointerReorder.originalIndex && j > _pointerReorder.originalIndex && j <= target)
+            {
+                shift = -_pointerReorder.draggedWidth;
+            }
+            else if (target < _pointerReorder.originalIndex && j >= target && j < _pointerReorder.originalIndex)
+            {
+                shift = _pointerReorder.draggedWidth;
+            }
+            auto transform = t.RenderTransform().try_as<Windows::UI::Xaml::Media::TranslateTransform>();
+            if (!transform)
+            {
+                transform = Windows::UI::Xaml::Media::TranslateTransform{};
+                t.RenderTransform(transform);
+            }
+            transform.X(shift);
+        }
+
+        e.Handled(true);
+    }
+
+    void TerminalPage::_EndPointerReorder()
+    {
+        _pointerReorder.pointerCaptureLost.revoke();
+
+        // Transforms and z-index are only ever applied once a drag actually starts, so there's
+        // nothing to undo unless we were dragging.
+        if (_pointerReorder.dragging)
+        {
+            // Commit the reorder once, then drop every drag transform in the same tick so the
+            // final layout renders clean (no intermediate frame with stale offsets).
+            if (_pointerReorder.targetIndex != _pointerReorder.originalIndex)
+            {
+                _TryMoveTab(_pointerReorder.originalIndex, gsl::narrow_cast<int32_t>(_pointerReorder.targetIndex));
+            }
+
+            const auto items = _tabView.TabItems();
+            for (uint32_t j = 0; j < items.Size(); ++j)
+            {
+                if (const auto t = items.GetAt(j).try_as<MUX::Controls::TabViewItem>())
+                {
+                    t.RenderTransform(nullptr);
+                    Controls::Canvas::SetZIndex(t, 0);
+                }
+            }
+        }
+
+        _pointerReorder.dragTransform = nullptr;
+        _pointerReorder.naturalLefts.clear();
+        _pointerReorder.naturalWidths.clear();
+        _pointerReorder.dragging = false;
+        _pointerReorder.item = nullptr;
+        _pointerReorder.pointerId = 0;
+        _pointerReorder.originalIndex = 0;
+        _pointerReorder.targetIndex = 0;
     }
 
     void TerminalPage::_UpdatedSelectedTab(const winrt::TerminalApp::Tab& tab)

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -175,7 +175,7 @@ namespace winrt::TerminalApp::implementation
         // that case (the left-button PointerPressed is consumed by TabViewItem for selection).
         if (!CanDragDrop())
         {
-            tabViewItem.PointerMoved({ this, &TerminalPage::_OnTabPointerMoved });
+            tabViewItem.PointerMoved({ this, &TerminalPage::_OnTabElevatedPointerMoved });
         }
 
         // When the tab requests close, try to close it (prompt for approval, if required)
@@ -1073,10 +1073,17 @@ namespace winrt::TerminalApp::implementation
     // GH#6661: drives custom tab reorder for elevated sessions; only hooked when CanDragDrop() is
     // false. TabViewItem consumes the left-button PointerPressed for selection, so tracking begins
     // on the first left-button PointerMoved instead.
-    void TerminalPage::_OnTabPointerMoved(const IInspectable& sender, const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e)
+    void TerminalPage::_OnTabElevatedPointerMoved(const IInspectable& sender, const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e)
     {
         const auto item = sender.try_as<MUX::Controls::TabViewItem>();
         if (!item)
+        {
+            return;
+        }
+
+        // While a drag is in flight, ignore any other pointer (e.g. a stray touch contact
+        // during a mouse drag) so it can't restart tracking and commit the reorder early.
+        if (_pointerReorder.dragging && e.Pointer().PointerId() != _pointerReorder.pointerId)
         {
             return;
         }
@@ -1085,24 +1092,24 @@ namespace winrt::TerminalApp::implementation
         {
             if (_pointerReorder.item)
             {
-                _EndPointerReorder();
+                _EndElevatedPointerReorder();
             }
             return;
         }
 
         if (_pointerReorder.item != item)
         {
-            _BeginPointerReorder(item, e);
+            _BeginElevatedPointerReorder(item, e);
         }
 
-        _UpdatePointerReorder(e);
+        _UpdateElevatedPointerReorder(e);
     }
 
-    void TerminalPage::_BeginPointerReorder(const MUX::Controls::TabViewItem& item,
-                                            const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e)
+    void TerminalPage::_BeginElevatedPointerReorder(const MUX::Controls::TabViewItem& item,
+                                                    const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e)
     {
         // Reset any stale tracking from a previous interaction.
-        _EndPointerReorder();
+        _EndElevatedPointerReorder();
 
         uint32_t index{};
         if (!_tabView.TabItems().IndexOf(item, index))
@@ -1122,12 +1129,12 @@ namespace winrt::TerminalApp::implementation
                                                                      [weakThis{ get_weak() }](auto&&, auto&&) {
                                                                          if (const auto page = weakThis.get())
                                                                          {
-                                                                             page->_EndPointerReorder();
+                                                                             page->_EndElevatedPointerReorder();
                                                                          }
                                                                      });
     }
 
-    void TerminalPage::_UpdatePointerReorder(const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e)
+    void TerminalPage::_UpdateElevatedPointerReorder(const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e)
     {
         if (!_pointerReorder.item)
         {
@@ -1142,7 +1149,8 @@ namespace winrt::TerminalApp::implementation
 
         if (!_pointerReorder.dragging)
         {
-            if (std::abs(pointInTabView.X - _pointerReorder.anchorX) < _pointerReorderThresholdPx)
+            static constexpr double pointerReorderThresholdPx{ 8.0 };
+            if (std::abs(pointInTabView.X - _pointerReorder.anchorX) < pointerReorderThresholdPx)
             {
                 return;
             }
@@ -1150,14 +1158,14 @@ namespace winrt::TerminalApp::implementation
             // events as it travels over sibling tabs.
             if (!_pointerReorder.item.CapturePointer(e.Pointer()))
             {
-                _EndPointerReorder();
+                _EndElevatedPointerReorder();
                 return;
             }
             _pointerReorder.dragging = true;
 
             // Snapshot each tab's natural slot. We don't mutate the collection during the drag,
             // so these positions stay valid and the dragged tab follows the pointer smoothly.
-            const auto snapshot = _tabView.TabItems();
+            const auto& snapshot = _tabView.TabItems();
             const auto snapshotCount = snapshot.Size();
 
             // Re-resolve the dragged tab's index against this snapshot so it can't be stale or
@@ -1165,7 +1173,7 @@ namespace winrt::TerminalApp::implementation
             uint32_t originalIndex{};
             if (!snapshot.IndexOf(_pointerReorder.item, originalIndex))
             {
-                _EndPointerReorder();
+                _EndElevatedPointerReorder();
                 return;
             }
             _pointerReorder.originalIndex = originalIndex;
@@ -1213,7 +1221,7 @@ namespace winrt::TerminalApp::implementation
         _pointerReorder.targetIndex = target;
 
         // Slide siblings aside to open a gap at the target slot.
-        const auto live = _tabView.TabItems();
+        const auto& live = _tabView.TabItems();
         for (uint32_t j = 0; j < count && j < live.Size(); ++j)
         {
             if (j == _pointerReorder.originalIndex)
@@ -1246,22 +1254,30 @@ namespace winrt::TerminalApp::implementation
         e.Handled(true);
     }
 
-    void TerminalPage::_EndPointerReorder()
+    void TerminalPage::_EndElevatedPointerReorder()
     {
+        // Revoke before mutating anything: committing the move below can drop the pointer
+        // capture, and the PointerCaptureLost handler would re-enter us mid-teardown.
         _pointerReorder.pointerCaptureLost.revoke();
 
         // Transforms and z-index are only ever applied once a drag actually starts, so there's
         // nothing to undo unless we were dragging.
         if (_pointerReorder.dragging)
         {
-            // Commit the reorder once, then drop every drag transform in the same tick so the
-            // final layout renders clean (no intermediate frame with stale offsets).
-            if (_pointerReorder.targetIndex != _pointerReorder.originalIndex)
+            const auto& items = _tabView.TabItems();
+
+            // The tab list can change mid-drag (e.g. a tab's process exits and closes it), so
+            // re-resolve the dragged tab's index rather than trusting the one from drag-start;
+            // _TryMoveTab indexes _tabs directly with whatever we hand it.
+            uint32_t currentIndex{};
+            if (items.IndexOf(_pointerReorder.item, currentIndex) &&
+                _pointerReorder.targetIndex != currentIndex)
             {
-                _TryMoveTab(_pointerReorder.originalIndex, gsl::narrow_cast<int32_t>(_pointerReorder.targetIndex));
+                _TryMoveTab(currentIndex, gsl::narrow_cast<int32_t>(_pointerReorder.targetIndex));
             }
 
-            const auto items = _tabView.TabItems();
+            // Drop every drag transform in the same tick as the commit so the final layout
+            // renders clean (no intermediate frame with stale offsets).
             for (uint32_t j = 0; j < items.Size(); ++j)
             {
                 if (const auto t = items.GetAt(j).try_as<MUX::Controls::TabViewItem>())
@@ -1272,14 +1288,7 @@ namespace winrt::TerminalApp::implementation
             }
         }
 
-        _pointerReorder.dragTransform = nullptr;
-        _pointerReorder.naturalLefts.clear();
-        _pointerReorder.naturalWidths.clear();
-        _pointerReorder.dragging = false;
-        _pointerReorder.item = nullptr;
-        _pointerReorder.pointerId = 0;
-        _pointerReorder.originalIndex = 0;
-        _pointerReorder.targetIndex = 0;
+        _pointerReorder.reset();
     }
 
     void TerminalPage::_UpdatedSelectedTab(const winrt::TerminalApp::Tab& tab)

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -469,6 +469,32 @@ namespace winrt::TerminalApp::implementation
         void _OnTabPointerPressed(const IInspectable& sender, const Windows::UI::Xaml::Input::PointerRoutedEventArgs& eventArgs);
         safe_void_coroutine _OnTabPointerReleasedCloseTab(IInspectable sender);
 
+        // GH#6661: when the OS drag/drop pipeline is disabled (elevated session),
+        // implement tab reorder ourselves via raw pointer events on each TabViewItem.
+        struct PointerReorderState
+        {
+            bool dragging{ false };
+            uint32_t pointerId{ 0 };
+            double anchorX{ 0.0 };
+            double grabOffsetX{ 0.0 };
+            double naturalLeft{ 0.0 };
+            double draggedWidth{ 0.0 };
+            uint32_t originalIndex{ 0 };
+            uint32_t targetIndex{ 0 };
+            std::vector<float> naturalLefts;
+            std::vector<float> naturalWidths;
+            winrt::Microsoft::UI::Xaml::Controls::TabViewItem item{ nullptr };
+            winrt::Windows::UI::Xaml::Media::TranslateTransform dragTransform{ nullptr };
+            winrt::Windows::UI::Xaml::UIElement::PointerCaptureLost_revoker pointerCaptureLost;
+        };
+        PointerReorderState _pointerReorder{};
+        static constexpr double _pointerReorderThresholdPx{ 8.0 };
+        void _OnTabPointerMoved(const IInspectable& sender, const Windows::UI::Xaml::Input::PointerRoutedEventArgs& eventArgs);
+        void _BeginPointerReorder(const winrt::Microsoft::UI::Xaml::Controls::TabViewItem& item,
+                                  const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e);
+        void _UpdatePointerReorder(const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e);
+        void _EndPointerReorder();
+
         void _OnTabSelectionChanged(const IInspectable& sender, const Windows::UI::Xaml::Controls::SelectionChangedEventArgs& eventArgs);
         void _OnTabItemsChanged(const IInspectable& sender, const Windows::Foundation::Collections::IVectorChangedEventArgs& eventArgs);
         void _OnTabCloseRequested(const IInspectable& sender, const Microsoft::UI::Xaml::Controls::TabViewTabCloseRequestedEventArgs& eventArgs);

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -486,14 +486,20 @@ namespace winrt::TerminalApp::implementation
             winrt::Microsoft::UI::Xaml::Controls::TabViewItem item{ nullptr };
             winrt::Windows::UI::Xaml::Media::TranslateTransform dragTransform{ nullptr };
             winrt::Windows::UI::Xaml::UIElement::PointerCaptureLost_revoker pointerCaptureLost;
+
+            void reset()
+            {
+                // Revoke first so the handler can't fire as we drop the rest of the state.
+                pointerCaptureLost.revoke();
+                *this = PointerReorderState{};
+            }
         };
         PointerReorderState _pointerReorder{};
-        static constexpr double _pointerReorderThresholdPx{ 8.0 };
-        void _OnTabPointerMoved(const IInspectable& sender, const Windows::UI::Xaml::Input::PointerRoutedEventArgs& eventArgs);
-        void _BeginPointerReorder(const winrt::Microsoft::UI::Xaml::Controls::TabViewItem& item,
-                                  const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e);
-        void _UpdatePointerReorder(const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e);
-        void _EndPointerReorder();
+        void _OnTabElevatedPointerMoved(const IInspectable& sender, const Windows::UI::Xaml::Input::PointerRoutedEventArgs& eventArgs);
+        void _BeginElevatedPointerReorder(const winrt::Microsoft::UI::Xaml::Controls::TabViewItem& item,
+                                          const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e);
+        void _UpdateElevatedPointerReorder(const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e);
+        void _EndElevatedPointerReorder();
 
         void _OnTabSelectionChanged(const IInspectable& sender, const Windows::UI::Xaml::Controls::SelectionChangedEventArgs& eventArgs);
         void _OnTabItemsChanged(const IInspectable& sender, const Windows::Foundation::Collections::IVectorChangedEventArgs& eventArgs);


### PR DESCRIPTION
## Summary of the Pull Request

Enables reordering tabs by dragging them when Windows Terminal is running elevated (as administrator). Today, dragging a tab in an elevated window does nothing, because the OS modern drag/drop service can't operate across integrity levels, so the `TabView`'s drag/reorder is disabled. This adds a small, self-contained, pointer-driven reorder that only activates when the native drag/drop path is unavailable.

## References and Relevant Issues

Addresses the in-strip tab-reorder portion of #6661.

This intentionally does **not** attempt to restore tab *tear-out* (dragging a tab out into its own window). Tear-out genuinely depends on the OS drag/drop service that is unavailable to elevated processes, so it remains disabled when elevated. The scope here is in-strip reordering only.

> **Note for maintainers:** I see this area is marked `External-Blocked-WinUI3`. I've kept this deliberately small — fully gated behind `!CanDragDrop()`, additive only (no existing lines changed), reusing the existing `_TryMoveTab` primitive, and trivially removable once a WinUI 3 migration restores native elevated drag/drop. It's intended as a low-risk stopgap for the current System XAML + WinUI 2 stack while that's pending, not a competing direction. Happy to adjust the approach based on your guidance.

## Detailed Description of the Pull Request / Additional comments

### Background

When Terminal runs elevated, `Utils::CanUwpDragDrop()` returns `false` (it already special-cases a fully UAC-disabled session, where there is no integrity separation and native drag still works). `TerminalPage` propagates this through `CanDragDrop()` and sets `TabView.CanReorderTabs` / `CanDragTabs` accordingly. So in a normal elevated session both are `false` and tabs can't be dragged at all. This is the long-standing workaround for the cross-integrity-level drag/drop crash.

### Approach

Rather than re-enabling the native (crashing) path, this drives reorder directly from raw pointer events — the same idea as the existing **Move tab forward/backward** actions, which already reorder without the drag/drop service:

- Each `TabViewItem` gets a `PointerMoved` handler (`_OnTabPointerMoved`), **registered only when `CanDragDrop()` is false**, so non-elevated sessions are completely unaffected (the handler isn't even attached).
- On a left-button drag past a small threshold, it captures the pointer and runs a custom reorder:
  - The dragged tab follows the pointer via a `TranslateTransform`, clamped to the tab-strip bounds so it can't slide off-screen.
  - Sibling tabs shift aside to preview the drop location.
  - The actual reorder is committed **once on release** (`PointerCaptureLost`) using the existing `_TryMoveTab` primitive.
- Left-button `PointerPressed` is consumed by `TabViewItem` for selection, so the drag begins from `PointerMoved` rather than `PointerPressed`. Single-click selection and middle-click-close are unaffected.

### Why this is safe

- It never invokes the OS drag/drop service, so the original cross-integrity crash cannot recur. `CanReorderTabs` / `CanDragTabs` stay `false` when elevated.
- It is gated entirely on `!CanDragDrop()`, so it is inert wherever native drag already works.
- The diff is additive only (no existing lines changed) and reuses existing reorder logic (`_TryMoveTab`).

## Validation Steps Performed

**Demo — reordering tabs in an elevated window:**

https://github.com/user-attachments/assets/dd3fe7ab-25c2-4a69-a69d-96f743e30014

Built and deployed the dev package and tested in an **elevated** window:

- Dragging a tab horizontally reorders it; the dragged tab follows the cursor and siblings shift to preview the drop.
- Dragging past the first/last tab clamps at the strip edge instead of sliding out of view.
- Single left-click still selects a tab; middle-click still closes a tab.
- Opening new tabs works (no crash).

In a **non-elevated** window:

- Tab drag/reorder and tear-out continue to use the native path, unchanged (the handler isn't registered when `CanDragDrop()` is true).

Automated tests: none added. This is a pointer- and layout-geometry-driven interaction (`TransformToVisual`, `ActualWidth`, pointer capture) that the TAEF `LocalTests_TerminalApp` host can't meaningfully exercise (no live visual layout), and the suite has no existing drag/reorder tests to extend. Validated manually as above.

## PR Checklist
- [ ] Closes #xxx — partially addresses #6661 (in-strip reorder only; not tear-out)
- [ ] Tests added/passed — see note above; interaction not unit-testable in TAEF
- [ ] Documentation updated — n/a (no new setting/action/UI surface)
- [ ] Schema updated (if necessary) — n/a
