### PR TITLE
feat(vt): add dark/light mode detection (DECSET 2031, CSI ? 996 n)

### DIFF
--- a/src/cascadia/TerminalCore/ICoreSettings.idl
+++ b/src/cascadia/TerminalCore/ICoreSettings.idl
@@ -102,6 +102,12 @@ namespace Microsoft.Terminal.Core
         Boolean IntenseIsBright { get; };
         AdjustTextMode AdjustIndistinguishableColors { get; };
 
+        // The resolved dark/light color *mode* (the OS/app appearance preference,
+        // with "use Windows theme" resolved from the OS), used for the dark/light
+        // mode reports (DECSET 2031 and the CSI ? 996 n query). This is NOT the
+        // terminal's color scheme.
+        Boolean DarkMode { get; };
+
         // NOTE! When adding something here, make sure to update ControlProperties.h too!
     };
 

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -218,16 +218,42 @@ void Terminal::UpdateAppearance(const ICoreAppearance& appearance)
 
     _defaultCursorShape = cursorShape;
 
-    UpdateColorScheme(appearance);
+    // Apply the new color scheme, and find out whether the palette actually
+    // changed as a result.
+    const auto paletteChanged = UpdateColorScheme(appearance);
+
+    // Inform the dispatcher of the resolved dark/light color mode (for CSI ? 996 n)
+    // and whether the palette changed. If either the mode or the palette changed,
+    // and an application enabled color theme update notifications (DECSET 2031), an
+    // unsolicited report is emitted. This rides the settings/appearance update,
+    // which WT re-runs both when the user changes the theme and when the OS
+    // appearance preference changes.
+    if (_stateMachine)
+    {
+        auto& engine = reinterpret_cast<OutputStateMachineEngine&>(_stateMachine->Engine());
+        engine.Dispatch().ColorSchemeUpdated(appearance.DarkMode(), paletteChanged);
+    }
 }
 
-void Terminal::UpdateColorScheme(const ICoreScheme& scheme)
+bool Terminal::UpdateColorScheme(const ICoreScheme& scheme)
 {
     auto& renderSettings = GetRenderSettings();
 
+    // Track whether the color palette actually changes, so callers can decide
+    // whether to emit an unsolicited dark/light mode report (DECSET 2031). Per
+    // the spec, the report is only sent when the terminal's color palette has
+    // actually been updated:
+    // https://contour-terminal.org/vt-extensions/color-palette-update-notifications/
+    auto paletteChanged = false;
+    const auto trackChange = [&](const size_t tableIndex, const til::color newColor) {
+        paletteChanged = paletteChanged || renderSettings.GetColorTableEntry(tableIndex) != static_cast<COLORREF>(newColor);
+    };
+
     const til::color newBackgroundColor{ scheme.DefaultBackground() };
+    trackChange(TextColor::DEFAULT_BACKGROUND, newBackgroundColor);
     renderSettings.SetColorAlias(ColorAlias::DefaultBackground, TextColor::DEFAULT_BACKGROUND, newBackgroundColor);
     const til::color newForegroundColor{ scheme.DefaultForeground() };
+    trackChange(TextColor::DEFAULT_FOREGROUND, newForegroundColor);
     renderSettings.SetColorAlias(ColorAlias::DefaultForeground, TextColor::DEFAULT_FOREGROUND, newForegroundColor);
     const til::color newCursorColor{ scheme.CursorColor() };
     renderSettings.SetColorTableEntry(TextColor::CURSOR_COLOR, newCursorColor);
@@ -241,13 +267,17 @@ void Terminal::UpdateColorScheme(const ICoreScheme& scheme)
 
     for (auto i = 0; i < 16; i++)
     {
-        renderSettings.SetColorTableEntry(i, til::color{ til::at(colors, i) });
+        const til::color newColor{ til::at(colors, i) };
+        trackChange(i, newColor);
+        renderSettings.SetColorTableEntry(i, newColor);
     }
 
     // Tell the control that the scrollbar has somehow changed. Used as a
     // workaround to force the control to redraw any scrollbar marks whose color
     // may have changed.
     _NotifyScrollEvent();
+
+    return paletteChanged;
 }
 
 void Terminal::SetHighContrastMode(bool hc) noexcept

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -92,7 +92,7 @@ public:
 
     void UpdateSettings(winrt::Microsoft::Terminal::Core::ICoreSettings settings);
     void UpdateAppearance(const winrt::Microsoft::Terminal::Core::ICoreAppearance& appearance);
-    void UpdateColorScheme(const winrt::Microsoft::Terminal::Core::ICoreScheme& scheme);
+    bool UpdateColorScheme(const winrt::Microsoft::Terminal::Core::ICoreScheme& scheme);
     void SetHighContrastMode(bool hc) noexcept;
     void SetFontInfo(const FontInfo& fontInfo);
     void SetCursorStyle(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::CursorStyle cursorStyle);

--- a/src/cascadia/TerminalSettingsAppAdapterLib/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettingsAppAdapterLib/TerminalSettings.cpp
@@ -211,6 +211,11 @@ namespace winrt::Microsoft::Terminal::Settings
                                  winrt::Windows::UI::Xaml::ElementTheme::Light;
         }
 
+        // Record the resolved dark/light color mode so the terminal can report it
+        // to applications (DECSET 2031 / CSI ? 996 n). This is the OS/app theme
+        // preference, not the color scheme.
+        _DarkMode = requestedTheme != winrt::Windows::UI::Xaml::ElementTheme::Light;
+
         switch (requestedTheme)
         {
         case winrt::Windows::UI::Xaml::ElementTheme::Light:

--- a/src/cascadia/inc/ControlProperties.h
+++ b/src/cascadia/inc/ControlProperties.h
@@ -13,7 +13,8 @@
     X(uint32_t, CursorHeight, DEFAULT_CURSOR_HEIGHT)                                                                      \
     X(til::color, SelectionBackground, DEFAULT_FOREGROUND)                                                                \
     X(bool, IntenseIsBold)                                                                                                \
-    X(bool, IntenseIsBright, true)                                                                                        \
+    X(bool, IntenseIsBright, true)                                                                                       \
+    X(bool, DarkMode, true)                                                                                              \
     X(winrt::Microsoft::Terminal::Core::AdjustTextMode, AdjustIndistinguishableColors, winrt::Microsoft::Terminal::Core::AdjustTextMode::Automatic)
 
 // --------------------------- Control Appearance ---------------------------

--- a/src/terminal/adapter/DispatchTypes.hpp
+++ b/src/terminal/adapter/DispatchTypes.hpp
@@ -510,6 +510,7 @@ namespace Microsoft::Console::VirtualTerminal::DispatchTypes
         MemoryChecksum = DECPrivateStatus(63),
         DataIntegrity = DECPrivateStatus(75),
         MultipleSessionStatus = DECPrivateStatus(85),
+        ColorSchemeReport = DECPrivateStatus(996),
     };
 
     using ANSIStandardMode = FlaggedEnumValue<0x00000000>;
@@ -546,6 +547,7 @@ namespace Microsoft::Console::VirtualTerminal::DispatchTypes
         XTERM_BracketedPasteMode = DECPrivateMode(2004),
         SO_SynchronizedOutput = DECPrivateMode(2026),
         GCM_GraphemeClusterMode = DECPrivateMode(2027),
+        ColorThemeUpdates = DECPrivateMode(2031),
         W32IM_Win32InputMode = DECPrivateMode(9001),
     };
 

--- a/src/terminal/adapter/ITermDispatch.hpp
+++ b/src/terminal/adapter/ITermDispatch.hpp
@@ -197,6 +197,8 @@ public:
     virtual void PlaySounds(const VTParameters parameters) = 0; // DECPS
 
     virtual void SetOptionalFeatures(const til::enumset<OptionalFeature> features) = 0;
+
+    virtual void ColorSchemeUpdated(const bool isDark, const bool paletteChanged) = 0; // Notify that the terminal's appearance was updated (records dark/light for CSI ? 996 n; may emit an unsolicited DECSET 2031 report)
 };
 inline Microsoft::Console::VirtualTerminal::ITermDispatch::~ITermDispatch() = default;
 #pragma warning(pop)

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1422,6 +1422,9 @@ void AdaptDispatch::DeviceStatusReport(const DispatchTypes::StatusType statusTyp
     case DispatchTypes::StatusType::MultipleSessionStatus:
         _DeviceStatusReport(MultipleSessionsNotSupported);
         break;
+    case DispatchTypes::StatusType::ColorSchemeReport:
+        _ReportColorScheme();
+        break;
     default:
         break;
     }
@@ -1537,6 +1540,45 @@ void AdaptDispatch::RequestTerminalParameters(const DispatchTypes::ReportingPerm
 void AdaptDispatch::_DeviceStatusReport(const wchar_t* parameters) const
 {
     _ReturnCsiResponse(fmt::format(FMT_COMPILE(L"{}n"), parameters));
+}
+
+// Routine Description:
+// - Reports whether the terminal is currently using a dark or light color
+//   scheme. This is the DSR reply to a `CSI ? 996 n` query, and is also the
+//   unsolicited notification sent when the appearance is updated while the
+//   color theme update mode (DECSET 2031) is enabled.
+//   See https://contour-terminal.org/vt-extensions/color-palette-update-notifications/
+// Return Value:
+// - <none>
+void AdaptDispatch::_ReportColorScheme() const
+{
+    // A value of 1 indicates a dark color scheme, and 2 indicates a light one.
+    const auto colorScheme = _colorSchemeIsDark ? 1 : 2;
+    _ReturnCsiResponse(fmt::format(FMT_COMPILE(L"?997;{}n"), colorScheme));
+}
+
+// Routine Description:
+// - Notifies the dispatcher that the terminal's appearance has been updated due
+//   to a change in the terminal emulator's configuration (e.g. the user changed
+//   the profile/color scheme, directly or indirectly by changing the operating
+//   system theme). The current dark/light value is recorded for the `CSI ? 996 n`
+//   query, and if either the dark/light mode or the color palette actually
+//   changed, an unsolicited report is emitted while the color theme update mode
+//   (DECSET 2031) is enabled.
+//   See https://contour-terminal.org/vt-extensions/color-palette-update-notifications/
+// Arguments:
+// - isDark - True if the resolved appearance is dark, false if it is light.
+// - paletteChanged - True if the color palette values actually changed.
+// Return Value:
+// - <none>
+void AdaptDispatch::ColorSchemeUpdated(const bool isDark, const bool paletteChanged)
+{
+    const auto modeChanged = isDark != _colorSchemeIsDark;
+    _colorSchemeIsDark = isDark;
+    if ((modeChanged || paletteChanged) && _modes.test(Mode::ColorThemeUpdates))
+    {
+        _ReportColorScheme();
+    }
 }
 
 // Routine Description:
@@ -1888,6 +1930,9 @@ void AdaptDispatch::_ModeParamsHelper(const DispatchTypes::ModeParams param, con
             _renderer->SynchronizedOutputChanged();
         }
         break;
+    case DispatchTypes::ModeParams::ColorThemeUpdates:
+        _modes.set(Mode::ColorThemeUpdates, enable);
+        break;
     case DispatchTypes::ModeParams::GCM_GraphemeClusterMode:
         break;
     case DispatchTypes::ModeParams::W32IM_Win32InputMode:
@@ -2028,6 +2073,9 @@ void AdaptDispatch::RequestMode(const DispatchTypes::ModeParams param)
         break;
     case DispatchTypes::ModeParams::SO_SynchronizedOutput:
         state = mapTemp(_renderSettings.GetRenderMode(RenderSettings::Mode::SynchronizedOutput));
+        break;
+    case DispatchTypes::ModeParams::ColorThemeUpdates:
+        state = mapTemp(_modes.test(Mode::ColorThemeUpdates));
         break;
     case DispatchTypes::ModeParams::GCM_GraphemeClusterMode:
         state = mapPerm(CodepointWidthDetector::Singleton().GetMode() == TextMeasurementMode::Graphemes);

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -198,6 +198,8 @@ namespace Microsoft::Console::VirtualTerminal
 
         void SetOptionalFeatures(const til::enumset<OptionalFeature> features) noexcept override;
 
+        void ColorSchemeUpdated(const bool isDark, const bool paletteChanged) override;
+
     private:
         enum class Mode
         {
@@ -209,7 +211,8 @@ namespace Microsoft::Console::VirtualTerminal
             SixelDisplay,
             EraseColor,
             RectangularChangeExtent,
-            PageCursorCoupling
+            PageCursorCoupling,
+            ColorThemeUpdates
         };
         enum class ScrollDirection
         {
@@ -277,6 +280,7 @@ namespace Microsoft::Console::VirtualTerminal
         void _CursorPositionReport(const bool extendedReport);
         void _MacroSpaceReport() const;
         void _MacroChecksumReport(const VTParameter id) const;
+        void _ReportColorScheme() const;
 
         void _SetColumnMode(const bool enable);
         void _SetAlternateScreenBufferMode(const bool enable);
@@ -333,6 +337,12 @@ namespace Microsoft::Console::VirtualTerminal
         til::inclusive_rect _scrollMargins;
 
         til::enumset<Mode> _modes{ Mode::PageCursorCoupling };
+
+        // Whether the terminal's effective appearance is currently a dark theme.
+        // This drives the dark/light mode reports (DECSET 2031 / CSI ? 996 n) and
+        // is set explicitly from the resolved application/OS theme, not derived
+        // from the color palette. Defaults to dark, the historical terminal default.
+        bool _colorSchemeIsDark = true;
 
         SgrStack _sgrStack;
 

--- a/src/terminal/adapter/termDispatch.hpp
+++ b/src/terminal/adapter/termDispatch.hpp
@@ -187,6 +187,8 @@ public:
     void PlaySounds(const VTParameters /*parameters*/) override {}; // DECPS
 
     void SetOptionalFeatures(const til::enumset<OptionalFeature> /*features*/) override {};
+
+    void ColorSchemeUpdated(const bool /*isDark*/, const bool /*paletteChanged*/) override {}
 };
 
 #pragma warning(default : 26440) // Restore "can be declared noexcept" warning

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -1743,6 +1743,59 @@ public:
         _testGetSet->ValidateInputEvent(L"\x1b[?83n");
     }
 
+    TEST_METHOD(DeviceStatus_ColorSchemeReportTests)
+    {
+        Log::Comment(L"Starting test...");
+
+        Log::Comment(L"Test 1: Verify a dark appearance reports a dark scheme (1).");
+        _testGetSet->PrepData();
+        _pDispatch->ColorSchemeUpdated(true, false);
+        _pDispatch->DeviceStatusReport(DispatchTypes::StatusType::ColorSchemeReport, {});
+        _testGetSet->ValidateInputEvent(L"\x1b[?997;1n");
+
+        Log::Comment(L"Test 2: Verify a light appearance reports a light scheme (2).");
+        _testGetSet->PrepData();
+        _pDispatch->ColorSchemeUpdated(false, false);
+        _pDispatch->DeviceStatusReport(DispatchTypes::StatusType::ColorSchemeReport, {});
+        _testGetSet->ValidateInputEvent(L"\x1b[?997;2n");
+    }
+
+    TEST_METHOD(ColorSchemeUpdateNotificationTests)
+    {
+        Log::Comment(L"Starting test...");
+
+        Log::Comment(L"Test 1: No notification is sent while the mode is disabled.");
+        _testGetSet->PrepData();
+        _pDispatch->ColorSchemeUpdated(true, false);
+        _pDispatch->ResetMode(DispatchTypes::ColorThemeUpdates);
+        _testGetSet->_response.clear();
+        _pDispatch->ColorSchemeUpdated(false, true);
+        VERIFY_IS_TRUE(_testGetSet->_response.empty());
+
+        Log::Comment(L"Test 2: A dark/light mode change alone sends a report (e.g. OS theme change with a single color scheme).");
+        _testGetSet->PrepData();
+        _pDispatch->ColorSchemeUpdated(true, false);
+        _pDispatch->SetMode(DispatchTypes::ColorThemeUpdates);
+        _testGetSet->_response.clear();
+        _pDispatch->ColorSchemeUpdated(false, false);
+        _testGetSet->ValidateInputEvent(L"\x1b[?997;2n");
+
+        Log::Comment(L"Test 3: A palette change alone (same mode) sends a report (e.g. user changed color scheme).");
+        _testGetSet->_response.clear();
+        _pDispatch->ColorSchemeUpdated(false, true);
+        _testGetSet->ValidateInputEvent(L"\x1b[?997;2n");
+
+        Log::Comment(L"Test 4: An update with neither a mode change nor a palette change sends nothing.");
+        _testGetSet->_response.clear();
+        _pDispatch->ColorSchemeUpdated(false, false);
+        VERIFY_IS_TRUE(_testGetSet->_response.empty());
+
+        Log::Comment(L"Test 5: A mode change back to dark sends a dark report (1).");
+        _testGetSet->_response.clear();
+        _pDispatch->ColorSchemeUpdated(true, false);
+        _testGetSet->ValidateInputEvent(L"\x1b[?997;1n");
+    }
+
     TEST_METHOD(DeviceAttributesTests)
     {
         Log::Comment(L"Starting test...");
@@ -2123,7 +2176,7 @@ public:
         // and DECRQM would not then be applicable.
 
         BEGIN_TEST_METHOD_PROPERTIES()
-            TEST_METHOD_PROPERTY(L"Data:modeNumber", L"{1, 3, 5, 6, 7, 8, 12, 25, 40, 66, 67, 69, 117, 1000, 1002, 1003, 1004, 1005, 1006, 1007, 1049, 2004, 9001}")
+            TEST_METHOD_PROPERTY(L"Data:modeNumber", L"{1, 3, 5, 6, 7, 8, 12, 25, 40, 66, 67, 69, 117, 1000, 1002, 1003, 1004, 1005, 1006, 1007, 1049, 2004, 2031, 9001}")
         END_TEST_METHOD_PROPERTIES()
 
         VTInt modeNumber;


### PR DESCRIPTION
## Summary of the Pull Request

Adds support for the de-facto "color palette update notifications" extension (a.k.a. dark/light mode detection), so applications running in the terminal can query and follow the terminal's dark/light appearance:

- `CSI ? 996 n` queries the current color mode. The terminal replies with `CSI ? 997 ; 1 n` for dark and `CSI ? 997 ; 2 n` for light.
- `CSI ? 2031 h` / `CSI ? 2031 l` enable/disable unsolicited reports. While enabled, the terminal emits the same `CSI ? 997 ; ... n` report whenever its color palette is updated because the user changed the profile/color scheme, or changed it indirectly by changing the OS theme and only when the palette or the dark/light mode actually changed.

The reported dark/light value is the resolved application/OS theme (the global `theme` setting's `applicationTheme`, resolving "use Windows theme" via the OS appearance), not a guess based on the background color.

## References and Relevant Issues

- Closes #18375
- Specification: https://contour-terminal.org/vt-extensions/color-palette-update-notifications/

## Detailed Description of the Pull Request / Additional comments

Shared VT adapter (`src/terminal/adapter`):
- `StatusType::ColorSchemeReport` (DEC private DSR `996`) and `ModeParams::ColorThemeUpdates` (DEC private mode `2031`).
- `AdaptDispatch` stores the current dark/light value used to answer the `996` query.
- `ITermDispatch::ColorSchemeUpdated(isDark, paletteChanged)` records the dark/light value and emits a `997` report when the mode or the palette changed and `2031` is enabled.

TerminalCore (`src/cascadia/TerminalCore`):
- `Terminal::UpdateColorScheme` now reports whether the palette actually changed.
- `Terminal::UpdateAppearance` resolves the dark/light value (`ICoreAppearance.DarkMode`) and forwards it plus the palette-changed flag to the dispatcher on every appearance update. Windows Terminal re-runs this on profile/color-scheme changes and on OS theme changes (`WM_SETTINGCHANGE`/`ImmersiveColorSet` -> settings reload).

Under ConPTY the application's `2031`/`996` sequences pass through to the hosting terminal via `WriteCharsVT`; conhost does not respond to these (that is the terminal's job), and Windows Terminal -- which knows the theme -- answers and emits.

## Validation Steps Performed

- New `AdapterTest` cases covering the `996` reply (dark/light) and the `2031` unsolicited reports (dark/light mode change, palette change, and a no-op update). All passing.
- Built `TerminalCore`, `TerminalControl`, the settings adapter, and the adapter unit tests.

## PR Checklist
- [x] Closes #18375
- [x] Tests added/passed
- [ ] Documentation updated
- [ ] Schema updated (if necessary)
