### PR TITLE
chore: upgrade gsl to 4.2.2

### DIFF
--- a/OpenConsole.slnx
+++ b/OpenConsole.slnx
@@ -860,17 +860,6 @@
   <Folder Name="/_Dependencies/Console/">
     <File Path="dep/Console/winconp.h" />
   </Folder>
-  <Folder Name="/_Dependencies/gsl/">
-    <File Path="dep/gsl/include/gsl/gsl" />
-    <File Path="dep/gsl/include/gsl/gsl_algorithm" />
-    <File Path="dep/gsl/include/gsl/gsl_assert" />
-    <File Path="dep/gsl/include/gsl/gsl_byte" />
-    <File Path="dep/gsl/include/gsl/gsl_util" />
-    <File Path="dep/gsl/include/gsl/multi_span" />
-    <File Path="dep/gsl/include/gsl/pointers" />
-    <File Path="dep/gsl/include/gsl/span" />
-    <File Path="dep/gsl/include/gsl/string_span" />
-  </Folder>
   <Folder Name="/_Dependencies/wil/">
     <File Path="dep/wil/include/wil/common.h" />
     <File Path="dep/wil/include/wil/filesystem.h" />

--- a/src/inc/LibraryIncludes.h
+++ b/src/inc/LibraryIncludes.h
@@ -63,9 +63,8 @@
 #include <wil/nt_result_macros.h>
 
 // GSL
-// Block GSL Multi Span include because it both has C++17 deprecated iterators
-// and uses the C-namespaced "max" which conflicts with Windows definitions.
-#include <gsl/gsl_util>
+#include <gsl/narrow>
+#include <gsl/util>
 #include <gsl/pointers>
 
 // CppCoreCheck

--- a/src/renderer/atlas/pch.h
+++ b/src/renderer/atlas/pch.h
@@ -30,7 +30,8 @@
 #include <VersionHelpers.h>
 #include <wincodec.h>
 
-#include <gsl/gsl_util>
+#include <gsl/narrow>
+#include <gsl/util>
 #include <gsl/pointers>
 #include <wil/com.h>
 #include <wil/filesystem.h>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -21,7 +21,7 @@
     },
     {
       "name": "ms-gsl",
-      "version": "3.1.0"
+      "version": "4.2.2"
     },
     {
       "name": "jsoncpp",
@@ -36,7 +36,7 @@
       "version": "0.31.1"
     }
   ],
-  "builtin-baseline": "15e5f3820f0370f1ba7150853762cec0688cd396",
+  "builtin-baseline": "927f62e4b8838bd7e441e9c45103a16ffd75007e",
   "vcpkg-configuration": {
     "overlay-triplets": [
       "./dep/vcpkg-overlay-triplets"


### PR DESCRIPTION
GSL 4.2.2 contains a fix for a warning (in GSL itself, natch!) that was making MSVC quite upset with us.