### PR TITLE
Don't ignore the user's default environment inheritance setting for wt

### DIFF
--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -744,12 +744,21 @@ NewTerminalArgs AppCommandlineArgs::_getNewTerminalArgs(AppCommandlineArgs::NewT
         args.AppendCommandLine(_appendCommandLineOption);
     }
 
-    bool inheritEnv = hasCommandline;
+    std::optional<bool> inheritEnv;
+    if (hasCommandline)
+    {
+        inheritEnv = true;
+    }
+
     if (*subcommand.inheritEnvOption)
     {
         inheritEnv = _inheritEnvironment;
     }
-    args.ReloadEnvironmentVariables(!inheritEnv);
+
+    if (inheritEnv.has_value())
+    {
+        args.ReloadEnvironmentVariables(!*inheritEnv);
+    }
 
     return args;
 }


### PR DESCRIPTION
Our commandline handler would unconditionally turn on/off inheritance based on the presence of a commandline; doing this prevented the user's default settings (if they had set
`compatibility.reloadEnvironmentVariables` and expected to see a difference) from being applied.

Fixes #16226