### PR TITLE
Polish command-line help dialog formatting

### DIFF
--- a/src/cascadia/LocalTests_TerminalApp/CommandlineTest.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/CommandlineTest.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 #include "pch.h"
+#include <sstream>
 #include <WexTestClass.h>
 
 #include "../types/inc/utils.hpp"
@@ -115,6 +116,26 @@ namespace TerminalAppLocalTests
             }
             Log::Comment(NoThrowString().Format(L"%s", buffer.c_str()));
         }
+
+        void _verifyHelpTextFitsDialog(const std::string& message)
+        {
+            static constexpr size_t maxHelpLineLength = 72;
+
+            std::istringstream lines{ message };
+            std::string line;
+            size_t lineNumber = 0;
+            while (std::getline(lines, line))
+            {
+                ++lineNumber;
+                if (!line.empty() && line.back() == '\r')
+                {
+                    line.pop_back();
+                }
+
+                VERIFY_IS_TRUE(line.size() <= maxHelpLineLength,
+                               NoThrowString().Format(L"line %zu has %zu chars: %hs", lineNumber, line.size(), line.c_str()));
+            }
+        }
     };
 
     void CommandlineTest::ParseSimpleCommandline()
@@ -210,6 +231,7 @@ namespace TerminalAppLocalTests
                 appArgs._exitMessage.c_str()));
             VERIFY_ARE_EQUAL(0, result);
             VERIFY_ARE_NOT_EQUAL("", appArgs._exitMessage);
+            _verifyHelpTextFitsDialog(appArgs._exitMessage);
         }
     }
 
@@ -277,6 +299,7 @@ namespace TerminalAppLocalTests
                 appArgs._exitMessage.c_str()));
             VERIFY_ARE_EQUAL(0, result);
             VERIFY_ARE_NOT_EQUAL("", appArgs._exitMessage);
+            _verifyHelpTextFitsDialog(appArgs._exitMessage);
         }
     }
 

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -9,6 +9,13 @@
 using namespace winrt::Microsoft::Terminal::Settings::Model;
 using namespace TerminalApp;
 
+namespace
+{
+    constexpr std::size_t HelpTextLeftColumnWidth{ 24 };
+    constexpr std::size_t HelpTextRightColumnWidth{ 48 };
+    constexpr std::size_t HelpTextParagraphWidth{ HelpTextLeftColumnWidth + HelpTextRightColumnWidth };
+}
+
 // Either a ; at the start of a line, or a ; preceded by any non-\ char.
 const std::wregex AppCommandlineArgs::_commandDelimiterRegex{ LR"(^;|[^\\];)" };
 
@@ -135,6 +142,10 @@ int AppCommandlineArgs::_handleExit(const CLI::App& command, const CLI::Error& e
 // - <none>
 void AppCommandlineArgs::_buildParser()
 {
+    _app.get_formatter()->column_width(HelpTextLeftColumnWidth);
+    _app.get_formatter()->right_column_width(HelpTextRightColumnWidth);
+    _app.get_formatter()->description_paragraph_width(HelpTextParagraphWidth);
+
     // We define or parser as a prefix command, to support "implicit new tab subcommand" scenario.
     // In this scenario we will try to parse the prefix that contains parameters like launch mode,
     // but will not encounter an explicit command.

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -1037,7 +1037,7 @@ safe_void_coroutine WindowEmperor::_showMessageBox(winrt::hstring message, bool 
     const auto messageTitle = error ? IDS_ERROR_DIALOG_TITLE : IDS_HELP_DIALOG_TITLE;
     const auto messageIcon = error ? MB_ICONERROR : MB_ICONWARNING;
     // The dialog cannot have our _window as the parent, because that one is always hidden/invisible.
-    // TODO:GH#4134: polish this dialog more, to make the text more like msiexec /?
+    // Command-line help text is wrapped by the CLI formatter before it reaches this dialog.
     MessageBoxW(nullptr, message.c_str(), GetStringResource(messageTitle).c_str(), MB_OK | messageIcon);
 }
 


### PR DESCRIPTION
## Summary of the Pull Request

Narrows the generated `wt` command-line help formatting so the text shown in the help MessageBox wraps at a dialog-friendly width.

## References and Relevant Issues

Closes #4134

## Detailed Description of the Pull Request / Additional comments

The command-line help text is produced by CLI11 before `WindowEmperor` displays it in a MessageBox. This updates the shared CLI formatter to use narrower help columns and a 72-character paragraph width, so top-level and subcommand help avoid long horizontal lines in the fixed-size dialog.

The existing command-line help tests now assert that generated help lines stay within that 72-character limit, and the stale GH#4134 TODO at the MessageBox call site has been replaced with a comment pointing to the formatter behavior.

## Validation Steps Performed

- Verified the touched files keep the repository's CRLF line endings.
- Ran a targeted trailing-whitespace check on the touched files.
- Reviewed the final diff.
- Could not run the Windows TAEF/msbuild test suite from this macOS environment.

## PR Checklist
- [x] Closes #4134
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
