### PR TITLE
docs: fix DevOps capitalization in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ resources useful and interesting:
   Session](https://www.youtube.com/watch?v=KMudkRcwjCw)
 * Run As Radio: [Show 645 - Windows Terminal with Richard
   Turner](https://www.runasradio.com/Shows/Show/645)
-* Azure Devops Podcast: [Episode 54 - Kayla Cinnamon and Rich Turner on DevOps
+* Azure DevOps Podcast: [Episode 54 - Kayla Cinnamon and Rich Turner on DevOps
   on the Windows
   Terminal](http://azuredevopspodcast.clear-measure.com/kayla-cinnamon-and-rich-turner-on-devops-on-the-windows-terminal-team-episode-54)
 * Microsoft Ignite 2019 Session: [The Modern Windows Command Line: Windows


### PR DESCRIPTION
## Summary of the Pull Request
Fix DevOps capitalization in README.

## Detailed Description of the Pull Request / Additional comments
Updated "Devops" to "DevOps" in README for consistent capitalization.

## Validation Steps Performed
* Checked README formatting
* Verified markdown renders correctly