### PR TITLE
Add "Restore window position and size" setting to persist last window geometry

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2287,13 +2287,21 @@ namespace winrt::TerminalApp::implementation
 
     void TerminalPage::PersistState()
     {
-        // This method may be called for a window even if it hasn't had a tab yet or lost all of them.
-        // We shouldn't persist such windows.
-        const auto tabCount = _tabs.Size();
-        if (_startupState != StartupState::Initialized || tabCount == 0)
+        if (_startupState != StartupState::Initialized)
         {
             return;
         }
+
+        const auto& globalSettings = _settings.GlobalSettings();
+        const auto restoreWindowPosition = globalSettings.RestoreWindowPosition();
+        const auto shouldPersistLayout = globalSettings.ShouldUsePersistedLayout();
+
+        if (!restoreWindowPosition && !shouldPersistLayout)
+        {
+            return;
+        }
+
+        const auto tabCount = _tabs.Size();
 
         std::vector<ActionAndArgs> actions;
 
@@ -2305,7 +2313,7 @@ namespace winrt::TerminalApp::implementation
         }
 
         // Avoid persisting a window with zero tabs, because `BuildStartupActions` happened to return an empty vector.
-        if (actions.empty())
+        if (actions.empty() && !restoreWindowPosition)
         {
             return;
         }
@@ -2334,7 +2342,10 @@ namespace winrt::TerminalApp::implementation
         }
 
         WindowLayout layout;
-        layout.TabLayout(winrt::single_threaded_vector<ActionAndArgs>(std::move(actions)));
+        if (!actions.empty())
+        {
+            layout.TabLayout(winrt::single_threaded_vector<ActionAndArgs>(std::move(actions)));
+        }
 
         auto mode = LaunchMode::DefaultMode;
         WI_SetFlagIf(mode, LaunchMode::FullscreenMode, _isFullscreen);

--- a/src/cascadia/TerminalApp/TerminalWindow.cpp
+++ b/src/cascadia/TerminalApp/TerminalWindow.cpp
@@ -166,11 +166,11 @@ namespace winrt::TerminalApp::implementation
         {
             _root->SetStartupActions(std::move(_initialContentArgs));
         }
-        else if (const auto& layout = LoadPersistedLayout())
+        else if (_settings.GlobalSettings().ShouldUsePersistedLayout() && LoadPersistedLayout())
         {
             // layout will only ever be non-null if there were >0 tabs persisted in
             // .TabLayout(). We can re-evaluate that as a part of TODO: GH#12633
-            _root->SetStartupActions(wil::to_vector(layout.TabLayout()));
+            _root->SetStartupActions(wil::to_vector(LoadPersistedLayout().TabLayout()));
         }
         else if (_appArgs)
         {
@@ -1157,7 +1157,21 @@ namespace winrt::TerminalApp::implementation
     // - non-null if there is a particular saved layout to use
     std::optional<uint32_t> TerminalWindow::LoadPersistedLayoutIdx() const
     {
-        return _settings.GlobalSettings().ShouldUsePersistedLayout() ? _loadFromPersistedLayoutIdx : std::nullopt;
+        if (_settings.GlobalSettings().ShouldUsePersistedLayout())
+        {
+            return _loadFromPersistedLayoutIdx;
+        }
+
+        if (_settings.GlobalSettings().RestoreWindowPosition())
+        {
+            const auto layouts = ApplicationState::SharedInstance().PersistedWindowLayouts();
+            if (layouts && layouts.Size() > 0)
+            {
+                return static_cast<uint32_t>(layouts.Size() - 1);
+            }
+        }
+
+        return std::nullopt;
     }
 
     WindowLayout TerminalWindow::LoadPersistedLayout()
@@ -1175,11 +1189,12 @@ namespace winrt::TerminalApp::implementation
             {
                 auto layout = layouts.GetAt(i);
 
-                // TODO: GH#12633: Right now, we're manually making sure that we
-                // have at least one tab to restore. If we ever want to come
-                // back and make it so that you can persist position and size,
-                // but not the tabs themselves, we can revisit this assumption.
-                _cachedLayout = (layout.TabLayout() && layout.TabLayout().Size() > 0) ? layout : nullptr;
+                // If we have tabs to restore, or if RestoreWindowPosition is enabled
+                // (which allows us to restore position/size even without tabs),
+                // then use this layout.
+                const auto hasTabLayout = layout.TabLayout() && layout.TabLayout().Size() > 0;
+                const auto shouldRestorePosition = _settings.GlobalSettings().RestoreWindowPosition();
+                _cachedLayout = (hasTabLayout || shouldRestorePosition) ? layout : nullptr;
                 return *_cachedLayout;
             }
         }

--- a/src/cascadia/TerminalSettingsEditor/Launch.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Launch.xaml
@@ -248,6 +248,7 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
@@ -313,6 +314,15 @@
                                   Grid.Row="2"
                                   Grid.Column="1"
                                   IsOn="{x:Bind ViewModel.CenterOnLaunch, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <TextBlock x:Uid="Globals_RestoreWindowPosition"
+                               Grid.Row="3"
+                               Grid.Column="0"
+                               VerticalAlignment="Center" />
+                    <ToggleSwitch x:Name="RestoreWindowPositionToggle"
+                                  Grid.Row="3"
+                                  Grid.Column="1"
+                                  IsOn="{x:Bind ViewModel.RestoreWindowPosition, Mode=TwoWay}"
                                   Style="{StaticResource ToggleSwitchInExpanderStyle}" />
                 </Grid>
             </local:SettingContainer>

--- a/src/cascadia/TerminalSettingsEditor/LaunchViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/LaunchViewModel.cpp
@@ -61,7 +61,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // unique view model members.
         PropertyChanged([this](auto&&, const PropertyChangedEventArgs& args) {
             const auto viewModelProperty{ args.PropertyName() };
-            if (viewModelProperty == L"CenterOnLaunch")
+            if (viewModelProperty == L"CenterOnLaunch" || viewModelProperty == L"RestoreWindowPosition")
             {
                 _NotifyChanges(L"LaunchParametersCurrentValue");
             }
@@ -226,6 +226,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         // Append the CenterOnLaunch part
         result = CenterOnLaunch() ? til::hstring_format(FMT_COMPILE(L"{}, {}"), result, RS_(L"Globals_CenterOnLaunchCentered")) : result;
+        
+        // Append the RestoreWindowPosition part
+        result = RestoreWindowPosition() ? til::hstring_format(FMT_COMPILE(L"{}, {}"), result, RS_(L"Globals_RestoreWindowPosition/Content")) : result;
         return result;
     }
 

--- a/src/cascadia/TerminalSettingsEditor/LaunchViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/LaunchViewModel.h
@@ -51,6 +51,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         GETSET_BINDABLE_ENUM_SETTING(WindowingBehavior, Model::WindowingMode, _Settings.GlobalSettings().WindowingBehavior);
 
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_Settings.GlobalSettings(), CenterOnLaunch);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_Settings.GlobalSettings(), RestoreWindowPosition);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_Settings.GlobalSettings(), InitialRows);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_Settings.GlobalSettings(), InitialCols);
 

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -553,6 +553,18 @@
     <value>When enabled, the window will be placed in the center of the screen when launched.</value>
     <comment>A description for what the "center on launch" setting does. Presented near "Globals_CenterOnLaunch.Header".</comment>
   </data>
+  <data name="Globals_RestoreWindowPosition/Content" xml:space="preserve">
+    <value>Restored</value>
+    <comment>Shorthand, explanatory text displayed when the user has enabled the feature indicated by "Globals_RestoreWindowPosition.Text".</comment>
+  </data>
+  <data name="Globals_RestoreWindowPosition.Text" xml:space="preserve">
+    <value>Restore window position and size</value>
+    <comment>Header for a control to toggle whether the app should restore the last used window position and size when launched.</comment>
+  </data>
+  <data name="Globals_RestoreWindowPosition.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>When enabled, the window will be restored to its last used position and size when launched.</value>
+    <comment>A description for what the "restore window position and size" setting does. Presented near "Globals_RestoreWindowPosition.Header".</comment>
+  </data>
   <data name="Globals_AlwaysOnTop.Header" xml:space="preserve">
     <value>Always on top</value>
     <comment>Header for a control to toggle if the app will always be presented on top of other windows, or is treated normally (when disabled).</comment>

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
@@ -115,6 +115,7 @@ namespace Microsoft.Terminal.Settings.Model
         INHERITABLE_SETTING(Boolean, AllowHeadless);
         INHERITABLE_SETTING(String, SearchWebDefaultQueryUrl);
         INHERITABLE_SETTING(IVector<String>, SafeUriSchemes);
+        INHERITABLE_SETTING(Boolean, RestoreWindowPosition);
 
         Windows.Foundation.Collections.IMapView<String, ColorScheme> ColorSchemes();
         void AddColorScheme(ColorScheme scheme);

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -72,7 +72,8 @@ Author(s):
     X(winrt::Windows::Foundation::Collections::IVector<Model::NewTabMenuEntry>, NewTabMenu, "newTabMenu", winrt::single_threaded_vector<Model::NewTabMenuEntry>({ Model::RemainingProfilesEntry{} })) \
     X(bool, AllowHeadless, "compatibility.allowHeadless", false)                                                                                                                                      \
     X(hstring, SearchWebDefaultQueryUrl, "searchWebDefaultQueryUrl", L"https://www.bing.com/search?q=%22%s%22")                                                                                       \
-    X(bool, ShowTabsFullscreen, "showTabsFullscreen", false)
+    X(bool, ShowTabsFullscreen, "showTabsFullscreen", false)                                                                                                                                          \
+    X(bool, RestoreWindowPosition, "restoreWindowPosition", false)
 
 // Also add these settings to:
 // * Profile.idl

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -1246,7 +1246,9 @@ void WindowEmperor::_persistState(const ApplicationState& state) const
         state.PersistedWindowLayouts(nullptr);
     }
 
-    if (_app.Logic().Settings().GlobalSettings().FirstWindowPreference() != FirstWindowPreference::DefaultProfile)
+    const auto& globalSettings = _app.Logic().Settings().GlobalSettings();
+    if (globalSettings.FirstWindowPreference() != FirstWindowPreference::DefaultProfile ||
+        globalSettings.RestoreWindowPosition())
     {
         for (const auto& w : _windows)
         {


### PR DESCRIPTION
## Summary

Adds a new global setting `restoreWindowPosition` that automatically saves and restores the last used window position, size, and launch mode, independently of full tab layout persistence.

## Motivation

Currently, Windows Terminal can only restore window geometry when `firstWindowPreference` is set to `"persistedWindowLayout"`, which also restores all previously open tabs. Users who want to preserve their window position and size across sessions without restoring old tabs have no way to do so.

## Changes

**New setting:** `restoreWindowPosition` (boolean, default: `false`)

When enabled:
- On close: saves the window's position, size, and launch mode to `state.json`
- On launch: restores the saved geometry without restoring tab layouts

**Files modified (9 files, +73/-17):**

| File | Change |
|------|--------|
| `MTSMSettings.h` | Add `restoreWindowPosition` to global settings |
| `GlobalAppSettings.idl` | Add WinRT projection |
| `WindowEmperor.cpp` | Trigger persistence when setting is enabled |
| `TerminalPage.cpp` | Save position/size/mode even without tabs |
| `TerminalWindow.cpp` | Restore geometry from last layout; fix cached layout to work without tabs |
| `LaunchViewModel.h` | Expose setting to UI |
| `LaunchViewModel.cpp` | Update summary text and property notifications |
| `Launch.xaml` | Add toggle switch in Launch settings |
| `Resources.resw` | Add English string resources |

## Behavior

- **Independent control:** Works separately from `firstWindowPreference` — users can restore window geometry without persisting tabs
- **Backward compatible:** Defaults to `false`, no change to existing behavior
- **Command-line priority:** CLI arguments (`--pos`, `--maximized`, etc.) still override persisted values
- **Center-on-launch:** Automatically disabled when a persisted position exists

## How to test

1. Enable "Restore window position and size" in Settings → Launch
2. Resize and reposition the Terminal window
3. Close and reopen Terminal
4. Verify the window appears at the same position and size
5. Verify tabs are NOT restored (only the default profile launches)

Closes #12633
