### PR TITLE
Fix tab row acrylic mixed-source flicker

### DIFF
--- a/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
@@ -94,6 +94,7 @@ namespace TerminalAppLocalTests
         TEST_METHOD(TestPreviewCommitScheme);
         TEST_METHOD(TestPreviewDismissScheme);
         TEST_METHOD(TestPreviewSchemeWhilePreviewing);
+        TEST_METHOD(TabRowAcrylicUsesSolidTitlebarWhenTerminalUsesInAppAcrylic);
 
         TEST_METHOD(TestClampSwitchToTab);
 
@@ -1472,6 +1473,61 @@ namespace TerminalAppLocalTests
             const auto backgroundColor{ _getControlBackgroundColor(_contentManager.get(), activeControl) };
             VERIFY_ARE_EQUAL(til::color{ 0xffFAFAFA }, backgroundColor);
         });
+        Log::Comment(L"Sleep to let events propagate");
+        Sleep(250);
+    }
+
+    void TabTests::TabRowAcrylicUsesSolidTitlebarWhenTerminalUsesInAppAcrylic()
+    {
+        BEGIN_TEST_METHOD_PROPERTIES()
+            TEST_METHOD_PROPERTY(L"IsolationLevel", L"Method")
+        END_TEST_METHOD_PROPERTIES()
+
+        static constexpr std::wstring_view settingsJson0{ LR"(
+        {
+            "defaultProfile": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
+            "showTabsInTitlebar": true,
+            "useAcrylicInTabRow": true,
+            "compatibility.enableUnfocusedAcrylic": true,
+            "profiles": [
+                {
+                    "name" : "profile0",
+                    "guid": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
+                    "historySize": 1,
+                    "closeOnExit": "never",
+                    "useAcrylic": true,
+                    "opacity": 82
+                }
+            ]
+        })" };
+
+        CascadiaSettings settings0{ settingsJson0, {} };
+        VERIFY_IS_NOT_NULL(settings0);
+
+        winrt::com_ptr<winrt::TerminalApp::implementation::TerminalPage> page{ nullptr };
+        _initializeTerminalPage(page, settings0);
+
+        TestOnUIThread([&page]() {
+            page->WindowActivated(false);
+
+            const auto& activeControl{ page->_GetActiveControl() };
+            VERIFY_IS_NOT_NULL(activeControl);
+
+            const auto terminalBrush{ activeControl.BackgroundBrush() };
+            VERIFY_IS_NOT_NULL(terminalBrush);
+
+            const auto terminalAcrylicBrush{ terminalBrush.try_as<winrt::Windows::UI::Xaml::Media::AcrylicBrush>() };
+            VERIFY_IS_NOT_NULL(terminalAcrylicBrush);
+            VERIFY_ARE_EQUAL(winrt::Windows::UI::Xaml::Media::AcrylicBackgroundSource::Backdrop, terminalAcrylicBrush.BackgroundSource());
+
+            page->_updateThemeColors();
+
+            const auto titlebarBrush{ page->TitlebarBrush() };
+            VERIFY_IS_NOT_NULL(titlebarBrush);
+            VERIFY_IS_NULL(titlebarBrush.try_as<winrt::Windows::UI::Xaml::Media::AcrylicBrush>());
+            VERIFY_IS_NOT_NULL(titlebarBrush.try_as<winrt::Windows::UI::Xaml::Media::SolidColorBrush>());
+        });
+
         Log::Comment(L"Sleep to let events propagate");
         Sleep(250);
     }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -5108,20 +5108,52 @@ namespace winrt::TerminalApp::implementation
                                                             theme.TabRow().UnfocusedBackground()) :
                                               ThemeColor{ nullptr } };
 
-        if (_settings.GlobalSettings().UseAcrylicInTabRow() && (_activated || _settings.GlobalSettings().EnableUnfocusedAcrylic()))
+        const auto terminalAcrylicBrush{ terminalBrush ? terminalBrush.try_as<Media::AcrylicBrush>() : nullptr };
+        const auto terminalUsesInAppAcrylic{ terminalAcrylicBrush != nullptr && terminalAcrylicBrush.BackgroundSource() == Media::AcrylicBackgroundSource::Backdrop };
+        // In tabs-in-titlebar mode, the XAML tab row is drawn over the original
+        // User32 titlebar. Don't layer HostBackdrop tab-row acrylic over
+        // in-app profile acrylic; that mixed-source stack flickers and cannot
+        // satisfy unfocused acrylic semantics.
+        const auto wantsTabRowAcrylic{ _settings.GlobalSettings().UseAcrylicInTabRow() &&
+                                       (_activated || _settings.GlobalSettings().EnableUnfocusedAcrylic()) };
+        const auto suppressTitlebarAcrylic{ wantsTabRowAcrylic &&
+                                            _settings.GlobalSettings().ShowTabsInTitlebar() &&
+                                            terminalUsesInAppAcrylic };
+        const auto useTabRowAcrylic{ wantsTabRowAcrylic && !suppressTitlebarAcrylic };
+
+        if (useTabRowAcrylic)
         {
             if (tabRowBg)
             {
                 bgColor = ThemeColor::ColorFromBrush(tabRowBg.Evaluate(res, terminalBrush, true));
             }
 
-            const auto acrylicBrush = Media::AcrylicBrush();
+            Media::AcrylicBrush acrylicBrush{ nullptr };
+            if (const auto titlebarBrush{ TitlebarBrush() })
+            {
+                acrylicBrush = titlebarBrush.try_as<Media::AcrylicBrush>();
+            }
+            if (!acrylicBrush)
+            {
+                acrylicBrush = Media::AcrylicBrush();
+                TitlebarBrush(acrylicBrush);
+            }
+
             acrylicBrush.BackgroundSource(Media::AcrylicBackgroundSource::HostBackdrop);
             acrylicBrush.FallbackColor(bgColor);
             acrylicBrush.TintColor(bgColor);
             acrylicBrush.TintOpacity(0.5);
+        }
+        else if (suppressTitlebarAcrylic)
+        {
+            if (tabRowBg)
+            {
+                bgColor = ThemeColor::ColorFromBrush(tabRowBg.Evaluate(res, terminalBrush, true));
+            }
 
-            TitlebarBrush(acrylicBrush);
+            Media::SolidColorBrush solidBrush{};
+            solidBrush.Color(bgColor);
+            TitlebarBrush(solidBrush);
         }
         else if (tabRowBg)
         {


### PR DESCRIPTION
Note: This PR was prepared with Codex assistance in my local environment. I personally experience the tab-row flickering described in #14384, but the patch authoring, evidence synthesis, and validation notes below were prepared by Codex.

## Summary of the Pull Request

When `useAcrylicInTabRow` and `enableUnfocusedAcrylic` are both enabled, the tab row should not layer titlebar `HostBackdrop` acrylic over terminal content that is already using in-app `Backdrop` acrylic. This changes only that mixed-source tabs-in-titlebar case to use the evaluated solid titlebar/tab-row brush, while preserving the existing `HostBackdrop` acrylic path for non-mixed cases.

## References and Relevant Issues

Closes #14384.

## Detailed Description of the Pull Request / Additional comments

`TerminalPage.cpp` now detects when all of these are true:

- tab-row acrylic is requested,
- tabs are shown in the titlebar,
- the active terminal content is using in-app `AcrylicBackgroundSource::Backdrop`,
- and the tab row would otherwise use titlebar `AcrylicBackgroundSource::HostBackdrop` acrylic.

In that combination, `TitlebarBrush` is set to a `SolidColorBrush` using the evaluated tab-row/titlebar color. Existing behavior is retained for titlebar-only acrylic cases and for non-mixed-source cases.

`TabTests.cpp` adds `TabRowAcrylicUsesSolidTitlebarWhenTerminalUsesInAppAcrylic`. The test enables tabs in titlebar, tab-row acrylic, unfocused acrylic, profile acrylic, and opacity below 100%, then verifies that after `WindowActivated(false)` the active terminal background uses `Backdrop` while the titlebar brush is solid rather than acrylic.

Process note: I converted this PR to Draft after opening it because the Contributor's Guide asks contributors to start with a Draft PR while the approach is discussed. The patch and exact-head validation are included here so maintainers can review the approach with concrete evidence.

## Validation Steps Performed

Exact-head Windows-native validation:

- Branch: `Rokurolize:fix-tab-row-acrylic-mixed-source`
- Commit: `8ab20192d085773a6c3fbbe3287334aab9308888`
- Windows-local checkout head matched the expected PR head commit before validation.
- NuGet package restore for `dep\nuget\packages.config` passed.
- Debug x64 `Terminal\Tests\TestHostApp` solution-target build passed; this built `TerminalApp.LocalTests.dll` for the hosted local test run.
- Focused hosted TAEF passed for `TerminalAppLocalTests::TabTests::TabRowAcrylicUsesSolidTitlebarWhenTerminalUsesInAppAcrylic`.
- TAEF summary: `Total=1, Passed=1, Failed=0, Blocked=0, Not Run=0, Skipped=0`.

## PR Checklist

- [x] Closes #14384
- [x] Tests added/passed
- [ ] Documentation updated
  - Not applicable: this PR does not add, remove, or rename user-facing settings, commands, localized strings, schema entries, or configuration syntax. It only changes runtime brush selection for an existing combination of `showTabsInTitlebar`, `useAcrylicInTabRow`, `compatibility.enableUnfocusedAcrylic`, profile `useAcrylic`, and profile `opacity`.
- [ ] Schema updated
  - Not applicable: the relevant settings already exist in both the settings model and `doc/cascadia/profiles.schema.json`; this PR does not add or change schema keys.
