### PR TITLE
Revert "Fix Settings tab color mismatch with Settings page background (#19999)"

### DIFF
--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -192,7 +192,7 @@
                                             ResourceKey="TabViewBackground" />
 
                             <SolidColorBrush x:Key="SettingsUiTabBrush"
-                                             Color="#282828" />
+                                             Color="#0c0c0c" />
 
                             <SolidColorBrush x:Key="BroadcastPaneBorderColor"
                                              Color="{StaticResource SystemAccentColorDark2}" />
@@ -211,7 +211,7 @@
                                             ResourceKey="TabViewBackground" />
 
                             <SolidColorBrush x:Key="SettingsUiTabBrush"
-                                             Color="#F9F9F9" />
+                                             Color="#ffffff" />
 
                             <SolidColorBrush x:Key="BroadcastPaneBorderColor"
                                              Color="{StaticResource SystemAccentColorLight2}" />
@@ -234,7 +234,7 @@
                                             ResourceKey="SystemColorButtonFaceColorBrush" />
 
                             <StaticResource x:Key="SettingsUiTabBrush"
-                                            ResourceKey="SystemColorWindowBrush" />
+                                            ResourceKey="SystemControlBackgroundBaseLowBrush" />
 
                             <SolidColorBrush x:Key="BroadcastPaneBorderColor"
                                              Color="{StaticResource SystemColorHighlightColor}" />


### PR DESCRIPTION
This reverts commit 3ab2acc2ad4970d06b2e07acc12eed49009ea3b9 aka Fix Settings tab color mismatch with Settings page background (#19999).

Closes #20186
Re-opens #19873