### PR TITLE
Update formatting scripts for Preview-only VS and pwsh 7

### DIFF
--- a/tools/OpenConsole.psm1
+++ b/tools/OpenConsole.psm1
@@ -416,7 +416,7 @@ function Invoke-CodeFormat() {
         [switch]$IgnoreXaml
     )
 
-    $clangFormatPath = & 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' -latest -find "**\x64\bin\clang-format.exe"
+    $clangFormatPath = & 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' -latest -prerelease -find "**\x64\bin\clang-format.exe"
     If ([String]::IsNullOrEmpty($clangFormatPath)) {
         Write-Error "No Visual Studio-supplied version of clang-format could be found."
     }

--- a/tools/runformat.cmd
+++ b/tools/runformat.cmd
@@ -2,4 +2,4 @@
 
 rem run clang-format on c++ files
 
-powershell -noprofile "import-module %OPENCON_TOOLS%\openconsole.psm1; Invoke-CodeFormat"
+pwsh -noprofile -c "import-module %OPENCON_TOOLS%\openconsole.psm1; Invoke-CodeFormat"


### PR DESCRIPTION
This is a pair of changes to make the code formatting scripts work, circa 2026.

* If you only have VS Insiders installed, then vswhere can't actually find a clang-format to build with. You need `-prerelease` to let it also find preview builds of VS.
* Years ago we updated OpenConsole.psm1 to only support pwsh 7. I, of course, use `cmd` as my dev env for terminal, so I use `runformat.cmd`, which always shelled to `powershell` (5). This updates that tool to use pwsh 7. Clearly this impacted only me ever.

related to #20162
