### PR TITLE
Fix rendering artifacts at non-standard Windows scaling levels

### DIFF
--- a/src/cascadia/TerminalApp/MinMaxCloseControl.xaml
+++ b/src/cascadia/TerminalApp/MinMaxCloseControl.xaml
@@ -177,13 +177,11 @@
                                     BorderBrush="{TemplateBinding BorderBrush}"
                                     BorderThickness="{TemplateBinding BorderThickness}"
                                     CornerRadius="{TemplateBinding CornerRadius}">
-                                <Viewbox Width="10"
-                                         Height="10">
-                                    <FontIcon x:Name="ButtonIcon"
-                                              FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                              Foreground="{ThemeResource CaptionButtonForeground}"
-                                              Glyph="{ThemeResource CaptionButtonGlyph}" />
-                                </Viewbox>
+                                <FontIcon x:Name="ButtonIcon"
+                                          FontSize="10"
+                                          FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                          Foreground="{ThemeResource CaptionButtonForeground}"
+                                          Glyph="{ThemeResource CaptionButtonGlyph}" />
 
                                 <VisualStateManager.VisualStateGroups>
                                     <VisualStateGroup x:Name="CommonStates">

--- a/src/cascadia/TerminalApp/TabRowControl.xaml
+++ b/src/cascadia/TerminalApp/TabRowControl.xaml
@@ -25,6 +25,7 @@
     -->
 
     <mux:TabView x:Name="TabView"
+                 Margin="0,1,0,-1"
                  VerticalAlignment="Bottom"
                  HorizontalContentAlignment="Stretch"
                  AllowDropTabs="True"


### PR DESCRIPTION
## Summary of the Pull Request

Fix rendering artifacts that occur when Windows display scaling is set to non-standard values (e.g. 116%). The changes ensure UI elements render consistently across different DPI scaling configurations.

## References and Relevant Issues

Closes #20281

## Detailed Description of the Pull Request / Additional comments

This PR addresses rendering inconsistencies observed when Windows scaling is configured to values other than the commonly used 125%.

The fix adjusts the scaling/rendering logic to properly handle non-standard DPI values, preventing visual artifacts such as:
- Incorrectly rendered tab underlines
- UI control rendering inconsistencies
- Visual glitches caused by scaling rounding errors

## Validation Steps Performed

- Tested with Windows scaling set to 116%
- Verified that rendering artifacts are no longer visible
- Verified that tab bar rendering appears correct
- Verified that window controls render correctly
- Confirmed no regressions at standard scaling levels (100%, 125%)

## PR Checklist

- [x] Closes #20281
- [x] Tests added/passed
- [ ] Documentation updated
- [ ] Schema updated (if necessary)