### PR TITLE
Update profile subpages

### DIFF
--- a/.github/actions/spelling/allow/allow.txt
+++ b/.github/actions/spelling/allow/allow.txt
@@ -1,6 +1,7 @@
 aci
 addref
 allcolors
+Affordance
 breadcrumb
 breadcrumbs
 ccmp

--- a/.github/actions/spelling/allow/allow.txt
+++ b/.github/actions/spelling/allow/allow.txt
@@ -1,5 +1,6 @@
 aci
 allcolors
+Affordance
 breadcrumb
 breadcrumbs
 ccmp

--- a/src/cascadia/TerminalSettingsAppAdapterLib/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettingsAppAdapterLib/TerminalSettings.cpp
@@ -70,6 +70,22 @@ namespace winrt::Microsoft::Terminal::Settings
     }
 
     // Method Description:
+    // - Like CreateForPreview, but overlays the profile's unfocused appearance on top of the
+    //   resolved focused settings so the preview reflects the unfocused appearance. If the profile
+    //   has no unfocused appearance, this behaves like CreateForPreview (the focused appearance).
+    winrt::com_ptr<TerminalSettings> TerminalSettings::CreateForPreviewUnfocused(const Model::CascadiaSettings& appSettings, const Model::Profile& profile)
+    {
+        const auto settings = _CreateWithProfileCommon(appSettings, profile);
+        settings->_UseBackgroundImageForWindow = false;
+        if (const auto& unfocusedAppearance{ profile.UnfocusedAppearance() })
+        {
+            const auto globals = appSettings.GlobalSettings();
+            settings->_ApplyAppearanceSettings(unfocusedAppearance, globals.ColorSchemes(), globals.CurrentTheme());
+        }
+        return settings;
+    }
+
+    // Method Description:
     // - Create a TerminalSettingsCreateResult for the provided profile guid. We'll
     //   use the guid to look up the profile that should be used to
     //   create these TerminalSettings. Then, we'll apply settings contained in the

--- a/src/cascadia/TerminalSettingsAppAdapterLib/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettingsAppAdapterLib/TerminalSettings.cpp
@@ -70,6 +70,22 @@ namespace winrt::Microsoft::Terminal::Settings
     }
 
     // Method Description:
+    // - Like CreateForPreview, but overlays the profile's unfocused appearance on top of the
+    //   resolved focused settings so the preview reflects the unfocused appearance. If the profile
+    //   has no unfocused appearance, this behaves like CreateForPreview (the focused appearance).
+    winrt::com_ptr<TerminalSettings> TerminalSettings::CreateForPreviewUnfocused(const Model::CascadiaSettings& appSettings, const Model::WindowSettings& windowSettings, const Model::Profile& profile)
+    {
+        const auto settings = _CreateWithProfileCommon(appSettings, windowSettings, profile);
+        settings->_UseBackgroundImageForWindow = false;
+        if (const auto& unfocusedAppearance{ profile.UnfocusedAppearance() })
+        {
+            const auto globals = appSettings.GlobalSettings();
+            settings->_ApplyAppearanceSettings(unfocusedAppearance, globals.ColorSchemes(), globals.CurrentTheme(windowSettings));
+        }
+        return settings;
+    }
+
+    // Method Description:
     // - Create a TerminalSettingsCreateResult for the provided profile guid. We'll
     //   use the guid to look up the profile that should be used to
     //   create these TerminalSettings. Then, we'll apply settings contained in the

--- a/src/cascadia/TerminalSettingsAppAdapterLib/TerminalSettings.h
+++ b/src/cascadia/TerminalSettingsAppAdapterLib/TerminalSettings.h
@@ -58,6 +58,7 @@ namespace winrt::Microsoft::Terminal::Settings
         TerminalSettings() = default;
 
         static winrt::com_ptr<TerminalSettings> CreateForPreview(const Model::CascadiaSettings& appSettings, const Model::Profile& profile);
+        static winrt::com_ptr<TerminalSettings> CreateForPreviewUnfocused(const Model::CascadiaSettings& appSettings, const Model::Profile& profile);
 
         static TerminalSettingsCreateResult CreateWithProfile(const Model::CascadiaSettings& appSettings,
                                                               const Model::Profile& profile);

--- a/src/cascadia/TerminalSettingsAppAdapterLib/TerminalSettings.h
+++ b/src/cascadia/TerminalSettingsAppAdapterLib/TerminalSettings.h
@@ -60,6 +60,9 @@ namespace winrt::Microsoft::Terminal::Settings
         static winrt::com_ptr<TerminalSettings> CreateForPreview(const Model::CascadiaSettings& appSettings,
                                                                  const Model::WindowSettings& windowSettings,
                                                                  const Model::Profile& profile);
+        static winrt::com_ptr<TerminalSettings> CreateForPreviewUnfocused(const Model::CascadiaSettings& appSettings,
+                                                                          const Model::WindowSettings& windowSettings,
+                                                                          const Model::Profile& profile);
 
         static TerminalSettingsCreateResult CreateWithProfile(const Model::CascadiaSettings& appSettings,
                                                               const Model::WindowSettings& windowSettings,

--- a/src/cascadia/TerminalSettingsEditor/Appearances.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.cpp
@@ -248,7 +248,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             }
             else if (viewModelProperty == L"DarkColorSchemeName" || viewModelProperty == L"LightColorSchemeName")
             {
-                _NotifyChanges(L"CurrentColorScheme");
+                _NotifyChanges(L"CurrentColorScheme", L"ColorScheme", L"HasColorScheme");
             }
             else if (viewModelProperty == L"CurrentColorScheme")
             {
@@ -1011,6 +1011,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     void AppearanceViewModel::ClearColorScheme()
     {
         ClearDarkColorSchemeName();
+        ClearLightColorSchemeName();
         _NotifyChanges(L"CurrentColorScheme");
     }
 

--- a/src/cascadia/TerminalSettingsEditor/Appearances.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.cpp
@@ -1205,11 +1205,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             Automation::AutomationProperties::SetName(biButton, unbox_value<hstring>(tooltip));
         }
 
-        const auto showAllFontsCheckboxTooltip{ ToolTipService::GetToolTip(ShowAllFontsCheckbox()) };
-        Automation::AutomationProperties::SetFullDescription(ShowAllFontsCheckbox(), unbox_value<hstring>(showAllFontsCheckboxTooltip));
-
-        const auto backgroundImgCheckboxTooltip{ ToolTipService::GetToolTip(UseDesktopImageCheckBox()) };
-        Automation::AutomationProperties::SetFullDescription(UseDesktopImageCheckBox(), unbox_value<hstring>(backgroundImgCheckboxTooltip));
+        Automation::AutomationProperties::SetFullDescription(ShowAllFontsCheckbox(), RS_(L"Profile_FontFaceShowAllFonts/[using:Windows.UI.Xaml.Controls]ToolTipService/ToolTip"));
+        Automation::AutomationProperties::SetFullDescription(UseDesktopImageCheckBox(), RS_(L"Profile_UseDesktopImage/[using:Windows.UI.Xaml.Controls]ToolTipService/ToolTip"));
+        Automation::AutomationProperties::SetName(BackgroundImageBrowse(), RS_(L"Profile_BackgroundImageBrowse/[using:Windows.UI.Xaml.Controls]ToolTipService/ToolTip"));
 
         INITIALIZE_BINDABLE_ENUM_SETTING(IntenseTextStyle, IntenseTextStyle, winrt::Microsoft::Terminal::Settings::Model::IntenseStyle, L"Appearance_IntenseTextStyle", L"Content");
     }

--- a/src/cascadia/TerminalSettingsEditor/Appearances.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.cpp
@@ -232,19 +232,19 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             }
             else if (viewModelProperty == L"Foreground")
             {
-                _NotifyChanges(L"ForegroundPreview");
+                _NotifyChanges(L"ForegroundPreview", L"ForegroundAccessibleName");
             }
             else if (viewModelProperty == L"Background")
             {
-                _NotifyChanges(L"BackgroundPreview");
+                _NotifyChanges(L"BackgroundPreview", L"BackgroundAccessibleName");
             }
             else if (viewModelProperty == L"SelectionBackground")
             {
-                _NotifyChanges(L"SelectionBackgroundPreview");
+                _NotifyChanges(L"SelectionBackgroundPreview", L"SelectionBackgroundAccessibleName");
             }
             else if (viewModelProperty == L"CursorColor")
             {
-                _NotifyChanges(L"CursorColorPreview");
+                _NotifyChanges(L"CursorColorPreview", L"CursorColorAccessibleName");
             }
             else if (viewModelProperty == L"DarkColorSchemeName" || viewModelProperty == L"LightColorSchemeName")
             {
@@ -252,7 +252,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             }
             else if (viewModelProperty == L"CurrentColorScheme")
             {
-                _NotifyChanges(L"ForegroundPreview", L"BackgroundPreview", L"SelectionBackgroundPreview", L"CursorColorPreview");
+                _NotifyChanges(L"ForegroundPreview", L"BackgroundPreview", L"SelectionBackgroundPreview", L"CursorColorPreview", L"ForegroundAccessibleName", L"BackgroundAccessibleName", L"SelectionBackgroundAccessibleName", L"CursorColorAccessibleName");
             }
         });
 
@@ -1145,6 +1145,26 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     Windows::UI::Color AppearanceViewModel::CursorColorPreview() const
     {
         return _getColorPreview(_appearance.CursorColor(), CurrentColorScheme().CursorColor().Color());
+    }
+
+    hstring AppearanceViewModel::ForegroundAccessibleName() const
+    {
+        return FormatAccessibleName(USES_RESOURCE(L"Profile_Foreground/Header"), ColorToHexString(ForegroundPreview()));
+    }
+
+    hstring AppearanceViewModel::BackgroundAccessibleName() const
+    {
+        return FormatAccessibleName(USES_RESOURCE(L"Profile_Background/Header"), ColorToHexString(BackgroundPreview()));
+    }
+
+    hstring AppearanceViewModel::SelectionBackgroundAccessibleName() const
+    {
+        return FormatAccessibleName(USES_RESOURCE(L"Profile_SelectionBackground/Header"), ColorToHexString(SelectionBackgroundPreview()));
+    }
+
+    hstring AppearanceViewModel::CursorColorAccessibleName() const
+    {
+        return FormatAccessibleName(USES_RESOURCE(L"Profile_CursorColor/Header"), ColorToHexString(CursorColorPreview()));
     }
 
     DependencyProperty Appearances::_AppearanceProperty{ nullptr };

--- a/src/cascadia/TerminalSettingsEditor/Appearances.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.cpp
@@ -1014,6 +1014,80 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _NotifyChanges(L"CurrentColorScheme");
     }
 
+    bool AppearanceViewModel::HasSetting(const hstring& name)
+    {
+        const std::wstring_view n{ name };
+        if (n == L"ColorScheme")
+        {
+            return HasDarkColorSchemeName() || HasLightColorSchemeName();
+        }
+#define HANDLE(Setting)        \
+    if (n == L## #Setting)     \
+    {                          \
+        return Has##Setting(); \
+    }
+#define HANDLE_PROJECTED(target, Setting) HANDLE(Setting)
+        APPEARANCE_INHERITABLE_SETTINGS(HANDLE_PROJECTED, HANDLE)
+#undef HANDLE_PROJECTED
+#undef HANDLE
+        return false;
+    }
+
+    void AppearanceViewModel::ClearSetting(const hstring& name)
+    {
+        const std::wstring_view n{ name };
+        if (n == L"ColorScheme")
+        {
+            ClearColorScheme();
+            return;
+        }
+#define HANDLE(Setting)    \
+    if (n == L## #Setting) \
+    {                      \
+        Clear##Setting();  \
+        return;            \
+    }
+#define HANDLE_PROJECTED(target, Setting) HANDLE(Setting)
+        APPEARANCE_INHERITABLE_SETTINGS(HANDLE_PROJECTED, HANDLE)
+#undef HANDLE_PROJECTED
+#undef HANDLE
+    }
+
+    Windows::Foundation::IInspectable AppearanceViewModel::SettingOverrideSource(const hstring& name)
+    {
+        const std::wstring_view n{ name };
+        if (n == L"ColorScheme")
+        {
+            return DarkColorSchemeNameOverrideSource();
+        }
+#define HANDLE(Setting)                   \
+    if (n == L## #Setting)                \
+    {                                     \
+        return Setting##OverrideSource(); \
+    }
+#define HANDLE_PROJECTED(target, Setting) HANDLE(Setting)
+        APPEARANCE_INHERITABLE_SETTINGS(HANDLE_PROJECTED, HANDLE)
+#undef HANDLE_PROJECTED
+#undef HANDLE
+        return nullptr;
+    }
+
+    // Compile-time tripwire. APPEARANCE_INHERITABLE_SETTINGS now generates both the
+    // property accessors and the dispatch above, so those two can no longer drift.
+    // Every inheritable setting must ALSO be projected in Appearances.idl and
+    // given a reset button in the relevant *.xaml - neither of which is
+    // generated from this list. If you add or remove a setting, this count changes and
+    // forces you to revisit those two hand-maintained places before bumping it.
+#define APPEARANCE_COUNT(target, name) +1
+#define APPEARANCE_COUNT_CUSTOM(name) +1
+    static_assert(0 APPEARANCE_INHERITABLE_SETTINGS(APPEARANCE_COUNT, APPEARANCE_COUNT_CUSTOM) == 24,
+                  "The set of inheritable appearance settings changed. Update this count, then make "
+                  "sure the new/removed setting is also reflected in Appearances.idl and in the XAML "
+                  "reset buttons.");
+#undef APPEARANCE_COUNT
+#undef APPEARANCE_COUNT_CUSTOM
+#undef APPEARANCE_INHERITABLE_SETTINGS
+
     Editor::ColorSchemeViewModel AppearanceViewModel::CurrentColorScheme() const
     {
         const auto schemeName{ DarkColorSchemeName() };

--- a/src/cascadia/TerminalSettingsEditor/Appearances.h
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.h
@@ -79,6 +79,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         AppearanceViewModel(const Model::AppearanceConfig& appearance);
 
+        // IInheritableViewModel
+        bool HasSetting(const hstring& name);
+        void ClearSetting(const hstring& name);
+        Windows::Foundation::IInspectable SettingOverrideSource(const hstring& name);
+
         winrt::hstring FontFace() const;
         void FontFace(const winrt::hstring& value);
         bool HasFontFace() const;
@@ -138,31 +143,50 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         WINRT_PROPERTY(bool, IsDefault, false);
 
-        // These settings are not defined in AppearanceConfig, so we grab them
-        // from the source profile itself. The reason we still want them in the
-        // AppearanceViewModel is so we can continue to have the 'Text' grouping
-        // we currently have in xaml, since that grouping has some settings that
-        // are defined in AppearanceConfig and some that are not.
-        OBSERVABLE_PROJECTED_SETTING(_appearance.SourceProfile().FontInfo(), FontSize);
-        OBSERVABLE_PROJECTED_SETTING(_appearance.SourceProfile().FontInfo(), FontWeight);
-        OBSERVABLE_PROJECTED_SETTING(_appearance.SourceProfile().FontInfo(), EnableBuiltinGlyphs);
-        OBSERVABLE_PROJECTED_SETTING(_appearance.SourceProfile().FontInfo(), EnableColorGlyphs);
+// Inheritable appearance settings that expose a reset button.
+// Each entry is wired up automatically in two places:
+//   * the projected property accessors generated immediately below, and
+//   * the HasSetting/ClearSetting/SettingOverrideSource dispatch in Appearances.cpp.
+// To add a new inheritable appearance setting, add exactly ONE line here:
+//   * PROJECTED(target, Name) - a standard setting backed by OBSERVABLE_PROJECTED_SETTING.
+//   * CUSTOM(Name)            - a setting whose Name()/Has##Name()/Clear##Name()/
+//                               Name##OverrideSource() accessors are hand-written above
+//                               (e.g. FontFace, FontAxes). It still participates in
+//                               dispatch, but no property is generated for it here.
+// "ColorScheme" is special-cased in the dispatch (it is backed by the Dark/Light
+// scheme names) and so is intentionally not listed here.
+#define APPEARANCE_INHERITABLE_SETTINGS(PROJECTED, CUSTOM)          \
+    CUSTOM(FontFace)                                                \
+    PROJECTED(_appearance.SourceProfile().FontInfo(), FontSize)     \
+    CUSTOM(LineHeight)                                              \
+    CUSTOM(CellWidth)                                               \
+    PROJECTED(_appearance.SourceProfile().FontInfo(), FontWeight)   \
+    PROJECTED(_appearance.SourceProfile().FontInfo(), EnableBuiltinGlyphs) \
+    PROJECTED(_appearance.SourceProfile().FontInfo(), EnableColorGlyphs)   \
+    CUSTOM(FontAxes)                                                \
+    CUSTOM(FontFeatures)                                            \
+    PROJECTED(_appearance, RetroTerminalEffect)                    \
+    PROJECTED(_appearance, CursorShape)                            \
+    PROJECTED(_appearance, CursorHeight)                           \
+    PROJECTED(_appearance, DarkColorSchemeName)                    \
+    PROJECTED(_appearance, LightColorSchemeName)                   \
+    PROJECTED(_appearance, BackgroundImagePath)                    \
+    PROJECTED(_appearance, BackgroundImageOpacity)                 \
+    PROJECTED(_appearance, BackgroundImageStretchMode)             \
+    PROJECTED(_appearance, BackgroundImageAlignment)               \
+    PROJECTED(_appearance, IntenseTextStyle)                       \
+    PROJECTED(_appearance, AdjustIndistinguishableColors)          \
+    PROJECTED(_appearance, Foreground)                             \
+    PROJECTED(_appearance, Background)                             \
+    PROJECTED(_appearance, SelectionBackground)                    \
+    PROJECTED(_appearance, CursorColor)
 
-        OBSERVABLE_PROJECTED_SETTING(_appearance, RetroTerminalEffect);
-        OBSERVABLE_PROJECTED_SETTING(_appearance, CursorShape);
-        OBSERVABLE_PROJECTED_SETTING(_appearance, CursorHeight);
-        OBSERVABLE_PROJECTED_SETTING(_appearance, DarkColorSchemeName);
-        OBSERVABLE_PROJECTED_SETTING(_appearance, LightColorSchemeName);
-        OBSERVABLE_PROJECTED_SETTING(_appearance, BackgroundImagePath);
-        OBSERVABLE_PROJECTED_SETTING(_appearance, BackgroundImageOpacity);
-        OBSERVABLE_PROJECTED_SETTING(_appearance, BackgroundImageStretchMode);
-        OBSERVABLE_PROJECTED_SETTING(_appearance, BackgroundImageAlignment);
-        OBSERVABLE_PROJECTED_SETTING(_appearance, IntenseTextStyle);
-        OBSERVABLE_PROJECTED_SETTING(_appearance, AdjustIndistinguishableColors);
-        OBSERVABLE_PROJECTED_SETTING(_appearance, Foreground);
-        OBSERVABLE_PROJECTED_SETTING(_appearance, Background);
-        OBSERVABLE_PROJECTED_SETTING(_appearance, SelectionBackground);
-        OBSERVABLE_PROJECTED_SETTING(_appearance, CursorColor);
+#define APPEARANCE_GEN_PROJECTED(target, name) OBSERVABLE_PROJECTED_SETTING(target, name);
+#define APPEARANCE_GEN_CUSTOM(name)
+        APPEARANCE_INHERITABLE_SETTINGS(APPEARANCE_GEN_PROJECTED, APPEARANCE_GEN_CUSTOM)
+#undef APPEARANCE_GEN_PROJECTED
+#undef APPEARANCE_GEN_CUSTOM
+
         WINRT_OBSERVABLE_PROPERTY(Windows::Foundation::Collections::IObservableVector<Editor::ColorSchemeViewModel>, SchemesList, _propertyChangedHandlers, nullptr);
 
     private:

--- a/src/cascadia/TerminalSettingsEditor/Appearances.h
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.h
@@ -155,30 +155,30 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 //                               dispatch, but no property is generated for it here.
 // "ColorScheme" is special-cased in the dispatch (it is backed by the Dark/Light
 // scheme names) and so is intentionally not listed here.
-#define APPEARANCE_INHERITABLE_SETTINGS(PROJECTED, CUSTOM)          \
-    CUSTOM(FontFace)                                                \
-    PROJECTED(_appearance.SourceProfile().FontInfo(), FontSize)     \
-    CUSTOM(LineHeight)                                              \
-    CUSTOM(CellWidth)                                               \
-    PROJECTED(_appearance.SourceProfile().FontInfo(), FontWeight)   \
+#define APPEARANCE_INHERITABLE_SETTINGS(PROJECTED, CUSTOM)                 \
+    CUSTOM(FontFace)                                                       \
+    PROJECTED(_appearance.SourceProfile().FontInfo(), FontSize)            \
+    CUSTOM(LineHeight)                                                     \
+    CUSTOM(CellWidth)                                                      \
+    PROJECTED(_appearance.SourceProfile().FontInfo(), FontWeight)          \
     PROJECTED(_appearance.SourceProfile().FontInfo(), EnableBuiltinGlyphs) \
     PROJECTED(_appearance.SourceProfile().FontInfo(), EnableColorGlyphs)   \
-    CUSTOM(FontAxes)                                                \
-    CUSTOM(FontFeatures)                                            \
-    PROJECTED(_appearance, RetroTerminalEffect)                    \
-    PROJECTED(_appearance, CursorShape)                            \
-    PROJECTED(_appearance, CursorHeight)                           \
-    PROJECTED(_appearance, DarkColorSchemeName)                    \
-    PROJECTED(_appearance, LightColorSchemeName)                   \
-    PROJECTED(_appearance, BackgroundImagePath)                    \
-    PROJECTED(_appearance, BackgroundImageOpacity)                 \
-    PROJECTED(_appearance, BackgroundImageStretchMode)             \
-    PROJECTED(_appearance, BackgroundImageAlignment)               \
-    PROJECTED(_appearance, IntenseTextStyle)                       \
-    PROJECTED(_appearance, AdjustIndistinguishableColors)          \
-    PROJECTED(_appearance, Foreground)                             \
-    PROJECTED(_appearance, Background)                             \
-    PROJECTED(_appearance, SelectionBackground)                    \
+    CUSTOM(FontAxes)                                                       \
+    CUSTOM(FontFeatures)                                                   \
+    PROJECTED(_appearance, RetroTerminalEffect)                            \
+    PROJECTED(_appearance, CursorShape)                                    \
+    PROJECTED(_appearance, CursorHeight)                                   \
+    PROJECTED(_appearance, DarkColorSchemeName)                            \
+    PROJECTED(_appearance, LightColorSchemeName)                           \
+    PROJECTED(_appearance, BackgroundImagePath)                            \
+    PROJECTED(_appearance, BackgroundImageOpacity)                         \
+    PROJECTED(_appearance, BackgroundImageStretchMode)                     \
+    PROJECTED(_appearance, BackgroundImageAlignment)                       \
+    PROJECTED(_appearance, IntenseTextStyle)                               \
+    PROJECTED(_appearance, AdjustIndistinguishableColors)                  \
+    PROJECTED(_appearance, Foreground)                                     \
+    PROJECTED(_appearance, Background)                                     \
+    PROJECTED(_appearance, SelectionBackground)                            \
     PROJECTED(_appearance, CursorColor)
 
 #define APPEARANCE_GEN_PROJECTED(target, name) OBSERVABLE_PROJECTED_SETTING(target, name);

--- a/src/cascadia/TerminalSettingsEditor/Appearances.h
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.h
@@ -141,6 +141,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         Windows::UI::Color SelectionBackgroundPreview() const;
         Windows::UI::Color CursorColorPreview() const;
 
+        hstring ForegroundAccessibleName() const;
+        hstring BackgroundAccessibleName() const;
+        hstring SelectionBackgroundAccessibleName() const;
+        hstring CursorColorAccessibleName() const;
+
         WINRT_PROPERTY(bool, IsDefault, false);
 
 // Inheritable appearance settings that expose a reset button.

--- a/src/cascadia/TerminalSettingsEditor/Appearances.idl
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.idl
@@ -31,7 +31,7 @@ namespace Microsoft.Terminal.Settings.Editor
         String AutomationName { get; };
     }
 
-    runtimeclass AppearanceViewModel : Windows.UI.Xaml.Data.INotifyPropertyChanged
+    runtimeclass AppearanceViewModel : Windows.UI.Xaml.Data.INotifyPropertyChanged, IInheritableViewModel
     {
         Boolean IsDefault;
 

--- a/src/cascadia/TerminalSettingsEditor/Appearances.idl
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.idl
@@ -53,6 +53,11 @@ namespace Microsoft.Terminal.Settings.Editor
         Windows.UI.Color SelectionBackgroundPreview { get; };
         Windows.UI.Color CursorColorPreview { get; };
 
+        String ForegroundAccessibleName { get; };
+        String BackgroundAccessibleName { get; };
+        String SelectionBackgroundAccessibleName { get; };
+        String CursorColorAccessibleName { get; };
+
         String MissingFontFaces { get; };
         String ProportionalFontFaces { get; };
         Boolean HasPowerlineCharacters { get; };

--- a/src/cascadia/TerminalSettingsEditor/Appearances.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.xaml
@@ -72,8 +72,7 @@
         <TextBlock x:Uid="Profile_TextHeader"
                    Margin="0,0,0,4"
                    Style="{StaticResource TextBlockSubHeaderStyle}" />
-        <StackPanel Spacing="2"
-                    Style="{StaticResource PivotStackStyle}">
+        <StackPanel Style="{StaticResource SettingsStackStyle}">
             <!--  Color Scheme  -->
             <!--  This currently only display the Dark color scheme, even if the user has a pair of schemes set.  -->
             <local:SettingsExpander x:Name="ColorScheme"
@@ -267,50 +266,58 @@
                 </local:SettingsExpander.ItemsHeader>
             </local:SettingsExpander>
             <!--  Font Face  -->
-            <local:SettingsCard x:Name="FontFaceContainer"
-                                x:Uid="Profile_FontFace"
-                                Visibility="{x:Bind Appearance.IsDefault, Mode=OneWay}">
+            <!--
+                Grouped with its diagnostic cards so collapsed warnings don't add phantom spacing.
+                Manually adding Margin to work around WinUI 2 adding spacing for hidden elements.
+            -->
+            <StackPanel>
+                <local:SettingsCard x:Name="FontFaceContainer"
+                                    x:Uid="Profile_FontFace"
+                                    Visibility="{x:Bind Appearance.IsDefault, Mode=OneWay}">
 
-                <StackPanel Margin="0,8,0,0">
-                    <AutoSuggestBox x:Uid="Profile_FontFaceBox"
-                                    GotFocus="FontFaceBox_GotFocus"
-                                    ItemTemplate="{StaticResource FontFaceComboBoxItemTemplate}"
-                                    ItemsSource="{x:Bind FilteredFontList, Mode=OneWay}"
-                                    LostFocus="FontFaceBox_LostFocus"
-                                    QuerySubmitted="FontFaceBox_QuerySubmitted"
-                                    Text="{x:Bind Appearance.FontFace, Mode=OneWay}"
-                                    TextBoxStyle="{StaticResource TextBoxSettingStyle}"
-                                    TextChanged="FontFaceBox_TextChanged"
-                                    UpdateTextOnSelect="False" />
-                    <CheckBox x:Name="ShowAllFontsCheckbox"
-                              x:Uid="Profile_FontFaceShowAllFonts"
-                              IsChecked="{x:Bind ShowAllFonts, Mode=TwoWay}" />
-                </StackPanel>
-            </local:SettingsCard>
-            <local:SettingsCard x:Name="MissingFontFaces"
-                                x:Uid="Profile_MissingFontFaces"
-                                Background="{ThemeResource SettingContainerErrorSeverityBackgroundBrush}"
-                                Description="{x:Bind Appearance.MissingFontFaces, Mode=OneWay}"
-                                Visibility="{x:Bind mtu:Converters.StringNotEmptyToVisibility(Appearance.MissingFontFaces), Mode=OneWay}">
-                <local:SettingsCard.HeaderIcon>
-                    <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                              FontSize="{StaticResource SettingContainerIconFontSize}"
-                              Foreground="{ThemeResource SettingContainerErrorSeverityIconBackground}"
-                              Glyph="{StaticResource SettingContainerErrorIconGlyph}" />
-                </local:SettingsCard.HeaderIcon>
-            </local:SettingsCard>
-            <local:SettingsCard x:Name="ProportionalFontFaces"
-                                x:Uid="Profile_ProportionalFontFaces"
-                                Background="{ThemeResource SettingContainerWarningSeverityBackgroundBrush}"
-                                Description="{x:Bind Appearance.ProportionalFontFaces, Mode=OneWay}"
-                                Visibility="{x:Bind mtu:Converters.StringNotEmptyToVisibility(Appearance.ProportionalFontFaces), Mode=OneWay}">
-                <local:SettingsCard.HeaderIcon>
-                    <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                              FontSize="{StaticResource SettingContainerIconFontSize}"
-                              Foreground="{ThemeResource SettingContainerWarningSeverityIconBackground}"
-                              Glyph="{StaticResource SettingContainerWarningIconGlyph}" />
-                </local:SettingsCard.HeaderIcon>
-            </local:SettingsCard>
+                    <StackPanel Margin="0,8,0,0">
+                        <AutoSuggestBox x:Uid="Profile_FontFaceBox"
+                                        GotFocus="FontFaceBox_GotFocus"
+                                        ItemTemplate="{StaticResource FontFaceComboBoxItemTemplate}"
+                                        ItemsSource="{x:Bind FilteredFontList, Mode=OneWay}"
+                                        LostFocus="FontFaceBox_LostFocus"
+                                        QuerySubmitted="FontFaceBox_QuerySubmitted"
+                                        Text="{x:Bind Appearance.FontFace, Mode=OneWay}"
+                                        TextBoxStyle="{StaticResource TextBoxSettingStyle}"
+                                        TextChanged="FontFaceBox_TextChanged"
+                                        UpdateTextOnSelect="False" />
+                        <CheckBox x:Name="ShowAllFontsCheckbox"
+                                  x:Uid="Profile_FontFaceShowAllFonts"
+                                  IsChecked="{x:Bind ShowAllFonts, Mode=TwoWay}" />
+                    </StackPanel>
+                </local:SettingsCard>
+                <local:SettingsCard x:Name="MissingFontFaces"
+                                    x:Uid="Profile_MissingFontFaces"
+                                    Margin="0,6,0,0"
+                                    Background="{ThemeResource SettingContainerErrorSeverityBackgroundBrush}"
+                                    Description="{x:Bind Appearance.MissingFontFaces, Mode=OneWay}"
+                                    Visibility="{x:Bind mtu:Converters.StringNotEmptyToVisibility(Appearance.MissingFontFaces), Mode=OneWay}">
+                    <local:SettingsCard.HeaderIcon>
+                        <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                  FontSize="{StaticResource SettingContainerIconFontSize}"
+                                  Foreground="{ThemeResource SettingContainerErrorSeverityIconBackground}"
+                                  Glyph="{StaticResource SettingContainerErrorIconGlyph}" />
+                    </local:SettingsCard.HeaderIcon>
+                </local:SettingsCard>
+                <local:SettingsCard x:Name="ProportionalFontFaces"
+                                    x:Uid="Profile_ProportionalFontFaces"
+                                    Margin="0,6,0,0"
+                                    Background="{ThemeResource SettingContainerWarningSeverityBackgroundBrush}"
+                                    Description="{x:Bind Appearance.ProportionalFontFaces, Mode=OneWay}"
+                                    Visibility="{x:Bind mtu:Converters.StringNotEmptyToVisibility(Appearance.ProportionalFontFaces), Mode=OneWay}">
+                    <local:SettingsCard.HeaderIcon>
+                        <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                  FontSize="{StaticResource SettingContainerIconFontSize}"
+                                  Foreground="{ThemeResource SettingContainerWarningSeverityIconBackground}"
+                                  Glyph="{StaticResource SettingContainerWarningIconGlyph}" />
+                    </local:SettingsCard.HeaderIcon>
+                </local:SettingsCard>
+            </StackPanel>
 
             <!--  Font Size  -->
             <local:SettingsCard x:Name="FontSize"
@@ -481,8 +488,7 @@
         <!--  Grouping: Cursor  -->
         <TextBlock x:Uid="Profile_CursorHeader"
                    Style="{StaticResource TextBlockSubHeaderStyle}" />
-        <StackPanel Spacing="2"
-                    Style="{StaticResource PivotStackStyle}">
+        <StackPanel Style="{StaticResource SettingsStackStyle}">
             <!--  Cursor Shape  -->
             <local:SettingsCard x:Name="CursorShape"
                                 x:Uid="Profile_CursorShape">
@@ -496,7 +502,7 @@
             <!--  Cursor Height  -->
             <local:SettingsCard x:Name="CursorHeight"
                                 x:Uid="Profile_CursorHeight"
-                                Visibility="{x:Bind IsVintageCursor, Mode=OneWay}">
+                                IsEnabled="{x:Bind IsVintageCursor, Mode=OneWay}">
                 <Grid Style="{StaticResource CustomSliderControlGridStyle}">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
@@ -535,13 +541,13 @@
         <!--  Grouping: Background  -->
         <TextBlock x:Uid="Profile_BackgroundHeader"
                    Style="{StaticResource TextBlockSubHeaderStyle}" />
-        <StackPanel Spacing="2"
-                    Style="{StaticResource PivotStackStyle}">
+        <StackPanel Style="{StaticResource SettingsStackStyle}">
             <!--  Background Image  -->
             <local:SettingsExpander x:Name="BackgroundImageContainer"
                                     x:Uid="Profile_BackgroundImage">
                 <local:SettingsExpander.Content>
-                    <StackPanel Orientation="Vertical">
+                    <StackPanel Margin="0,8,0,0"
+                                Orientation="Vertical">
                         <StackPanel Orientation="Horizontal"
                                     Spacing="8">
                             <TextBox x:Uid="Profile_BackgroundImageBox"
@@ -780,8 +786,7 @@
         <!--  Grouping: Text Formatting  -->
         <TextBlock x:Uid="Appearance_TextFormattingHeader"
                    Style="{StaticResource TextBlockSubHeaderStyle}" />
-        <StackPanel Spacing="2"
-                    Style="{StaticResource PivotStackStyle}">
+        <StackPanel Style="{StaticResource SettingsStackStyle}">
             <!--  Intense is bold, bright  -->
             <local:SettingsCard x:Name="IntenseTextStyle"
                                 x:Uid="Appearance_IntenseTextStyle">

--- a/src/cascadia/TerminalSettingsEditor/Appearances.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.xaml
@@ -72,7 +72,12 @@
         <TextBlock x:Uid="Profile_TextHeader"
                    Margin="0,0,0,4"
                    Style="{StaticResource TextBlockSubHeaderStyle}" />
-        <StackPanel Style="{StaticResource SettingsStackStyle}">
+        <!--
+            Spacing is intentionally 0 to work around WinUI 2's StackPanel.Spacing reserving space for
+            hidden items. Instead apply a margin to each item.
+        -->
+        <StackPanel Spacing="0"
+                    Style="{StaticResource SettingsStackStyle}">
             <!--  Color Scheme  -->
             <!--  This currently only display the Dark color scheme, even if the user has a pair of schemes set.  -->
             <local:SettingsExpander x:Name="ColorScheme"
@@ -81,129 +86,129 @@
                 <local:SettingsExpander.Content>
                     <StackPanel Style="{StaticResource SettingControlStackStyle}">
                         <ComboBox Padding="4"
-                              ItemsSource="{x:Bind Appearance.SchemesList, Mode=OneWay}"
-                              SelectedItem="{x:Bind Appearance.CurrentColorScheme, Mode=TwoWay}"
-                              Style="{StaticResource ComboBoxSettingStyle}">
-                        <ComboBox.ItemTemplate>
-                            <DataTemplate x:DataType="local:ColorSchemeViewModel">
-                                <Grid Grid.Column="0"
-                                      Padding="8"
-                                      VerticalAlignment="Center"
-                                      Background="{x:Bind mtu:Converters.ColorToBrush(BackgroundColor.Color), Mode=OneWay}"
-                                      ColumnSpacing="1"
-                                      CornerRadius="2"
-                                      RowSpacing="1">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="Auto" />
-                                    </Grid.ColumnDefinitions>
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="Auto" />
-                                        <RowDefinition Height="Auto" />
-                                    </Grid.RowDefinitions>
-                                    <ContentControl Grid.Row="0"
-                                                    Grid.Column="0"
-                                                    Content="{x:Bind ColorEntryAt(0), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="0"
-                                                    Grid.Column="1"
-                                                    Content="{x:Bind ColorEntryAt(1), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="0"
-                                                    Grid.Column="2"
-                                                    Content="{x:Bind ColorEntryAt(2), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="0"
-                                                    Grid.Column="3"
-                                                    Content="{x:Bind ColorEntryAt(3), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="0"
-                                                    Grid.Column="4"
-                                                    Content="{x:Bind ColorEntryAt(4), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="0"
-                                                    Grid.Column="5"
-                                                    Content="{x:Bind ColorEntryAt(5), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="0"
-                                                    Grid.Column="6"
-                                                    Content="{x:Bind ColorEntryAt(6), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="0"
-                                                    Grid.Column="7"
-                                                    Content="{x:Bind ColorEntryAt(7), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="1"
-                                                    Grid.Column="0"
-                                                    Content="{x:Bind ColorEntryAt(8), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="1"
-                                                    Grid.Column="1"
-                                                    Content="{x:Bind ColorEntryAt(9), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="1"
-                                                    Grid.Column="2"
-                                                    Content="{x:Bind ColorEntryAt(10), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="1"
-                                                    Grid.Column="3"
-                                                    Content="{x:Bind ColorEntryAt(11), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="1"
-                                                    Grid.Column="4"
-                                                    Content="{x:Bind ColorEntryAt(12), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="1"
-                                                    Grid.Column="5"
-                                                    Content="{x:Bind ColorEntryAt(13), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="1"
-                                                    Grid.Column="6"
-                                                    Content="{x:Bind ColorEntryAt(14), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="1"
-                                                    Grid.Column="7"
-                                                    Content="{x:Bind ColorEntryAt(15), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <TextBlock Grid.RowSpan="2"
-                                               Grid.Column="8"
-                                               MaxWidth="192"
-                                               Margin="4,0,4,0"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               AutomationProperties.AccessibilityView="Raw"
-                                               FontFamily="Cascadia Code"
-                                               Foreground="{x:Bind mtu:Converters.ColorToBrush(ForegroundColor.Color), Mode=OneWay}"
-                                               Text="{x:Bind Name, Mode=OneWay}"
-                                               TextTrimming="WordEllipsis"
-                                               ToolTipService.ToolTip="{x:Bind Name, Mode=OneWay}" />
-                                </Grid>
-                            </DataTemplate>
-                        </ComboBox.ItemTemplate>
-                    </ComboBox>
+                                  ItemsSource="{x:Bind Appearance.SchemesList, Mode=OneWay}"
+                                  SelectedItem="{x:Bind Appearance.CurrentColorScheme, Mode=TwoWay}"
+                                  Style="{StaticResource ComboBoxSettingStyle}">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate x:DataType="local:ColorSchemeViewModel">
+                                    <Grid Grid.Column="0"
+                                          Padding="8"
+                                          VerticalAlignment="Center"
+                                          Background="{x:Bind mtu:Converters.ColorToBrush(BackgroundColor.Color), Mode=OneWay}"
+                                          ColumnSpacing="1"
+                                          CornerRadius="2"
+                                          RowSpacing="1">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                        </Grid.RowDefinitions>
+                                        <ContentControl Grid.Row="0"
+                                                        Grid.Column="0"
+                                                        Content="{x:Bind ColorEntryAt(0), Mode=OneWay}"
+                                                        ContentTemplate="{StaticResource ColorChipTemplate}"
+                                                        IsTabStop="False" />
+                                        <ContentControl Grid.Row="0"
+                                                        Grid.Column="1"
+                                                        Content="{x:Bind ColorEntryAt(1), Mode=OneWay}"
+                                                        ContentTemplate="{StaticResource ColorChipTemplate}"
+                                                        IsTabStop="False" />
+                                        <ContentControl Grid.Row="0"
+                                                        Grid.Column="2"
+                                                        Content="{x:Bind ColorEntryAt(2), Mode=OneWay}"
+                                                        ContentTemplate="{StaticResource ColorChipTemplate}"
+                                                        IsTabStop="False" />
+                                        <ContentControl Grid.Row="0"
+                                                        Grid.Column="3"
+                                                        Content="{x:Bind ColorEntryAt(3), Mode=OneWay}"
+                                                        ContentTemplate="{StaticResource ColorChipTemplate}"
+                                                        IsTabStop="False" />
+                                        <ContentControl Grid.Row="0"
+                                                        Grid.Column="4"
+                                                        Content="{x:Bind ColorEntryAt(4), Mode=OneWay}"
+                                                        ContentTemplate="{StaticResource ColorChipTemplate}"
+                                                        IsTabStop="False" />
+                                        <ContentControl Grid.Row="0"
+                                                        Grid.Column="5"
+                                                        Content="{x:Bind ColorEntryAt(5), Mode=OneWay}"
+                                                        ContentTemplate="{StaticResource ColorChipTemplate}"
+                                                        IsTabStop="False" />
+                                        <ContentControl Grid.Row="0"
+                                                        Grid.Column="6"
+                                                        Content="{x:Bind ColorEntryAt(6), Mode=OneWay}"
+                                                        ContentTemplate="{StaticResource ColorChipTemplate}"
+                                                        IsTabStop="False" />
+                                        <ContentControl Grid.Row="0"
+                                                        Grid.Column="7"
+                                                        Content="{x:Bind ColorEntryAt(7), Mode=OneWay}"
+                                                        ContentTemplate="{StaticResource ColorChipTemplate}"
+                                                        IsTabStop="False" />
+                                        <ContentControl Grid.Row="1"
+                                                        Grid.Column="0"
+                                                        Content="{x:Bind ColorEntryAt(8), Mode=OneWay}"
+                                                        ContentTemplate="{StaticResource ColorChipTemplate}"
+                                                        IsTabStop="False" />
+                                        <ContentControl Grid.Row="1"
+                                                        Grid.Column="1"
+                                                        Content="{x:Bind ColorEntryAt(9), Mode=OneWay}"
+                                                        ContentTemplate="{StaticResource ColorChipTemplate}"
+                                                        IsTabStop="False" />
+                                        <ContentControl Grid.Row="1"
+                                                        Grid.Column="2"
+                                                        Content="{x:Bind ColorEntryAt(10), Mode=OneWay}"
+                                                        ContentTemplate="{StaticResource ColorChipTemplate}"
+                                                        IsTabStop="False" />
+                                        <ContentControl Grid.Row="1"
+                                                        Grid.Column="3"
+                                                        Content="{x:Bind ColorEntryAt(11), Mode=OneWay}"
+                                                        ContentTemplate="{StaticResource ColorChipTemplate}"
+                                                        IsTabStop="False" />
+                                        <ContentControl Grid.Row="1"
+                                                        Grid.Column="4"
+                                                        Content="{x:Bind ColorEntryAt(12), Mode=OneWay}"
+                                                        ContentTemplate="{StaticResource ColorChipTemplate}"
+                                                        IsTabStop="False" />
+                                        <ContentControl Grid.Row="1"
+                                                        Grid.Column="5"
+                                                        Content="{x:Bind ColorEntryAt(13), Mode=OneWay}"
+                                                        ContentTemplate="{StaticResource ColorChipTemplate}"
+                                                        IsTabStop="False" />
+                                        <ContentControl Grid.Row="1"
+                                                        Grid.Column="6"
+                                                        Content="{x:Bind ColorEntryAt(14), Mode=OneWay}"
+                                                        ContentTemplate="{StaticResource ColorChipTemplate}"
+                                                        IsTabStop="False" />
+                                        <ContentControl Grid.Row="1"
+                                                        Grid.Column="7"
+                                                        Content="{x:Bind ColorEntryAt(15), Mode=OneWay}"
+                                                        ContentTemplate="{StaticResource ColorChipTemplate}"
+                                                        IsTabStop="False" />
+                                        <TextBlock Grid.RowSpan="2"
+                                                   Grid.Column="8"
+                                                   MaxWidth="192"
+                                                   Margin="4,0,4,0"
+                                                   HorizontalAlignment="Center"
+                                                   VerticalAlignment="Center"
+                                                   AutomationProperties.AccessibilityView="Raw"
+                                                   FontFamily="Cascadia Code"
+                                                   Foreground="{x:Bind mtu:Converters.ColorToBrush(ForegroundColor.Color), Mode=OneWay}"
+                                                   Text="{x:Bind Name, Mode=OneWay}"
+                                                   TextTrimming="WordEllipsis"
+                                                   ToolTipService.ToolTip="{x:Bind Name, Mode=OneWay}" />
+                                    </Grid>
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
                         <local:SettingResetButton SettingName="ColorScheme"
                                                   Target="{x:Bind Appearance}" />
                     </StackPanel>
@@ -284,159 +289,163 @@
                     </ContentPresenter>
                 </local:SettingsExpander.ItemsHeader>
             </local:SettingsExpander>
-            <!--  Font Face  -->
             <!--
-                Grouped with its diagnostic cards so collapsed warnings don't add phantom spacing.
-                Manually adding Margin to work around WinUI 2 adding spacing for hidden elements.
+                The cards below only apply to the default appearance.
+                Group them in a single visibility-gated group to avoid phantom spacing when collapsed.
             -->
-            <StackPanel>
-                <local:SettingsCard x:Name="FontFaceContainer"
-                                    x:Uid="Profile_FontFace"
-                                    Visibility="{x:Bind Appearance.IsDefault, Mode=OneWay}">
-
-                    <StackPanel Margin="0,8,0,0">
-                        <StackPanel Style="{StaticResource SettingControlStackStyle}">
-                            <AutoSuggestBox x:Uid="Profile_FontFaceBox"
-                                            GotFocus="FontFaceBox_GotFocus"
-                                            ItemTemplate="{StaticResource FontFaceComboBoxItemTemplate}"
-                                            ItemsSource="{x:Bind FilteredFontList, Mode=OneWay}"
-                                            LostFocus="FontFaceBox_LostFocus"
-                                            QuerySubmitted="FontFaceBox_QuerySubmitted"
-                                            Text="{x:Bind Appearance.FontFace, Mode=OneWay}"
-                                            TextBoxStyle="{StaticResource TextBoxSettingStyle}"
-                                            TextChanged="FontFaceBox_TextChanged"
-                                            UpdateTextOnSelect="False" />
-                            <local:SettingResetButton SettingName="FontFace"
-                                                      Target="{x:Bind Appearance}" />
-                        </StackPanel>
-                        <CheckBox x:Name="ShowAllFontsCheckbox"
-                                  x:Uid="Profile_FontFaceShowAllFonts"
-                                  IsChecked="{x:Bind ShowAllFonts, Mode=TwoWay}" />
-                    </StackPanel>
-                </local:SettingsCard>
-                <local:SettingsCard x:Name="MissingFontFaces"
-                                    x:Uid="Profile_MissingFontFaces"
-                                    Margin="0,6,0,0"
-                                    Background="{ThemeResource SettingContainerErrorSeverityBackgroundBrush}"
-                                    Description="{x:Bind Appearance.MissingFontFaces, Mode=OneWay}"
-                                    Visibility="{x:Bind mtu:Converters.StringNotEmptyToVisibility(Appearance.MissingFontFaces), Mode=OneWay}">
-                    <local:SettingsCard.HeaderIcon>
-                        <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                  FontSize="{StaticResource SettingContainerIconFontSize}"
-                                  Foreground="{ThemeResource SettingContainerErrorSeverityIconBackground}"
-                                  Glyph="{StaticResource SettingContainerErrorIconGlyph}" />
-                    </local:SettingsCard.HeaderIcon>
-                </local:SettingsCard>
-                <local:SettingsCard x:Name="ProportionalFontFaces"
-                                    x:Uid="Profile_ProportionalFontFaces"
-                                    Margin="0,6,0,0"
-                                    Background="{ThemeResource SettingContainerWarningSeverityBackgroundBrush}"
-                                    Description="{x:Bind Appearance.ProportionalFontFaces, Mode=OneWay}"
-                                    Visibility="{x:Bind mtu:Converters.StringNotEmptyToVisibility(Appearance.ProportionalFontFaces), Mode=OneWay}">
-                    <local:SettingsCard.HeaderIcon>
-                        <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                  FontSize="{StaticResource SettingContainerIconFontSize}"
-                                  Foreground="{ThemeResource SettingContainerWarningSeverityIconBackground}"
-                                  Glyph="{StaticResource SettingContainerWarningIconGlyph}" />
-                    </local:SettingsCard.HeaderIcon>
-                </local:SettingsCard>
-            </StackPanel>
-
-            <!--  Font Size  -->
-            <local:SettingsCard x:Name="FontSize"
-                                x:Uid="Profile_FontSize"
-                                Visibility="{x:Bind Appearance.IsDefault, Mode=OneWay}">
-                <StackPanel Style="{StaticResource SettingControlStackStyle}">
-                    <muxc:NumberBox x:Name="_fontSizeBox"
-                                    x:Uid="Profile_FontSizeBox"
-                                    LargeChange="10"
-                                    Maximum="128"
-                                    Minimum="1"
-                                    SmallChange="1"
-                                    Style="{StaticResource NumberBoxSettingStyle}"
-                                    Value="{x:Bind Appearance.FontSize, Mode=TwoWay}" />
-                    <local:SettingResetButton SettingName="FontSize"
-                                              Target="{x:Bind Appearance}" />
-                </StackPanel>
-            </local:SettingsCard>
-
-            <!--  Line Height  -->
-            <local:SettingsCard x:Name="LineHeight"
-                                x:Uid="Profile_LineHeight"
-                                Visibility="{x:Bind Appearance.IsDefault, Mode=OneWay}">
-                <StackPanel Style="{StaticResource SettingControlStackStyle}">
-                    <muxc:NumberBox x:Name="_lineHeightBox"
-                                    x:Uid="Profile_LineHeightBox"
-                                    LargeChange="0.1"
-                                    Maximum="10"
-                                    Minimum="0.1"
-                                    SmallChange="0.1"
-                                    Style="{StaticResource NumberBoxSettingStyle}"
-                                    Value="{x:Bind Appearance.LineHeight, Mode=TwoWay}" />
-                    <local:SettingResetButton SettingName="LineHeight"
-                                              Target="{x:Bind Appearance}" />
-                </StackPanel>
-            </local:SettingsCard>
-
-            <!--  Cell Width  -->
-            <local:SettingsCard x:Name="CellWidth"
-                                x:Uid="Profile_CellWidth"
-                                Visibility="{x:Bind Appearance.IsDefault, Mode=OneWay}">
-                <StackPanel Style="{StaticResource SettingControlStackStyle}">
-                    <muxc:NumberBox x:Name="_cellWidthBox"
-                                    x:Uid="Profile_CellWidthBox"
-                                    LargeChange="0.1"
-                                    Maximum="10"
-                                    Minimum="0.1"
-                                    SmallChange="0.1"
-                                    Style="{StaticResource NumberBoxSettingStyle}"
-                                    Value="{x:Bind Appearance.CellWidth, Mode=TwoWay}" />
-                    <local:SettingResetButton SettingName="CellWidth"
-                                              Target="{x:Bind Appearance}" />
-                </StackPanel>
-            </local:SettingsCard>
-
-            <!--  Font Weight  -->
-            <local:SettingsCard x:Name="FontWeight"
-                                x:Uid="Profile_FontWeight"
-                                Visibility="{x:Bind Appearance.IsDefault, Mode=OneWay}">
+            <StackPanel Margin="0,4,0,0"
+                        Style="{StaticResource SettingsStackStyle}"
+                        Visibility="{x:Bind Appearance.IsDefault, Mode=OneWay}">
+                <!--  Font Face  -->
+                <!--
+                    Grouped with its diagnostic cards so collapsed warnings don't add phantom spacing.
+                    Manually adding Margin to work around WinUI 2 adding spacing for hidden elements.
+                -->
                 <StackPanel>
+                    <local:SettingsCard x:Name="FontFaceContainer"
+                                        x:Uid="Profile_FontFace">
+
+                        <StackPanel Margin="0,8,0,0">
+                            <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                                <AutoSuggestBox x:Uid="Profile_FontFaceBox"
+                                                GotFocus="FontFaceBox_GotFocus"
+                                                ItemTemplate="{StaticResource FontFaceComboBoxItemTemplate}"
+                                                ItemsSource="{x:Bind FilteredFontList, Mode=OneWay}"
+                                                LostFocus="FontFaceBox_LostFocus"
+                                                QuerySubmitted="FontFaceBox_QuerySubmitted"
+                                                Text="{x:Bind Appearance.FontFace, Mode=OneWay}"
+                                                TextBoxStyle="{StaticResource TextBoxSettingStyle}"
+                                                TextChanged="FontFaceBox_TextChanged"
+                                                UpdateTextOnSelect="False" />
+                                <local:SettingResetButton SettingName="FontFace"
+                                                          Target="{x:Bind Appearance}" />
+                            </StackPanel>
+                            <CheckBox x:Name="ShowAllFontsCheckbox"
+                                      x:Uid="Profile_FontFaceShowAllFonts"
+                                      IsChecked="{x:Bind ShowAllFonts, Mode=TwoWay}" />
+                        </StackPanel>
+                    </local:SettingsCard>
+                    <local:SettingsCard x:Name="MissingFontFaces"
+                                        x:Uid="Profile_MissingFontFaces"
+                                        Margin="0,6,0,0"
+                                        Background="{ThemeResource SettingContainerErrorSeverityBackgroundBrush}"
+                                        Description="{x:Bind Appearance.MissingFontFaces, Mode=OneWay}"
+                                        Visibility="{x:Bind mtu:Converters.StringNotEmptyToVisibility(Appearance.MissingFontFaces), Mode=OneWay}">
+                        <local:SettingsCard.HeaderIcon>
+                            <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                      FontSize="{StaticResource SettingContainerIconFontSize}"
+                                      Foreground="{ThemeResource SettingContainerErrorSeverityIconBackground}"
+                                      Glyph="{StaticResource SettingContainerErrorIconGlyph}" />
+                        </local:SettingsCard.HeaderIcon>
+                    </local:SettingsCard>
+                    <local:SettingsCard x:Name="ProportionalFontFaces"
+                                        x:Uid="Profile_ProportionalFontFaces"
+                                        Margin="0,6,0,0"
+                                        Background="{ThemeResource SettingContainerWarningSeverityBackgroundBrush}"
+                                        Description="{x:Bind Appearance.ProportionalFontFaces, Mode=OneWay}"
+                                        Visibility="{x:Bind mtu:Converters.StringNotEmptyToVisibility(Appearance.ProportionalFontFaces), Mode=OneWay}">
+                        <local:SettingsCard.HeaderIcon>
+                            <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                      FontSize="{StaticResource SettingContainerIconFontSize}"
+                                      Foreground="{ThemeResource SettingContainerWarningSeverityIconBackground}"
+                                      Glyph="{StaticResource SettingContainerWarningIconGlyph}" />
+                        </local:SettingsCard.HeaderIcon>
+                    </local:SettingsCard>
+                </StackPanel>
+
+                <!--  Font Size  -->
+                <local:SettingsCard x:Name="FontSize"
+                                    x:Uid="Profile_FontSize">
                     <StackPanel Style="{StaticResource SettingControlStackStyle}">
-                        <ComboBox x:Name="FontWeightComboBox"
-                                  x:Uid="Profile_FontWeightComboBox"
-                                  ItemTemplate="{StaticResource EnumComboBoxTemplate}"
-                                  ItemsSource="{x:Bind FontWeightList, Mode=OneWay}"
-                                  SelectedItem="{x:Bind CurrentFontWeight, Mode=TwoWay}"
-                                  Style="{StaticResource ComboBoxSettingStyle}" />
-                        <local:SettingResetButton SettingName="FontWeight"
+                        <muxc:NumberBox x:Name="_fontSizeBox"
+                                        x:Uid="Profile_FontSizeBox"
+                                        LargeChange="10"
+                                        Maximum="128"
+                                        Minimum="1"
+                                        SmallChange="1"
+                                        Style="{StaticResource NumberBoxSettingStyle}"
+                                        Value="{x:Bind Appearance.FontSize, Mode=TwoWay}" />
+                        <local:SettingResetButton SettingName="FontSize"
                                                   Target="{x:Bind Appearance}" />
                     </StackPanel>
+                </local:SettingsCard>
 
-                    <!--  Custom Font Weight Control  -->
-                    <Grid Margin="0,10,0,0"
-                          Style="{StaticResource CustomSliderControlGridStyle}"
-                          Visibility="{x:Bind IsCustomFontWeight, Mode=OneWay}">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        <Slider x:Name="FontWeightSlider"
-                                x:Uid="Profile_FontWeightSlider"
-                                Grid.Column="0"
-                                Maximum="1000"
-                                Minimum="0"
-                                TickFrequency="50"
-                                TickPlacement="Outside"
-                                Value="{x:Bind mtu:Converters.FontWeightToDouble(Appearance.FontWeight), BindBack=Appearance.SetFontWeightFromDouble, Mode=TwoWay}" />
-                        <TextBlock Grid.Column="1"
-                                   Margin="10,0,0,0"
-                                   Style="{StaticResource SliderValueLabelStyle}"
-                                   Text="{Binding ElementName=FontWeightSlider, Path=Value, Mode=OneWay}" />
-                    </Grid>
-                </StackPanel>
-            </local:SettingsCard>
+                <!--  Line Height  -->
+                <local:SettingsCard x:Name="LineHeight"
+                                    x:Uid="Profile_LineHeight">
+                    <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                        <muxc:NumberBox x:Name="_lineHeightBox"
+                                        x:Uid="Profile_LineHeightBox"
+                                        LargeChange="0.1"
+                                        Maximum="10"
+                                        Minimum="0.1"
+                                        SmallChange="0.1"
+                                        Style="{StaticResource NumberBoxSettingStyle}"
+                                        Value="{x:Bind Appearance.LineHeight, Mode=TwoWay}" />
+                        <local:SettingResetButton SettingName="LineHeight"
+                                                  Target="{x:Bind Appearance}" />
+                    </StackPanel>
+                </local:SettingsCard>
+
+                <!--  Cell Width  -->
+                <local:SettingsCard x:Name="CellWidth"
+                                    x:Uid="Profile_CellWidth">
+                    <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                        <muxc:NumberBox x:Name="_cellWidthBox"
+                                        x:Uid="Profile_CellWidthBox"
+                                        LargeChange="0.1"
+                                        Maximum="10"
+                                        Minimum="0.1"
+                                        SmallChange="0.1"
+                                        Style="{StaticResource NumberBoxSettingStyle}"
+                                        Value="{x:Bind Appearance.CellWidth, Mode=TwoWay}" />
+                        <local:SettingResetButton SettingName="CellWidth"
+                                                  Target="{x:Bind Appearance}" />
+                    </StackPanel>
+                </local:SettingsCard>
+
+                <!--  Font Weight  -->
+                <local:SettingsCard x:Name="FontWeight"
+                                    x:Uid="Profile_FontWeight">
+                    <StackPanel>
+                        <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                            <ComboBox x:Name="FontWeightComboBox"
+                                      x:Uid="Profile_FontWeightComboBox"
+                                      ItemTemplate="{StaticResource EnumComboBoxTemplate}"
+                                      ItemsSource="{x:Bind FontWeightList, Mode=OneWay}"
+                                      SelectedItem="{x:Bind CurrentFontWeight, Mode=TwoWay}"
+                                      Style="{StaticResource ComboBoxSettingStyle}" />
+                            <local:SettingResetButton SettingName="FontWeight"
+                                                      Target="{x:Bind Appearance}" />
+                        </StackPanel>
+
+                        <!--  Custom Font Weight Control  -->
+                        <Grid Margin="0,10,0,0"
+                              Style="{StaticResource CustomSliderControlGridStyle}"
+                              Visibility="{x:Bind IsCustomFontWeight, Mode=OneWay}">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Slider x:Name="FontWeightSlider"
+                                    x:Uid="Profile_FontWeightSlider"
+                                    Grid.Column="0"
+                                    Maximum="1000"
+                                    Minimum="0"
+                                    TickFrequency="50"
+                                    TickPlacement="Outside"
+                                    Value="{x:Bind mtu:Converters.FontWeightToDouble(Appearance.FontWeight), BindBack=Appearance.SetFontWeightFromDouble, Mode=TwoWay}" />
+                            <TextBlock Grid.Column="1"
+                                       Margin="10,0,0,0"
+                                       Style="{StaticResource SliderValueLabelStyle}"
+                                       Text="{Binding ElementName=FontWeightSlider, Path=Value, Mode=OneWay}" />
+                        </Grid>
+                    </StackPanel>
+                </local:SettingsCard>
+            </StackPanel>
             <local:SettingsExpander x:Name="FontAxes"
-                                    x:Uid="Profile_FontAxes">
+                                    x:Uid="Profile_FontAxes"
+                                    Margin="0,4,0,0">
                 <local:SettingsExpander.Content>
                     <local:SettingResetButton SettingName="FontAxes"
                                               Target="{x:Bind Appearance}" />
@@ -468,7 +477,8 @@
                 </local:SettingsExpander.ItemsHeader>
             </local:SettingsExpander>
             <local:SettingsExpander x:Name="FontFeatures"
-                                    x:Uid="Profile_FontFeatures">
+                                    x:Uid="Profile_FontFeatures"
+                                    Margin="0,4,0,0">
                 <local:SettingsExpander.Content>
                     <local:SettingResetButton SettingName="FontFeatures"
                                               Target="{x:Bind Appearance}" />
@@ -502,7 +512,8 @@
 
             <!--  Builtin Glyphs  -->
             <local:SettingsCard x:Name="EnableBuiltinGlyphs"
-                                x:Uid="Profile_EnableBuiltinGlyphs">
+                                x:Uid="Profile_EnableBuiltinGlyphs"
+                                Margin="0,4,0,0">
                 <StackPanel Style="{StaticResource SettingControlStackStyle}">
                     <ToggleSwitch VerticalAlignment="Center"
                                   IsOn="{x:Bind Appearance.EnableBuiltinGlyphs, Mode=TwoWay}"
@@ -514,7 +525,8 @@
 
             <!--  Color Glyphs  -->
             <local:SettingsCard x:Name="EnableColorGlyphs"
-                                x:Uid="Profile_EnableColorGlyphs">
+                                x:Uid="Profile_EnableColorGlyphs"
+                                Margin="0,4,0,0">
                 <StackPanel Style="{StaticResource SettingControlStackStyle}">
                     <ToggleSwitch VerticalAlignment="Center"
                                   IsOn="{x:Bind Appearance.EnableColorGlyphs, Mode=TwoWay}"
@@ -526,7 +538,8 @@
 
             <!--  Retro Terminal Effect  -->
             <local:SettingsCard x:Name="RetroTerminalEffect"
-                                x:Uid="Profile_RetroTerminalEffect">
+                                x:Uid="Profile_RetroTerminalEffect"
+                                Margin="0,4,0,0">
                 <StackPanel Style="{StaticResource SettingControlStackStyle}">
                     <ToggleSwitch VerticalAlignment="Center"
                                   IsOn="{x:Bind Appearance.RetroTerminalEffect, Mode=TwoWay}"
@@ -538,7 +551,8 @@
 
             <!--  Adjust Indistinguishable Colors  -->
             <local:SettingsCard x:Name="AdjustIndistinguishableColors"
-                                x:Uid="Profile_AdjustIndistinguishableColors">
+                                x:Uid="Profile_AdjustIndistinguishableColors"
+                                Margin="0,4,0,0">
                 <StackPanel Style="{StaticResource SettingControlStackStyle}">
                     <ComboBox AutomationProperties.AccessibilityView="Content"
                               ItemTemplate="{StaticResource EnumComboBoxTemplate}"

--- a/src/cascadia/TerminalSettingsEditor/Appearances.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.xaml
@@ -79,7 +79,8 @@
                                     x:Uid="Profile_ColorScheme"
                                     AutomationProperties.Name="{x:Bind Appearance.CurrentColorScheme.Name, Mode=OneWay}">
                 <local:SettingsExpander.Content>
-                    <ComboBox Padding="4"
+                    <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                        <ComboBox Padding="4"
                               ItemsSource="{x:Bind Appearance.SchemesList, Mode=OneWay}"
                               SelectedItem="{x:Bind Appearance.CurrentColorScheme, Mode=TwoWay}"
                               Style="{StaticResource ComboBoxSettingStyle}">
@@ -203,6 +204,9 @@
                             </DataTemplate>
                         </ComboBox.ItemTemplate>
                     </ComboBox>
+                        <local:SettingResetButton SettingName="ColorScheme"
+                                                  Target="{x:Bind Appearance}" />
+                    </StackPanel>
                 </local:SettingsExpander.Content>
                 <local:SettingsExpander.ItemsHeader>
                     <ContentPresenter Padding="16,12,16,16">
@@ -213,8 +217,13 @@
                                                     x:Uid="Profile_Foreground"
                                                     AutomationProperties.Name="{x:Bind Appearance.ForegroundPreview, Converter={StaticResource ColorToStringConverter}, Mode=OneWay}">
                                 <local:SettingsExpander.Content>
-                                    <ContentControl Content="{x:Bind Appearance.ForegroundPreview, Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorPreviewTemplate}" />
+                                    <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                                        <ContentControl VerticalAlignment="Center"
+                                                        Content="{x:Bind Appearance.ForegroundPreview, Mode=OneWay}"
+                                                        ContentTemplate="{StaticResource ColorPreviewTemplate}" />
+                                        <local:SettingResetButton SettingName="Foreground"
+                                                                  Target="{x:Bind Appearance}" />
+                                    </StackPanel>
                                 </local:SettingsExpander.Content>
                                 <local:SettingsExpander.ItemsHeader>
                                     <ContentPresenter Padding="16,12,16,16">
@@ -231,8 +240,13 @@
                                                     x:Uid="Profile_Background"
                                                     AutomationProperties.Name="{x:Bind Appearance.BackgroundPreview, Converter={StaticResource ColorToStringConverter}, Mode=OneWay}">
                                 <local:SettingsExpander.Content>
-                                    <ContentControl Content="{x:Bind Appearance.BackgroundPreview, Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorPreviewTemplate}" />
+                                    <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                                        <ContentControl VerticalAlignment="Center"
+                                                        Content="{x:Bind Appearance.BackgroundPreview, Mode=OneWay}"
+                                                        ContentTemplate="{StaticResource ColorPreviewTemplate}" />
+                                        <local:SettingResetButton SettingName="Background"
+                                                                  Target="{x:Bind Appearance}" />
+                                    </StackPanel>
                                 </local:SettingsExpander.Content>
                                 <local:SettingsExpander.ItemsHeader>
                                     <ContentPresenter Padding="16,12,16,16">
@@ -249,8 +263,13 @@
                                                     x:Uid="Profile_SelectionBackground"
                                                     AutomationProperties.Name="{x:Bind Appearance.SelectionBackgroundPreview, Converter={StaticResource ColorToStringConverter}, Mode=OneWay}">
                                 <local:SettingsExpander.Content>
-                                    <ContentControl Content="{x:Bind Appearance.SelectionBackgroundPreview, Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorPreviewTemplate}" />
+                                    <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                                        <ContentControl VerticalAlignment="Center"
+                                                        Content="{x:Bind Appearance.SelectionBackgroundPreview, Mode=OneWay}"
+                                                        ContentTemplate="{StaticResource ColorPreviewTemplate}" />
+                                        <local:SettingResetButton SettingName="SelectionBackground"
+                                                                  Target="{x:Bind Appearance}" />
+                                    </StackPanel>
                                 </local:SettingsExpander.Content>
                                 <local:SettingsExpander.ItemsHeader>
                                     <ContentPresenter Padding="16,12,16,16">
@@ -276,16 +295,20 @@
                                     Visibility="{x:Bind Appearance.IsDefault, Mode=OneWay}">
 
                     <StackPanel Margin="0,8,0,0">
-                        <AutoSuggestBox x:Uid="Profile_FontFaceBox"
-                                        GotFocus="FontFaceBox_GotFocus"
-                                        ItemTemplate="{StaticResource FontFaceComboBoxItemTemplate}"
-                                        ItemsSource="{x:Bind FilteredFontList, Mode=OneWay}"
-                                        LostFocus="FontFaceBox_LostFocus"
-                                        QuerySubmitted="FontFaceBox_QuerySubmitted"
-                                        Text="{x:Bind Appearance.FontFace, Mode=OneWay}"
-                                        TextBoxStyle="{StaticResource TextBoxSettingStyle}"
-                                        TextChanged="FontFaceBox_TextChanged"
-                                        UpdateTextOnSelect="False" />
+                        <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                            <AutoSuggestBox x:Uid="Profile_FontFaceBox"
+                                            GotFocus="FontFaceBox_GotFocus"
+                                            ItemTemplate="{StaticResource FontFaceComboBoxItemTemplate}"
+                                            ItemsSource="{x:Bind FilteredFontList, Mode=OneWay}"
+                                            LostFocus="FontFaceBox_LostFocus"
+                                            QuerySubmitted="FontFaceBox_QuerySubmitted"
+                                            Text="{x:Bind Appearance.FontFace, Mode=OneWay}"
+                                            TextBoxStyle="{StaticResource TextBoxSettingStyle}"
+                                            TextChanged="FontFaceBox_TextChanged"
+                                            UpdateTextOnSelect="False" />
+                            <local:SettingResetButton SettingName="FontFace"
+                                                      Target="{x:Bind Appearance}" />
+                        </StackPanel>
                         <CheckBox x:Name="ShowAllFontsCheckbox"
                                   x:Uid="Profile_FontFaceShowAllFonts"
                                   IsChecked="{x:Bind ShowAllFonts, Mode=TwoWay}" />
@@ -323,42 +346,54 @@
             <local:SettingsCard x:Name="FontSize"
                                 x:Uid="Profile_FontSize"
                                 Visibility="{x:Bind Appearance.IsDefault, Mode=OneWay}">
-                <muxc:NumberBox x:Name="_fontSizeBox"
-                                x:Uid="Profile_FontSizeBox"
-                                LargeChange="10"
-                                Maximum="128"
-                                Minimum="1"
-                                SmallChange="1"
-                                Style="{StaticResource NumberBoxSettingStyle}"
-                                Value="{x:Bind Appearance.FontSize, Mode=TwoWay}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <muxc:NumberBox x:Name="_fontSizeBox"
+                                    x:Uid="Profile_FontSizeBox"
+                                    LargeChange="10"
+                                    Maximum="128"
+                                    Minimum="1"
+                                    SmallChange="1"
+                                    Style="{StaticResource NumberBoxSettingStyle}"
+                                    Value="{x:Bind Appearance.FontSize, Mode=TwoWay}" />
+                    <local:SettingResetButton SettingName="FontSize"
+                                              Target="{x:Bind Appearance}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Line Height  -->
             <local:SettingsCard x:Name="LineHeight"
                                 x:Uid="Profile_LineHeight"
                                 Visibility="{x:Bind Appearance.IsDefault, Mode=OneWay}">
-                <muxc:NumberBox x:Name="_lineHeightBox"
-                                x:Uid="Profile_LineHeightBox"
-                                LargeChange="0.1"
-                                Maximum="10"
-                                Minimum="0.1"
-                                SmallChange="0.1"
-                                Style="{StaticResource NumberBoxSettingStyle}"
-                                Value="{x:Bind Appearance.LineHeight, Mode=TwoWay}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <muxc:NumberBox x:Name="_lineHeightBox"
+                                    x:Uid="Profile_LineHeightBox"
+                                    LargeChange="0.1"
+                                    Maximum="10"
+                                    Minimum="0.1"
+                                    SmallChange="0.1"
+                                    Style="{StaticResource NumberBoxSettingStyle}"
+                                    Value="{x:Bind Appearance.LineHeight, Mode=TwoWay}" />
+                    <local:SettingResetButton SettingName="LineHeight"
+                                              Target="{x:Bind Appearance}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Cell Width  -->
             <local:SettingsCard x:Name="CellWidth"
                                 x:Uid="Profile_CellWidth"
                                 Visibility="{x:Bind Appearance.IsDefault, Mode=OneWay}">
-                <muxc:NumberBox x:Name="_cellWidthBox"
-                                x:Uid="Profile_CellWidthBox"
-                                LargeChange="0.1"
-                                Maximum="10"
-                                Minimum="0.1"
-                                SmallChange="0.1"
-                                Style="{StaticResource NumberBoxSettingStyle}"
-                                Value="{x:Bind Appearance.CellWidth, Mode=TwoWay}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <muxc:NumberBox x:Name="_cellWidthBox"
+                                    x:Uid="Profile_CellWidthBox"
+                                    LargeChange="0.1"
+                                    Maximum="10"
+                                    Minimum="0.1"
+                                    SmallChange="0.1"
+                                    Style="{StaticResource NumberBoxSettingStyle}"
+                                    Value="{x:Bind Appearance.CellWidth, Mode=TwoWay}" />
+                    <local:SettingResetButton SettingName="CellWidth"
+                                              Target="{x:Bind Appearance}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Font Weight  -->
@@ -366,12 +401,16 @@
                                 x:Uid="Profile_FontWeight"
                                 Visibility="{x:Bind Appearance.IsDefault, Mode=OneWay}">
                 <StackPanel>
-                    <ComboBox x:Name="FontWeightComboBox"
-                              x:Uid="Profile_FontWeightComboBox"
-                              ItemTemplate="{StaticResource EnumComboBoxTemplate}"
-                              ItemsSource="{x:Bind FontWeightList, Mode=OneWay}"
-                              SelectedItem="{x:Bind CurrentFontWeight, Mode=TwoWay}"
-                              Style="{StaticResource ComboBoxSettingStyle}" />
+                    <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                        <ComboBox x:Name="FontWeightComboBox"
+                                  x:Uid="Profile_FontWeightComboBox"
+                                  ItemTemplate="{StaticResource EnumComboBoxTemplate}"
+                                  ItemsSource="{x:Bind FontWeightList, Mode=OneWay}"
+                                  SelectedItem="{x:Bind CurrentFontWeight, Mode=TwoWay}"
+                                  Style="{StaticResource ComboBoxSettingStyle}" />
+                        <local:SettingResetButton SettingName="FontWeight"
+                                                  Target="{x:Bind Appearance}" />
+                    </StackPanel>
 
                     <!--  Custom Font Weight Control  -->
                     <Grid Margin="0,10,0,0"
@@ -398,6 +437,10 @@
             </local:SettingsCard>
             <local:SettingsExpander x:Name="FontAxes"
                                     x:Uid="Profile_FontAxes">
+                <local:SettingsExpander.Content>
+                    <local:SettingResetButton SettingName="FontAxes"
+                                              Target="{x:Bind Appearance}" />
+                </local:SettingsExpander.Content>
                 <local:SettingsExpander.ItemsHeader>
                     <ContentPresenter Padding="16,12,16,16">
                         <StackPanel Spacing="16">
@@ -426,6 +469,10 @@
             </local:SettingsExpander>
             <local:SettingsExpander x:Name="FontFeatures"
                                     x:Uid="Profile_FontFeatures">
+                <local:SettingsExpander.Content>
+                    <local:SettingResetButton SettingName="FontFeatures"
+                                              Target="{x:Bind Appearance}" />
+                </local:SettingsExpander.Content>
                 <local:SettingsExpander.ItemsHeader>
                     <ContentPresenter Padding="16,12,16,16">
                         <StackPanel Spacing="16">
@@ -456,32 +503,51 @@
             <!--  Builtin Glyphs  -->
             <local:SettingsCard x:Name="EnableBuiltinGlyphs"
                                 x:Uid="Profile_EnableBuiltinGlyphs">
-                <ToggleSwitch IsOn="{x:Bind Appearance.EnableBuiltinGlyphs, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Appearance.EnableBuiltinGlyphs, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="EnableBuiltinGlyphs"
+                                              Target="{x:Bind Appearance}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Color Glyphs  -->
             <local:SettingsCard x:Name="EnableColorGlyphs"
                                 x:Uid="Profile_EnableColorGlyphs">
-                <ToggleSwitch IsOn="{x:Bind Appearance.EnableColorGlyphs, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Appearance.EnableColorGlyphs, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="EnableColorGlyphs"
+                                              Target="{x:Bind Appearance}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Retro Terminal Effect  -->
             <local:SettingsCard x:Name="RetroTerminalEffect"
                                 x:Uid="Profile_RetroTerminalEffect">
-                <ToggleSwitch IsOn="{x:Bind Appearance.RetroTerminalEffect, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Appearance.RetroTerminalEffect, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="RetroTerminalEffect"
+                                              Target="{x:Bind Appearance}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Adjust Indistinguishable Colors  -->
             <local:SettingsCard x:Name="AdjustIndistinguishableColors"
                                 x:Uid="Profile_AdjustIndistinguishableColors">
-                <ComboBox AutomationProperties.AccessibilityView="Content"
-                          ItemTemplate="{StaticResource EnumComboBoxTemplate}"
-                          ItemsSource="{x:Bind AdjustIndistinguishableColorsList, Mode=OneWay}"
-                          SelectedItem="{x:Bind CurrentAdjustIndistinguishableColors, Mode=TwoWay}"
-                          Style="{StaticResource ComboBoxSettingStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ComboBox AutomationProperties.AccessibilityView="Content"
+                              ItemTemplate="{StaticResource EnumComboBoxTemplate}"
+                              ItemsSource="{x:Bind AdjustIndistinguishableColorsList, Mode=OneWay}"
+                              SelectedItem="{x:Bind CurrentAdjustIndistinguishableColors, Mode=TwoWay}"
+                              Style="{StaticResource ComboBoxSettingStyle}" />
+                    <local:SettingResetButton SettingName="AdjustIndistinguishableColors"
+                                              Target="{x:Bind Appearance}" />
+                </StackPanel>
             </local:SettingsCard>
         </StackPanel>
 
@@ -492,11 +558,15 @@
             <!--  Cursor Shape  -->
             <local:SettingsCard x:Name="CursorShape"
                                 x:Uid="Profile_CursorShape">
-                <ComboBox AutomationProperties.AccessibilityView="Content"
-                          ItemTemplate="{StaticResource EnumComboBoxTemplate}"
-                          ItemsSource="{x:Bind CursorShapeList, Mode=OneWay}"
-                          SelectedItem="{x:Bind CurrentCursorShape, Mode=TwoWay}"
-                          Style="{StaticResource ComboBoxSettingStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ComboBox AutomationProperties.AccessibilityView="Content"
+                              ItemTemplate="{StaticResource EnumComboBoxTemplate}"
+                              ItemsSource="{x:Bind CursorShapeList, Mode=OneWay}"
+                              SelectedItem="{x:Bind CurrentCursorShape, Mode=TwoWay}"
+                              Style="{StaticResource ComboBoxSettingStyle}" />
+                    <local:SettingResetButton SettingName="CursorShape"
+                                              Target="{x:Bind Appearance}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Cursor Height  -->
@@ -507,6 +577,7 @@
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
                     <Slider x:Name="CursorHeightSlider"
                             Grid.Column="0"
@@ -516,6 +587,10 @@
                     <TextBlock Grid.Column="1"
                                Style="{StaticResource SliderValueLabelStyle}"
                                Text="{Binding ElementName=CursorHeightSlider, Path=Value, Mode=OneWay}" />
+                    <local:SettingResetButton Grid.Column="2"
+                                              Margin="8,0,0,0"
+                                              SettingName="CursorHeight"
+                                              Target="{x:Bind Appearance}" />
                 </Grid>
             </local:SettingsCard>
 
@@ -524,8 +599,13 @@
                                     x:Uid="Profile_CursorColor"
                                     AutomationProperties.Name="{x:Bind Appearance.CursorColorPreview, Converter={StaticResource ColorToStringConverter}, Mode=OneWay}">
                 <local:SettingsExpander.Content>
-                    <ContentControl Content="{x:Bind Appearance.CursorColorPreview, Mode=OneWay}"
-                                    ContentTemplate="{StaticResource ColorPreviewTemplate}" />
+                    <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                        <ContentControl VerticalAlignment="Center"
+                                        Content="{x:Bind Appearance.CursorColorPreview, Mode=OneWay}"
+                                        ContentTemplate="{StaticResource ColorPreviewTemplate}" />
+                        <local:SettingResetButton SettingName="CursorColor"
+                                                  Target="{x:Bind Appearance}" />
+                    </StackPanel>
                 </local:SettingsExpander.Content>
                 <local:SettingsExpander.ItemsHeader>
                     <ContentPresenter Padding="16,12,16,16">
@@ -548,8 +628,7 @@
                 <local:SettingsExpander.Content>
                     <StackPanel Margin="0,8,0,0"
                                 Orientation="Vertical">
-                        <StackPanel Orientation="Horizontal"
-                                    Spacing="8">
+                        <StackPanel Style="{StaticResource SettingControlStackStyle}">
                             <TextBox x:Uid="Profile_BackgroundImageBox"
                                      IsEnabled="{x:Bind mtu:Converters.InvertBoolean(Appearance.UseDesktopBGImage), Mode=OneWay}"
                                      IsSpellCheckEnabled="False"
@@ -559,6 +638,8 @@
                                     Click="BackgroundImage_Click"
                                     IsEnabled="{x:Bind mtu:Converters.InvertBoolean(Appearance.UseDesktopBGImage), Mode=OneWay}"
                                     Style="{StaticResource BrowseButtonStyle}" />
+                            <local:SettingResetButton SettingName="BackgroundImagePath"
+                                                      Target="{x:Bind Appearance}" />
                         </StackPanel>
                         <CheckBox x:Name="UseDesktopImageCheckBox"
                                   x:Uid="Profile_UseDesktopImage"
@@ -571,11 +652,15 @@
                     <local:SettingsCard x:Name="BackgroundImageStretchMode"
                                         x:Uid="Profile_BackgroundImageStretchMode"
                                         IsEnabled="{x:Bind Appearance.BackgroundImageSettingsEnabled, Mode=OneWay}">
-                        <ComboBox AutomationProperties.AccessibilityView="Content"
-                                  ItemTemplate="{StaticResource EnumComboBoxTemplate}"
-                                  ItemsSource="{x:Bind BackgroundImageStretchModeList, Mode=OneWay}"
-                                  SelectedItem="{x:Bind CurrentBackgroundImageStretchMode, Mode=TwoWay}"
-                                  Style="{StaticResource ComboBoxSettingStyle}" />
+                        <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                            <ComboBox AutomationProperties.AccessibilityView="Content"
+                                      ItemTemplate="{StaticResource EnumComboBoxTemplate}"
+                                      ItemsSource="{x:Bind BackgroundImageStretchModeList, Mode=OneWay}"
+                                      SelectedItem="{x:Bind CurrentBackgroundImageStretchMode, Mode=TwoWay}"
+                                      Style="{StaticResource ComboBoxSettingStyle}" />
+                            <local:SettingResetButton SettingName="BackgroundImageStretchMode"
+                                                      Target="{x:Bind Appearance}" />
+                        </StackPanel>
                     </local:SettingsCard>
 
                     <!--  Background Image Alignment  -->
@@ -589,6 +674,7 @@
                                 <RowDefinition Height="Auto" />
                             </Grid.RowDefinitions>
                             <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="Auto" />
@@ -759,6 +845,13 @@
                                               Glyph="&#xEA5F;" />
                                 </ToggleButton.Content>
                             </ToggleButton>
+                            <local:SettingResetButton Grid.Row="0"
+                                                      Grid.RowSpan="3"
+                                                      Grid.Column="3"
+                                                      Margin="8,0,0,0"
+                                                      VerticalAlignment="Center"
+                                                      SettingName="BackgroundImageAlignment"
+                                                      Target="{x:Bind Appearance}" />
                         </Grid>
                     </local:SettingsCard>
 
@@ -770,6 +863,7 @@
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <Slider x:Uid="Profile_BackgroundImageOpacitySlider"
                                     Grid.Column="0"
@@ -777,6 +871,10 @@
                             <TextBlock Grid.Column="1"
                                        Style="{StaticResource SliderValueLabelStyle}"
                                        Text="{x:Bind mtu:Converters.PercentageToPercentageString(Appearance.BackgroundImageOpacity), Mode=OneWay}" />
+                            <local:SettingResetButton Grid.Column="2"
+                                                      Margin="8,0,0,0"
+                                                      SettingName="BackgroundImageOpacity"
+                                                      Target="{x:Bind Appearance}" />
                         </Grid>
                     </local:SettingsCard>
                 </local:SettingsExpander.Items>
@@ -790,11 +888,15 @@
             <!--  Intense is bold, bright  -->
             <local:SettingsCard x:Name="IntenseTextStyle"
                                 x:Uid="Appearance_IntenseTextStyle">
-                <ComboBox AutomationProperties.AccessibilityView="Content"
-                          ItemTemplate="{StaticResource EnumComboBoxTemplate}"
-                          ItemsSource="{x:Bind IntenseTextStyleList, Mode=OneWay}"
-                          SelectedItem="{x:Bind CurrentIntenseTextStyle, Mode=TwoWay}"
-                          Style="{StaticResource ComboBoxSettingStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ComboBox AutomationProperties.AccessibilityView="Content"
+                              ItemTemplate="{StaticResource EnumComboBoxTemplate}"
+                              ItemsSource="{x:Bind IntenseTextStyleList, Mode=OneWay}"
+                              SelectedItem="{x:Bind CurrentIntenseTextStyle, Mode=TwoWay}"
+                              Style="{StaticResource ComboBoxSettingStyle}" />
+                    <local:SettingResetButton SettingName="IntenseTextStyle"
+                                              Target="{x:Bind Appearance}" />
+                </StackPanel>
             </local:SettingsCard>
         </StackPanel>
 

--- a/src/cascadia/TerminalSettingsEditor/Appearances.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.xaml
@@ -220,7 +220,7 @@
                             <!--  Foreground Color  -->
                             <local:SettingsExpander x:Name="Foreground"
                                                     x:Uid="Profile_Foreground"
-                                                    AutomationProperties.Name="{x:Bind Appearance.ForegroundPreview, Converter={StaticResource ColorToStringConverter}, Mode=OneWay}">
+                                                    AutomationProperties.Name="{x:Bind Appearance.ForegroundAccessibleName, Mode=OneWay}">
                                 <local:SettingsExpander.Content>
                                     <StackPanel Style="{StaticResource SettingControlStackStyle}">
                                         <ContentControl VerticalAlignment="Center"
@@ -243,7 +243,7 @@
                             <!--  Background Color  -->
                             <local:SettingsExpander x:Name="Background"
                                                     x:Uid="Profile_Background"
-                                                    AutomationProperties.Name="{x:Bind Appearance.BackgroundPreview, Converter={StaticResource ColorToStringConverter}, Mode=OneWay}">
+                                                    AutomationProperties.Name="{x:Bind Appearance.BackgroundAccessibleName, Mode=OneWay}">
                                 <local:SettingsExpander.Content>
                                     <StackPanel Style="{StaticResource SettingControlStackStyle}">
                                         <ContentControl VerticalAlignment="Center"
@@ -266,7 +266,7 @@
                             <!--  Selection Background Color  -->
                             <local:SettingsExpander x:Name="SelectionBackground"
                                                     x:Uid="Profile_SelectionBackground"
-                                                    AutomationProperties.Name="{x:Bind Appearance.SelectionBackgroundPreview, Converter={StaticResource ColorToStringConverter}, Mode=OneWay}">
+                                                    AutomationProperties.Name="{x:Bind Appearance.SelectionBackgroundAccessibleName, Mode=OneWay}">
                                 <local:SettingsExpander.Content>
                                     <StackPanel Style="{StaticResource SettingControlStackStyle}">
                                         <ContentControl VerticalAlignment="Center"
@@ -624,7 +624,7 @@
             <!--  Cursor Color  -->
             <local:SettingsExpander x:Name="CursorColor"
                                     x:Uid="Profile_CursorColor"
-                                    AutomationProperties.Name="{x:Bind Appearance.CursorColorPreview, Converter={StaticResource ColorToStringConverter}, Mode=OneWay}">
+                                    AutomationProperties.Name="{x:Bind Appearance.CursorColorAccessibleName, Mode=OneWay}">
                 <local:SettingsExpander.Content>
                     <StackPanel Style="{StaticResource SettingControlStackStyle}">
                         <ContentControl VerticalAlignment="Center"

--- a/src/cascadia/TerminalSettingsEditor/Appearances.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.xaml
@@ -661,10 +661,14 @@
                                      IsSpellCheckEnabled="False"
                                      Style="{StaticResource TextBoxSettingStyle}"
                                      Text="{x:Bind mtu:Converters.StringOrEmptyIfPlaceholder('desktopWallpaper', Appearance.BackgroundImagePath.Path), Mode=TwoWay, BindBack=Appearance.SetBackgroundImagePath}" />
-                            <Button x:Uid="Profile_BackgroundImageBrowse"
+                            <Button x:Name="BackgroundImageBrowse"
+                                    x:Uid="Profile_BackgroundImageBrowse"
                                     Click="BackgroundImage_Click"
                                     IsEnabled="{x:Bind mtu:Converters.InvertBoolean(Appearance.UseDesktopBGImage), Mode=OneWay}"
-                                    Style="{StaticResource BrowseButtonStyle}" />
+                                    Style="{StaticResource BrowseButtonStyle}">
+                                <FontIcon FontSize="{StaticResource StandardIconSize}"
+                                          Glyph="&#xE838;" />
+                            </Button>
                             <local:SettingResetButton SettingName="BackgroundImagePath"
                                                       Target="{x:Bind Appearance}" />
                         </StackPanel>

--- a/src/cascadia/TerminalSettingsEditor/Appearances.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.xaml
@@ -303,7 +303,8 @@
                 -->
                 <StackPanel>
                     <local:SettingsCard x:Name="FontFaceContainer"
-                                        x:Uid="Profile_FontFace">
+                                        x:Uid="Profile_FontFace"
+                                        Style="{StaticResource ExpanderAlignedSettingsCardStyle}">
 
                         <StackPanel Margin="0,8,0,0">
                             <StackPanel Style="{StaticResource SettingControlStackStyle}">
@@ -330,6 +331,7 @@
                                         Margin="0,6,0,0"
                                         Background="{ThemeResource SettingContainerErrorSeverityBackgroundBrush}"
                                         Description="{x:Bind Appearance.MissingFontFaces, Mode=OneWay}"
+                                        Style="{StaticResource ExpanderAlignedSettingsCardStyle}"
                                         Visibility="{x:Bind mtu:Converters.StringNotEmptyToVisibility(Appearance.MissingFontFaces), Mode=OneWay}">
                         <local:SettingsCard.HeaderIcon>
                             <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"
@@ -343,6 +345,7 @@
                                         Margin="0,6,0,0"
                                         Background="{ThemeResource SettingContainerWarningSeverityBackgroundBrush}"
                                         Description="{x:Bind Appearance.ProportionalFontFaces, Mode=OneWay}"
+                                        Style="{StaticResource ExpanderAlignedSettingsCardStyle}"
                                         Visibility="{x:Bind mtu:Converters.StringNotEmptyToVisibility(Appearance.ProportionalFontFaces), Mode=OneWay}">
                         <local:SettingsCard.HeaderIcon>
                             <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"
@@ -355,7 +358,8 @@
 
                 <!--  Font Size  -->
                 <local:SettingsCard x:Name="FontSize"
-                                    x:Uid="Profile_FontSize">
+                                    x:Uid="Profile_FontSize"
+                                    Style="{StaticResource ExpanderAlignedSettingsCardStyle}">
                     <StackPanel Style="{StaticResource SettingControlStackStyle}">
                         <muxc:NumberBox x:Name="_fontSizeBox"
                                         x:Uid="Profile_FontSizeBox"
@@ -372,7 +376,8 @@
 
                 <!--  Line Height  -->
                 <local:SettingsCard x:Name="LineHeight"
-                                    x:Uid="Profile_LineHeight">
+                                    x:Uid="Profile_LineHeight"
+                                    Style="{StaticResource ExpanderAlignedSettingsCardStyle}">
                     <StackPanel Style="{StaticResource SettingControlStackStyle}">
                         <muxc:NumberBox x:Name="_lineHeightBox"
                                         x:Uid="Profile_LineHeightBox"
@@ -389,7 +394,8 @@
 
                 <!--  Cell Width  -->
                 <local:SettingsCard x:Name="CellWidth"
-                                    x:Uid="Profile_CellWidth">
+                                    x:Uid="Profile_CellWidth"
+                                    Style="{StaticResource ExpanderAlignedSettingsCardStyle}">
                     <StackPanel Style="{StaticResource SettingControlStackStyle}">
                         <muxc:NumberBox x:Name="_cellWidthBox"
                                         x:Uid="Profile_CellWidthBox"
@@ -406,7 +412,8 @@
 
                 <!--  Font Weight  -->
                 <local:SettingsCard x:Name="FontWeight"
-                                    x:Uid="Profile_FontWeight">
+                                    x:Uid="Profile_FontWeight"
+                                    Style="{StaticResource ExpanderAlignedSettingsCardStyle}">
                     <StackPanel>
                         <StackPanel Style="{StaticResource SettingControlStackStyle}">
                             <ComboBox x:Name="FontWeightComboBox"
@@ -513,7 +520,8 @@
             <!--  Builtin Glyphs  -->
             <local:SettingsCard x:Name="EnableBuiltinGlyphs"
                                 x:Uid="Profile_EnableBuiltinGlyphs"
-                                Margin="0,4,0,0">
+                                Margin="0,4,0,0"
+                                Style="{StaticResource ExpanderAlignedSettingsCardStyle}">
                 <StackPanel Style="{StaticResource SettingControlStackStyle}">
                     <ToggleSwitch VerticalAlignment="Center"
                                   IsOn="{x:Bind Appearance.EnableBuiltinGlyphs, Mode=TwoWay}"
@@ -526,7 +534,8 @@
             <!--  Color Glyphs  -->
             <local:SettingsCard x:Name="EnableColorGlyphs"
                                 x:Uid="Profile_EnableColorGlyphs"
-                                Margin="0,4,0,0">
+                                Margin="0,4,0,0"
+                                Style="{StaticResource ExpanderAlignedSettingsCardStyle}">
                 <StackPanel Style="{StaticResource SettingControlStackStyle}">
                     <ToggleSwitch VerticalAlignment="Center"
                                   IsOn="{x:Bind Appearance.EnableColorGlyphs, Mode=TwoWay}"
@@ -539,7 +548,8 @@
             <!--  Retro Terminal Effect  -->
             <local:SettingsCard x:Name="RetroTerminalEffect"
                                 x:Uid="Profile_RetroTerminalEffect"
-                                Margin="0,4,0,0">
+                                Margin="0,4,0,0"
+                                Style="{StaticResource ExpanderAlignedSettingsCardStyle}">
                 <StackPanel Style="{StaticResource SettingControlStackStyle}">
                     <ToggleSwitch VerticalAlignment="Center"
                                   IsOn="{x:Bind Appearance.RetroTerminalEffect, Mode=TwoWay}"
@@ -552,7 +562,8 @@
             <!--  Adjust Indistinguishable Colors  -->
             <local:SettingsCard x:Name="AdjustIndistinguishableColors"
                                 x:Uid="Profile_AdjustIndistinguishableColors"
-                                Margin="0,4,0,0">
+                                Margin="0,4,0,0"
+                                Style="{StaticResource ExpanderAlignedSettingsCardStyle}">
                 <StackPanel Style="{StaticResource SettingControlStackStyle}">
                     <ComboBox AutomationProperties.AccessibilityView="Content"
                               ItemTemplate="{StaticResource EnumComboBoxTemplate}"
@@ -571,7 +582,8 @@
         <StackPanel Style="{StaticResource SettingsStackStyle}">
             <!--  Cursor Shape  -->
             <local:SettingsCard x:Name="CursorShape"
-                                x:Uid="Profile_CursorShape">
+                                x:Uid="Profile_CursorShape"
+                                Style="{StaticResource ExpanderAlignedSettingsCardStyle}">
                 <StackPanel Style="{StaticResource SettingControlStackStyle}">
                     <ComboBox AutomationProperties.AccessibilityView="Content"
                               ItemTemplate="{StaticResource EnumComboBoxTemplate}"
@@ -586,7 +598,8 @@
             <!--  Cursor Height  -->
             <local:SettingsCard x:Name="CursorHeight"
                                 x:Uid="Profile_CursorHeight"
-                                IsEnabled="{x:Bind IsVintageCursor, Mode=OneWay}">
+                                IsEnabled="{x:Bind IsVintageCursor, Mode=OneWay}"
+                                Style="{StaticResource ExpanderAlignedSettingsCardStyle}">
                 <Grid Style="{StaticResource CustomSliderControlGridStyle}">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
@@ -901,7 +914,8 @@
         <StackPanel Style="{StaticResource SettingsStackStyle}">
             <!--  Intense is bold, bright  -->
             <local:SettingsCard x:Name="IntenseTextStyle"
-                                x:Uid="Appearance_IntenseTextStyle">
+                                x:Uid="Appearance_IntenseTextStyle"
+                                Style="{StaticResource ExpanderAlignedSettingsCardStyle}">
                 <StackPanel Style="{StaticResource SettingControlStackStyle}">
                     <ComboBox AutomationProperties.AccessibilityView="Content"
                               ItemTemplate="{StaticResource EnumComboBoxTemplate}"

--- a/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
+++ b/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
@@ -177,12 +177,7 @@
     <Style x:Key="SettingsStackStyle"
            TargetType="StackPanel">
         <Setter Property="MaxWidth" Value="{StaticResource StandardControlMaxWidth}" />
-    </Style>
-
-    <!--  Used to stack a group of settings inside a pivot  -->
-    <Style x:Key="PivotStackStyle"
-           TargetType="StackPanel">
-        <Setter Property="MaxWidth" Value="{StaticResource StandardControlMaxWidth}" />
+        <Setter Property="Spacing" Value="4" />
     </Style>
 
     <!--  Combo Box  -->

--- a/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
+++ b/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
@@ -180,6 +180,13 @@
         <Setter Property="Spacing" Value="4" />
     </Style>
 
+    <!--  Used to lay out a setting's control alongside its reset button  -->
+    <Style x:Key="SettingControlStackStyle"
+           TargetType="StackPanel">
+        <Setter Property="Orientation" Value="Horizontal" />
+        <Setter Property="Spacing" Value="8" />
+    </Style>
+
     <!--  Combo Box  -->
     <Style x:Key="ComboBoxSettingStyle"
            BasedOn="{StaticResource DefaultComboBoxStyle}"
@@ -271,6 +278,17 @@
     <Style x:Key="BrowseButtonStyle"
            BasedOn="{StaticResource BaseButtonStyle}"
            TargetType="Button">
+        <Setter Property="MinHeight" Value="32" />
+    </Style>
+
+    <!--
+        Implicit style for the per-setting "reset value" button shown next to
+        Profile settings. Matches BrowseButtonStyle (DefaultButtonStyle + centered + 32px
+        min height) so the reset button visually pairs with the adjacent Browse buttons.
+    -->
+    <Style BasedOn="{StaticResource DefaultButtonStyle}"
+           TargetType="local:SettingResetButton">
+        <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="MinHeight" Value="32" />
     </Style>
 

--- a/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
+++ b/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
@@ -180,6 +180,13 @@
         <Setter Property="Spacing" Value="4" />
     </Style>
 
+    <!--  Used to lay out a setting's control alongside its reset button  -->
+    <Style x:Key="SettingControlStackStyle"
+           TargetType="StackPanel">
+        <Setter Property="Orientation" Value="Horizontal" />
+        <Setter Property="Spacing" Value="8" />
+    </Style>
+
     <!--  Combo Box  -->
     <Style x:Key="ComboBoxSettingStyle"
            BasedOn="{StaticResource DefaultComboBoxStyle}"
@@ -286,6 +293,17 @@
     <Style x:Key="BrowseButtonStyle"
            BasedOn="{StaticResource BaseButtonStyle}"
            TargetType="Button">
+        <Setter Property="MinHeight" Value="32" />
+    </Style>
+
+    <!--
+        Implicit style for the per-setting "reset value" button shown next to
+        Profile settings. Matches BrowseButtonStyle (DefaultButtonStyle + centered + 32px
+        min height) so the reset button visually pairs with the adjacent Browse buttons.
+    -->
+    <Style BasedOn="{StaticResource DefaultButtonStyle}"
+           TargetType="local:SettingResetButton">
+        <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="MinHeight" Value="32" />
     </Style>
 

--- a/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
+++ b/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
@@ -177,7 +177,7 @@
     <Style x:Key="SettingsStackStyle"
            TargetType="StackPanel">
         <Setter Property="MaxWidth" Value="{StaticResource StandardControlMaxWidth}" />
-        <Setter Property="Spacing" Value="4" />
+        <Setter Property="Spacing" Value="2" />
     </Style>
 
     <!--  Used to lay out a setting's control alongside its reset button  -->

--- a/src/cascadia/TerminalSettingsEditor/EditAction.cpp
+++ b/src/cascadia/TerminalSettingsEditor/EditAction.cpp
@@ -49,6 +49,16 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         Automation::AutomationProperties::SetName(NewKeyBinding(), RS_(L"EditAction_NewKeyBinding/Header"));
     }
 
+    // The browse buttons live inside data templates, so we can't reference them by name.
+    // They only display an icon, so pull their accessible name from the tooltip resource as they're loaded.
+    void EditAction::BrowseButton_Loaded(const IInspectable& sender, const RoutedEventArgs&)
+    {
+        if (const auto& element{ sender.try_as<DependencyObject>() })
+        {
+            Automation::AutomationProperties::SetName(element, RS_(L"Actions_Browse/[using:Windows.UI.Xaml.Controls]ToolTipService/ToolTip"));
+        }
+    }
+
     void EditAction::OnNavigatedTo(const NavigationEventArgs& e)
     {
         const auto args = e.Parameter().as<Editor::NavigateToPageArgs>();

--- a/src/cascadia/TerminalSettingsEditor/EditAction.h
+++ b/src/cascadia/TerminalSettingsEditor/EditAction.h
@@ -26,6 +26,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void ShortcutActionBox_TextChanged(const winrt::Windows::UI::Xaml::Controls::AutoSuggestBox& sender, const winrt::Windows::UI::Xaml::Controls::AutoSuggestBoxTextChangedEventArgs& args);
         void ShortcutActionBox_QuerySubmitted(const winrt::Windows::UI::Xaml::Controls::AutoSuggestBox& sender, const winrt::Windows::UI::Xaml::Controls::AutoSuggestBoxQuerySubmittedEventArgs& args);
         void ShortcutActionBox_LostFocus(const winrt::Windows::Foundation::IInspectable& sender, const winrt::Windows::UI::Xaml::RoutedEventArgs& args);
+        void BrowseButton_Loaded(const winrt::Windows::Foundation::IInspectable& sender, const winrt::Windows::UI::Xaml::RoutedEventArgs& args);
 
     private:
         friend struct EditActionT<EditAction>; // for Xaml to bind events

--- a/src/cascadia/TerminalSettingsEditor/EditAction.xaml
+++ b/src/cascadia/TerminalSettingsEditor/EditAction.xaml
@@ -283,7 +283,11 @@
                         <Button x:Uid="Actions_Browse"
                                 Grid.Column="1"
                                 Click="{x:Bind BrowseForFile_Click}"
-                                Style="{StaticResource BrowseButtonStyle}" />
+                                Loaded="BrowseButton_Loaded"
+                                Style="{StaticResource BrowseButtonStyle}">
+                            <FontIcon FontSize="{StaticResource StandardIconSize}"
+                                      Glyph="&#xE838;" />
+                        </Button>
                     </Grid>
                 </local:SettingsCard>
             </DataTemplate>
@@ -306,7 +310,11 @@
                         <Button x:Uid="Actions_Browse"
                                 Grid.Column="1"
                                 Click="{x:Bind BrowseForFolder_Click}"
-                                Style="{StaticResource BrowseButtonStyle}" />
+                                Loaded="BrowseButton_Loaded"
+                                Style="{StaticResource BrowseButtonStyle}">
+                            <FontIcon FontSize="{StaticResource StandardIconSize}"
+                                      Glyph="&#xE838;" />
+                        </Button>
                     </Grid>
                 </local:SettingsCard>
             </DataTemplate>

--- a/src/cascadia/TerminalSettingsEditor/IconPicker.cpp
+++ b/src/cascadia/TerminalSettingsEditor/IconPicker.cpp
@@ -70,6 +70,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _InitializeProperties();
         InitializeComponent();
 
+        Automation::AutomationProperties::SetName(IconBrowseButton(), RS_(L"IconPicker_IconBrowse/[using:Windows.UI.Xaml.Controls]ToolTipService/ToolTip"));
+
         _DeduceCurrentIconType();
         PropertyChanged([this](auto&&, const PropertyChangedEventArgs& args) {
             const auto propertyName{ args.PropertyName() };

--- a/src/cascadia/TerminalSettingsEditor/IconPicker.xaml
+++ b/src/cascadia/TerminalSettingsEditor/IconPicker.xaml
@@ -79,13 +79,17 @@
                  Style="{StaticResource TextBoxSettingStyle}"
                  Text="{x:Bind CurrentIconPath, Mode=TwoWay}"
                  Visibility="{x:Bind UsingImageIcon, Mode=OneWay}" />
-        <Button x:Uid="IconPicker_IconBrowse"
+        <Button x:Name="IconBrowseButton"
+                x:Uid="IconPicker_IconBrowse"
                 Grid.Column="2"
                 Margin="0"
                 VerticalAlignment="Top"
                 Click="Icon_Click"
                 Style="{StaticResource BrowseButtonStyle}"
-                Visibility="{x:Bind UsingImageIcon, Mode=OneWay}" />
+                Visibility="{x:Bind UsingImageIcon, Mode=OneWay}">
+            <FontIcon FontSize="{StaticResource StandardIconSize}"
+                      Glyph="&#xE838;" />
+        </Button>
 
         <!--  Emoji Icon  -->
         <TextBox x:Uid="IconPicker_EmojiBox"

--- a/src/cascadia/TerminalSettingsEditor/LaunchViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/LaunchViewModel.cpp
@@ -216,7 +216,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     winrt::hstring LaunchViewModel::LaunchSizeAccessibleName() const
     {
-        return til::hstring_format(FMT_COMPILE(L"{}: {}"), RS_(L"Globals_LaunchSize/Header"), LaunchSizeCurrentValue());
+        return FormatAccessibleName(USES_RESOURCE(L"Globals_LaunchSize/Header"), LaunchSizeCurrentValue());
     }
 
     winrt::hstring LaunchViewModel::LaunchParametersCurrentValue()
@@ -244,7 +244,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     winrt::hstring LaunchViewModel::LaunchParametersAccessibleName()
     {
-        return til::hstring_format(FMT_COMPILE(L"{}: {}"), RS_(L"Globals_LaunchParameters/Header"), LaunchParametersCurrentValue());
+        return FormatAccessibleName(USES_RESOURCE(L"Globals_LaunchParameters/Header"), LaunchParametersCurrentValue());
     }
 
     double LaunchViewModel::InitialPosX()

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -88,6 +88,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             return ProfileSubPage::Base;
         case BreadcrumbSubPage::Profile_Appearance:
             return ProfileSubPage::Appearance;
+        case BreadcrumbSubPage::Profile_UnfocusedAppearance:
+            return ProfileSubPage::UnfocusedAppearance;
         case BreadcrumbSubPage::Profile_Terminal:
             return ProfileSubPage::Terminal;
         case BreadcrumbSubPage::Profile_Advanced:
@@ -514,6 +516,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         {
             contentFrame().Navigate(xaml_typename<Editor::Profiles_Appearance>(), winrt::make<NavigateToPageArgs>(profile, *this, elementToFocus));
             _breadcrumbs.Append(winrt::make<Breadcrumb>(breadcrumbTag, RS_(L"Profile_Appearance/Header"), BreadcrumbSubPage::Profile_Appearance));
+        }
+        else if (page == ProfileSubPage::UnfocusedAppearance)
+        {
+            contentFrame().Navigate(xaml_typename<Editor::Profiles_UnfocusedAppearance>(), winrt::make<NavigateToPageArgs>(profile, *this, elementToFocus));
+            _breadcrumbs.Append(winrt::make<Breadcrumb>(breadcrumbTag, RS_(L"Profile_UnfocusedAppearanceTextBlock/Text"), BreadcrumbSubPage::Profile_UnfocusedAppearance));
         }
         else if (page == ProfileSubPage::Terminal)
         {

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -89,7 +89,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         case BreadcrumbSubPage::Profile_Appearance:
             return ProfileSubPage::Appearance;
         case BreadcrumbSubPage::Profile_UnfocusedAppearance:
-            // If the profile has no unfocused appearance, fallback to the base page.
+            // If the profile has no unfocused appearance, fall back to the base page.
             return profile.HasUnfocusedAppearance() ? ProfileSubPage::UnfocusedAppearance : ProfileSubPage::Base;
         case BreadcrumbSubPage::Profile_Terminal:
             return ProfileSubPage::Terminal;

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -80,7 +80,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         return winrt::make<implementation::ProfileViewModel>(profile, appSettings, windowSettings, dispatcher);
     }
 
-    static ProfileSubPage ProfileSubPageFromBreadcrumb(BreadcrumbSubPage subPage)
+    static ProfileSubPage ProfileSubPageFromBreadcrumb(BreadcrumbSubPage subPage, const Editor::ProfileViewModel& profile)
     {
         switch (subPage)
         {
@@ -89,7 +89,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         case BreadcrumbSubPage::Profile_Appearance:
             return ProfileSubPage::Appearance;
         case BreadcrumbSubPage::Profile_UnfocusedAppearance:
-            return ProfileSubPage::UnfocusedAppearance;
+            // If the profile has no unfocused appearance, fallback to the base page.
+            return profile.HasUnfocusedAppearance() ? ProfileSubPage::UnfocusedAppearance : ProfileSubPage::Base;
         case BreadcrumbSubPage::Profile_Terminal:
             return ProfileSubPage::Terminal;
         case BreadcrumbSubPage::Profile_Advanced:
@@ -527,6 +528,16 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         });
     }
 
+    void MainPage::_LazyLoadProfileDefaultsViewModel()
+    {
+        if (!_profileDefaultsVM)
+        {
+            _profileDefaultsVM = _viewModelForProfile(_settingsClone.ProfileDefaults(), _settingsClone, _windowSettingsClone, Dispatcher());
+            _profileDefaultsVM.SetupAppearances(_colorSchemesPageVM.AllColorSchemes());
+            _profileDefaultsVM.IsBaseLayer(true);
+        }
+    }
+
     // Method Description:
     // - Navigates to the page corresponding to the given nav tag. Updates the breadcrumb bar and selected nav view item accordingly.
     // Arguments:
@@ -624,16 +635,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             {
                 _AppendProfilesRootCrumb();
 
-                // lazy load profile defaults VM
-                if (!_profileDefaultsVM)
-                {
-                    _profileDefaultsVM = _viewModelForProfile(_settingsClone.ProfileDefaults(), _settingsClone, _windowSettingsClone, Dispatcher());
-                    _profileDefaultsVM.SetupAppearances(_colorSchemesPageVM.AllColorSchemes());
-                    _profileDefaultsVM.IsBaseLayer(true);
-                }
+                _LazyLoadProfileDefaultsViewModel();
 
                 // Set CurrentPage before registering the handler to avoid double-navigation
-                const ProfileSubPage profileSubPage = ProfileSubPageFromBreadcrumb(subPage);
+                const ProfileSubPage profileSubPage = ProfileSubPageFromBreadcrumb(subPage, _profileDefaultsVM);
                 _profileDefaultsVM.CurrentPage(profileSubPage);
 
                 // Navigate directly to the correct sub-page
@@ -680,7 +685,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             else
             {
                 // Set CurrentPage before registering the handler to avoid double-navigation
-                const ProfileSubPage profileSubPage = ProfileSubPageFromBreadcrumb(subPage);
+                const ProfileSubPage profileSubPage = ProfileSubPageFromBreadcrumb(subPage, profile);
                 profile.CurrentPage(profileSubPage);
 
                 // Navigate directly to the correct sub-page
@@ -1162,6 +1167,21 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             const auto& navigationArg{ chosenResult->NavigationArg() };
             const auto& subpage{ indexEntry.Entry->SubPage };
             const hstring elementToFocus{ indexEntry.Entry->ElementName };
+
+            // User explicitly wants to see the unfocused appearance, so create it if it doesn't exist yet.
+            if (subpage == BreadcrumbSubPage::Profile_UnfocusedAppearance)
+            {
+                if (const auto& profileVM{ navigationArg.try_as<Editor::ProfileViewModel>() })
+                {
+                    profileVM.CreateUnfocusedAppearance();
+                }
+                else if (const auto& navTag{ navigationArg.try_as<hstring>() }; navTag && *navTag == globalProfileTag)
+                {
+                    _LazyLoadProfileDefaultsViewModel();
+                    _profileDefaultsVM.CreateUnfocusedAppearance();
+                }
+            }
+
             _Navigate(navigationArg, subpage, elementToFocus);
             SettingsSearchBox().Text(L"");
         }

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -88,6 +88,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             return ProfileSubPage::Base;
         case BreadcrumbSubPage::Profile_Appearance:
             return ProfileSubPage::Appearance;
+        case BreadcrumbSubPage::Profile_UnfocusedAppearance:
+            return ProfileSubPage::UnfocusedAppearance;
         case BreadcrumbSubPage::Profile_Terminal:
             return ProfileSubPage::Terminal;
         case BreadcrumbSubPage::Profile_Advanced:
@@ -483,6 +485,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         {
             contentFrame().Navigate(xaml_typename<Editor::Profiles_Appearance>(), winrt::make<NavigateToPageArgs>(profile, *this, elementToFocus));
             _breadcrumbs.Append(winrt::make<Breadcrumb>(breadcrumbTag, RS_(L"Profile_Appearance/Header"), BreadcrumbSubPage::Profile_Appearance));
+        }
+        else if (page == ProfileSubPage::UnfocusedAppearance)
+        {
+            contentFrame().Navigate(xaml_typename<Editor::Profiles_UnfocusedAppearance>(), winrt::make<NavigateToPageArgs>(profile, *this, elementToFocus));
+            _breadcrumbs.Append(winrt::make<Breadcrumb>(breadcrumbTag, RS_(L"Profile_UnfocusedAppearanceTextBlock/Text"), BreadcrumbSubPage::Profile_UnfocusedAppearance));
         }
         else if (page == ProfileSubPage::Terminal)
         {

--- a/src/cascadia/TerminalSettingsEditor/MainPage.h
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.h
@@ -99,6 +99,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void _NavigateToProfileSubPage(const Editor::ProfileViewModel& profile, ProfileSubPage page, const IInspectable& breadcrumbTag, const hstring& elementToFocus);
 
         void _PreNavigateHelper();
+        void _LazyLoadProfileDefaultsViewModel();
         void _Navigate(const IInspectable& vm, BreadcrumbSubPage subPage = BreadcrumbSubPage::None, hstring elementToFocus = {});
         void _NavigateToProfileHandler(const IInspectable& sender, winrt::guid profileGuid);
         void _NavigateToColorSchemeHandler(const IInspectable& sender, const IInspectable& args);

--- a/src/cascadia/TerminalSettingsEditor/MainPage.idl
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.idl
@@ -35,6 +35,7 @@ namespace Microsoft.Terminal.Settings.Editor
     {
         None = 0,
         Profile_Appearance,
+        Profile_UnfocusedAppearance,
         Profile_Terminal,
         Profile_Advanced,
         ColorSchemes_Edit,

--- a/src/cascadia/TerminalSettingsEditor/MainPage.idl
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.idl
@@ -16,6 +16,13 @@ namespace Microsoft.Terminal.Settings.Editor
         UInt64 GetHostingWindow();
     }
 
+    interface IInheritableViewModel
+    {
+        Boolean HasSetting(String name);
+        void ClearSetting(String name);
+        Object SettingOverrideSource(String name);
+    }
+
     // This is used to pass data between pages during navigation.
     runtimeclass NavigateToPageArgs
     {

--- a/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
+++ b/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
@@ -173,6 +173,9 @@
     <ClInclude Include="SettingsCard.h">
       <DependentUpon>SettingsCard.idl</DependentUpon>
     </ClInclude>
+    <ClInclude Include="SettingResetButton.h">
+      <DependentUpon>SettingResetButton.idl</DependentUpon>
+    </ClInclude>
     <ClInclude Include="SettingsExpander.h">
       <DependentUpon>SettingsExpander.idl</DependentUpon>
     </ClInclude>
@@ -394,6 +397,9 @@
     <ClCompile Include="SettingsCard.cpp">
       <DependentUpon>SettingsCard.idl</DependentUpon>
     </ClCompile>
+    <ClCompile Include="SettingResetButton.cpp">
+      <DependentUpon>SettingResetButton.idl</DependentUpon>
+    </ClCompile>
     <ClCompile Include="SettingsExpander.cpp">
       <DependentUpon>SettingsExpander.idl</DependentUpon>
     </ClCompile>
@@ -505,6 +511,9 @@
       <SubType>Code</SubType>
     </Midl>
     <Midl Include="SettingsCard.idl">
+      <SubType>Code</SubType>
+    </Midl>
+    <Midl Include="SettingResetButton.idl">
       <SubType>Code</SubType>
     </Midl>
     <Midl Include="SettingsExpander.idl">

--- a/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
+++ b/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
@@ -159,6 +159,10 @@
       <DependentUpon>Profiles_Appearance.xaml</DependentUpon>
       <SubType>Code</SubType>
     </ClInclude>
+    <ClInclude Include="Profiles_UnfocusedAppearance.h">
+      <DependentUpon>Profiles_UnfocusedAppearance.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
     <ClInclude Include="Profiles_Terminal.h">
       <DependentUpon>Profiles_Terminal.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -247,6 +251,9 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="Profiles_Appearance.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Profiles_UnfocusedAppearance.xaml">
       <SubType>Designer</SubType>
     </Page>
     <Page Include="Profiles_Terminal.xaml">
@@ -383,6 +390,10 @@
       <DependentUpon>Profiles_Appearance.xaml</DependentUpon>
       <SubType>Code</SubType>
     </ClCompile>
+    <ClCompile Include="Profiles_UnfocusedAppearance.cpp">
+      <DependentUpon>Profiles_UnfocusedAppearance.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
     <ClCompile Include="Profiles_Terminal.cpp">
       <DependentUpon>Profiles_Terminal.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -500,6 +511,10 @@
     </Midl>
     <Midl Include="Profiles_Appearance.idl">
       <DependentUpon>Profiles_Appearance.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Midl>
+    <Midl Include="Profiles_UnfocusedAppearance.idl">
+      <DependentUpon>Profiles_UnfocusedAppearance.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Midl>
     <Midl Include="Profiles_Terminal.idl">

--- a/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
+++ b/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
@@ -177,6 +177,9 @@
     <ClInclude Include="SettingsCard.h">
       <DependentUpon>SettingsCard.idl</DependentUpon>
     </ClInclude>
+    <ClInclude Include="SettingResetButton.h">
+      <DependentUpon>SettingResetButton.idl</DependentUpon>
+    </ClInclude>
     <ClInclude Include="SettingsExpander.h">
       <DependentUpon>SettingsExpander.idl</DependentUpon>
     </ClInclude>
@@ -405,6 +408,9 @@
     <ClCompile Include="SettingsCard.cpp">
       <DependentUpon>SettingsCard.idl</DependentUpon>
     </ClCompile>
+    <ClCompile Include="SettingResetButton.cpp">
+      <DependentUpon>SettingResetButton.idl</DependentUpon>
+    </ClCompile>
     <ClCompile Include="SettingsExpander.cpp">
       <DependentUpon>SettingsExpander.idl</DependentUpon>
     </ClCompile>
@@ -520,6 +526,9 @@
       <SubType>Code</SubType>
     </Midl>
     <Midl Include="SettingsCard.idl">
+      <SubType>Code</SubType>
+    </Midl>
+    <Midl Include="SettingResetButton.idl">
       <SubType>Code</SubType>
     </Midl>
     <Midl Include="SettingsExpander.idl">

--- a/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
+++ b/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
@@ -163,6 +163,10 @@
       <DependentUpon>Profiles_Appearance.xaml</DependentUpon>
       <SubType>Code</SubType>
     </ClInclude>
+    <ClInclude Include="Profiles_UnfocusedAppearance.h">
+      <DependentUpon>Profiles_UnfocusedAppearance.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
     <ClInclude Include="Profiles_Terminal.h">
       <DependentUpon>Profiles_Terminal.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -254,6 +258,9 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="Profiles_Appearance.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Profiles_UnfocusedAppearance.xaml">
       <SubType>Designer</SubType>
     </Page>
     <Page Include="Profiles_Terminal.xaml">
@@ -394,6 +401,10 @@
       <DependentUpon>Profiles_Appearance.xaml</DependentUpon>
       <SubType>Code</SubType>
     </ClCompile>
+    <ClCompile Include="Profiles_UnfocusedAppearance.cpp">
+      <DependentUpon>Profiles_UnfocusedAppearance.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
     <ClCompile Include="Profiles_Terminal.cpp">
       <DependentUpon>Profiles_Terminal.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -515,6 +526,10 @@
     </Midl>
     <Midl Include="Profiles_Appearance.idl">
       <DependentUpon>Profiles_Appearance.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Midl>
+    <Midl Include="Profiles_UnfocusedAppearance.idl">
+      <DependentUpon>Profiles_UnfocusedAppearance.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Midl>
     <Midl Include="Profiles_Terminal.idl">

--- a/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj.filters
+++ b/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj.filters
@@ -50,6 +50,7 @@
     <Page Include="Profiles_Base.xaml" />
     <Page Include="Profiles_Advanced.xaml" />
     <Page Include="Profiles_Appearance.xaml" />
+    <Page Include="Profiles_UnfocusedAppearance.xaml" />
     <Page Include="Appearances.xaml" />
     <Page Include="Rendering.xaml" />
     <Page Include="Actions.xaml" />

--- a/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj.filters
+++ b/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj.filters
@@ -30,6 +30,7 @@
     <Midl Include="LaunchViewModel.idl" />
     <Midl Include="EnumEntry.idl" />
     <Midl Include="SettingsCard.idl" />
+    <Midl Include="SettingResetButton.idl" />
     <Midl Include="SettingsExpander.idl" />
     <Midl Include="SettingsControlsHelpers.idl" />
     <Midl Include="TerminalColorConverters.idl" />

--- a/src/cascadia/TerminalSettingsEditor/NewTabMenuViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/NewTabMenuViewModel.cpp
@@ -182,7 +182,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     hstring NewTabMenuViewModel::CurrentFolderNameAccessibleName() const
     {
-        return til::hstring_format(FMT_COMPILE(L"{}: {}"), RS_(L"NewTabMenu_CurrentFolderName/Header"), CurrentFolderName());
+        return FormatAccessibleName(USES_RESOURCE(L"NewTabMenu_CurrentFolderName/Header"), CurrentFolderName());
     }
 
     void NewTabMenuViewModel::CurrentFolderName(const hstring& value)

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
@@ -193,12 +193,21 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         return _parsedPadding.Bottom;
     }
+
     Control::IControlSettings ProfileViewModel::TermSettings() const
     {
         // This may look pricey, but it only resolves resources that have not been visited
         // and the preview update is debounced.
         _appSettings.ResolveMediaResources();
         return *Settings::TerminalSettings::CreateForPreview(_appSettings, _profile);
+    }
+
+    Control::IControlSettings ProfileViewModel::TermSettingsUnfocused() const
+    {
+        // This may look pricey, but it only resolves resources that have not been visited
+        // and the preview update is debounced.
+        _appSettings.ResolveMediaResources();
+        return *Settings::TerminalSettings::CreateForPreviewUnfocused(_appSettings, _profile);
     }
 
     // Method Description:
@@ -361,9 +370,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     Windows::Foundation::IInspectable ProfileViewModel::SettingOverrideSource(const hstring& name)
     {
         const std::wstring_view n{ name };
-#define HANDLE(Setting)                  \
-    if (n == L## #Setting)               \
-    {                                    \
+#define HANDLE(Setting)                   \
+    if (n == L## #Setting)                \
+    {                                     \
         return Setting##OverrideSource(); \
     }
 #define HANDLE_PROJECTED(target, Setting) HANDLE(Setting)
@@ -481,6 +490,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         return EditableUnfocusedAppearance() && HasUnfocusedAppearance();
     }
 
+    hstring ProfileViewModel::UnfocusedAppearanceCardValue()
+    {
+        return HasUnfocusedAppearance() ? hstring{} : RS_(L"Profile_UnfocusedAppearanceNone");
+    }
+
     void ProfileViewModel::CreateUnfocusedAppearance()
     {
         _profile.CreateUnfocusedAppearance();
@@ -488,7 +502,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _unfocusedAppearanceViewModel = winrt::make<implementation::AppearanceViewModel>(_profile.UnfocusedAppearance().try_as<AppearanceConfig>());
         _unfocusedAppearanceViewModel.SchemesList(DefaultAppearance().SchemesList());
 
-        _NotifyChanges(L"UnfocusedAppearance", L"HasUnfocusedAppearance", L"ShowUnfocusedAppearance");
+        _NotifyChanges(L"UnfocusedAppearance", L"HasUnfocusedAppearance", L"ShowUnfocusedAppearance", L"UnfocusedAppearanceCardValue");
     }
 
     void ProfileViewModel::DeleteUnfocusedAppearance()
@@ -497,7 +511,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         _unfocusedAppearanceViewModel = nullptr;
 
-        _NotifyChanges(L"UnfocusedAppearance", L"HasUnfocusedAppearance", L"ShowUnfocusedAppearance");
+        _NotifyChanges(L"UnfocusedAppearance", L"HasUnfocusedAppearance", L"ShowUnfocusedAppearance", L"UnfocusedAppearanceCardValue");
     }
 
     Editor::AppearanceViewModel ProfileViewModel::UnfocusedAppearance() const

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
@@ -112,19 +112,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 _parsedPadding = StringToXamlThickness(_profile.Padding());
                 _NotifyChanges(L"LeftPadding", L"TopPadding", L"RightPadding", L"BottomPadding");
             }
-            else if (viewModelProperty == L"TabTitle")
-            {
-                _NotifyChanges(L"TabTitlePreview");
-            }
-            else if (viewModelProperty == L"AnswerbackMessage")
-            {
-                _NotifyChanges(L"AnswerbackMessagePreview");
-            }
-            else if (viewModelProperty == L"TabColor")
-            {
-                _NotifyChanges(L"TabColorPreview");
-            }
-            else if (viewModelProperty == L"TabThemeColorPreview")
+            else if (viewModelProperty == L"TabColor" || viewModelProperty == L"TabThemeColorPreview")
             {
                 _NotifyChanges(L"TabColorPreview");
             }
@@ -340,23 +328,60 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         return _profile.Orphaned();
     }
 
-    hstring ProfileViewModel::TabTitlePreview() const
+    bool ProfileViewModel::HasSetting(const hstring& name)
     {
-        if (const auto tabTitle{ TabTitle() }; !tabTitle.empty())
-        {
-            return tabTitle;
-        }
-        return RS_(L"Profile_TabTitleNone");
+        const std::wstring_view n{ name };
+#define HANDLE(Setting)        \
+    if (n == L## #Setting)     \
+    {                          \
+        return Has##Setting(); \
+    }
+#define HANDLE_PROJECTED(target, Setting) HANDLE(Setting)
+        PROFILE_INHERITABLE_SETTINGS(HANDLE_PROJECTED)
+#undef HANDLE_PROJECTED
+#undef HANDLE
+        return false;
     }
 
-    hstring ProfileViewModel::AnswerbackMessagePreview() const
+    void ProfileViewModel::ClearSetting(const hstring& name)
     {
-        if (const auto answerbackMessage{ AnswerbackMessage() }; !answerbackMessage.empty())
-        {
-            return answerbackMessage;
-        }
-        return RS_(L"Profile_AnswerbackMessageNone");
+        const std::wstring_view n{ name };
+#define HANDLE(Setting)    \
+    if (n == L## #Setting) \
+    {                      \
+        Clear##Setting();  \
+        return;            \
     }
+#define HANDLE_PROJECTED(target, Setting) HANDLE(Setting)
+        PROFILE_INHERITABLE_SETTINGS(HANDLE_PROJECTED)
+#undef HANDLE_PROJECTED
+#undef HANDLE
+    }
+
+    Windows::Foundation::IInspectable ProfileViewModel::SettingOverrideSource(const hstring& name)
+    {
+        const std::wstring_view n{ name };
+#define HANDLE(Setting)                  \
+    if (n == L## #Setting)               \
+    {                                    \
+        return Setting##OverrideSource(); \
+    }
+#define HANDLE_PROJECTED(target, Setting) HANDLE(Setting)
+        PROFILE_INHERITABLE_SETTINGS(HANDLE_PROJECTED)
+#undef HANDLE_PROJECTED
+#undef HANDLE
+        return nullptr;
+    }
+
+    // Compile-time tripwire. PROFILE_INHERITABLE_SETTINGS now generates both the
+    // property accessors and the dispatch above, so those two can no longer drift.
+#define PROFILE_COUNT(target, name) +1
+    static_assert(0 PROFILE_INHERITABLE_SETTINGS(PROFILE_COUNT) == 34,
+                  "The set of inheritable profile settings changed. Update this count, then make "
+                  "sure the new/removed setting is also reflected in ProfileViewModel.idl and in the "
+                  "XAML reset buttons.");
+#undef PROFILE_COUNT
+#undef PROFILE_INHERITABLE_SETTINGS
 
     Windows::UI::Color ProfileViewModel::TabColorPreview() const
     {

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
@@ -227,6 +227,14 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         return *Settings::TerminalSettings::CreateForPreview(_appSettings, _windowSettings, _profile);
     }
 
+    Control::IControlSettings ProfileViewModel::TermSettingsUnfocused() const
+    {
+        // This may look pricey, but it only resolves resources that have not been visited
+        // and the preview update is debounced.
+        _appSettings.ResolveMediaResources();
+        return *Settings::TerminalSettings::CreateForPreviewUnfocused(_appSettings, _windowSettings, _profile);
+    }
+
     // Method Description:
     // - Updates the lists of fonts and sorts them alphabetically
     void ProfileViewModel::UpdateFontList() noexcept
@@ -417,9 +425,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     Windows::Foundation::IInspectable ProfileViewModel::SettingOverrideSource(const hstring& name)
     {
         const std::wstring_view n{ name };
-#define HANDLE(Setting)                  \
-    if (n == L## #Setting)               \
-    {                                    \
+#define HANDLE(Setting)                   \
+    if (n == L## #Setting)                \
+    {                                     \
         return Setting##OverrideSource(); \
     }
 #define HANDLE_PROJECTED(target, Setting) HANDLE(Setting)
@@ -537,6 +545,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         return EditableUnfocusedAppearance() && HasUnfocusedAppearance();
     }
 
+    hstring ProfileViewModel::UnfocusedAppearanceCardValue()
+    {
+        return HasUnfocusedAppearance() ? hstring{} : RS_(L"Profile_UnfocusedAppearanceNone");
+    }
+
     void ProfileViewModel::CreateUnfocusedAppearance()
     {
         _profile.CreateUnfocusedAppearance();
@@ -544,7 +557,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _unfocusedAppearanceViewModel = winrt::make<implementation::AppearanceViewModel>(_profile.UnfocusedAppearance().try_as<AppearanceConfig>());
         _unfocusedAppearanceViewModel.SchemesList(DefaultAppearance().SchemesList());
 
-        _NotifyChanges(L"UnfocusedAppearance", L"HasUnfocusedAppearance", L"ShowUnfocusedAppearance");
+        _NotifyChanges(L"UnfocusedAppearance", L"HasUnfocusedAppearance", L"ShowUnfocusedAppearance", L"UnfocusedAppearanceCardValue");
     }
 
     void ProfileViewModel::DeleteUnfocusedAppearance()
@@ -553,7 +566,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         _unfocusedAppearanceViewModel = nullptr;
 
-        _NotifyChanges(L"UnfocusedAppearance", L"HasUnfocusedAppearance", L"ShowUnfocusedAppearance");
+        _NotifyChanges(L"UnfocusedAppearance", L"HasUnfocusedAppearance", L"ShowUnfocusedAppearance", L"UnfocusedAppearanceCardValue");
     }
 
     Editor::AppearanceViewModel ProfileViewModel::UnfocusedAppearance() const

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
@@ -90,7 +90,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                                L"IconPreview",
                                L"IconPath",
                                L"EvaluatedIcon",
-                               L"UsingNoIcon");
+                               L"UsingNoIcon",
+                               L"IconAccessibleName");
             }
             else if (viewModelProperty == L"CurrentBellSounds")
             {
@@ -122,7 +123,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             }
             else if (viewModelProperty == L"TabColor" || viewModelProperty == L"TabThemeColorPreview")
             {
-                _NotifyChanges(L"TabColorPreview");
+                _NotifyChanges(L"TabColorPreview", L"TabColorAccessibleName");
             }
             else if (viewModelProperty == L"Hidden")
             {
@@ -216,7 +217,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     hstring ProfileViewModel::PaddingAccessibleName() const
     {
-        return til::hstring_format(FMT_COMPILE(L"{}: {}"), RS_(L"Profile_Padding/Header"), Padding());
+        return FormatAccessibleName(USES_RESOURCE(L"Profile_Padding/Header"), Padding());
     }
 
     Control::IControlSettings ProfileViewModel::TermSettings() const
@@ -525,6 +526,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         };
     }
 
+    hstring ProfileViewModel::TabColorAccessibleName() const
+    {
+        return FormatAccessibleName(USES_RESOURCE(L"Profile_TabColor/Header"), ColorToHexString(TabColorPreview()));
+    }
+
     Editor::AppearanceViewModel ProfileViewModel::DefaultAppearance() const
     {
         return _defaultAppearanceViewModel;
@@ -658,6 +664,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         return IconPath(); // For display as a string
     }
 
+    winrt::hstring ProfileViewModel::IconAccessibleName() const
+    {
+        return FormatAccessibleName(USES_RESOURCE(L"Profile_Icon/Header"), LocalizedIcon());
+    }
+
     Windows::UI::Xaml::Controls::IconElement ProfileViewModel::IconPreview() const
     {
         // IconWUX sets the icon width/height to 32 by default
@@ -722,7 +733,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     hstring ProfileViewModel::BellStyleAccessibleName() const
     {
-        return til::hstring_format(FMT_COMPILE(L"{}: {}"), RS_(L"Profile_BellStyle/Header"), BellStylePreview());
+        return FormatAccessibleName(USES_RESOURCE(L"Profile_BellStyle/Header"), BellStylePreview());
     }
 
     bool ProfileViewModel::IsBellStyleFlagSet(const uint32_t flag)
@@ -870,7 +881,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     hstring ProfileViewModel::BellSoundAccessibleName()
     {
-        return til::hstring_format(FMT_COMPILE(L"{}: {}"), RS_(L"Profile_BellSound/Header"), BellSoundPreview());
+        return FormatAccessibleName(USES_RESOURCE(L"Profile_BellSound/Header"), BellSoundPreview());
     }
 
     void ProfileViewModel::RequestAddBellSound(hstring path)

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
@@ -120,23 +120,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 _parsedPadding = StringToXamlThickness(_profile.Padding());
                 _NotifyChanges(L"LeftPadding", L"TopPadding", L"RightPadding", L"BottomPadding", L"PaddingAccessibleName");
             }
-            else if (viewModelProperty == L"TabTitle")
-            {
-                _NotifyChanges(L"TabTitlePreview");
-            }
-            else if (viewModelProperty == L"AnswerbackMessage")
-            {
-                _NotifyChanges(L"AnswerbackMessagePreview");
-            }
-            else if (viewModelProperty == L"AnswerbackMessagePreview")
-            {
-                _NotifyChanges(L"AnswerbackMessageAccessibleName");
-            }
-            else if (viewModelProperty == L"TabColor")
-            {
-                _NotifyChanges(L"TabColorPreview");
-            }
-            else if (viewModelProperty == L"TabThemeColorPreview")
+            else if (viewModelProperty == L"TabColor" || viewModelProperty == L"TabThemeColorPreview")
             {
                 _NotifyChanges(L"TabColorPreview");
             }
@@ -153,7 +137,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 _NotifyChanges(L"TabThemeColorPreview");
             }
         });
-
         // Do the same for the starting directory
         if (!StartingDirectory().empty())
         {
@@ -401,28 +384,60 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         return Hidden() && !Orphaned();
     }
 
-    hstring ProfileViewModel::TabTitlePreview() const
+    bool ProfileViewModel::HasSetting(const hstring& name)
     {
-        if (const auto tabTitle{ TabTitle() }; !tabTitle.empty())
-        {
-            return tabTitle;
-        }
-        return RS_(L"Profile_TabTitleNone");
+        const std::wstring_view n{ name };
+#define HANDLE(Setting)        \
+    if (n == L## #Setting)     \
+    {                          \
+        return Has##Setting(); \
+    }
+#define HANDLE_PROJECTED(target, Setting) HANDLE(Setting)
+        PROFILE_INHERITABLE_SETTINGS(HANDLE_PROJECTED)
+#undef HANDLE_PROJECTED
+#undef HANDLE
+        return false;
     }
 
-    hstring ProfileViewModel::AnswerbackMessagePreview() const
+    void ProfileViewModel::ClearSetting(const hstring& name)
     {
-        if (const auto answerbackMessage{ AnswerbackMessage() }; !answerbackMessage.empty())
-        {
-            return answerbackMessage;
-        }
-        return RS_(L"Profile_AnswerbackMessageNone");
+        const std::wstring_view n{ name };
+#define HANDLE(Setting)    \
+    if (n == L## #Setting) \
+    {                      \
+        Clear##Setting();  \
+        return;            \
+    }
+#define HANDLE_PROJECTED(target, Setting) HANDLE(Setting)
+        PROFILE_INHERITABLE_SETTINGS(HANDLE_PROJECTED)
+#undef HANDLE_PROJECTED
+#undef HANDLE
     }
 
-    hstring ProfileViewModel::AnswerbackMessageAccessibleName() const
+    Windows::Foundation::IInspectable ProfileViewModel::SettingOverrideSource(const hstring& name)
     {
-        return til::hstring_format(FMT_COMPILE(L"{}: {}"), RS_(L"Profile_AnswerbackMessage/Header"), AnswerbackMessagePreview());
+        const std::wstring_view n{ name };
+#define HANDLE(Setting)                  \
+    if (n == L## #Setting)               \
+    {                                    \
+        return Setting##OverrideSource(); \
     }
+#define HANDLE_PROJECTED(target, Setting) HANDLE(Setting)
+        PROFILE_INHERITABLE_SETTINGS(HANDLE_PROJECTED)
+#undef HANDLE_PROJECTED
+#undef HANDLE
+        return nullptr;
+    }
+
+    // Compile-time tripwire. PROFILE_INHERITABLE_SETTINGS now generates both the
+    // property accessors and the dispatch above, so those two can no longer drift.
+#define PROFILE_COUNT(target, name) +1
+    static_assert(0 PROFILE_INHERITABLE_SETTINGS(PROFILE_COUNT) == 34,
+                  "The set of inheritable profile settings changed. Update this count, then make "
+                  "sure the new/removed setting is also reflected in ProfileViewModel.idl and in the "
+                  "XAML reset buttons.");
+#undef PROFILE_COUNT
+#undef PROFILE_INHERITABLE_SETTINGS
 
     Windows::UI::Color ProfileViewModel::TabColorPreview() const
     {

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
@@ -552,6 +552,22 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     void ProfileViewModel::CreateUnfocusedAppearance()
     {
+        if (_profile.HasUnfocusedAppearance())
+        {
+            // Profile already has an unfocused appearance. Don't create a new one.
+            return;
+        }
+
+        TraceLoggingWrite(
+            g_hTerminalSettingsEditorProvider,
+            "CreateUnfocusedAppearance",
+            TraceLoggingDescription("Event emitted when the user creates an unfocused appearance for a profile"),
+            TraceLoggingValue(IsBaseLayer(), "IsProfileDefaults", "If the modified profile is the profile.defaults object"),
+            TraceLoggingValue(static_cast<GUID>(Guid()), "ProfileGuid", "The guid of the profile that was navigated to"),
+            TraceLoggingValue(Source().c_str(), "ProfileSource", "The source of the profile that was navigated to"),
+            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+            TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
+
         _profile.CreateUnfocusedAppearance();
 
         _unfocusedAppearanceViewModel = winrt::make<implementation::AppearanceViewModel>(_profile.UnfocusedAppearance().try_as<AppearanceConfig>());

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
@@ -36,6 +36,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         ProfileViewModel(const Model::Profile& profile, const Model::CascadiaSettings& settings, const Windows::UI::Core::CoreDispatcher& dispatcher);
         Control::IControlSettings TermSettings() const;
+        Control::IControlSettings TermSettingsUnfocused() const;
         void DeleteProfile();
 
         void SetupAppearances(Windows::Foundation::Collections::IObservableVector<Editor::ColorSchemeViewModel> schemesList);
@@ -93,6 +94,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         bool HasUnfocusedAppearance();
         bool EditableUnfocusedAppearance() const noexcept;
         bool ShowUnfocusedAppearance();
+        hstring UnfocusedAppearanceCardValue();
         void CreateUnfocusedAppearance();
         void DeleteUnfocusedAppearance();
 
@@ -121,7 +123,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
 // Settings that expose a reset button.
 // Wired into both the property accessors and the reset dispatch automatically.
-#define PROFILE_INHERITABLE_SETTINGS(X) \
+#define PROFILE_INHERITABLE_SETTINGS(X)         \
     X(_profile, Name)                           \
     X(_profile, Hidden)                         \
     X(_profile, Icon)                           \

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
@@ -101,8 +101,12 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         bool RepositionCursorWithMouseAvailable() const noexcept;
 
         bool Orphaned() const;
-        hstring TabTitlePreview() const;
-        hstring AnswerbackMessagePreview() const;
+
+        // IInheritableViewModel
+        bool HasSetting(const hstring& name);
+        void ClearSetting(const hstring& name);
+        Windows::Foundation::IInspectable SettingOverrideSource(const hstring& name);
+
         Windows::UI::Color TabColorPreview() const;
         Windows::UI::Color TabThemeColorPreview() const;
 
@@ -113,41 +117,50 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_profile, Guid);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_profile, ConnectionType);
-        OBSERVABLE_PROJECTED_SETTING(_profile, Name);
         OBSERVABLE_PROJECTED_SETTING(_profile, Source);
-        OBSERVABLE_PROJECTED_SETTING(_profile, Hidden);
-        OBSERVABLE_PROJECTED_SETTING(_profile, Icon);
-        OBSERVABLE_PROJECTED_SETTING(_profile, CloseOnExit);
-        OBSERVABLE_PROJECTED_SETTING(_profile, TabTitle);
-        OBSERVABLE_PROJECTED_SETTING(_profile, TabColor);
-        OBSERVABLE_PROJECTED_SETTING(_profile, SuppressApplicationTitle);
-        OBSERVABLE_PROJECTED_SETTING(_profile, ScrollState);
-        OBSERVABLE_PROJECTED_SETTING(_profile, Padding);
-        OBSERVABLE_PROJECTED_SETTING(_profile, Commandline);
-        OBSERVABLE_PROJECTED_SETTING(_profile, StartingDirectory);
-        OBSERVABLE_PROJECTED_SETTING(_profile, AntialiasingMode);
-        OBSERVABLE_PROJECTED_SETTING(_profile.DefaultAppearance(), Opacity);
-        OBSERVABLE_PROJECTED_SETTING(_profile.DefaultAppearance(), UseAcrylic);
-        OBSERVABLE_PROJECTED_SETTING(_profile, HistorySize);
-        OBSERVABLE_PROJECTED_SETTING(_profile, SnapOnInput);
-        OBSERVABLE_PROJECTED_SETTING(_profile, AltGrAliasing);
-        OBSERVABLE_PROJECTED_SETTING(_profile, BellStyle);
-        OBSERVABLE_PROJECTED_SETTING(_profile, BellSound);
-        OBSERVABLE_PROJECTED_SETTING(_profile, Elevate);
-        OBSERVABLE_PROJECTED_SETTING(_profile, ReloadEnvironmentVariables);
-        OBSERVABLE_PROJECTED_SETTING(_profile, RightClickContextMenu);
-        OBSERVABLE_PROJECTED_SETTING(_profile, ShowMarks);
-        OBSERVABLE_PROJECTED_SETTING(_profile, AutoMarkPrompts);
-        OBSERVABLE_PROJECTED_SETTING(_profile, RepositionCursorWithMouse);
-        OBSERVABLE_PROJECTED_SETTING(_profile, ForceVTInput);
-        OBSERVABLE_PROJECTED_SETTING(_profile, AllowKittyKeyboardMode);
-        OBSERVABLE_PROJECTED_SETTING(_profile, AllowVtChecksumReport);
-        OBSERVABLE_PROJECTED_SETTING(_profile, AllowVtClipboardWrite);
-        OBSERVABLE_PROJECTED_SETTING(_profile, AllowOscNotifications);
-        OBSERVABLE_PROJECTED_SETTING(_profile, AnswerbackMessage);
-        OBSERVABLE_PROJECTED_SETTING(_profile, RainbowSuggestions);
-        OBSERVABLE_PROJECTED_SETTING(_profile, PathTranslationStyle);
-        OBSERVABLE_PROJECTED_SETTING(_profile, DragDropDelimiter);
+
+// Settings that expose a reset button.
+// Wired into both the property accessors and the reset dispatch automatically.
+#define PROFILE_INHERITABLE_SETTINGS(X) \
+    X(_profile, Name)                           \
+    X(_profile, Hidden)                         \
+    X(_profile, Icon)                           \
+    X(_profile, CloseOnExit)                    \
+    X(_profile, TabTitle)                       \
+    X(_profile, TabColor)                       \
+    X(_profile, SuppressApplicationTitle)       \
+    X(_profile, ScrollState)                    \
+    X(_profile, Padding)                        \
+    X(_profile, Commandline)                    \
+    X(_profile, StartingDirectory)              \
+    X(_profile, AntialiasingMode)               \
+    X(_profile.DefaultAppearance(), Opacity)    \
+    X(_profile.DefaultAppearance(), UseAcrylic) \
+    X(_profile, HistorySize)                    \
+    X(_profile, SnapOnInput)                    \
+    X(_profile, AltGrAliasing)                  \
+    X(_profile, BellStyle)                      \
+    X(_profile, BellSound)                      \
+    X(_profile, Elevate)                        \
+    X(_profile, ReloadEnvironmentVariables)     \
+    X(_profile, RightClickContextMenu)          \
+    X(_profile, ShowMarks)                      \
+    X(_profile, AutoMarkPrompts)                \
+    X(_profile, RepositionCursorWithMouse)      \
+    X(_profile, ForceVTInput)                   \
+    X(_profile, AllowKittyKeyboardMode)         \
+    X(_profile, AllowVtChecksumReport)          \
+    X(_profile, AllowVtClipboardWrite)          \
+    X(_profile, AllowOscNotifications)          \
+    X(_profile, AnswerbackMessage)              \
+    X(_profile, RainbowSuggestions)             \
+    X(_profile, PathTranslationStyle)           \
+    X(_profile, DragDropDelimiter)
+
+        // Generate the projected property accessors from the list above.
+#define PROFILE_GEN_PROJECTED(target, name) OBSERVABLE_PROJECTED_SETTING(target, name);
+        PROFILE_INHERITABLE_SETTINGS(PROFILE_GEN_PROJECTED)
+#undef PROFILE_GEN_PROJECTED
 
         WINRT_PROPERTY(bool, IsBaseLayer, false);
         WINRT_PROPERTY(bool, FocusDeleteButton, false);

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
@@ -76,6 +76,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
         Windows::UI::Xaml::Controls::IconElement IconPreview() const;
         winrt::hstring LocalizedIcon() const;
+        winrt::hstring IconAccessibleName() const;
         winrt::hstring IconPath() const { return _profile.Icon().Path(); }
         void IconPath(const winrt::hstring& path)
         {
@@ -116,6 +117,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         Windows::UI::Color TabColorPreview() const;
         Windows::UI::Color TabThemeColorPreview() const;
+        hstring TabColorAccessibleName() const;
 
         til::typed_event<Editor::ProfileViewModel, Editor::DeleteProfileEventArgs> DeleteProfileRequested;
 

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
@@ -36,6 +36,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         ProfileViewModel(const Model::Profile& profile, const Model::CascadiaSettings& settings, const Model::WindowSettings& windowSettings, const Windows::UI::Core::CoreDispatcher& dispatcher);
         Control::IControlSettings TermSettings() const;
+        Control::IControlSettings TermSettingsUnfocused() const;
         void DeleteProfile();
 
         void SetupAppearances(Windows::Foundation::Collections::IObservableVector<Editor::ColorSchemeViewModel> schemesList);
@@ -96,6 +97,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         bool HasUnfocusedAppearance();
         bool EditableUnfocusedAppearance() const noexcept;
         bool ShowUnfocusedAppearance();
+        hstring UnfocusedAppearanceCardValue();
         void CreateUnfocusedAppearance();
         void DeleteUnfocusedAppearance();
 
@@ -126,7 +128,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
 // Settings that expose a reset button.
 // Wired into both the property accessors and the reset dispatch automatically.
-#define PROFILE_INHERITABLE_SETTINGS(X) \
+#define PROFILE_INHERITABLE_SETTINGS(X)         \
     X(_profile, Name)                           \
     X(_profile, Hidden)                         \
     X(_profile, Icon)                           \

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
@@ -106,9 +106,12 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         bool Orphaned() const;
         hstring AccessibleStateDescription() const;
         bool ShowHiddenBadge() const;
-        hstring TabTitlePreview() const;
-        hstring AnswerbackMessagePreview() const;
-        hstring AnswerbackMessageAccessibleName() const;
+
+        // IInheritableViewModel
+        bool HasSetting(const hstring& name);
+        void ClearSetting(const hstring& name);
+        Windows::Foundation::IInspectable SettingOverrideSource(const hstring& name);
+
         Windows::UI::Color TabColorPreview() const;
         Windows::UI::Color TabThemeColorPreview() const;
 
@@ -119,41 +122,50 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_profile, Guid);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_profile, ConnectionType);
-        OBSERVABLE_PROJECTED_SETTING(_profile, Name);
         OBSERVABLE_PROJECTED_SETTING(_profile, Source);
-        OBSERVABLE_PROJECTED_SETTING(_profile, Hidden);
-        OBSERVABLE_PROJECTED_SETTING(_profile, Icon);
-        OBSERVABLE_PROJECTED_SETTING(_profile, CloseOnExit);
-        OBSERVABLE_PROJECTED_SETTING(_profile, TabTitle);
-        OBSERVABLE_PROJECTED_SETTING(_profile, TabColor);
-        OBSERVABLE_PROJECTED_SETTING(_profile, SuppressApplicationTitle);
-        OBSERVABLE_PROJECTED_SETTING(_profile, ScrollState);
-        OBSERVABLE_PROJECTED_SETTING(_profile, Padding);
-        OBSERVABLE_PROJECTED_SETTING(_profile, Commandline);
-        OBSERVABLE_PROJECTED_SETTING(_profile, StartingDirectory);
-        OBSERVABLE_PROJECTED_SETTING(_profile, AntialiasingMode);
-        OBSERVABLE_PROJECTED_SETTING(_profile.DefaultAppearance(), Opacity);
-        OBSERVABLE_PROJECTED_SETTING(_profile.DefaultAppearance(), UseAcrylic);
-        OBSERVABLE_PROJECTED_SETTING(_profile, HistorySize);
-        OBSERVABLE_PROJECTED_SETTING(_profile, SnapOnInput);
-        OBSERVABLE_PROJECTED_SETTING(_profile, AltGrAliasing);
-        OBSERVABLE_PROJECTED_SETTING(_profile, BellStyle);
-        OBSERVABLE_PROJECTED_SETTING(_profile, BellSound);
-        OBSERVABLE_PROJECTED_SETTING(_profile, Elevate);
-        OBSERVABLE_PROJECTED_SETTING(_profile, ReloadEnvironmentVariables);
-        OBSERVABLE_PROJECTED_SETTING(_profile, RightClickContextMenu);
-        OBSERVABLE_PROJECTED_SETTING(_profile, ShowMarks);
-        OBSERVABLE_PROJECTED_SETTING(_profile, AutoMarkPrompts);
-        OBSERVABLE_PROJECTED_SETTING(_profile, RepositionCursorWithMouse);
-        OBSERVABLE_PROJECTED_SETTING(_profile, ForceVTInput);
-        OBSERVABLE_PROJECTED_SETTING(_profile, AllowKittyKeyboardMode);
-        OBSERVABLE_PROJECTED_SETTING(_profile, AllowVtChecksumReport);
-        OBSERVABLE_PROJECTED_SETTING(_profile, AllowVtClipboardWrite);
-        OBSERVABLE_PROJECTED_SETTING(_profile, AllowOscNotifications);
-        OBSERVABLE_PROJECTED_SETTING(_profile, AnswerbackMessage);
-        OBSERVABLE_PROJECTED_SETTING(_profile, RainbowSuggestions);
-        OBSERVABLE_PROJECTED_SETTING(_profile, PathTranslationStyle);
-        OBSERVABLE_PROJECTED_SETTING(_profile, DragDropDelimiter);
+
+// Settings that expose a reset button.
+// Wired into both the property accessors and the reset dispatch automatically.
+#define PROFILE_INHERITABLE_SETTINGS(X) \
+    X(_profile, Name)                           \
+    X(_profile, Hidden)                         \
+    X(_profile, Icon)                           \
+    X(_profile, CloseOnExit)                    \
+    X(_profile, TabTitle)                       \
+    X(_profile, TabColor)                       \
+    X(_profile, SuppressApplicationTitle)       \
+    X(_profile, ScrollState)                    \
+    X(_profile, Padding)                        \
+    X(_profile, Commandline)                    \
+    X(_profile, StartingDirectory)              \
+    X(_profile, AntialiasingMode)               \
+    X(_profile.DefaultAppearance(), Opacity)    \
+    X(_profile.DefaultAppearance(), UseAcrylic) \
+    X(_profile, HistorySize)                    \
+    X(_profile, SnapOnInput)                    \
+    X(_profile, AltGrAliasing)                  \
+    X(_profile, BellStyle)                      \
+    X(_profile, BellSound)                      \
+    X(_profile, Elevate)                        \
+    X(_profile, ReloadEnvironmentVariables)     \
+    X(_profile, RightClickContextMenu)          \
+    X(_profile, ShowMarks)                      \
+    X(_profile, AutoMarkPrompts)                \
+    X(_profile, RepositionCursorWithMouse)      \
+    X(_profile, ForceVTInput)                   \
+    X(_profile, AllowKittyKeyboardMode)         \
+    X(_profile, AllowVtChecksumReport)          \
+    X(_profile, AllowVtClipboardWrite)          \
+    X(_profile, AllowOscNotifications)          \
+    X(_profile, AnswerbackMessage)              \
+    X(_profile, RainbowSuggestions)             \
+    X(_profile, PathTranslationStyle)           \
+    X(_profile, DragDropDelimiter)
+
+        // Generate the projected property accessors from the list above.
+#define PROFILE_GEN_PROJECTED(target, name) OBSERVABLE_PROJECTED_SETTING(target, name);
+        PROFILE_INHERITABLE_SETTINGS(PROFILE_GEN_PROJECTED)
+#undef PROFILE_GEN_PROJECTED
 
         WINRT_PROPERTY(bool, IsBaseLayer, false);
         WINRT_PROPERTY(bool, FocusDeleteButton, false);

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
@@ -33,7 +33,8 @@ namespace Microsoft.Terminal.Settings.Editor
         Base = 0,
         Appearance = 1,
         Terminal = 2,
-        Advanced = 3
+        Advanced = 3,
+        UnfocusedAppearance = 4
     };
 
     runtimeclass ProfileViewModel : Windows.UI.Xaml.Data.INotifyPropertyChanged, IInheritableViewModel
@@ -85,6 +86,7 @@ namespace Microsoft.Terminal.Settings.Editor
         Boolean HasUnfocusedAppearance { get; };
         Boolean EditableUnfocusedAppearance { get; };
         Boolean ShowUnfocusedAppearance { get; };
+        String UnfocusedAppearanceCardValue { get; };
         AppearanceViewModel UnfocusedAppearance { get; };
 
         Boolean ShowMarksAvailable { get; };

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
@@ -36,7 +36,7 @@ namespace Microsoft.Terminal.Settings.Editor
         Advanced = 3
     };
 
-    runtimeclass ProfileViewModel : Windows.UI.Xaml.Data.INotifyPropertyChanged
+    runtimeclass ProfileViewModel : Windows.UI.Xaml.Data.INotifyPropertyChanged, IInheritableViewModel
     {
         event Windows.Foundation.TypedEventHandler<ProfileViewModel, DeleteProfileEventArgs> DeleteProfileRequested;
 
@@ -97,8 +97,6 @@ namespace Microsoft.Terminal.Settings.Editor
         String IconPath;
         Boolean UsingNoIcon { get; };
 
-        String TabTitlePreview { get; };
-        String AnswerbackMessagePreview { get; };
         Windows.UI.Color TabColorPreview { get; };
         Windows.UI.Color TabThemeColorPreview { get; };
 

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
@@ -33,7 +33,8 @@ namespace Microsoft.Terminal.Settings.Editor
         Base = 0,
         Appearance = 1,
         Terminal = 2,
-        Advanced = 3
+        Advanced = 3,
+        UnfocusedAppearance = 4
     };
 
     runtimeclass ProfileViewModel : Windows.UI.Xaml.Data.INotifyPropertyChanged, IInheritableViewModel
@@ -88,6 +89,7 @@ namespace Microsoft.Terminal.Settings.Editor
         Boolean HasUnfocusedAppearance { get; };
         Boolean EditableUnfocusedAppearance { get; };
         Boolean ShowUnfocusedAppearance { get; };
+        String UnfocusedAppearanceCardValue { get; };
         AppearanceViewModel UnfocusedAppearance { get; };
 
         Boolean ShowMarksAvailable { get; };

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
@@ -36,7 +36,7 @@ namespace Microsoft.Terminal.Settings.Editor
         Advanced = 3
     };
 
-    runtimeclass ProfileViewModel : Windows.UI.Xaml.Data.INotifyPropertyChanged
+    runtimeclass ProfileViewModel : Windows.UI.Xaml.Data.INotifyPropertyChanged, IInheritableViewModel
     {
         event Windows.Foundation.TypedEventHandler<ProfileViewModel, DeleteProfileEventArgs> DeleteProfileRequested;
 
@@ -100,9 +100,6 @@ namespace Microsoft.Terminal.Settings.Editor
         String IconPath;
         Boolean UsingNoIcon { get; };
 
-        String TabTitlePreview { get; };
-        String AnswerbackMessagePreview { get; };
-        String AnswerbackMessageAccessibleName { get; };
         Windows.UI.Color TabColorPreview { get; };
         Windows.UI.Color TabThemeColorPreview { get; };
 

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
@@ -99,11 +99,13 @@ namespace Microsoft.Terminal.Settings.Editor
         Windows.UI.Xaml.Controls.IconElement IconPreview { get; };
         String EvaluatedIcon { get; };
         String LocalizedIcon { get; };
+        String IconAccessibleName { get; };
         String IconPath;
         Boolean UsingNoIcon { get; };
 
         Windows.UI.Color TabColorPreview { get; };
         Windows.UI.Color TabThemeColorPreview { get; };
+        String TabColorAccessibleName { get; };
 
         void CreateUnfocusedAppearance();
         void DeleteUnfocusedAppearance();

--- a/src/cascadia/TerminalSettingsEditor/Profiles.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.cpp
@@ -39,7 +39,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
     }
 
-    // The primary "+" half of the SplitButton — adds either a new empty
+    // The primary "+" half of the SplitButton. Adds either a new empty
     // profile or a duplicate of the currently selected source profile,
     // depending on what the user picked from the flyout.
     void Profiles::AddProfile_Click(const winrt::Microsoft::UI::Xaml::Controls::SplitButton& /*sender*/,
@@ -62,7 +62,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     // Rebuilds the MenuFlyout each time it opens so newly added/removed
     // profiles are reflected without having to subscribe to VectorChanged.
     // Selecting a flyout item updates which profile the SplitButton's primary
-    // action will use as its source — it does NOT add a profile on its own.
+    // action will use as its source. It does NOT add a profile on its own.
     void Profiles::AddProfileFlyout_Opening(const IInspectable& sender, const IInspectable& /*args*/)
     {
         const auto flyout = sender.try_as<MenuFlyout>();
@@ -78,7 +78,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         const auto selected = _ViewModel.SelectedSourceProfile();
         const auto weakViewModel = winrt::make_weak(_ViewModel);
 
-        // "New empty profile" item — picking this resets the SplitButton to its
+        // "New empty profile" item. Picking this resets the SplitButton to its
         // default state where the primary action creates a brand-new profile.
         {
             winrt::Microsoft::UI::Xaml::Controls::RadioMenuFlyoutItem newEmptyItem;
@@ -103,7 +103,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         items.Append(MenuFlyoutSeparator{});
 
-        // One RadioMenuFlyoutItem per existing profile — picking one swaps the
+        // One RadioMenuFlyoutItem per existing profile. Picking one swaps the
         // SplitButton's primary action over to "duplicate this profile".
         for (const auto& profileVM : _ViewModel.Profiles())
         {

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.xaml
@@ -35,7 +35,6 @@
                    Style="{StaticResource DisclaimerStyle}"
                    Visibility="{x:Bind Profile.IsBaseLayer}" />
         <StackPanel Grid.Row="1"
-                    Spacing="2"
                     Style="{StaticResource SettingsStackStyle}">
             <!--  Antialiasing Mode  -->
             <local:SettingsCard x:Name="AntialiasingMode"

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.xaml
@@ -39,54 +39,81 @@
             <!--  Antialiasing Mode  -->
             <local:SettingsCard x:Name="AntialiasingMode"
                                 x:Uid="Profile_AntialiasingMode">
-                <ComboBox AutomationProperties.AccessibilityView="Content"
-                          ItemTemplate="{StaticResource EnumComboBoxTemplate}"
-                          ItemsSource="{x:Bind Profile.AntiAliasingModeList, Mode=OneWay}"
-                          SelectedItem="{x:Bind Profile.CurrentAntiAliasingMode, Mode=TwoWay}"
-                          Style="{StaticResource ComboBoxSettingStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ComboBox AutomationProperties.AccessibilityView="Content"
+                              ItemTemplate="{StaticResource EnumComboBoxTemplate}"
+                              ItemsSource="{x:Bind Profile.AntiAliasingModeList, Mode=OneWay}"
+                              SelectedItem="{x:Bind Profile.CurrentAntiAliasingMode, Mode=TwoWay}"
+                              Style="{StaticResource ComboBoxSettingStyle}" />
+                    <local:SettingResetButton SettingName="AntialiasingMode"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  AltGr Aliasing  -->
             <local:SettingsCard x:Name="AltGrAliasing"
                                 x:Uid="Profile_AltGrAliasing">
-                <ToggleSwitch IsOn="{x:Bind Profile.AltGrAliasing, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.AltGrAliasing, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="AltGrAliasing"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Snap On Input  -->
             <local:SettingsCard x:Name="SnapOnInput"
                                 x:Uid="Profile_SnapOnInput">
-                <ToggleSwitch IsOn="{x:Bind Profile.SnapOnInput, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.SnapOnInput, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="SnapOnInput"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  History Size  -->
             <local:SettingsCard x:Name="HistorySize"
                                 x:Uid="Profile_HistorySize">
-                <muxc:NumberBox x:Uid="Profile_HistorySizeBox"
-                                LargeChange="100"
-                                Minimum="0"
-                                SmallChange="10"
-                                Style="{StaticResource NumberBoxSettingStyle}"
-                                Value="{x:Bind Profile.HistorySize, Mode=TwoWay}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <muxc:NumberBox x:Uid="Profile_HistorySizeBox"
+                                    LargeChange="100"
+                                    Minimum="0"
+                                    SmallChange="10"
+                                    Style="{StaticResource NumberBoxSettingStyle}"
+                                    Value="{x:Bind Profile.HistorySize, Mode=TwoWay}" />
+                    <local:SettingResetButton SettingName="HistorySize"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Close On Exit  -->
             <local:SettingsCard x:Name="CloseOnExit"
                                 x:Uid="Profile_CloseOnExit">
-                <ComboBox AutomationProperties.AccessibilityView="Content"
-                          ItemTemplate="{StaticResource EnumComboBoxTemplate}"
-                          ItemsSource="{x:Bind Profile.CloseOnExitModeList, Mode=OneWay}"
-                          SelectedItem="{x:Bind Profile.CurrentCloseOnExitMode, Mode=TwoWay}"
-                          Style="{StaticResource ComboBoxSettingStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ComboBox AutomationProperties.AccessibilityView="Content"
+                              ItemTemplate="{StaticResource EnumComboBoxTemplate}"
+                              ItemsSource="{x:Bind Profile.CloseOnExitModeList, Mode=OneWay}"
+                              SelectedItem="{x:Bind Profile.CurrentCloseOnExitMode, Mode=TwoWay}"
+                              Style="{StaticResource ComboBoxSettingStyle}" />
+                    <local:SettingResetButton SettingName="CloseOnExit"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Bell Style  -->
             <local:SettingsExpander x:Name="BellStyle"
                                     x:Uid="Profile_BellStyle">
                 <local:SettingsExpander.Content>
-                    <TextBlock Style="{StaticResource SettingContainerCurrentValueTextBlockStyle}"
-                               Text="{x:Bind Profile.BellStylePreview, Mode=OneWay}" />
+                    <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                        <TextBlock VerticalAlignment="Center"
+                                   Style="{StaticResource SettingContainerCurrentValueTextBlockStyle}"
+                                   Text="{x:Bind Profile.BellStylePreview, Mode=OneWay}" />
+                        <local:SettingResetButton SettingName="BellStyle"
+                                                  Target="{x:Bind Profile}" />
+                    </StackPanel>
                 </local:SettingsExpander.Content>
                 <local:SettingsExpander.ItemsHeader>
                     <ContentPresenter Padding="16,12,16,16">
@@ -108,8 +135,13 @@
             <local:SettingsExpander x:Name="BellSound"
                                     x:Uid="Profile_BellSound">
                 <local:SettingsExpander.Content>
-                    <TextBlock Style="{StaticResource SettingContainerCurrentValueTextBlockStyle}"
-                               Text="{x:Bind Profile.BellSoundPreview, Mode=OneWay}" />
+                    <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                        <TextBlock VerticalAlignment="Center"
+                                   Style="{StaticResource SettingContainerCurrentValueTextBlockStyle}"
+                                   Text="{x:Bind Profile.BellSoundPreview, Mode=OneWay}" />
+                        <local:SettingResetButton SettingName="BellSound"
+                                                  Target="{x:Bind Profile}" />
+                    </StackPanel>
                 </local:SettingsExpander.Content>
                 <local:SettingsExpander.ItemsHeader>
                     <ContentPresenter Padding="16,12,16,16">
@@ -192,63 +224,101 @@
             <!--  RightClickContextMenu  -->
             <local:SettingsCard x:Name="RightClickContextMenu"
                                 x:Uid="Profile_RightClickContextMenu">
-                <ToggleSwitch IsOn="{x:Bind Profile.RightClickContextMenu, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.RightClickContextMenu, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="RightClickContextMenu"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  ShowMarks  -->
             <local:SettingsCard x:Name="ShowMarks"
                                 x:Uid="Profile_ShowMarks"
                                 Visibility="{x:Bind Profile.ShowMarksAvailable}">
-                <ToggleSwitch IsOn="{x:Bind Profile.ShowMarks, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.ShowMarks, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="ShowMarks"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  AutoMarkPrompts  -->
             <local:SettingsCard x:Name="AutoMarkPrompts"
                                 x:Uid="Profile_AutoMarkPrompts"
                                 Visibility="{x:Bind Profile.AutoMarkPromptsAvailable}">
-                <ToggleSwitch IsOn="{x:Bind Profile.AutoMarkPrompts, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.AutoMarkPrompts, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="AutoMarkPrompts"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  ReloadEnvVars  -->
             <local:SettingsCard x:Name="ReloadEnvVars"
                                 x:Uid="Profile_ReloadEnvVars">
-                <ToggleSwitch IsOn="{x:Bind Profile.ReloadEnvironmentVariables, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.ReloadEnvironmentVariables, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="ReloadEnvironmentVariables"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  RepositionCursorWithMouse  -->
             <local:SettingsCard x:Name="RepositionCursorWithMouse"
                                 x:Uid="Profile_RepositionCursorWithMouse"
                                 Visibility="{x:Bind Profile.RepositionCursorWithMouseAvailable}">
-                <ToggleSwitch IsOn="{x:Bind Profile.RepositionCursorWithMouse, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.RepositionCursorWithMouse, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="RepositionCursorWithMouse"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  RainbowSuggestions  -->
             <local:SettingsCard x:Name="RainbowSuggestions"
                                 x:Uid="Profile_RainbowSuggestions">
-                <ToggleSwitch IsOn="{x:Bind Profile.RainbowSuggestions, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.RainbowSuggestions, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="RainbowSuggestions"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Path Translation  -->
             <local:SettingsCard x:Name="PathTranslationStyle"
                                 x:Uid="Profile_PathTranslationStyle">
-                <ComboBox AutomationProperties.AccessibilityView="Content"
-                          ItemTemplate="{StaticResource EnumComboBoxTemplate}"
-                          ItemsSource="{x:Bind Profile.PathTranslationStyleList, Mode=OneWay}"
-                          SelectedItem="{x:Bind Profile.CurrentPathTranslationStyle, Mode=TwoWay}"
-                          Style="{StaticResource ComboBoxSettingStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ComboBox AutomationProperties.AccessibilityView="Content"
+                              ItemTemplate="{StaticResource EnumComboBoxTemplate}"
+                              ItemsSource="{x:Bind Profile.PathTranslationStyleList, Mode=OneWay}"
+                              SelectedItem="{x:Bind Profile.CurrentPathTranslationStyle, Mode=TwoWay}"
+                              Style="{StaticResource ComboBoxSettingStyle}" />
+                    <local:SettingResetButton SettingName="PathTranslationStyle"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Drag Drop Delimiter  -->
             <local:SettingsCard x:Name="DragDropDelimiter"
                                 x:Uid="Profile_DragDropDelimiter">
-                <TextBox Style="{StaticResource TextBoxSettingStyle}"
-                         Text="{x:Bind Profile.DragDropDelimiter, Mode=TwoWay}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <TextBox Style="{StaticResource TextBoxSettingStyle}"
+                             Text="{x:Bind Profile.DragDropDelimiter, Mode=TwoWay}" />
+                    <local:SettingResetButton SettingName="DragDropDelimiter"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
         </StackPanel>

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.xaml
@@ -39,46 +39,68 @@
             <!--  Antialiasing Mode  -->
             <local:SettingsCard x:Name="AntialiasingMode"
                                 x:Uid="Profile_AntialiasingMode">
-                <ComboBox AutomationProperties.AccessibilityView="Content"
-                          ItemTemplate="{StaticResource EnumComboBoxTemplate}"
-                          ItemsSource="{x:Bind Profile.AntiAliasingModeList, Mode=OneWay}"
-                          SelectedItem="{x:Bind Profile.CurrentAntiAliasingMode, Mode=TwoWay}"
-                          Style="{StaticResource ComboBoxSettingStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ComboBox AutomationProperties.AccessibilityView="Content"
+                              ItemTemplate="{StaticResource EnumComboBoxTemplate}"
+                              ItemsSource="{x:Bind Profile.AntiAliasingModeList, Mode=OneWay}"
+                              SelectedItem="{x:Bind Profile.CurrentAntiAliasingMode, Mode=TwoWay}"
+                              Style="{StaticResource ComboBoxSettingStyle}" />
+                    <local:SettingResetButton SettingName="AntialiasingMode"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  AltGr Aliasing  -->
             <local:SettingsCard x:Name="AltGrAliasing"
                                 x:Uid="Profile_AltGrAliasing">
-                <ToggleSwitch IsOn="{x:Bind Profile.AltGrAliasing, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.AltGrAliasing, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="AltGrAliasing"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Snap On Input  -->
             <local:SettingsCard x:Name="SnapOnInput"
                                 x:Uid="Profile_SnapOnInput">
-                <ToggleSwitch IsOn="{x:Bind Profile.SnapOnInput, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.SnapOnInput, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="SnapOnInput"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  History Size  -->
             <local:SettingsCard x:Name="HistorySize"
                                 x:Uid="Profile_HistorySize">
-                <muxc:NumberBox x:Uid="Profile_HistorySizeBox"
-                                LargeChange="100"
-                                Minimum="0"
-                                SmallChange="10"
-                                Style="{StaticResource NumberBoxSettingStyle}"
-                                Value="{x:Bind Profile.HistorySize, Mode=TwoWay}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <muxc:NumberBox x:Uid="Profile_HistorySizeBox"
+                                    LargeChange="100"
+                                    Minimum="0"
+                                    SmallChange="10"
+                                    Style="{StaticResource NumberBoxSettingStyle}"
+                                    Value="{x:Bind Profile.HistorySize, Mode=TwoWay}" />
+                    <local:SettingResetButton SettingName="HistorySize"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Close On Exit  -->
             <local:SettingsCard x:Name="CloseOnExit"
                                 x:Uid="Profile_CloseOnExit">
-                <ComboBox AutomationProperties.AccessibilityView="Content"
-                          ItemTemplate="{StaticResource EnumComboBoxTemplate}"
-                          ItemsSource="{x:Bind Profile.CloseOnExitModeList, Mode=OneWay}"
-                          SelectedItem="{x:Bind Profile.CurrentCloseOnExitMode, Mode=TwoWay}"
-                          Style="{StaticResource ComboBoxSettingStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ComboBox AutomationProperties.AccessibilityView="Content"
+                              ItemTemplate="{StaticResource EnumComboBoxTemplate}"
+                              ItemsSource="{x:Bind Profile.CloseOnExitModeList, Mode=OneWay}"
+                              SelectedItem="{x:Bind Profile.CurrentCloseOnExitMode, Mode=TwoWay}"
+                              Style="{StaticResource ComboBoxSettingStyle}" />
+                    <local:SettingResetButton SettingName="CloseOnExit"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Bell Style  -->
@@ -86,8 +108,13 @@
                                     x:Uid="Profile_BellStyle"
                                     AutomationProperties.Name="{x:Bind Profile.BellStyleAccessibleName, Mode=OneWay}">
                 <local:SettingsExpander.Content>
-                    <TextBlock Style="{StaticResource SettingContainerCurrentValueTextBlockStyle}"
-                               Text="{x:Bind Profile.BellStylePreview, Mode=OneWay}" />
+                    <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                        <TextBlock VerticalAlignment="Center"
+                                   Style="{StaticResource SettingContainerCurrentValueTextBlockStyle}"
+                                   Text="{x:Bind Profile.BellStylePreview, Mode=OneWay}" />
+                        <local:SettingResetButton SettingName="BellStyle"
+                                                  Target="{x:Bind Profile}" />
+                    </StackPanel>
                 </local:SettingsExpander.Content>
                 <local:SettingsExpander.ItemsHeader>
                     <ContentPresenter Padding="16,12,16,16">
@@ -110,8 +137,13 @@
                                     x:Uid="Profile_BellSound"
                                     AutomationProperties.Name="{x:Bind Profile.BellSoundAccessibleName, Mode=OneWay}">
                 <local:SettingsExpander.Content>
-                    <TextBlock Style="{StaticResource SettingContainerCurrentValueTextBlockStyle}"
-                               Text="{x:Bind Profile.BellSoundPreview, Mode=OneWay}" />
+                    <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                        <TextBlock VerticalAlignment="Center"
+                                   Style="{StaticResource SettingContainerCurrentValueTextBlockStyle}"
+                                   Text="{x:Bind Profile.BellSoundPreview, Mode=OneWay}" />
+                        <local:SettingResetButton SettingName="BellSound"
+                                                  Target="{x:Bind Profile}" />
+                    </StackPanel>
                 </local:SettingsExpander.Content>
                 <local:SettingsExpander.ItemsHeader>
                     <ContentPresenter Padding="16,12,16,16">
@@ -194,63 +226,101 @@
             <!--  RightClickContextMenu  -->
             <local:SettingsCard x:Name="RightClickContextMenu"
                                 x:Uid="Profile_RightClickContextMenu">
-                <ToggleSwitch IsOn="{x:Bind Profile.RightClickContextMenu, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.RightClickContextMenu, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="RightClickContextMenu"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  ShowMarks  -->
             <local:SettingsCard x:Name="ShowMarks"
                                 x:Uid="Profile_ShowMarks"
                                 Visibility="{x:Bind Profile.ShowMarksAvailable}">
-                <ToggleSwitch IsOn="{x:Bind Profile.ShowMarks, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.ShowMarks, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="ShowMarks"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  AutoMarkPrompts  -->
             <local:SettingsCard x:Name="AutoMarkPrompts"
                                 x:Uid="Profile_AutoMarkPrompts"
                                 Visibility="{x:Bind Profile.AutoMarkPromptsAvailable}">
-                <ToggleSwitch IsOn="{x:Bind Profile.AutoMarkPrompts, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.AutoMarkPrompts, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="AutoMarkPrompts"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  ReloadEnvVars  -->
             <local:SettingsCard x:Name="ReloadEnvVars"
                                 x:Uid="Profile_ReloadEnvVars">
-                <ToggleSwitch IsOn="{x:Bind Profile.ReloadEnvironmentVariables, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.ReloadEnvironmentVariables, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="ReloadEnvironmentVariables"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  RepositionCursorWithMouse  -->
             <local:SettingsCard x:Name="RepositionCursorWithMouse"
                                 x:Uid="Profile_RepositionCursorWithMouse"
                                 Visibility="{x:Bind Profile.RepositionCursorWithMouseAvailable}">
-                <ToggleSwitch IsOn="{x:Bind Profile.RepositionCursorWithMouse, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.RepositionCursorWithMouse, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="RepositionCursorWithMouse"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  RainbowSuggestions  -->
             <local:SettingsCard x:Name="RainbowSuggestions"
                                 x:Uid="Profile_RainbowSuggestions">
-                <ToggleSwitch IsOn="{x:Bind Profile.RainbowSuggestions, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.RainbowSuggestions, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="RainbowSuggestions"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Path Translation  -->
             <local:SettingsCard x:Name="PathTranslationStyle"
                                 x:Uid="Profile_PathTranslationStyle">
-                <ComboBox AutomationProperties.AccessibilityView="Content"
-                          ItemTemplate="{StaticResource EnumComboBoxTemplate}"
-                          ItemsSource="{x:Bind Profile.PathTranslationStyleList, Mode=OneWay}"
-                          SelectedItem="{x:Bind Profile.CurrentPathTranslationStyle, Mode=TwoWay}"
-                          Style="{StaticResource ComboBoxSettingStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ComboBox AutomationProperties.AccessibilityView="Content"
+                              ItemTemplate="{StaticResource EnumComboBoxTemplate}"
+                              ItemsSource="{x:Bind Profile.PathTranslationStyleList, Mode=OneWay}"
+                              SelectedItem="{x:Bind Profile.CurrentPathTranslationStyle, Mode=TwoWay}"
+                              Style="{StaticResource ComboBoxSettingStyle}" />
+                    <local:SettingResetButton SettingName="PathTranslationStyle"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Drag Drop Delimiter  -->
             <local:SettingsCard x:Name="DragDropDelimiter"
                                 x:Uid="Profile_DragDropDelimiter">
-                <TextBox Style="{StaticResource TextBoxSettingStyle}"
-                         Text="{x:Bind Profile.DragDropDelimiter, Mode=TwoWay}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <TextBox Style="{StaticResource TextBoxSettingStyle}"
+                             Text="{x:Bind Profile.DragDropDelimiter, Mode=TwoWay}" />
+                    <local:SettingResetButton SettingName="DragDropDelimiter"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
         </StackPanel>

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.xaml
@@ -38,7 +38,8 @@
                     Style="{StaticResource SettingsStackStyle}">
             <!--  Antialiasing Mode  -->
             <local:SettingsCard x:Name="AntialiasingMode"
-                                x:Uid="Profile_AntialiasingMode">
+                                x:Uid="Profile_AntialiasingMode"
+                                Style="{StaticResource ExpanderAlignedSettingsCardStyle}">
                 <StackPanel Style="{StaticResource SettingControlStackStyle}">
                     <ComboBox AutomationProperties.AccessibilityView="Content"
                               ItemTemplate="{StaticResource EnumComboBoxTemplate}"
@@ -52,7 +53,8 @@
 
             <!--  AltGr Aliasing  -->
             <local:SettingsCard x:Name="AltGrAliasing"
-                                x:Uid="Profile_AltGrAliasing">
+                                x:Uid="Profile_AltGrAliasing"
+                                Style="{StaticResource ExpanderAlignedSettingsCardStyle}">
                 <StackPanel Style="{StaticResource SettingControlStackStyle}">
                     <ToggleSwitch VerticalAlignment="Center"
                                   IsOn="{x:Bind Profile.AltGrAliasing, Mode=TwoWay}"
@@ -64,7 +66,8 @@
 
             <!--  Snap On Input  -->
             <local:SettingsCard x:Name="SnapOnInput"
-                                x:Uid="Profile_SnapOnInput">
+                                x:Uid="Profile_SnapOnInput"
+                                Style="{StaticResource ExpanderAlignedSettingsCardStyle}">
                 <StackPanel Style="{StaticResource SettingControlStackStyle}">
                     <ToggleSwitch VerticalAlignment="Center"
                                   IsOn="{x:Bind Profile.SnapOnInput, Mode=TwoWay}"
@@ -76,7 +79,8 @@
 
             <!--  History Size  -->
             <local:SettingsCard x:Name="HistorySize"
-                                x:Uid="Profile_HistorySize">
+                                x:Uid="Profile_HistorySize"
+                                Style="{StaticResource ExpanderAlignedSettingsCardStyle}">
                 <StackPanel Style="{StaticResource SettingControlStackStyle}">
                     <muxc:NumberBox x:Uid="Profile_HistorySizeBox"
                                     LargeChange="100"
@@ -91,7 +95,8 @@
 
             <!--  Close On Exit  -->
             <local:SettingsCard x:Name="CloseOnExit"
-                                x:Uid="Profile_CloseOnExit">
+                                x:Uid="Profile_CloseOnExit"
+                                Style="{StaticResource ExpanderAlignedSettingsCardStyle}">
                 <StackPanel Style="{StaticResource SettingControlStackStyle}">
                     <ComboBox AutomationProperties.AccessibilityView="Content"
                               ItemTemplate="{StaticResource EnumComboBoxTemplate}"
@@ -225,7 +230,8 @@
 
             <!--  RightClickContextMenu  -->
             <local:SettingsCard x:Name="RightClickContextMenu"
-                                x:Uid="Profile_RightClickContextMenu">
+                                x:Uid="Profile_RightClickContextMenu"
+                                Style="{StaticResource ExpanderAlignedSettingsCardStyle}">
                 <StackPanel Style="{StaticResource SettingControlStackStyle}">
                     <ToggleSwitch VerticalAlignment="Center"
                                   IsOn="{x:Bind Profile.RightClickContextMenu, Mode=TwoWay}"
@@ -238,6 +244,7 @@
             <!--  ShowMarks  -->
             <local:SettingsCard x:Name="ShowMarks"
                                 x:Uid="Profile_ShowMarks"
+                                Style="{StaticResource ExpanderAlignedSettingsCardStyle}"
                                 Visibility="{x:Bind Profile.ShowMarksAvailable}">
                 <StackPanel Style="{StaticResource SettingControlStackStyle}">
                     <ToggleSwitch VerticalAlignment="Center"
@@ -251,6 +258,7 @@
             <!--  AutoMarkPrompts  -->
             <local:SettingsCard x:Name="AutoMarkPrompts"
                                 x:Uid="Profile_AutoMarkPrompts"
+                                Style="{StaticResource ExpanderAlignedSettingsCardStyle}"
                                 Visibility="{x:Bind Profile.AutoMarkPromptsAvailable}">
                 <StackPanel Style="{StaticResource SettingControlStackStyle}">
                     <ToggleSwitch VerticalAlignment="Center"
@@ -263,7 +271,8 @@
 
             <!--  ReloadEnvVars  -->
             <local:SettingsCard x:Name="ReloadEnvVars"
-                                x:Uid="Profile_ReloadEnvVars">
+                                x:Uid="Profile_ReloadEnvVars"
+                                Style="{StaticResource ExpanderAlignedSettingsCardStyle}">
                 <StackPanel Style="{StaticResource SettingControlStackStyle}">
                     <ToggleSwitch VerticalAlignment="Center"
                                   IsOn="{x:Bind Profile.ReloadEnvironmentVariables, Mode=TwoWay}"
@@ -276,6 +285,7 @@
             <!--  RepositionCursorWithMouse  -->
             <local:SettingsCard x:Name="RepositionCursorWithMouse"
                                 x:Uid="Profile_RepositionCursorWithMouse"
+                                Style="{StaticResource ExpanderAlignedSettingsCardStyle}"
                                 Visibility="{x:Bind Profile.RepositionCursorWithMouseAvailable}">
                 <StackPanel Style="{StaticResource SettingControlStackStyle}">
                     <ToggleSwitch VerticalAlignment="Center"
@@ -288,7 +298,8 @@
 
             <!--  RainbowSuggestions  -->
             <local:SettingsCard x:Name="RainbowSuggestions"
-                                x:Uid="Profile_RainbowSuggestions">
+                                x:Uid="Profile_RainbowSuggestions"
+                                Style="{StaticResource ExpanderAlignedSettingsCardStyle}">
                 <StackPanel Style="{StaticResource SettingControlStackStyle}">
                     <ToggleSwitch VerticalAlignment="Center"
                                   IsOn="{x:Bind Profile.RainbowSuggestions, Mode=TwoWay}"
@@ -300,7 +311,8 @@
 
             <!--  Path Translation  -->
             <local:SettingsCard x:Name="PathTranslationStyle"
-                                x:Uid="Profile_PathTranslationStyle">
+                                x:Uid="Profile_PathTranslationStyle"
+                                Style="{StaticResource ExpanderAlignedSettingsCardStyle}">
                 <StackPanel Style="{StaticResource SettingControlStackStyle}">
                     <ComboBox AutomationProperties.AccessibilityView="Content"
                               ItemTemplate="{StaticResource EnumComboBoxTemplate}"
@@ -314,7 +326,8 @@
 
             <!--  Drag Drop Delimiter  -->
             <local:SettingsCard x:Name="DragDropDelimiter"
-                                x:Uid="Profile_DragDropDelimiter">
+                                x:Uid="Profile_DragDropDelimiter"
+                                Style="{StaticResource ExpanderAlignedSettingsCardStyle}">
                 <StackPanel Style="{StaticResource SettingControlStackStyle}">
                     <TextBox Style="{StaticResource TextBoxSettingStyle}"
                              Text="{x:Bind Profile.DragDropDelimiter, Mode=TwoWay}" />

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.cpp
@@ -82,26 +82,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _AppearanceViewModelChangedRevoker.revoke();
     }
 
-    void Profiles_Appearance::CreateUnfocusedAppearance_Click(const IInspectable& /*sender*/, const RoutedEventArgs& /*e*/)
-    {
-        TraceLoggingWrite(
-            g_hTerminalSettingsEditorProvider,
-            "CreateUnfocusedAppearance",
-            TraceLoggingDescription("Event emitted when the user creates an unfocused appearance for a profile"),
-            TraceLoggingValue(_Profile.IsBaseLayer(), "IsProfileDefaults", "If the modified profile is the profile.defaults object"),
-            TraceLoggingValue(static_cast<GUID>(_Profile.Guid()), "ProfileGuid", "The guid of the profile that was navigated to"),
-            TraceLoggingValue(_Profile.Source().c_str(), "ProfileSource", "The source of the profile that was navigated to"),
-            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
-            TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
-
-        _Profile.CreateUnfocusedAppearance();
-    }
-
-    void Profiles_Appearance::DeleteUnfocusedAppearance_Click(const IInspectable& /*sender*/, const RoutedEventArgs& /*e*/)
-    {
-        _Profile.DeleteUnfocusedAppearance();
-    }
-
     void Profiles_Appearance::_onProfilePropertyChanged(const IInspectable&, const PropertyChangedEventArgs&)
     {
         if (!_updatePreviewControl)

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.h
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.h
@@ -19,9 +19,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void OnNavigatedTo(const Windows::UI::Xaml::Navigation::NavigationEventArgs& e);
         void OnNavigatedFrom(const Windows::UI::Xaml::Navigation::NavigationEventArgs& e);
 
-        void CreateUnfocusedAppearance_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& e);
-        void DeleteUnfocusedAppearance_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& e);
-
         Editor::IHostedInWindow WindowRoot() const noexcept { return _weakWindowRoot.get(); };
 
         til::property_changed_event PropertyChanged;

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.xaml
@@ -92,6 +92,7 @@
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <Slider x:Uid="Profile_OpacitySlider"
                                     Grid.Column="0"
@@ -99,6 +100,10 @@
                             <TextBlock Grid.Column="1"
                                        Style="{StaticResource SliderValueLabelStyle}"
                                        Text="{x:Bind mtu:Converters.PercentageToPercentageString(Profile.Opacity), Mode=OneWay}" />
+                            <local:SettingResetButton Grid.Column="2"
+                                                      Margin="8,0,0,0"
+                                                      SettingName="Opacity"
+                                                      Target="{x:Bind Profile}" />
                         </Grid>
                     </StackPanel>
                 </local:SettingsCard>
@@ -106,8 +111,13 @@
                 <!--  Use Acrylic  -->
                 <local:SettingsCard x:Name="UseAcrylic"
                                     x:Uid="Profile_UseAcrylic">
-                    <ToggleSwitch IsOn="{x:Bind Profile.UseAcrylic, Mode=TwoWay}"
-                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                        <ToggleSwitch VerticalAlignment="Center"
+                                      IsOn="{x:Bind Profile.UseAcrylic, Mode=TwoWay}"
+                                      Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                        <local:SettingResetButton SettingName="UseAcrylic"
+                                                  Target="{x:Bind Profile}" />
+                    </StackPanel>
                 </local:SettingsCard>
 
             </StackPanel>
@@ -120,8 +130,13 @@
                 <local:SettingsExpander x:Name="Padding"
                                         x:Uid="Profile_Padding">
                     <local:SettingsExpander.Content>
-                        <TextBlock Style="{StaticResource SettingContainerCurrentValueTextBlockStyle}"
-                                   Text="{x:Bind Profile.Padding, Mode=OneWay}" />
+                        <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                            <TextBlock VerticalAlignment="Center"
+                                       Style="{StaticResource SettingContainerCurrentValueTextBlockStyle}"
+                                       Text="{x:Bind Profile.Padding, Mode=OneWay}" />
+                            <local:SettingResetButton SettingName="Padding"
+                                                      Target="{x:Bind Profile}" />
+                        </StackPanel>
                     </local:SettingsExpander.Content>
                     <local:SettingsExpander.ItemsHeader>
                         <ContentPresenter Padding="16,12,16,16">
@@ -190,11 +205,15 @@
                 <!--  Scrollbar Visibility  -->
                 <local:SettingsCard x:Name="ScrollbarVisibility"
                                     x:Uid="Profile_ScrollbarVisibility">
-                    <ComboBox AutomationProperties.AccessibilityView="Content"
-                              ItemTemplate="{StaticResource EnumComboBoxTemplate}"
-                              ItemsSource="{x:Bind Profile.ScrollStateList, Mode=OneWay}"
-                              SelectedItem="{x:Bind Profile.CurrentScrollState, Mode=TwoWay}"
-                              Style="{StaticResource ComboBoxSettingStyle}" />
+                    <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                        <ComboBox AutomationProperties.AccessibilityView="Content"
+                                  ItemTemplate="{StaticResource EnumComboBoxTemplate}"
+                                  ItemsSource="{x:Bind Profile.ScrollStateList, Mode=OneWay}"
+                                  SelectedItem="{x:Bind Profile.CurrentScrollState, Mode=TwoWay}"
+                                  Style="{StaticResource ComboBoxSettingStyle}" />
+                        <local:SettingResetButton SettingName="ScrollState"
+                                                  Target="{x:Bind Profile}" />
+                    </StackPanel>
                 </local:SettingsCard>
             </StackPanel>
             <StackPanel MaxWidth="{StaticResource StandardControlMaxWidth}">

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.xaml
@@ -216,59 +216,6 @@
                     </StackPanel>
                 </local:SettingsCard>
             </StackPanel>
-            <StackPanel MaxWidth="{StaticResource StandardControlMaxWidth}">
-                <StackPanel Orientation="Horizontal"
-                            Visibility="{x:Bind Profile.EditableUnfocusedAppearance, Mode=OneWay}">
-                    <TextBlock x:Uid="Profile_UnfocusedAppearanceTextBlock"
-                               Style="{StaticResource TextBlockSubtitleStyle}" />
-
-                    <!--  Create Unfocused Appearance  -->
-                    <Button x:Name="CreateUnfocusedAppearance"
-                            x:Uid="Profile_CreateUnfocusedAppearanceButton"
-                            Margin="8,0,0,0"
-                            VerticalAlignment="Bottom"
-                            Click="CreateUnfocusedAppearance_Click"
-                            Style="{StaticResource BaseButtonStyle}"
-                            Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(Profile.HasUnfocusedAppearance), Mode=OneWay}">
-                        <Button.Content>
-                            <StackPanel Orientation="Horizontal">
-                                <FontIcon Margin="0,4,0,0"
-                                          FontSize="{StaticResource StandardIconSize}"
-                                          Glyph="&#xE710;" />
-                                <TextBlock x:Uid="Profile_AddAppearanceButton"
-                                           Margin="8,0,0,0"
-                                           FontSize="{StaticResource StandardIconSize}" />
-                            </StackPanel>
-                        </Button.Content>
-                    </Button>
-
-                    <!--  Delete Unfocused Appearance  -->
-                    <Button x:Name="DeleteUnfocusedAppearance"
-                            x:Uid="Profile_DeleteUnfocusedAppearanceButton"
-                            Margin="8,0,0,0"
-                            VerticalAlignment="Bottom"
-                            Click="DeleteUnfocusedAppearance_Click"
-                            Style="{StaticResource DeleteButtonStyle}"
-                            Visibility="{x:Bind Profile.HasUnfocusedAppearance, Mode=OneWay}">
-                        <Button.Content>
-                            <StackPanel Orientation="Horizontal">
-                                <FontIcon FontSize="{StaticResource StandardIconSize}"
-                                          Glyph="&#xE74D;" />
-                                <TextBlock x:Uid="Profile_DeleteAppearanceButton"
-                                           Margin="8,0,0,0"
-                                           FontSize="{StaticResource StandardIconSize}" />
-                            </StackPanel>
-                        </Button.Content>
-                    </Button>
-                </StackPanel>
-
-                <!--  Unfocused Appearance  -->
-                <local:Appearances x:Name="UnfocusedAppearanceView"
-                                   Appearance="{x:Bind Profile.UnfocusedAppearance, Mode=OneWay}"
-                                   SourceProfile="{x:Bind Profile, Mode=OneWay}"
-                                   Visibility="{x:Bind Profile.ShowUnfocusedAppearance, Mode=OneWay}"
-                                   WindowRoot="{x:Bind WindowRoot, Mode=OneTime}" />
-            </StackPanel>
         </StackPanel>
     </Grid>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.xaml
@@ -83,8 +83,7 @@
             <!--  Grouping: Transparency  -->
             <TextBlock x:Uid="Profile_TransparencyHeader"
                        Style="{StaticResource TextBlockSubHeaderStyle}" />
-            <StackPanel Spacing="2"
-                        Style="{StaticResource PivotStackStyle}">
+            <StackPanel Style="{StaticResource SettingsStackStyle}">
                 <!--  Opacity  -->
                 <local:SettingsCard x:Name="Opacity"
                                     x:Uid="Profile_Opacity">
@@ -116,8 +115,7 @@
             <!--  Grouping: Window  -->
             <TextBlock x:Uid="Profile_WindowHeader"
                        Style="{StaticResource TextBlockSubHeaderStyle}" />
-            <StackPanel Spacing="2"
-                        Style="{StaticResource PivotStackStyle}">
+            <StackPanel Style="{StaticResource SettingsStackStyle}">
                 <!--  Padding  -->
                 <local:SettingsExpander x:Name="Padding"
                                         x:Uid="Profile_Padding">

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.xaml
@@ -217,59 +217,6 @@
                     </StackPanel>
                 </local:SettingsCard>
             </StackPanel>
-            <StackPanel MaxWidth="{StaticResource StandardControlMaxWidth}">
-                <StackPanel Orientation="Horizontal"
-                            Visibility="{x:Bind Profile.EditableUnfocusedAppearance, Mode=OneWay}">
-                    <TextBlock x:Uid="Profile_UnfocusedAppearanceTextBlock"
-                               Style="{StaticResource TextBlockSubtitleStyle}" />
-
-                    <!--  Create Unfocused Appearance  -->
-                    <Button x:Name="CreateUnfocusedAppearance"
-                            x:Uid="Profile_CreateUnfocusedAppearanceButton"
-                            Margin="8,0,0,0"
-                            VerticalAlignment="Bottom"
-                            Click="CreateUnfocusedAppearance_Click"
-                            Style="{StaticResource BaseButtonStyle}"
-                            Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(Profile.HasUnfocusedAppearance), Mode=OneWay}">
-                        <Button.Content>
-                            <StackPanel Orientation="Horizontal">
-                                <FontIcon Margin="0,4,0,0"
-                                          FontSize="{StaticResource StandardIconSize}"
-                                          Glyph="&#xE710;" />
-                                <TextBlock x:Uid="Profile_AddAppearanceButton"
-                                           Margin="8,0,0,0"
-                                           FontSize="{StaticResource StandardIconSize}" />
-                            </StackPanel>
-                        </Button.Content>
-                    </Button>
-
-                    <!--  Delete Unfocused Appearance  -->
-                    <Button x:Name="DeleteUnfocusedAppearance"
-                            x:Uid="Profile_DeleteUnfocusedAppearanceButton"
-                            Margin="8,0,0,0"
-                            VerticalAlignment="Bottom"
-                            Click="DeleteUnfocusedAppearance_Click"
-                            Style="{StaticResource DeleteButtonStyle}"
-                            Visibility="{x:Bind Profile.HasUnfocusedAppearance, Mode=OneWay}">
-                        <Button.Content>
-                            <StackPanel Orientation="Horizontal">
-                                <FontIcon FontSize="{StaticResource StandardIconSize}"
-                                          Glyph="&#xE74D;" />
-                                <TextBlock x:Uid="Profile_DeleteAppearanceButton"
-                                           Margin="8,0,0,0"
-                                           FontSize="{StaticResource StandardIconSize}" />
-                            </StackPanel>
-                        </Button.Content>
-                    </Button>
-                </StackPanel>
-
-                <!--  Unfocused Appearance  -->
-                <local:Appearances x:Name="UnfocusedAppearanceView"
-                                   Appearance="{x:Bind Profile.UnfocusedAppearance, Mode=OneWay}"
-                                   SourceProfile="{x:Bind Profile, Mode=OneWay}"
-                                   Visibility="{x:Bind Profile.ShowUnfocusedAppearance, Mode=OneWay}"
-                                   WindowRoot="{x:Bind WindowRoot, Mode=OneTime}" />
-            </StackPanel>
         </StackPanel>
     </Grid>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.xaml
@@ -92,6 +92,7 @@
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <Slider x:Uid="Profile_OpacitySlider"
                                     Grid.Column="0"
@@ -99,6 +100,10 @@
                             <TextBlock Grid.Column="1"
                                        Style="{StaticResource SliderValueLabelStyle}"
                                        Text="{x:Bind mtu:Converters.PercentageToPercentageString(Profile.Opacity), Mode=OneWay}" />
+                            <local:SettingResetButton Grid.Column="2"
+                                                      Margin="8,0,0,0"
+                                                      SettingName="Opacity"
+                                                      Target="{x:Bind Profile}" />
                         </Grid>
                     </StackPanel>
                 </local:SettingsCard>
@@ -106,8 +111,13 @@
                 <!--  Use Acrylic  -->
                 <local:SettingsCard x:Name="UseAcrylic"
                                     x:Uid="Profile_UseAcrylic">
-                    <ToggleSwitch IsOn="{x:Bind Profile.UseAcrylic, Mode=TwoWay}"
-                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                        <ToggleSwitch VerticalAlignment="Center"
+                                      IsOn="{x:Bind Profile.UseAcrylic, Mode=TwoWay}"
+                                      Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                        <local:SettingResetButton SettingName="UseAcrylic"
+                                                  Target="{x:Bind Profile}" />
+                    </StackPanel>
                 </local:SettingsCard>
 
             </StackPanel>
@@ -121,8 +131,13 @@
                                         x:Uid="Profile_Padding"
                                         AutomationProperties.Name="{x:Bind Profile.PaddingAccessibleName, Mode=OneWay}">
                     <local:SettingsExpander.Content>
-                        <TextBlock Style="{StaticResource SettingContainerCurrentValueTextBlockStyle}"
-                                   Text="{x:Bind Profile.Padding, Mode=OneWay}" />
+                        <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                            <TextBlock VerticalAlignment="Center"
+                                       Style="{StaticResource SettingContainerCurrentValueTextBlockStyle}"
+                                       Text="{x:Bind Profile.Padding, Mode=OneWay}" />
+                            <local:SettingResetButton SettingName="Padding"
+                                                      Target="{x:Bind Profile}" />
+                        </StackPanel>
                     </local:SettingsExpander.Content>
                     <local:SettingsExpander.ItemsHeader>
                         <ContentPresenter Padding="16,12,16,16">
@@ -191,11 +206,15 @@
                 <!--  Scrollbar Visibility  -->
                 <local:SettingsCard x:Name="ScrollbarVisibility"
                                     x:Uid="Profile_ScrollbarVisibility">
-                    <ComboBox AutomationProperties.AccessibilityView="Content"
-                              ItemTemplate="{StaticResource EnumComboBoxTemplate}"
-                              ItemsSource="{x:Bind Profile.ScrollStateList, Mode=OneWay}"
-                              SelectedItem="{x:Bind Profile.CurrentScrollState, Mode=TwoWay}"
-                              Style="{StaticResource ComboBoxSettingStyle}" />
+                    <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                        <ComboBox AutomationProperties.AccessibilityView="Content"
+                                  ItemTemplate="{StaticResource EnumComboBoxTemplate}"
+                                  ItemsSource="{x:Bind Profile.ScrollStateList, Mode=OneWay}"
+                                  SelectedItem="{x:Bind Profile.CurrentScrollState, Mode=TwoWay}"
+                                  Style="{StaticResource ComboBoxSettingStyle}" />
+                        <local:SettingResetButton SettingName="ScrollState"
+                                                  Target="{x:Bind Profile}" />
+                    </StackPanel>
                 </local:SettingsCard>
             </StackPanel>
             <StackPanel MaxWidth="{StaticResource StandardControlMaxWidth}">

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.xaml
@@ -83,8 +83,7 @@
             <!--  Grouping: Transparency  -->
             <TextBlock x:Uid="Profile_TransparencyHeader"
                        Style="{StaticResource TextBlockSubHeaderStyle}" />
-            <StackPanel Spacing="2"
-                        Style="{StaticResource PivotStackStyle}">
+            <StackPanel Style="{StaticResource SettingsStackStyle}">
                 <!--  Opacity  -->
                 <local:SettingsCard x:Name="Opacity"
                                     x:Uid="Profile_Opacity">
@@ -116,8 +115,7 @@
             <!--  Grouping: Window  -->
             <TextBlock x:Uid="Profile_WindowHeader"
                        Style="{StaticResource TextBlockSubHeaderStyle}" />
-            <StackPanel Spacing="2"
-                        Style="{StaticResource PivotStackStyle}">
+            <StackPanel Style="{StaticResource SettingsStackStyle}">
                 <!--  Padding  -->
                 <local:SettingsExpander x:Name="Padding"
                                         x:Uid="Profile_Padding"

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.xaml
@@ -86,7 +86,8 @@
             <StackPanel Style="{StaticResource SettingsStackStyle}">
                 <!--  Opacity  -->
                 <local:SettingsCard x:Name="Opacity"
-                                    x:Uid="Profile_Opacity">
+                                    x:Uid="Profile_Opacity"
+                                    Style="{StaticResource ExpanderAlignedSettingsCardStyle}">
                     <StackPanel>
                         <Grid Style="{StaticResource CustomSliderControlGridStyle}">
                             <Grid.ColumnDefinitions>
@@ -110,7 +111,8 @@
 
                 <!--  Use Acrylic  -->
                 <local:SettingsCard x:Name="UseAcrylic"
-                                    x:Uid="Profile_UseAcrylic">
+                                    x:Uid="Profile_UseAcrylic"
+                                    Style="{StaticResource ExpanderAlignedSettingsCardStyle}">
                     <StackPanel Style="{StaticResource SettingControlStackStyle}">
                         <ToggleSwitch VerticalAlignment="Center"
                                       IsOn="{x:Bind Profile.UseAcrylic, Mode=TwoWay}"
@@ -205,7 +207,8 @@
 
                 <!--  Scrollbar Visibility  -->
                 <local:SettingsCard x:Name="ScrollbarVisibility"
-                                    x:Uid="Profile_ScrollbarVisibility">
+                                    x:Uid="Profile_ScrollbarVisibility"
+                                    Style="{StaticResource ExpanderAlignedSettingsCardStyle}">
                     <StackPanel Style="{StaticResource SettingControlStackStyle}">
                         <ComboBox AutomationProperties.AccessibilityView="Content"
                                   ItemTemplate="{StaticResource EnumComboBoxTemplate}"

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.cpp
@@ -22,7 +22,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         Automation::AutomationProperties::SetFullDescription(StartingDirectoryUseParentCheckbox(), unbox_value<hstring>(startingDirCheckboxTooltip));
 
         AppearanceNavigator().Header(box_value(RS_(L"Profile_Appearance/Header")));
+        AppearanceNavigator().Description(box_value(RS_(L"Profile_AppearanceNavigator/Description")));
         TerminalNavigator().Header(box_value(RS_(L"Profile_Terminal/Header")));
+        TerminalNavigator().Description(box_value(RS_(L"Profile_TerminalNavigator/Description")));
         AdvancedNavigator().Header(box_value(RS_(L"Profile_Advanced/Header")));
     }
 

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.cpp
@@ -23,6 +23,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         AppearanceNavigator().Header(box_value(RS_(L"Profile_Appearance/Header")));
         AppearanceNavigator().Description(box_value(RS_(L"Profile_AppearanceNavigator/Description")));
+        UnfocusedAppearanceNavigator().Header(box_value(RS_(L"Profile_UnfocusedAppearanceTextBlock/Text")));
+        UnfocusedAppearanceNavigator().Description(box_value(RS_(L"Profile_UnfocusedAppearanceNavigator/Description")));
         TerminalNavigator().Header(box_value(RS_(L"Profile_Terminal/Header")));
         TerminalNavigator().Description(box_value(RS_(L"Profile_TerminalNavigator/Description")));
         AdvancedNavigator().Header(box_value(RS_(L"Profile_Advanced/Header")));
@@ -77,6 +79,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     void Profiles_Base::Appearance_Click(const IInspectable& /*sender*/, const RoutedEventArgs& /*args*/)
     {
         _Profile.CurrentPage(ProfileSubPage::Appearance);
+    }
+
+    void Profiles_Base::UnfocusedAppearance_Click(const IInspectable& /*sender*/, const RoutedEventArgs& /*args*/)
+    {
+        _Profile.CurrentPage(ProfileSubPage::UnfocusedAppearance);
     }
 
     void Profiles_Base::Terminal_Click(const IInspectable& /*sender*/, const RoutedEventArgs& /*args*/)

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.cpp
@@ -23,7 +23,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         AppearanceNavigator().Header(box_value(RS_(L"Profile_Appearance/Header")));
         AppearanceNavigator().Description(box_value(RS_(L"Profile_AppearanceNavigator/Description")));
-        UnfocusedAppearanceNavigator().Header(box_value(RS_(L"Profile_UnfocusedAppearanceTextBlock/Text")));
         UnfocusedAppearanceNavigator().Description(box_value(RS_(L"Profile_UnfocusedAppearanceNavigator/Description")));
         TerminalNavigator().Header(box_value(RS_(L"Profile_Terminal/Header")));
         TerminalNavigator().Description(box_value(RS_(L"Profile_TerminalNavigator/Description")));

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.cpp
@@ -18,8 +18,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         InitializeComponent();
 
-        const auto startingDirCheckboxTooltip{ ToolTipService::GetToolTip(StartingDirectoryUseParentCheckbox()) };
-        Automation::AutomationProperties::SetFullDescription(StartingDirectoryUseParentCheckbox(), unbox_value<hstring>(startingDirCheckboxTooltip));
+        Automation::AutomationProperties::SetFullDescription(StartingDirectoryUseParentCheckbox(), RS_(L"Profile_StartingDirectoryUseParentCheckbox/[using:Windows.UI.Xaml.Controls]ToolTipService/ToolTip"));
+        Automation::AutomationProperties::SetName(CommandlineBrowse(), RS_(L"Profile_CommandlineBrowse/[using:Windows.UI.Xaml.Controls]ToolTipService/ToolTip"));
+        Automation::AutomationProperties::SetName(StartingDirectoryBrowse(), RS_(L"Profile_StartingDirectoryBrowse/[using:Windows.UI.Xaml.Controls]ToolTipService/ToolTip"));
 
         AppearanceNavigator().Header(box_value(RS_(L"Profile_Appearance/Header")));
         AppearanceNavigator().Description(box_value(RS_(L"Profile_AppearanceNavigator/Description")));

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.cpp
@@ -83,6 +83,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     void Profiles_Base::UnfocusedAppearance_Click(const IInspectable& /*sender*/, const RoutedEventArgs& /*args*/)
     {
+        // User explicitly wants to see the unfocused appearance, so create it if it doesn't exist yet.
+        _Profile.CreateUnfocusedAppearance();
         _Profile.CurrentPage(ProfileSubPage::UnfocusedAppearance);
     }
 

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.cpp
@@ -37,6 +37,20 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _weakWindowRoot = args.WindowRoot();
         BringIntoViewWhenLoaded(args.ElementToFocus());
 
+        // Update the primary expander for profile defaults
+        if (_Profile.IsBaseLayer())
+        {
+            Name().Header(box_value(RS_(L"Profile_NameBaseLayer/Header")));
+            Name().Description(nullptr);
+            Automation::AutomationProperties::SetName(Name(), RS_(L"Profile_NameBaseLayer/Header"));
+        }
+        else
+        {
+            Name().Header(box_value(RS_(L"Profile_Name/Header")));
+            Name().Description(box_value(RS_(L"Profile_Name/Description")));
+            Automation::AutomationProperties::SetName(Name(), RS_(L"Profile_Name/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name"));
+        }
+
         // Check the use parent directory box if the starting directory is empty
         if (_Profile.StartingDirectory().empty())
         {

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.h
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.h
@@ -20,6 +20,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         safe_void_coroutine StartingDirectory_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& e);
         safe_void_coroutine Commandline_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& e);
         void Appearance_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& e);
+        void UnfocusedAppearance_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& e);
         void Terminal_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& e);
         void Advanced_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& e);
         void DeleteConfirmation_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& e);

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
@@ -32,56 +32,132 @@
                    Style="{StaticResource DisclaimerStyle}"
                    Visibility="{x:Bind Profile.IsBaseLayer}" />
         <StackPanel Grid.Row="1"
-                    Spacing="2"
                     Style="{StaticResource SettingsStackStyle}">
 
             <!--  Name  -->
-            <local:SettingsCard x:Name="Name"
-                                x:Uid="Profile_Name"
-                                Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(Profile.IsBaseLayer), Mode=OneWay}">
+            <local:SettingsExpander x:Name="Name"
+                                    x:Uid="Profile_Name"
+                                    IsExpanded="True">
+                <TextBox x:Uid="Profile_NameBox"
+                         Style="{StaticResource TextBoxSettingStyle}"
+                         Text="{x:Bind Profile.Name, Mode=TwoWay}"
+                         Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(Profile.IsBaseLayer), Mode=OneWay}" />
+                <local:SettingsExpander.HeaderIcon>
+                    <FontIcon Glyph="&#xE8D4;" />
+                </local:SettingsExpander.HeaderIcon>
+                <local:SettingsExpander.Items>
+
+                    <!--  Commandline  -->
+                    <local:SettingsCard x:Name="Commandline"
+                                        x:Uid="Profile_Commandline"
+                                        Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(Profile.IsBaseLayer), Mode=OneWay}">
+                        <StackPanel Orientation="Horizontal"
+                                    Spacing="8">
+                            <TextBox x:Uid="Profile_CommandlineBox"
+                                     IsSpellCheckEnabled="False"
+                                     Style="{StaticResource TextBoxSettingStyle}"
+                                     Text="{x:Bind Profile.Commandline, Mode=TwoWay}" />
+                            <Button x:Uid="Profile_CommandlineBrowse"
+                                    Click="Commandline_Click"
+                                    Style="{StaticResource BrowseButtonStyle}">
+                                <FontIcon FontSize="{StaticResource StandardIconSize}"
+                                          Glyph="&#xE838;" />
+                            </Button>
+                        </StackPanel>
+                    </local:SettingsCard>
+
+                    <!--  Starting Directory  -->
+                    <local:SettingsCard x:Uid="Profile_StartingDirectory"
+                                        IsEnabled="{x:Bind mtu:Converters.InvertBoolean(Profile.UseParentProcessDirectory), Mode=OneWay}">
+                        <StackPanel Orientation="Horizontal"
+                                    Spacing="8">
+                            <TextBox x:Uid="Profile_StartingDirectoryBox"
+                                     IsSpellCheckEnabled="False"
+                                     Style="{StaticResource TextBoxSettingStyle}"
+                                     Text="{x:Bind Profile.StartingDirectory, Mode=TwoWay}" />
+                            <Button x:Name="StartingDirectoryBrowse"
+                                    x:Uid="Profile_StartingDirectoryBrowse"
+                                    Click="StartingDirectory_Click"
+                                    Style="{StaticResource BrowseButtonStyle}">
+                                <FontIcon FontSize="{StaticResource StandardIconSize}"
+                                          Glyph="&#xE838;" />
+                            </Button>
+                        </StackPanel>
+                    </local:SettingsCard>
+
+                    <local:SettingsCard x:Name="StartingDirectory"
+                                        ContentAlignment="Left">
+                        <CheckBox x:Name="StartingDirectoryUseParentCheckbox"
+                                  x:Uid="Profile_StartingDirectoryUseParentCheckbox"
+                                  IsChecked="{x:Bind Profile.UseParentProcessDirectory, Mode=TwoWay}" />
+                    </local:SettingsCard>
+
+                    <!--  Elevate  -->
+                    <local:SettingsCard x:Name="Elevate"
+                                        ContentAlignment="Left">
+                        <CheckBox x:Uid="Profile_Elevate"
+                                  IsChecked="{x:Bind Profile.Elevate, Mode=TwoWay}" />
+                    </local:SettingsCard>
+
+                    <!--  Hidden  -->
+                    <local:SettingsCard x:Name="Hidden"
+                                        ContentAlignment="Left"
+                                        Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(Profile.IsBaseLayer), Mode=OneWay}">
+                        <CheckBox x:Uid="Profile_Hidden"
+                                  IsChecked="{x:Bind Profile.Hidden, Mode=TwoWay}" />
+                    </local:SettingsCard>
+
+                    <!--  Delete Profile  -->
+                    <local:SettingsCard x:Name="DeleteProfile"
+                                        x:Uid="Profile_DeleteProfile"
+                                        Visibility="{x:Bind Profile.CanDeleteProfile}">
+                        <Button x:Name="DeleteProfileButton"
+                                x:Uid="Profile_DeleteProfileButton"
+                                Style="{StaticResource DeleteButtonStyle}">
+                            <Button.Flyout>
+                                <Flyout>
+                                    <StackPanel>
+                                        <TextBlock x:Uid="Profile_DeleteConfirmationMessage"
+                                                   Style="{StaticResource CustomFlyoutTextStyle}" />
+                                        <Button x:Uid="Profile_DeleteConfirmationButton"
+                                                Click="DeleteConfirmation_Click" />
+                                    </StackPanel>
+                                </Flyout>
+                            </Button.Flyout>
+                        </Button>
+                    </local:SettingsCard>
+
+                </local:SettingsExpander.Items>
+            </local:SettingsExpander>
+
+            <!--  Section: Visual/UI Affordance  -->
+            <TextBlock x:Uid="Profile_Section_VisualUI"
+                       Style="{StaticResource TextBlockSubHeaderStyle}" />
+
+            <!--  Tab Title  -->
+            <local:SettingsCard x:Name="TabTitle"
+                                x:Uid="Profile_TabTitle">
                 <TextBox Style="{StaticResource TextBoxSettingStyle}"
-                         Text="{x:Bind Profile.Name, Mode=TwoWay}" />
+                         Text="{x:Bind Profile.TabTitle, Mode=TwoWay}" />
             </local:SettingsCard>
 
-            <!--  Commandline  -->
-            <local:SettingsCard x:Name="Commandline"
-                                x:Uid="Profile_Commandline"
-                                Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(Profile.IsBaseLayer), Mode=OneWay}">
-                <StackPanel Orientation="Horizontal"
-                            Spacing="8">
-                    <TextBox x:Uid="Profile_CommandlineBox"
-                             IsSpellCheckEnabled="False"
-                             Style="{StaticResource TextBoxSettingStyle}"
-                             Text="{x:Bind Profile.Commandline, Mode=TwoWay}" />
-                    <Button x:Uid="Profile_CommandlineBrowse"
-                            Click="Commandline_Click"
-                            Style="{StaticResource BrowseButtonStyle}" />
-                </StackPanel>
-            </local:SettingsCard>
-
-            <!--  Starting Directory  -->
-            <local:SettingsCard x:Name="StartingDirectory"
-                                x:Uid="Profile_StartingDirectory">
-                <StackPanel Orientation="Vertical">
-                    <StackPanel Orientation="Horizontal"
-                                Spacing="8">
-                        <TextBox x:Uid="Profile_StartingDirectoryBox"
-                                 IsEnabled="{x:Bind mtu:Converters.InvertBoolean(Profile.UseParentProcessDirectory), Mode=OneWay}"
-                                 IsSpellCheckEnabled="False"
-                                 Style="{StaticResource TextBoxSettingStyle}"
-                                 Text="{x:Bind Profile.StartingDirectory, Mode=TwoWay}" />
-                        <Button x:Name="StartingDirectoryBrowse"
-                                x:Uid="Profile_StartingDirectoryBrowse"
-                                Click="StartingDirectory_Click"
-                                IsEnabled="{x:Bind mtu:Converters.InvertBoolean(Profile.UseParentProcessDirectory), Mode=OneWay}"
-                                Style="{StaticResource BrowseButtonStyle}" />
-                    </StackPanel>
-                    <CheckBox x:Name="StartingDirectoryUseParentCheckbox"
-                              x:Uid="Profile_StartingDirectoryUseParentCheckbox"
-                              Margin="0,4,0,0"
-                              IsChecked="{x:Bind Profile.UseParentProcessDirectory, Mode=TwoWay}" />
-                </StackPanel>
-            </local:SettingsCard>
+            <!--  Tab Color  -->
+            <local:SettingsExpander x:Name="TabColor"
+                                    x:Uid="Profile_TabColor"
+                                    AutomationProperties.Name="{x:Bind Profile.TabColorPreview, Converter={StaticResource ColorToStringConverter}, Mode=OneWay}">
+                <local:SettingsExpander.Content>
+                    <ContentControl Content="{x:Bind Profile.TabColorPreview, Mode=OneWay}"
+                                    ContentTemplate="{StaticResource ColorPreviewTemplate}" />
+                </local:SettingsExpander.Content>
+                <local:SettingsExpander.ItemsHeader>
+                    <ContentPresenter Padding="16,12,16,16">
+                        <local:NullableColorPicker x:Uid="Profile_TabColor_NullableColorPicker"
+                                                   ColorSchemeVM="{x:Bind Profile.DefaultAppearance.CurrentColorScheme, Mode=OneWay}"
+                                                   CurrentColor="{x:Bind Profile.TabColor, Mode=TwoWay}"
+                                                   NullColorPreview="{x:Bind Profile.TabThemeColorPreview, Mode=OneWay}" />
+                    </ContentPresenter>
+                </local:SettingsExpander.ItemsHeader>
+            </local:SettingsExpander>
 
             <!--  Icon  -->
             <local:SettingsExpander x:Name="Icon"
@@ -111,79 +187,32 @@
                 </local:SettingsExpander.ItemsHeader>
             </local:SettingsExpander>
 
-            <!--  Tab Title  -->
-            <local:SettingsCard x:Name="TabTitle"
-                                x:Uid="Profile_TabTitle">
-                <TextBox Style="{StaticResource TextBoxSettingStyle}"
-                         Text="{x:Bind Profile.TabTitle, Mode=TwoWay}" />
-            </local:SettingsCard>
-
-            <!--  Tab Color  -->
-            <local:SettingsExpander x:Name="TabColor"
-                                    x:Uid="Profile_TabColor"
-                                    AutomationProperties.Name="{x:Bind Profile.TabColorPreview, Converter={StaticResource ColorToStringConverter}, Mode=OneWay}">
-                <local:SettingsExpander.Content>
-                    <ContentControl Content="{x:Bind Profile.TabColorPreview, Mode=OneWay}"
-                                    ContentTemplate="{StaticResource ColorPreviewTemplate}" />
-                </local:SettingsExpander.Content>
-                <local:SettingsExpander.ItemsHeader>
-                    <ContentPresenter Padding="16,12,16,16">
-                        <local:NullableColorPicker x:Uid="Profile_TabColor_NullableColorPicker"
-                                                   ColorSchemeVM="{x:Bind Profile.DefaultAppearance.CurrentColorScheme, Mode=OneWay}"
-                                                   CurrentColor="{x:Bind Profile.TabColor, Mode=TwoWay}"
-                                                   NullColorPreview="{x:Bind Profile.TabThemeColorPreview, Mode=OneWay}" />
-                    </ContentPresenter>
-                </local:SettingsExpander.ItemsHeader>
-            </local:SettingsExpander>
-
-            <!--  Elevate  -->
-            <local:SettingsCard x:Name="Elevate"
-                                x:Uid="Profile_Elevate">
-                <ToggleSwitch IsOn="{x:Bind Profile.Elevate, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
-            </local:SettingsCard>
-
-            <!--  Hidden  -->
-            <local:SettingsCard x:Name="Hidden"
-                                x:Uid="Profile_Hidden"
-                                Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(Profile.IsBaseLayer), Mode=OneWay}">
-                <ToggleSwitch IsOn="{x:Bind Profile.Hidden, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
-            </local:SettingsCard>
-
-            <!--  Delete Profile  -->
-            <local:SettingsCard x:Name="DeleteProfile"
-                                x:Uid="Profile_DeleteProfile"
-                                Visibility="{x:Bind Profile.CanDeleteProfile}">
-                <Button x:Name="DeleteProfileButton"
-                        x:Uid="Profile_DeleteProfileButton"
-                        Style="{StaticResource DeleteButtonStyle}">
-                    <Button.Flyout>
-                        <Flyout>
-                            <StackPanel>
-                                <TextBlock x:Uid="Profile_DeleteConfirmationMessage"
-                                           Style="{StaticResource CustomFlyoutTextStyle}" />
-                                <Button x:Uid="Profile_DeleteConfirmationButton"
-                                        Click="DeleteConfirmation_Click" />
-                            </StackPanel>
-                        </Flyout>
-                    </Button.Flyout>
-                </Button>
-            </local:SettingsCard>
-
+            <!--  Additional settings  -->
             <TextBlock x:Uid="Profile_AdditionalSettingsHeader"
                        Margin="0,32,0,4"
                        Style="{StaticResource TextBlockSubHeaderStyle}" />
 
             <local:SettingsCard x:Name="AppearanceNavigator"
                                 Click="Appearance_Click"
-                                IsClickEnabled="True" />
+                                IsClickEnabled="True">
+                <local:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE790;" />
+                </local:SettingsCard.HeaderIcon>
+            </local:SettingsCard>
             <local:SettingsCard x:Name="TerminalNavigator"
                                 Click="Terminal_Click"
-                                IsClickEnabled="True" />
+                                IsClickEnabled="True">
+                <local:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE950;" />
+                </local:SettingsCard.HeaderIcon>
+            </local:SettingsCard>
             <local:SettingsCard x:Name="AdvancedNavigator"
                                 Click="Advanced_Click"
-                                IsClickEnabled="True" />
+                                IsClickEnabled="True">
+                <local:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE9F5;" />
+                </local:SettingsCard.HeaderIcon>
+            </local:SettingsCard>
         </StackPanel>
     </Grid>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
@@ -38,10 +38,14 @@
             <local:SettingsExpander x:Name="Name"
                                     x:Uid="Profile_Name"
                                     IsExpanded="True">
-                <TextBox x:Uid="Profile_NameBox"
-                         Style="{StaticResource TextBoxSettingStyle}"
-                         Text="{x:Bind Profile.Name, Mode=TwoWay}"
-                         Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(Profile.IsBaseLayer), Mode=OneWay}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}"
+                            Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(Profile.IsBaseLayer), Mode=OneWay}">
+                    <TextBox x:Uid="Profile_NameBox"
+                             Style="{StaticResource TextBoxSettingStyle}"
+                             Text="{x:Bind Profile.Name, Mode=TwoWay}" />
+                    <local:SettingResetButton SettingName="Name"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
                 <local:SettingsExpander.HeaderIcon>
                     <FontIcon Glyph="&#xE8D4;" />
                 </local:SettingsExpander.HeaderIcon>
@@ -51,8 +55,7 @@
                     <local:SettingsCard x:Name="Commandline"
                                         x:Uid="Profile_Commandline"
                                         Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(Profile.IsBaseLayer), Mode=OneWay}">
-                        <StackPanel Orientation="Horizontal"
-                                    Spacing="8">
+                        <StackPanel Style="{StaticResource SettingControlStackStyle}">
                             <TextBox x:Uid="Profile_CommandlineBox"
                                      IsSpellCheckEnabled="False"
                                      Style="{StaticResource TextBoxSettingStyle}"
@@ -63,14 +66,15 @@
                                 <FontIcon FontSize="{StaticResource StandardIconSize}"
                                           Glyph="&#xE838;" />
                             </Button>
+                            <local:SettingResetButton SettingName="Commandline"
+                                                      Target="{x:Bind Profile}" />
                         </StackPanel>
                     </local:SettingsCard>
 
                     <!--  Starting Directory  -->
                     <local:SettingsCard x:Uid="Profile_StartingDirectory"
                                         IsEnabled="{x:Bind mtu:Converters.InvertBoolean(Profile.UseParentProcessDirectory), Mode=OneWay}">
-                        <StackPanel Orientation="Horizontal"
-                                    Spacing="8">
+                        <StackPanel Style="{StaticResource SettingControlStackStyle}">
                             <TextBox x:Uid="Profile_StartingDirectoryBox"
                                      IsSpellCheckEnabled="False"
                                      Style="{StaticResource TextBoxSettingStyle}"
@@ -82,6 +86,8 @@
                                 <FontIcon FontSize="{StaticResource StandardIconSize}"
                                           Glyph="&#xE838;" />
                             </Button>
+                            <local:SettingResetButton SettingName="StartingDirectory"
+                                                      Target="{x:Bind Profile}" />
                         </StackPanel>
                     </local:SettingsCard>
 
@@ -95,16 +101,26 @@
                     <!--  Elevate  -->
                     <local:SettingsCard x:Name="Elevate"
                                         ContentAlignment="Left">
-                        <CheckBox x:Uid="Profile_Elevate"
-                                  IsChecked="{x:Bind Profile.Elevate, Mode=TwoWay}" />
+                        <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                            <local:SettingResetButton SettingName="Elevate"
+                                                      Target="{x:Bind Profile}" />
+                            <CheckBox x:Uid="Profile_Elevate"
+                                      VerticalAlignment="Center"
+                                      IsChecked="{x:Bind Profile.Elevate, Mode=TwoWay}" />
+                        </StackPanel>
                     </local:SettingsCard>
 
                     <!--  Hidden  -->
                     <local:SettingsCard x:Name="Hidden"
                                         ContentAlignment="Left"
                                         Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(Profile.IsBaseLayer), Mode=OneWay}">
-                        <CheckBox x:Uid="Profile_Hidden"
-                                  IsChecked="{x:Bind Profile.Hidden, Mode=TwoWay}" />
+                        <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                            <local:SettingResetButton SettingName="Hidden"
+                                                      Target="{x:Bind Profile}" />
+                            <CheckBox x:Uid="Profile_Hidden"
+                                      VerticalAlignment="Center"
+                                      IsChecked="{x:Bind Profile.Hidden, Mode=TwoWay}" />
+                        </StackPanel>
                     </local:SettingsCard>
 
                     <!--  Delete Profile  -->
@@ -137,8 +153,12 @@
             <!--  Tab Title  -->
             <local:SettingsCard x:Name="TabTitle"
                                 x:Uid="Profile_TabTitle">
-                <TextBox Style="{StaticResource TextBoxSettingStyle}"
-                         Text="{x:Bind Profile.TabTitle, Mode=TwoWay}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <TextBox Style="{StaticResource TextBoxSettingStyle}"
+                             Text="{x:Bind Profile.TabTitle, Mode=TwoWay}" />
+                    <local:SettingResetButton SettingName="TabTitle"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Tab Color  -->
@@ -146,8 +166,13 @@
                                     x:Uid="Profile_TabColor"
                                     AutomationProperties.Name="{x:Bind Profile.TabColorPreview, Converter={StaticResource ColorToStringConverter}, Mode=OneWay}">
                 <local:SettingsExpander.Content>
-                    <ContentControl Content="{x:Bind Profile.TabColorPreview, Mode=OneWay}"
-                                    ContentTemplate="{StaticResource ColorPreviewTemplate}" />
+                    <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                        <ContentControl VerticalAlignment="Center"
+                                        Content="{x:Bind Profile.TabColorPreview, Mode=OneWay}"
+                                        ContentTemplate="{StaticResource ColorPreviewTemplate}" />
+                        <local:SettingResetButton SettingName="TabColor"
+                                                  Target="{x:Bind Profile}" />
+                    </StackPanel>
                 </local:SettingsExpander.Content>
                 <local:SettingsExpander.ItemsHeader>
                     <ContentPresenter Padding="16,12,16,16">
@@ -164,20 +189,24 @@
                                     x:Uid="Profile_Icon"
                                     AutomationProperties.Name="{x:Bind Profile.LocalizedIcon, Mode=OneWay}">
                 <local:SettingsExpander.Content>
-                    <Grid>
-                        <ContentControl Width="16"
-                                        Height="16"
-                                        Content="{x:Bind Profile.IconPreview, Mode=OneWay}"
-                                        IsTabStop="False"
-                                        Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(Profile.UsingNoIcon), Mode=OneWay}" />
-                        <TextBlock Margin="0,0,0,0"
-                                   HorizontalAlignment="Right"
-                                   VerticalAlignment="Center"
-                                   FontFamily="Segoe UI, Segoe Fluent Icons, Segoe MDL2 Assets"
-                                   Style="{StaticResource SettingsPageItemDescriptionStyle}"
-                                   Text="{x:Bind Profile.LocalizedIcon, Mode=OneWay}"
-                                   Visibility="{x:Bind Profile.UsingNoIcon, Mode=OneWay}" />
-                    </Grid>
+                    <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                        <Grid>
+                            <ContentControl Width="16"
+                                            Height="16"
+                                            Content="{x:Bind Profile.IconPreview, Mode=OneWay}"
+                                            IsTabStop="False"
+                                            Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(Profile.UsingNoIcon), Mode=OneWay}" />
+                            <TextBlock Margin="0,0,0,0"
+                                       HorizontalAlignment="Right"
+                                       VerticalAlignment="Center"
+                                       FontFamily="Segoe UI, Segoe Fluent Icons, Segoe MDL2 Assets"
+                                       Style="{StaticResource SettingsPageItemDescriptionStyle}"
+                                       Text="{x:Bind Profile.LocalizedIcon, Mode=OneWay}"
+                                       Visibility="{x:Bind Profile.UsingNoIcon, Mode=OneWay}" />
+                        </Grid>
+                        <local:SettingResetButton SettingName="Icon"
+                                                  Target="{x:Bind Profile}" />
+                    </StackPanel>
                 </local:SettingsExpander.Content>
                 <local:SettingsExpander.ItemsHeader>
                     <ContentPresenter Padding="16,12,16,16">

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
@@ -228,6 +228,17 @@
                     <FontIcon Glyph="&#xE790;" />
                 </local:SettingsCard.HeaderIcon>
             </local:SettingsCard>
+            <local:SettingsCard x:Name="UnfocusedAppearanceNavigator"
+                                Click="UnfocusedAppearance_Click"
+                                IsClickEnabled="True"
+                                Visibility="{x:Bind Profile.EditableUnfocusedAppearance, Mode=OneWay}">
+                <local:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE7B3;" />
+                </local:SettingsCard.HeaderIcon>
+                <TextBlock VerticalAlignment="Center"
+                           Style="{StaticResource SettingContainerCurrentValueTextBlockStyle}"
+                           Text="{x:Bind Profile.UnfocusedAppearanceCardValue, Mode=OneWay}" />
+            </local:SettingsCard>
             <local:SettingsCard x:Name="TerminalNavigator"
                                 Click="Terminal_Click"
                                 IsClickEnabled="True">

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
@@ -151,7 +151,8 @@
 
             <!--  Tab Title  -->
             <local:SettingsCard x:Name="TabTitle"
-                                x:Uid="Profile_TabTitle">
+                                x:Uid="Profile_TabTitle"
+                                Style="{StaticResource ExpanderAlignedSettingsCardStyle}">
                 <StackPanel Style="{StaticResource SettingControlStackStyle}">
                     <TextBox Style="{StaticResource TextBoxSettingStyle}"
                              Text="{x:Bind Profile.TabTitle, Mode=TwoWay}" />

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
@@ -72,30 +72,29 @@
                     </local:SettingsCard>
 
                     <!--  Starting Directory  -->
-                    <local:SettingsCard x:Uid="Profile_StartingDirectory"
-                                        IsEnabled="{x:Bind mtu:Converters.InvertBoolean(Profile.UseParentProcessDirectory), Mode=OneWay}">
-                        <StackPanel Style="{StaticResource SettingControlStackStyle}">
-                            <TextBox x:Uid="Profile_StartingDirectoryBox"
-                                     IsSpellCheckEnabled="False"
-                                     Style="{StaticResource TextBoxSettingStyle}"
-                                     Text="{x:Bind Profile.StartingDirectory, Mode=TwoWay}" />
-                            <Button x:Name="StartingDirectoryBrowse"
-                                    x:Uid="Profile_StartingDirectoryBrowse"
-                                    Click="StartingDirectory_Click"
-                                    Style="{StaticResource BrowseButtonStyle}">
-                                <FontIcon FontSize="{StaticResource StandardIconSize}"
-                                          Glyph="&#xE838;" />
-                            </Button>
-                            <local:SettingResetButton SettingName="StartingDirectory"
-                                                      Target="{x:Bind Profile}" />
+                    <local:SettingsCard x:Uid="Profile_StartingDirectory">
+                        <StackPanel Spacing="4">
+                            <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                                <TextBox x:Uid="Profile_StartingDirectoryBox"
+                                         IsEnabled="{x:Bind mtu:Converters.InvertBoolean(Profile.UseParentProcessDirectory), Mode=OneWay}"
+                                         IsSpellCheckEnabled="False"
+                                         Style="{StaticResource TextBoxSettingStyle}"
+                                         Text="{x:Bind Profile.StartingDirectory, Mode=TwoWay}" />
+                                <Button x:Name="StartingDirectoryBrowse"
+                                        x:Uid="Profile_StartingDirectoryBrowse"
+                                        Click="StartingDirectory_Click"
+                                        IsEnabled="{x:Bind mtu:Converters.InvertBoolean(Profile.UseParentProcessDirectory), Mode=OneWay}"
+                                        Style="{StaticResource BrowseButtonStyle}">
+                                    <FontIcon FontSize="{StaticResource StandardIconSize}"
+                                              Glyph="&#xE838;" />
+                                </Button>
+                                <local:SettingResetButton SettingName="StartingDirectory"
+                                                          Target="{x:Bind Profile}" />
+                            </StackPanel>
+                            <CheckBox x:Name="StartingDirectoryUseParentCheckbox"
+                                      x:Uid="Profile_StartingDirectoryUseParentCheckbox"
+                                      IsChecked="{x:Bind Profile.UseParentProcessDirectory, Mode=TwoWay}" />
                         </StackPanel>
-                    </local:SettingsCard>
-
-                    <local:SettingsCard x:Name="StartingDirectory"
-                                        ContentAlignment="Left">
-                        <CheckBox x:Name="StartingDirectoryUseParentCheckbox"
-                                  x:Uid="Profile_StartingDirectoryUseParentCheckbox"
-                                  IsChecked="{x:Bind Profile.UseParentProcessDirectory, Mode=TwoWay}" />
                     </local:SettingsCard>
 
                     <!--  Elevate  -->

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
@@ -229,6 +229,17 @@
                     <FontIcon Glyph="&#xE790;" />
                 </local:SettingsCard.HeaderIcon>
             </local:SettingsCard>
+            <local:SettingsCard x:Name="UnfocusedAppearanceNavigator"
+                                Click="UnfocusedAppearance_Click"
+                                IsClickEnabled="True"
+                                Visibility="{x:Bind Profile.EditableUnfocusedAppearance, Mode=OneWay}">
+                <local:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE7B3;" />
+                </local:SettingsCard.HeaderIcon>
+                <TextBlock VerticalAlignment="Center"
+                           Style="{StaticResource SettingContainerCurrentValueTextBlockStyle}"
+                           Text="{x:Bind Profile.UnfocusedAppearanceCardValue, Mode=OneWay}" />
+            </local:SettingsCard>
             <local:SettingsCard x:Name="TerminalNavigator"
                                 x:Uid="Profile_TerminalNavigator"
                                 Click="Terminal_Click"

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
@@ -165,12 +165,13 @@
             <!--  Tab Color  -->
             <local:SettingsExpander x:Name="TabColor"
                                     x:Uid="Profile_TabColor"
-                                    AutomationProperties.Name="{x:Bind Profile.TabColorPreview, Converter={StaticResource ColorToStringConverter}, Mode=OneWay}">
+                                    AutomationProperties.Name="{x:Bind Profile.TabColorAccessibleName, Mode=OneWay}">
                 <local:SettingsExpander.Content>
                     <StackPanel Style="{StaticResource SettingControlStackStyle}">
                         <ContentControl VerticalAlignment="Center"
                                         Content="{x:Bind Profile.TabColorPreview, Mode=OneWay}"
-                                        ContentTemplate="{StaticResource ColorPreviewTemplate}" />
+                                        ContentTemplate="{StaticResource ColorPreviewTemplate}"
+                                        IsTabStop="False" />
                         <local:SettingResetButton SettingName="TabColor"
                                                   Target="{x:Bind Profile}" />
                     </StackPanel>
@@ -188,7 +189,7 @@
             <!--  Icon  -->
             <local:SettingsExpander x:Name="Icon"
                                     x:Uid="Profile_Icon"
-                                    AutomationProperties.Name="{x:Bind Profile.LocalizedIcon, Mode=OneWay}">
+                                    AutomationProperties.Name="{x:Bind Profile.IconAccessibleName, Mode=OneWay}">
                 <local:SettingsExpander.Content>
                     <StackPanel Style="{StaticResource SettingControlStackStyle}">
                         <Grid>

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
@@ -145,8 +145,8 @@
                 </local:SettingsExpander.Items>
             </local:SettingsExpander>
 
-            <!--  Section: Visual/UI Affordance  -->
-            <TextBlock x:Uid="Profile_Section_VisualUI"
+            <!--  Section: Tab Appearance  -->
+            <TextBlock x:Uid="Profile_Section_TabAppearance"
                        Style="{StaticResource TextBlockSubHeaderStyle}" />
 
             <!--  Tab Title  -->

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
@@ -60,7 +60,8 @@
                                      IsSpellCheckEnabled="False"
                                      Style="{StaticResource TextBoxSettingStyle}"
                                      Text="{x:Bind Profile.Commandline, Mode=TwoWay}" />
-                            <Button x:Uid="Profile_CommandlineBrowse"
+                            <Button x:Name="CommandlineBrowse"
+                                    x:Uid="Profile_CommandlineBrowse"
                                     Click="Commandline_Click"
                                     Style="{StaticResource BrowseButtonStyle}">
                                 <FontIcon FontSize="{StaticResource StandardIconSize}"

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
@@ -32,56 +32,132 @@
                    Style="{StaticResource DisclaimerStyle}"
                    Visibility="{x:Bind Profile.IsBaseLayer}" />
         <StackPanel Grid.Row="1"
-                    Spacing="2"
                     Style="{StaticResource SettingsStackStyle}">
 
             <!--  Name  -->
-            <local:SettingsCard x:Name="Name"
-                                x:Uid="Profile_Name"
-                                Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(Profile.IsBaseLayer), Mode=OneWay}">
+            <local:SettingsExpander x:Name="Name"
+                                    x:Uid="Profile_Name"
+                                    IsExpanded="True">
+                <TextBox x:Uid="Profile_NameBox"
+                         Style="{StaticResource TextBoxSettingStyle}"
+                         Text="{x:Bind Profile.Name, Mode=TwoWay}"
+                         Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(Profile.IsBaseLayer), Mode=OneWay}" />
+                <local:SettingsExpander.HeaderIcon>
+                    <FontIcon Glyph="&#xE8D4;" />
+                </local:SettingsExpander.HeaderIcon>
+                <local:SettingsExpander.Items>
+
+                    <!--  Commandline  -->
+                    <local:SettingsCard x:Name="Commandline"
+                                        x:Uid="Profile_Commandline"
+                                        Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(Profile.IsBaseLayer), Mode=OneWay}">
+                        <StackPanel Orientation="Horizontal"
+                                    Spacing="8">
+                            <TextBox x:Uid="Profile_CommandlineBox"
+                                     IsSpellCheckEnabled="False"
+                                     Style="{StaticResource TextBoxSettingStyle}"
+                                     Text="{x:Bind Profile.Commandline, Mode=TwoWay}" />
+                            <Button x:Uid="Profile_CommandlineBrowse"
+                                    Click="Commandline_Click"
+                                    Style="{StaticResource BrowseButtonStyle}">
+                                <FontIcon FontSize="{StaticResource StandardIconSize}"
+                                          Glyph="&#xE838;" />
+                            </Button>
+                        </StackPanel>
+                    </local:SettingsCard>
+
+                    <!--  Starting Directory  -->
+                    <local:SettingsCard x:Uid="Profile_StartingDirectory"
+                                        IsEnabled="{x:Bind mtu:Converters.InvertBoolean(Profile.UseParentProcessDirectory), Mode=OneWay}">
+                        <StackPanel Orientation="Horizontal"
+                                    Spacing="8">
+                            <TextBox x:Uid="Profile_StartingDirectoryBox"
+                                     IsSpellCheckEnabled="False"
+                                     Style="{StaticResource TextBoxSettingStyle}"
+                                     Text="{x:Bind Profile.StartingDirectory, Mode=TwoWay}" />
+                            <Button x:Name="StartingDirectoryBrowse"
+                                    x:Uid="Profile_StartingDirectoryBrowse"
+                                    Click="StartingDirectory_Click"
+                                    Style="{StaticResource BrowseButtonStyle}">
+                                <FontIcon FontSize="{StaticResource StandardIconSize}"
+                                          Glyph="&#xE838;" />
+                            </Button>
+                        </StackPanel>
+                    </local:SettingsCard>
+
+                    <local:SettingsCard x:Name="StartingDirectory"
+                                        ContentAlignment="Left">
+                        <CheckBox x:Name="StartingDirectoryUseParentCheckbox"
+                                  x:Uid="Profile_StartingDirectoryUseParentCheckbox"
+                                  IsChecked="{x:Bind Profile.UseParentProcessDirectory, Mode=TwoWay}" />
+                    </local:SettingsCard>
+
+                    <!--  Elevate  -->
+                    <local:SettingsCard x:Name="Elevate"
+                                        ContentAlignment="Left">
+                        <CheckBox x:Uid="Profile_Elevate"
+                                  IsChecked="{x:Bind Profile.Elevate, Mode=TwoWay}" />
+                    </local:SettingsCard>
+
+                    <!--  Hidden  -->
+                    <local:SettingsCard x:Name="Hidden"
+                                        ContentAlignment="Left"
+                                        Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(Profile.IsBaseLayer), Mode=OneWay}">
+                        <CheckBox x:Uid="Profile_Hidden"
+                                  IsChecked="{x:Bind Profile.Hidden, Mode=TwoWay}" />
+                    </local:SettingsCard>
+
+                    <!--  Delete Profile  -->
+                    <local:SettingsCard x:Name="DeleteProfile"
+                                        x:Uid="Profile_DeleteProfile"
+                                        Visibility="{x:Bind Profile.CanDeleteProfile}">
+                        <Button x:Name="DeleteProfileButton"
+                                x:Uid="Profile_DeleteProfileButton"
+                                Style="{StaticResource DeleteButtonStyle}">
+                            <Button.Flyout>
+                                <Flyout>
+                                    <StackPanel>
+                                        <TextBlock x:Uid="Profile_DeleteConfirmationMessage"
+                                                   Style="{StaticResource CustomFlyoutTextStyle}" />
+                                        <Button x:Uid="Profile_DeleteConfirmationButton"
+                                                Click="DeleteConfirmation_Click" />
+                                    </StackPanel>
+                                </Flyout>
+                            </Button.Flyout>
+                        </Button>
+                    </local:SettingsCard>
+
+                </local:SettingsExpander.Items>
+            </local:SettingsExpander>
+
+            <!--  Section: Visual/UI Affordance  -->
+            <TextBlock x:Uid="Profile_Section_VisualUI"
+                       Style="{StaticResource TextBlockSubHeaderStyle}" />
+
+            <!--  Tab Title  -->
+            <local:SettingsCard x:Name="TabTitle"
+                                x:Uid="Profile_TabTitle">
                 <TextBox Style="{StaticResource TextBoxSettingStyle}"
-                         Text="{x:Bind Profile.Name, Mode=TwoWay}" />
+                         Text="{x:Bind Profile.TabTitle, Mode=TwoWay}" />
             </local:SettingsCard>
 
-            <!--  Commandline  -->
-            <local:SettingsCard x:Name="Commandline"
-                                x:Uid="Profile_Commandline"
-                                Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(Profile.IsBaseLayer), Mode=OneWay}">
-                <StackPanel Orientation="Horizontal"
-                            Spacing="8">
-                    <TextBox x:Uid="Profile_CommandlineBox"
-                             IsSpellCheckEnabled="False"
-                             Style="{StaticResource TextBoxSettingStyle}"
-                             Text="{x:Bind Profile.Commandline, Mode=TwoWay}" />
-                    <Button x:Uid="Profile_CommandlineBrowse"
-                            Click="Commandline_Click"
-                            Style="{StaticResource BrowseButtonStyle}" />
-                </StackPanel>
-            </local:SettingsCard>
-
-            <!--  Starting Directory  -->
-            <local:SettingsCard x:Name="StartingDirectory"
-                                x:Uid="Profile_StartingDirectory">
-                <StackPanel Orientation="Vertical">
-                    <StackPanel Orientation="Horizontal"
-                                Spacing="8">
-                        <TextBox x:Uid="Profile_StartingDirectoryBox"
-                                 IsEnabled="{x:Bind mtu:Converters.InvertBoolean(Profile.UseParentProcessDirectory), Mode=OneWay}"
-                                 IsSpellCheckEnabled="False"
-                                 Style="{StaticResource TextBoxSettingStyle}"
-                                 Text="{x:Bind Profile.StartingDirectory, Mode=TwoWay}" />
-                        <Button x:Name="StartingDirectoryBrowse"
-                                x:Uid="Profile_StartingDirectoryBrowse"
-                                Click="StartingDirectory_Click"
-                                IsEnabled="{x:Bind mtu:Converters.InvertBoolean(Profile.UseParentProcessDirectory), Mode=OneWay}"
-                                Style="{StaticResource BrowseButtonStyle}" />
-                    </StackPanel>
-                    <CheckBox x:Name="StartingDirectoryUseParentCheckbox"
-                              x:Uid="Profile_StartingDirectoryUseParentCheckbox"
-                              Margin="0,4,0,0"
-                              IsChecked="{x:Bind Profile.UseParentProcessDirectory, Mode=TwoWay}" />
-                </StackPanel>
-            </local:SettingsCard>
+            <!--  Tab Color  -->
+            <local:SettingsExpander x:Name="TabColor"
+                                    x:Uid="Profile_TabColor"
+                                    AutomationProperties.Name="{x:Bind Profile.TabColorPreview, Converter={StaticResource ColorToStringConverter}, Mode=OneWay}">
+                <local:SettingsExpander.Content>
+                    <ContentControl Content="{x:Bind Profile.TabColorPreview, Mode=OneWay}"
+                                    ContentTemplate="{StaticResource ColorPreviewTemplate}" />
+                </local:SettingsExpander.Content>
+                <local:SettingsExpander.ItemsHeader>
+                    <ContentPresenter Padding="16,12,16,16">
+                        <local:NullableColorPicker x:Uid="Profile_TabColor_NullableColorPicker"
+                                                   ColorSchemeVM="{x:Bind Profile.DefaultAppearance.CurrentColorScheme, Mode=OneWay}"
+                                                   CurrentColor="{x:Bind Profile.TabColor, Mode=TwoWay}"
+                                                   NullColorPreview="{x:Bind Profile.TabThemeColorPreview, Mode=OneWay}" />
+                    </ContentPresenter>
+                </local:SettingsExpander.ItemsHeader>
+            </local:SettingsExpander>
 
             <!--  Icon  -->
             <local:SettingsExpander x:Name="Icon"
@@ -111,66 +187,7 @@
                 </local:SettingsExpander.ItemsHeader>
             </local:SettingsExpander>
 
-            <!--  Tab Title  -->
-            <local:SettingsCard x:Name="TabTitle"
-                                x:Uid="Profile_TabTitle">
-                <TextBox Style="{StaticResource TextBoxSettingStyle}"
-                         Text="{x:Bind Profile.TabTitle, Mode=TwoWay}" />
-            </local:SettingsCard>
-
-            <!--  Tab Color  -->
-            <local:SettingsExpander x:Name="TabColor"
-                                    x:Uid="Profile_TabColor"
-                                    AutomationProperties.Name="{x:Bind Profile.TabColorPreview, Converter={StaticResource ColorToStringConverter}, Mode=OneWay}">
-                <local:SettingsExpander.Content>
-                    <ContentControl Content="{x:Bind Profile.TabColorPreview, Mode=OneWay}"
-                                    ContentTemplate="{StaticResource ColorPreviewTemplate}" />
-                </local:SettingsExpander.Content>
-                <local:SettingsExpander.ItemsHeader>
-                    <ContentPresenter Padding="16,12,16,16">
-                        <local:NullableColorPicker x:Uid="Profile_TabColor_NullableColorPicker"
-                                                   ColorSchemeVM="{x:Bind Profile.DefaultAppearance.CurrentColorScheme, Mode=OneWay}"
-                                                   CurrentColor="{x:Bind Profile.TabColor, Mode=TwoWay}"
-                                                   NullColorPreview="{x:Bind Profile.TabThemeColorPreview, Mode=OneWay}" />
-                    </ContentPresenter>
-                </local:SettingsExpander.ItemsHeader>
-            </local:SettingsExpander>
-
-            <!--  Elevate  -->
-            <local:SettingsCard x:Name="Elevate"
-                                x:Uid="Profile_Elevate">
-                <ToggleSwitch IsOn="{x:Bind Profile.Elevate, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
-            </local:SettingsCard>
-
-            <!--  Hidden  -->
-            <local:SettingsCard x:Name="Hidden"
-                                x:Uid="Profile_Hidden"
-                                Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(Profile.IsBaseLayer), Mode=OneWay}">
-                <ToggleSwitch IsOn="{x:Bind Profile.Hidden, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
-            </local:SettingsCard>
-
-            <!--  Delete Profile  -->
-            <local:SettingsCard x:Name="DeleteProfile"
-                                x:Uid="Profile_DeleteProfile"
-                                Visibility="{x:Bind Profile.CanDeleteProfile}">
-                <Button x:Name="DeleteProfileButton"
-                        x:Uid="Profile_DeleteProfileButton"
-                        Style="{StaticResource DeleteButtonStyle}">
-                    <Button.Flyout>
-                        <Flyout>
-                            <StackPanel>
-                                <TextBlock x:Uid="Profile_DeleteConfirmationMessage"
-                                           Style="{StaticResource CustomFlyoutTextStyle}" />
-                                <Button x:Uid="Profile_DeleteConfirmationButton"
-                                        Click="DeleteConfirmation_Click" />
-                            </StackPanel>
-                        </Flyout>
-                    </Button.Flyout>
-                </Button>
-            </local:SettingsCard>
-
+            <!--  Additional settings  -->
             <TextBlock x:Uid="Profile_AdditionalSettingsHeader"
                        Margin="0,32,0,4"
                        Style="{StaticResource TextBlockSubHeaderStyle}" />
@@ -178,15 +195,27 @@
             <local:SettingsCard x:Name="AppearanceNavigator"
                                 x:Uid="Profile_AppearanceNavigator"
                                 Click="Appearance_Click"
-                                IsClickEnabled="True" />
+                                IsClickEnabled="True">
+                <local:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE790;" />
+                </local:SettingsCard.HeaderIcon>
+            </local:SettingsCard>
             <local:SettingsCard x:Name="TerminalNavigator"
                                 x:Uid="Profile_TerminalNavigator"
                                 Click="Terminal_Click"
-                                IsClickEnabled="True" />
+                                IsClickEnabled="True">
+                <local:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE950;" />
+                </local:SettingsCard.HeaderIcon>
+            </local:SettingsCard>
             <local:SettingsCard x:Name="AdvancedNavigator"
                                 x:Uid="Profile_AdvancedNavigator"
                                 Click="Advanced_Click"
-                                IsClickEnabled="True" />
+                                IsClickEnabled="True">
+                <local:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE9F5;" />
+                </local:SettingsCard.HeaderIcon>
+            </local:SettingsCard>
         </StackPanel>
     </Grid>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
@@ -229,6 +229,7 @@
                 </local:SettingsCard.HeaderIcon>
             </local:SettingsCard>
             <local:SettingsCard x:Name="UnfocusedAppearanceNavigator"
+                                x:Uid="Profile_UnfocusedAppearanceNavigator"
                                 Click="UnfocusedAppearance_Click"
                                 IsClickEnabled="True"
                                 Visibility="{x:Bind Profile.EditableUnfocusedAppearance, Mode=OneWay}">

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Terminal.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Terminal.xaml
@@ -29,7 +29,6 @@
                    Style="{StaticResource DisclaimerStyle}"
                    Visibility="{x:Bind Profile.IsBaseLayer}" />
         <StackPanel Grid.Row="1"
-                    Spacing="2"
                     Style="{StaticResource SettingsStackStyle}">
 
             <!--  Suppress Application Title  -->

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Terminal.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Terminal.xaml
@@ -34,59 +34,85 @@
             <!--  Suppress Application Title  -->
             <local:SettingsCard x:Name="SuppressApplicationTitle"
                                 x:Uid="Profile_SuppressApplicationTitle">
-                <ToggleSwitch IsOn="{x:Bind Profile.SuppressApplicationTitle, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.SuppressApplicationTitle, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="SuppressApplicationTitle"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Force VT Input  -->
             <local:SettingsCard x:Name="ForceVTInput"
                                 x:Uid="Profile_ForceVTInput">
-                <ToggleSwitch IsOn="{x:Bind Profile.ForceVTInput, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.ForceVTInput, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="ForceVTInput"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Kitty Keyboard Mode  -->
             <local:SettingsCard x:Name="AllowKittyKeyboardMode"
                                 x:Uid="Profile_AllowKittyKeyboardMode">
-                <ToggleSwitch IsOn="{x:Bind Profile.AllowKittyKeyboardMode, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.AllowKittyKeyboardMode, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="AllowKittyKeyboardMode"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Allow VT Checksum Report  -->
             <local:SettingsCard x:Name="AllowVtChecksumReport"
                                 x:Uid="Profile_AllowVtChecksumReport">
-                <ToggleSwitch IsOn="{x:Bind Profile.AllowVtChecksumReport, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.AllowVtChecksumReport, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="AllowVtChecksumReport"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Allow VT Clipboard Writing  -->
             <local:SettingsCard x:Name="AllowVtClipboardWrite"
                                 x:Uid="Profile_AllowVtClipboardWrite">
-                <ToggleSwitch IsOn="{x:Bind Profile.AllowVtClipboardWrite, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.AllowVtClipboardWrite, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="AllowVtClipboardWrite"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Allow OSC 777 Desktop Notifications  -->
             <local:SettingsCard x:Name="AllowOscNotifications"
                                 x:Uid="Profile_AllowOscNotifications">
-                <ToggleSwitch IsOn="{x:Bind Profile.AllowOscNotifications, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.AllowOscNotifications, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="AllowOscNotifications"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Answerback Message  -->
-            <local:SettingsExpander x:Name="AnswerbackMessage"
-                                    x:Uid="Profile_AnswerbackMessage">
-                <local:SettingsExpander.Content>
-                    <TextBlock Style="{StaticResource SettingContainerCurrentValueTextBlockStyle}"
-                               Text="{x:Bind Profile.AnswerbackMessagePreview, Mode=OneWay}" />
-                </local:SettingsExpander.Content>
-                <local:SettingsExpander.ItemsHeader>
-                    <ContentPresenter Padding="16,12,16,16">
-                        <TextBox Style="{StaticResource TextBoxSettingStyle}"
-                                 Text="{x:Bind Profile.AnswerbackMessage, Mode=TwoWay}" />
-                    </ContentPresenter>
-                </local:SettingsExpander.ItemsHeader>
-            </local:SettingsExpander>
+            <local:SettingsCard x:Name="AnswerbackMessage"
+                                x:Uid="Profile_AnswerbackMessage">
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <TextBox Style="{StaticResource TextBoxSettingStyle}"
+                             Text="{x:Bind Profile.AnswerbackMessage, Mode=TwoWay}" />
+                    <local:SettingResetButton SettingName="AnswerbackMessage"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
+            </local:SettingsCard>
         </StackPanel>
     </Grid>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Terminal.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Terminal.xaml
@@ -34,60 +34,85 @@
             <!--  Suppress Application Title  -->
             <local:SettingsCard x:Name="SuppressApplicationTitle"
                                 x:Uid="Profile_SuppressApplicationTitle">
-                <ToggleSwitch IsOn="{x:Bind Profile.SuppressApplicationTitle, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.SuppressApplicationTitle, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="SuppressApplicationTitle"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Force VT Input  -->
             <local:SettingsCard x:Name="ForceVTInput"
                                 x:Uid="Profile_ForceVTInput">
-                <ToggleSwitch IsOn="{x:Bind Profile.ForceVTInput, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.ForceVTInput, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="ForceVTInput"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Kitty Keyboard Mode  -->
             <local:SettingsCard x:Name="AllowKittyKeyboardMode"
                                 x:Uid="Profile_AllowKittyKeyboardMode">
-                <ToggleSwitch IsOn="{x:Bind Profile.AllowKittyKeyboardMode, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.AllowKittyKeyboardMode, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="AllowKittyKeyboardMode"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Allow VT Checksum Report  -->
             <local:SettingsCard x:Name="AllowVtChecksumReport"
                                 x:Uid="Profile_AllowVtChecksumReport">
-                <ToggleSwitch IsOn="{x:Bind Profile.AllowVtChecksumReport, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.AllowVtChecksumReport, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="AllowVtChecksumReport"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Allow VT Clipboard Writing  -->
             <local:SettingsCard x:Name="AllowVtClipboardWrite"
                                 x:Uid="Profile_AllowVtClipboardWrite">
-                <ToggleSwitch IsOn="{x:Bind Profile.AllowVtClipboardWrite, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.AllowVtClipboardWrite, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="AllowVtClipboardWrite"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Allow OSC 777 Desktop Notifications  -->
             <local:SettingsCard x:Name="AllowOscNotifications"
                                 x:Uid="Profile_AllowOscNotifications">
-                <ToggleSwitch IsOn="{x:Bind Profile.AllowOscNotifications, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <ToggleSwitch VerticalAlignment="Center"
+                                  IsOn="{x:Bind Profile.AllowOscNotifications, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <local:SettingResetButton SettingName="AllowOscNotifications"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
             </local:SettingsCard>
 
             <!--  Answerback Message  -->
-            <local:SettingsExpander x:Name="AnswerbackMessage"
-                                    x:Uid="Profile_AnswerbackMessage"
-                                    AutomationProperties.Name="{x:Bind Profile.AnswerbackMessageAccessibleName, Mode=OneWay}">
-                <local:SettingsExpander.Content>
-                    <TextBlock Style="{StaticResource SettingContainerCurrentValueTextBlockStyle}"
-                               Text="{x:Bind Profile.AnswerbackMessagePreview, Mode=OneWay}" />
-                </local:SettingsExpander.Content>
-                <local:SettingsExpander.ItemsHeader>
-                    <ContentPresenter Padding="16,12,16,16">
-                        <TextBox Style="{StaticResource TextBoxSettingStyle}"
-                                 Text="{x:Bind Profile.AnswerbackMessage, Mode=TwoWay}" />
-                    </ContentPresenter>
-                </local:SettingsExpander.ItemsHeader>
-            </local:SettingsExpander>
+            <local:SettingsCard x:Name="AnswerbackMessage"
+                                x:Uid="Profile_AnswerbackMessage">
+                <StackPanel Style="{StaticResource SettingControlStackStyle}">
+                    <TextBox Style="{StaticResource TextBoxSettingStyle}"
+                             Text="{x:Bind Profile.AnswerbackMessage, Mode=TwoWay}" />
+                    <local:SettingResetButton SettingName="AnswerbackMessage"
+                                              Target="{x:Bind Profile}" />
+                </StackPanel>
+            </local:SettingsCard>
         </StackPanel>
     </Grid>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/Profiles_UnfocusedAppearance.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_UnfocusedAppearance.cpp
@@ -1,0 +1,133 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
+#include "Profiles_UnfocusedAppearance.h"
+#include "Appearances.h"
+
+#include "ProfileViewModel.h"
+#include "PreviewConnection.h"
+
+#include "Profiles_UnfocusedAppearance.g.cpp"
+
+using namespace winrt::Windows::UI::Xaml;
+using namespace winrt::Windows::UI::Xaml::Navigation;
+
+static constexpr std::wstring_view AppearanceSettingPrefix{ L"App." };
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
+{
+    Profiles_UnfocusedAppearance::Profiles_UnfocusedAppearance()
+    {
+        InitializeComponent();
+        _previewConnection = winrt::make_self<PreviewConnection>();
+    }
+
+    void Profiles_UnfocusedAppearance::OnNavigatedTo(const NavigationEventArgs& e)
+    {
+        const auto args = e.Parameter().as<Editor::NavigateToPageArgs>();
+        _Profile = args.ViewModel().as<Editor::ProfileViewModel>();
+        _weakWindowRoot = args.WindowRoot();
+
+        // Auto-create the unfocused appearance on navigate so the preview and editor are ready to go.
+        if (!_Profile.HasUnfocusedAppearance())
+        {
+            TraceLoggingWrite(
+                g_hTerminalSettingsEditorProvider,
+                "CreateUnfocusedAppearance",
+                TraceLoggingDescription("Event emitted when the user creates an unfocused appearance for a profile"),
+                TraceLoggingValue(_Profile.IsBaseLayer(), "IsProfileDefaults", "If the modified profile is the profile.defaults object"),
+                TraceLoggingValue(static_cast<GUID>(_Profile.Guid()), "ProfileGuid", "The guid of the profile that was navigated to"),
+                TraceLoggingValue(_Profile.Source().c_str(), "ProfileSource", "The source of the profile that was navigated to"),
+                TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+                TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
+
+            _Profile.CreateUnfocusedAppearance();
+        }
+
+        // Settings are stored in Profiles_UnfocusedAppearance and Appearances.
+        // We use the "App." prefix to indicate if it's in Appearances,
+        // and remove it on the way to Appearances object.
+        const auto elementToFocus = args.ElementToFocus();
+        if (elementToFocus.starts_with(AppearanceSettingPrefix))
+        {
+            std::wstring correctedName{ elementToFocus.c_str() };
+            get_self<implementation::Appearances>(UnfocusedAppearanceView())->BringIntoViewWhenLoaded(hstring{ correctedName.substr(AppearanceSettingPrefix.size()) });
+        }
+        else
+        {
+            BringIntoViewWhenLoaded(elementToFocus);
+        }
+
+        if (!_previewControl)
+        {
+            const auto settings = winrt::get_self<implementation::ProfileViewModel>(_Profile)->TermSettingsUnfocused();
+            _previewConnection->DisplayPowerlineGlyphs(_Profile.UnfocusedAppearance().HasPowerlineCharacters());
+            _previewControl = Control::TermControl(settings, settings, *_previewConnection);
+            _previewControl.CursorVisibility(Control::CursorDisplayState::Shown);
+            _previewControl.IsEnabled(false);
+            _previewControl.AllowFocusWhenDisabled(false);
+            ControlPreview().Child(_previewControl);
+        }
+
+        // Subscribe to some changes in the view model
+        // These changes should force us to update our own set of "Current<Setting>" members,
+        // and propagate those changes to the UI
+        _ViewModelChangedRevoker = _Profile.PropertyChanged(winrt::auto_revoke, { this, &Profiles_UnfocusedAppearance::_onProfilePropertyChanged });
+        // The Appearances object handles updating the values in the settings UI, but
+        // we still need to listen to the changes here just to update the preview control
+        _AppearanceViewModelChangedRevoker = _Profile.UnfocusedAppearance().PropertyChanged(winrt::auto_revoke, { this, &Profiles_UnfocusedAppearance::_onProfilePropertyChanged });
+
+        TraceLoggingWrite(
+            g_hTerminalSettingsEditorProvider,
+            "NavigatedToPage",
+            TraceLoggingDescription("Event emitted when the user navigates to a page in the settings UI"),
+            TraceLoggingValue("profile.unfocusedAppearance", "PageId", "The identifier of the page that was navigated to"),
+            TraceLoggingValue(_Profile.IsBaseLayer(), "IsProfileDefaults", "If the modified profile is the profile.defaults object"),
+            TraceLoggingValue(static_cast<GUID>(_Profile.Guid()), "ProfileGuid", "The guid of the profile that was navigated to"),
+            TraceLoggingValue(_Profile.Source().c_str(), "ProfileSource", "The source of the profile that was navigated to"),
+            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+            TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
+    }
+
+    void Profiles_UnfocusedAppearance::OnNavigatedFrom(const NavigationEventArgs& /*e*/)
+    {
+        _ViewModelChangedRevoker.revoke();
+        _AppearanceViewModelChangedRevoker.revoke();
+    }
+
+    void Profiles_UnfocusedAppearance::DeleteUnfocusedAppearance_Click(const IInspectable& /*sender*/, const RoutedEventArgs& /*e*/)
+    {
+        // Stop listening to the unfocused appearance before it goes away.
+        _AppearanceViewModelChangedRevoker.revoke();
+        _Profile.DeleteUnfocusedAppearance();
+
+        // Return to the base profile page now that there's no unfocused appearance to edit.
+        _Profile.CurrentPage(ProfileSubPage::Base);
+    }
+
+    void Profiles_UnfocusedAppearance::_onProfilePropertyChanged(const IInspectable&, const PropertyChangedEventArgs&)
+    {
+        if (!_updatePreviewControl)
+        {
+            _updatePreviewControl = std::make_shared<ThrottledFunc<>>(
+                winrt::Windows::System::DispatcherQueue::GetForCurrentThread(),
+                til::throttled_func_options{
+                    .delay = std::chrono::milliseconds{ 100 },
+                    .debounce = true,
+                    .trailing = true,
+                },
+                [this]() {
+                    if (!_Profile.HasUnfocusedAppearance())
+                    {
+                        return;
+                    }
+                    const auto settings = winrt::get_self<implementation::ProfileViewModel>(_Profile)->TermSettingsUnfocused();
+                    _previewConnection->DisplayPowerlineGlyphs(_Profile.UnfocusedAppearance().HasPowerlineCharacters());
+                    _previewControl.UpdateControlSettings(settings, settings);
+                });
+        }
+
+        _updatePreviewControl->Run();
+    }
+}

--- a/src/cascadia/TerminalSettingsEditor/Profiles_UnfocusedAppearance.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_UnfocusedAppearance.cpp
@@ -28,22 +28,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         const auto args = e.Parameter().as<Editor::NavigateToPageArgs>();
         _Profile = args.ViewModel().as<Editor::ProfileViewModel>();
         _weakWindowRoot = args.WindowRoot();
-
-        // Auto-create the unfocused appearance on navigate so the preview and editor are ready to go.
-        if (!_Profile.HasUnfocusedAppearance())
-        {
-            TraceLoggingWrite(
-                g_hTerminalSettingsEditorProvider,
-                "CreateUnfocusedAppearance",
-                TraceLoggingDescription("Event emitted when the user creates an unfocused appearance for a profile"),
-                TraceLoggingValue(_Profile.IsBaseLayer(), "IsProfileDefaults", "If the modified profile is the profile.defaults object"),
-                TraceLoggingValue(static_cast<GUID>(_Profile.Guid()), "ProfileGuid", "The guid of the profile that was navigated to"),
-                TraceLoggingValue(_Profile.Source().c_str(), "ProfileSource", "The source of the profile that was navigated to"),
-                TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
-                TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
-
-            _Profile.CreateUnfocusedAppearance();
-        }
+        assert(_Profile.HasUnfocusedAppearance());
 
         // Settings are stored in Profiles_UnfocusedAppearance and Appearances.
         // We use the "App." prefix to indicate if it's in Appearances,

--- a/src/cascadia/TerminalSettingsEditor/Profiles_UnfocusedAppearance.h
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_UnfocusedAppearance.h
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+
+#include <ThrottledFunc.h>
+
+#include "Profiles_UnfocusedAppearance.g.h"
+#include "PreviewConnection.h"
+#include "Utils.h"
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
+{
+    struct Profiles_UnfocusedAppearance : public HasScrollViewer<Profiles_UnfocusedAppearance>, Profiles_UnfocusedAppearanceT<Profiles_UnfocusedAppearance>
+    {
+    public:
+        Profiles_UnfocusedAppearance();
+
+        void OnNavigatedTo(const Windows::UI::Xaml::Navigation::NavigationEventArgs& e);
+        void OnNavigatedFrom(const Windows::UI::Xaml::Navigation::NavigationEventArgs& e);
+
+        void DeleteUnfocusedAppearance_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& e);
+
+        Editor::IHostedInWindow WindowRoot() const noexcept { return _weakWindowRoot.get(); };
+
+        til::property_changed_event PropertyChanged;
+        WINRT_PROPERTY(Editor::ProfileViewModel, Profile, nullptr);
+
+    private:
+        void _onProfilePropertyChanged(const IInspectable&, const PropertyChangedEventArgs&);
+
+        winrt::com_ptr<PreviewConnection> _previewConnection{ nullptr };
+        Microsoft::Terminal::Control::TermControl _previewControl{ nullptr };
+        std::shared_ptr<ThrottledFunc<>> _updatePreviewControl;
+        Windows::UI::Xaml::Data::INotifyPropertyChanged::PropertyChanged_revoker _ViewModelChangedRevoker;
+        Windows::UI::Xaml::Data::INotifyPropertyChanged::PropertyChanged_revoker _AppearanceViewModelChangedRevoker;
+        winrt::weak_ref<Editor::IHostedInWindow> _weakWindowRoot;
+    };
+};
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::factory_implementation
+{
+    BASIC_FACTORY(Profiles_UnfocusedAppearance);
+}

--- a/src/cascadia/TerminalSettingsEditor/Profiles_UnfocusedAppearance.idl
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_UnfocusedAppearance.idl
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "ProfileViewModel.idl";
+
+namespace Microsoft.Terminal.Settings.Editor
+{
+    [default_interface] runtimeclass Profiles_UnfocusedAppearance : Windows.UI.Xaml.Controls.Page, Windows.UI.Xaml.Data.INotifyPropertyChanged
+    {
+        Profiles_UnfocusedAppearance();
+        ProfileViewModel Profile { get; };
+        IHostedInWindow WindowRoot { get; };
+    }
+}

--- a/src/cascadia/TerminalSettingsEditor/Profiles_UnfocusedAppearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_UnfocusedAppearance.xaml
@@ -1,0 +1,70 @@
+<!--
+    Copyright (c) Microsoft Corporation. All rights reserved. Licensed under
+    the MIT License. See LICENSE in the project root for license information.
+-->
+<Page x:Class="Microsoft.Terminal.Settings.Editor.Profiles_UnfocusedAppearance"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:local="using:Microsoft.Terminal.Settings.Editor"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:model="using:Microsoft.Terminal.Settings.Model"
+      xmlns:mtu="using:Microsoft.Terminal.UI"
+      xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+      mc:Ignorable="d">
+
+    <Page.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="CommonResources.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Page.Resources>
+
+    <Grid MaxWidth="{StaticResource StandardControlMaxWidth}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <TextBlock x:Uid="Profile_BaseLayerDisclaimer"
+                   Grid.Row="0"
+                   Style="{StaticResource DisclaimerStyle}"
+                   Visibility="{x:Bind Profile.IsBaseLayer}" />
+        <StackPanel Grid.Row="1"
+                    Margin="0,12,0,0"
+                    Style="{StaticResource SettingsStackStyle}">
+            <!--  Control Preview  -->
+            <Border MaxWidth="{StaticResource StandardControlMaxWidth}"
+                    Margin="0,0,0,32"
+                    CornerRadius="{StaticResource ControlCornerRadius}">
+                <Border x:Name="ControlPreview"
+                        Width="400"
+                        Height="180"
+                        HorizontalAlignment="Left"
+                        BorderBrush="{ThemeResource ControlStrongStrokeColorDefaultBrush}"
+                        BorderThickness="1"
+                        CornerRadius="{StaticResource ControlCornerRadius}" />
+            </Border>
+
+            <local:Appearances x:Name="UnfocusedAppearanceView"
+                               Appearance="{x:Bind Profile.UnfocusedAppearance, Mode=OneWay}"
+                               SourceProfile="{x:Bind Profile, Mode=OneWay}"
+                               WindowRoot="{x:Bind WindowRoot, Mode=OneTime}" />
+
+            <!--  Delete Unfocused Appearance  -->
+            <local:SettingsCard x:Name="DeleteUnfocusedAppearance"
+                                x:Uid="Profile_DeleteUnfocusedAppearance"
+                                Margin="0,18,0,0">
+                <local:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE74D;" />
+                </local:SettingsCard.HeaderIcon>
+                <Button x:Name="DeleteUnfocusedAppearanceButton"
+                        x:Uid="Profile_DeleteUnfocusedAppearanceButton"
+                        Click="DeleteUnfocusedAppearance_Click"
+                        Style="{StaticResource DeleteButtonStyle}">
+                    <TextBlock x:Uid="Profile_DeleteAppearanceButton" />
+                </Button>
+            </local:SettingsCard>
+        </StackPanel>
+    </Grid>
+</Page>

--- a/src/cascadia/TerminalSettingsEditor/Profiles_UnfocusedAppearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_UnfocusedAppearance.xaml
@@ -54,7 +54,8 @@
             <!--  Delete Unfocused Appearance  -->
             <local:SettingsCard x:Name="DeleteUnfocusedAppearance"
                                 x:Uid="Profile_DeleteUnfocusedAppearance"
-                                Margin="0,18,0,0">
+                                Margin="0,18,0,0"
+                                Style="{StaticResource ExpanderAlignedSettingsCardStyle}">
                 <local:SettingsCard.HeaderIcon>
                     <FontIcon Glyph="&#xE74D;" />
                 </local:SettingsCard.HeaderIcon>

--- a/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
@@ -2649,10 +2649,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>Gibt die Software an, die dieses Profil ursprünglich erstellt hat.</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>Keine</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>Der automatische Start wurde im Abschnitt "Start-Apps" der einstellungen für Windows deaktiviert.</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2710,10 +2706,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>Keine</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>Keine</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>Auf Standardeinstellungen zurücksetzen</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
@@ -1241,10 +1241,6 @@
     <value>Unscharfes Erscheinungsbild</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Erscheinungsbild erstellen</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>Löschen</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1740,14 +1736,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Wenn diese Option aktiviert ist, werden alle installierten Schriftarten in der Liste oben angezeigt. Andernfalls wird nur die Liste der Schriftarten mit fester Breite angezeigt.</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Erscheinungsbild erstellen</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Erstellen Sie ein unscharfes Erscheinungsbild für dieses Profil. So sieht das Profil aus, als ob es inaktiv ist.</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Erscheinungsbild löschen</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
@@ -569,7 +569,7 @@
     <value>OSC 777 (Desktop Notification) zum Anzeigen von Popupbenachrichtigungen zulassen</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>Wenn diese Option aktiviert ist, können Anwendungen die OSC 777 Escapesequenz senden, um eine Desktopbenachrichtigung mit einem benutzerdefinierten Titel und Text auszulösen.</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -930,7 +930,7 @@
     <value>Im Profil verwendete ausführbare Datei.</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Durchsuchen…</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1101,21 +1101,13 @@
     <value>Die ausgewählte Schriftart weist keine Schriftartfeatures auf.</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>Profil in Dropdownliste ausblenden</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>Wenn diese Option aktiviert ist, wird das Profil nicht in der Liste der Profile angezeigt. Dies kann verwendet werden, um Standardprofile und dynamisch generierte Profile auszublenden, während sie in Ihrer Einstellungsdatei bleiben.</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>Dieses Profil als Administrator ausführen</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>Wenn diese Option aktiviert ist, wird das Profil automatisch in einem Admin Terminalfenster geöffnet. Wenn das aktuelle Fenster bereits als Administrator ausgeführt wird, wird es in diesem Fenster geöffnet.</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>Größe des Verlaufs</value>
@@ -1213,11 +1205,7 @@
     <value>Startverzeichnis</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>Das Verzeichnis, in dem das Profil gestartet wird, wenn es geladen wird.</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Durchsuchen…</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
@@ -1229,10 +1229,6 @@
     <value>Unscharfes Erscheinungsbild</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Erscheinungsbild erstellen</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>Löschen</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1724,14 +1720,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Wenn diese Option aktiviert ist, werden alle installierten Schriftarten in der Liste oben angezeigt. Andernfalls wird nur die Liste der Schriftarten mit fester Breite angezeigt.</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Erscheinungsbild erstellen</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Erstellen Sie ein unscharfes Erscheinungsbild für dieses Profil. So sieht das Profil aus, als ob es inaktiv ist.</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Erscheinungsbild löschen</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
@@ -2633,10 +2633,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>Gibt die Software an, die dieses Profil ursprünglich erstellt hat.</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>Keine</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>Der automatische Start wurde im Abschnitt "Start-Apps" der einstellungen für Windows deaktiviert.</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2694,10 +2690,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>Keine</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>Keine</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>Auf Standardeinstellungen zurücksetzen</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
@@ -809,7 +809,7 @@
     <value>Oben rechts</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
-  <data name="Profile_BackgroundImageBrowse.Content" xml:space="preserve">
+  <data name="Profile_BackgroundImageBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Durchsuchen…</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1129,7 +1129,7 @@
     <value>Emoji- oder Bilddateipfad des im Profil verwendeten Symbols.</value>
     <comment>A description for what the "icon" setting does. Presented near "Profile_Icon".</comment>
   </data>
-  <data name="IconPicker_IconBrowse.Content" xml:space="preserve">
+  <data name="IconPicker_IconBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Durchsuchen…</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -2101,7 +2101,7 @@
     <value>Keine Farbe</value>
     <comment>Label for a button directing the user to opt out of choosing a color.</comment>
   </data>
-  <data name="Actions_Browse.Content" xml:space="preserve">
+  <data name="Actions_Browse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Durchsuchen…</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
@@ -557,7 +557,7 @@
     <value>OSC 777 (Desktop Notification) zum Anzeigen von Popupbenachrichtigungen zulassen</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>Wenn diese Option aktiviert ist, können Anwendungen die OSC 777 Escapesequenz senden, um eine Desktopbenachrichtigung mit einem benutzerdefinierten Titel und Text auszulösen.</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -918,7 +918,7 @@
     <value>Im Profil verwendete ausführbare Datei.</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Durchsuchen…</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1089,21 +1089,13 @@
     <value>Die ausgewählte Schriftart weist keine Schriftartfeatures auf.</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>Profil in Dropdownliste ausblenden</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>Wenn diese Option aktiviert ist, wird das Profil nicht in der Liste der Profile angezeigt. Dies kann verwendet werden, um Standardprofile und dynamisch generierte Profile auszublenden, während sie in Ihrer Einstellungsdatei bleiben.</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>Dieses Profil als Administrator ausführen</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>Wenn diese Option aktiviert ist, wird das Profil automatisch in einem Admin Terminalfenster geöffnet. Wenn das aktuelle Fenster bereits als Administrator ausgeführt wird, wird es in diesem Fenster geöffnet.</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>Größe des Verlaufs</value>
@@ -1201,11 +1193,7 @@
     <value>Startverzeichnis</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>Das Verzeichnis, in dem das Profil gestartet wird, wenn es geladen wird.</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Durchsuchen…</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -569,7 +569,7 @@
     <value>Allow OSC 777 (Desktop Notification) to show toast notifications</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>When enabled, applications can send the OSC 777 escape sequence to trigger a desktop notification with a custom title and body.</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -930,7 +930,7 @@
     <value>Executable used in the profile.</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Browse...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1101,21 +1101,13 @@
     <value>The selected font has no font features.</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>Hide profile from dropdown</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>If enabled, the profile will not appear in the list of profiles. This can be used to hide default profiles and dynamically generated profiles, while leaving them in your settings file.</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
-    <value>Run this profile as Administrator</value>
+  <data name="Profile_Elevate.Content" xml:space="preserve">
+    <value>Run as administrator (uses current window if already elevated)</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>If enabled, the profile will open in an Admin terminal window automatically. If the current window is already running as admin, it will open in this window.</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>History size</value>
@@ -1206,18 +1198,14 @@
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
   <data name="Profile_StartingDirectory.Header" xml:space="preserve">
-    <value>Starting directory</value>
+    <value>Default starting directory</value>
     <comment>Header for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
   <data name="Profile_StartingDirectoryBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Starting directory</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>The directory the profile starts in when it is loaded.</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Browse...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1590,8 +1578,24 @@
     <comment>Name for a control to determine the name of the profile. This is a text box.</comment>
   </data>
   <data name="Profile_Name.Header" xml:space="preserve">
+    <value>Profile</value>
+    <comment>Header for the profile section of the profile settings page. Shown above a text box that lets the user edit the profile name.</comment>
+  </data>
+  <data name="Profile_NameBox.PlaceholderText" xml:space="preserve">
     <value>Name</value>
-    <comment>Header for a control to determine the name of the profile. This is a text box.</comment>
+    <comment>Placeholder text shown inside the empty profile name text box, hinting that the user should enter the profile's name here.</comment>
+  </data>
+  <data name="Profile_Section_VisualUI.Text" xml:space="preserve">
+    <value>Visual/UI Affordance</value>
+    <comment>Title of a section in a profile page that groups visual and UI settings (tab title, icon, tab color, etc.).</comment>
+  </data>
+  <data name="Profile_AppearanceNavigator.Description" xml:space="preserve">
+    <value>Customize the visual appearance of the profile, including colors, fonts, and text styling.</value>
+    <comment>Description shown below the "Appearance" navigator card on the profile page.</comment>
+  </data>
+  <data name="Profile_TerminalNavigator.Description" xml:space="preserve">
+    <value>Configure how the terminal interprets text and control sequences to behave like a traditional command-line terminal</value>
+    <comment>Description shown below the "Terminal Emulation" navigator card on the profile page.</comment>
   </data>
   <data name="Profile_TransparencyHeader.Text" xml:space="preserve">
     <value>Transparency</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -2681,10 +2681,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>Indicates the software that originally created this profile.</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>None</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>Automatic startup has been disabled in the Startup Apps section of Windows settings.</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2742,10 +2738,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>None</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>None</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>Reset to default settings</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -757,6 +757,10 @@
     <value>Appearance</value>
     <comment>Header for a sub-page of profile settings focused on customizing the appearance of the profile.</comment>
   </data>
+  <data name="Profile_UnfocusedAppearanceNone" xml:space="preserve">
+    <value>None</value>
+    <comment>Shown on the "Unfocused appearance" navigator card when no unfocused appearance has been defined for the profile.</comment>
+  </data>
   <data name="Profile_BackgroundImageBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Background image path</value>
     <comment>Name for a control to determine the image presented on the background of the app.</comment>
@@ -1241,10 +1245,6 @@
     <value>Unfocused appearance</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Create Appearance</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>Delete</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1593,6 +1593,10 @@
     <value>Customize the visual appearance of the profile, including colors, fonts, and text styling.</value>
     <comment>Description shown below the "Appearance" navigator card on the profile page.</comment>
   </data>
+  <data name="Profile_UnfocusedAppearanceNavigator.Description" xml:space="preserve">
+    <value>Customize the appearance of the profile when it is inactive (unfocused).</value>
+    <comment>Description shown below the "Unfocused appearance" navigator card on the profile page.</comment>
+  </data>
   <data name="Profile_TerminalNavigator.Description" xml:space="preserve">
     <value>Configure how the terminal interprets text and control sequences to behave like a traditional command-line terminal</value>
     <comment>Description shown below the "Terminal Emulation" navigator card on the profile page.</comment>
@@ -1769,14 +1773,6 @@
     <value>If enabled, show all installed fonts in the list above. Otherwise, only show the list of monospace fonts.</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
   </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Create Appearance</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Create an unfocused appearance for this profile. This will be the appearance of the profile when it is inactive.</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
-  </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Delete Appearance</value>
     <comment>Name for a control which deletes the unfocused appearance settings for this profile.</comment>
@@ -1784,6 +1780,14 @@
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Delete the unfocused appearance for this profile.</value>
     <comment>A description for what the delete unfocused appearance button does.</comment>
+  </data>
+  <data name="Profile_DeleteUnfocusedAppearance.Header" xml:space="preserve">
+    <value>Delete this unfocused appearance</value>
+    <comment>Header for a settings card that deletes the profile's unfocused appearance.</comment>
+  </data>
+  <data name="Profile_DeleteUnfocusedAppearance.Description" xml:space="preserve">
+    <value>Removes the unfocused appearance so the profile uses its default appearance when inactive</value>
+    <comment>Description for the delete unfocused appearance settings card.</comment>
   </data>
   <data name="Actions_Disclaimer.Content" xml:space="preserve">
     <value>Learn more about actions</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -1097,10 +1097,6 @@
     <value>Hide profile from dropdown</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>If enabled, the profile will not appear in the list of profiles. This can be used to hide default profiles and dynamically generated profiles, while leaving them in your settings file.</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
   <data name="Profile_HiddenBadge.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Hidden from the dropdown menu</value>
     <comment>Tooltip shown when hovering the InfoBadge next to a profile name on the Profiles landing page when that profile is hidden from the dropdown menu.</comment>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -745,6 +745,10 @@
     <value>Appearance</value>
     <comment>Header for a sub-page of profile settings focused on customizing the appearance of the profile.</comment>
   </data>
+  <data name="Profile_UnfocusedAppearanceNone" xml:space="preserve">
+    <value>None</value>
+    <comment>Shown on the "Unfocused appearance" navigator card when no unfocused appearance has been defined for the profile.</comment>
+  </data>
   <data name="Profile_BackgroundImageBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Background image path</value>
     <comment>Name for a control to determine the image presented on the background of the app.</comment>
@@ -1237,10 +1241,6 @@
     <value>Unfocused appearance</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Create Appearance</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>Delete</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1621,6 +1621,10 @@
     <value>Customize the visual appearance of the profile, including colors, fonts, and text styling.</value>
     <comment>Description shown below the "Appearance" navigator card on the profile page.</comment>
   </data>
+  <data name="Profile_UnfocusedAppearanceNavigator.Description" xml:space="preserve">
+    <value>Customize the appearance of the profile when it is inactive (unfocused).</value>
+    <comment>Description shown below the "Unfocused appearance" navigator card on the profile page.</comment>
+  </data>
   <data name="Profile_TerminalNavigator.Description" xml:space="preserve">
     <value>Configure how the terminal interprets text and control sequences to behave like a traditional command-line terminal</value>
     <comment>Description shown below the "Terminal Emulation" navigator card on the profile page.</comment>
@@ -1797,14 +1801,6 @@
     <value>If enabled, show all installed fonts in the list above. Otherwise, only show the list of monospace fonts.</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
   </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Create Appearance</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Create an unfocused appearance for this profile. This will be the appearance of the profile when it is inactive.</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
-  </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Delete Appearance</value>
     <comment>Name for a control which deletes the unfocused appearance settings for this profile.</comment>
@@ -1812,6 +1808,14 @@
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Delete the unfocused appearance for this profile.</value>
     <comment>A description for what the delete unfocused appearance button does.</comment>
+  </data>
+  <data name="Profile_DeleteUnfocusedAppearance.Header" xml:space="preserve">
+    <value>Delete this unfocused appearance</value>
+    <comment>Header for a settings card that deletes the profile's unfocused appearance.</comment>
+  </data>
+  <data name="Profile_DeleteUnfocusedAppearance.Description" xml:space="preserve">
+    <value>Removes the unfocused appearance so the profile uses its default appearance when inactive</value>
+    <comment>Description for the delete unfocused appearance settings card.</comment>
   </data>
   <data name="Actions_Disclaimer.Content" xml:space="preserve">
     <value>Learn more about shortcuts</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -813,7 +813,7 @@
     <value>Top right</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
-  <data name="Profile_BackgroundImageBrowse.Content" xml:space="preserve">
+  <data name="Profile_BackgroundImageBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Browse...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1137,7 +1137,7 @@
     <value>Emoji or image file location of the icon used in the profile.</value>
     <comment>A description for what the "icon" setting does. Presented near "Profile_Icon".</comment>
   </data>
-  <data name="IconPicker_IconBrowse.Content" xml:space="preserve">
+  <data name="IconPicker_IconBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Browse...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -2209,7 +2209,7 @@
     <value>No color</value>
     <comment>Label for a button directing the user to opt out of choosing a color.</comment>
   </data>
-  <data name="Actions_Browse.Content" xml:space="preserve">
+  <data name="Actions_Browse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Browse...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -557,7 +557,7 @@
     <value>Allow OSC 777 (Desktop Notification) to show toast notifications</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>When enabled, applications can send the OSC 777 escape sequence to trigger a desktop notification with a custom title and body.</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -918,7 +918,7 @@
     <value>Executable used in the profile.</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Browse...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1089,7 +1089,7 @@
     <value>The selected font has no font features.</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>Hide profile from dropdown</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
@@ -1101,13 +1101,9 @@
     <value>Hidden from the dropdown menu</value>
     <comment>Tooltip shown when hovering the InfoBadge next to a profile name on the Profiles landing page when that profile is hidden from the dropdown menu.</comment>
   </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
-    <value>Run this profile as Administrator</value>
+  <data name="Profile_Elevate.Content" xml:space="preserve">
+    <value>Run as administrator (uses current window if already elevated)</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>If enabled, the profile will open in an Admin terminal window automatically. If the current window is already running as admin, it will open in this window.</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>History size</value>
@@ -1198,18 +1194,14 @@
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
   <data name="Profile_StartingDirectory.Header" xml:space="preserve">
-    <value>Starting directory</value>
+    <value>Default starting directory</value>
     <comment>Header for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
   <data name="Profile_StartingDirectoryBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Starting directory</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>The directory the profile starts in when it is loaded.</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Browse...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1614,8 +1606,24 @@
     <comment>Name for a control to determine the name of the profile. This is a text box.</comment>
   </data>
   <data name="Profile_Name.Header" xml:space="preserve">
+    <value>Profile</value>
+    <comment>Header for the profile section of the profile settings page. Shown above a text box that lets the user edit the profile name.</comment>
+  </data>
+  <data name="Profile_NameBox.PlaceholderText" xml:space="preserve">
     <value>Name</value>
-    <comment>Header for a control to determine the name of the profile. This is a text box.</comment>
+    <comment>Placeholder text shown inside the empty profile name text box, hinting that the user should enter the profile's name here.</comment>
+  </data>
+  <data name="Profile_Section_VisualUI.Text" xml:space="preserve">
+    <value>Visual/UI Affordance</value>
+    <comment>Title of a section in a profile page that groups visual and UI settings (tab title, icon, tab color, etc.).</comment>
+  </data>
+  <data name="Profile_AppearanceNavigator.Description" xml:space="preserve">
+    <value>Customize the visual appearance of the profile, including colors, fonts, and text styling.</value>
+    <comment>Description shown below the "Appearance" navigator card on the profile page.</comment>
+  </data>
+  <data name="Profile_TerminalNavigator.Description" xml:space="preserve">
+    <value>Configure how the terminal interprets text and control sequences to behave like a traditional command-line terminal</value>
+    <comment>Description shown below the "Terminal Emulation" navigator card on the profile page.</comment>
   </data>
   <data name="Profile_TransparencyHeader.Text" xml:space="preserve">
     <value>Transparency</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -2734,10 +2734,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>Indicates the software that originally created this profile.</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>None</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>Automatic startup has been disabled in the Startup Apps section of Windows settings.</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2795,10 +2791,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>None</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>None</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>Reset to default settings</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -1622,7 +1622,7 @@
     <comment>Description shown below the "Unfocused appearance" navigator card on the profile page.</comment>
   </data>
   <data name="Profile_TerminalNavigator.Description" xml:space="preserve">
-    <value>Configure how the terminal interprets text and control sequences to behave like a traditional command-line terminal</value>
+    <value>Configure how the terminal handles keyboard input and control sequences</value>
     <comment>Description shown below the "Terminal Emulation" navigator card on the profile page.</comment>
   </data>
   <data name="Profile_TransparencyHeader.Text" xml:space="preserve">
@@ -2848,5 +2848,9 @@
   <data name="TextBoxSettingStyle_PlaceholderText.Value" xml:space="preserve">
     <value>None</value>
     <comment>Default placeholder text shown in text box settings when no value has been set.</comment>
+  </data>
+  <data name="Profile_UnfocusedAppearanceNavigator.Header" xml:space="preserve">
+    <value>Unfocused Appearance</value>
+    <comment>Title for the "Unfocused appearance" navigator card on the profile page. Navigates to a page to customize the appearance of the terminal when it is not focused.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -1609,8 +1609,8 @@
     <value>Name</value>
     <comment>Placeholder text shown inside the empty profile name text box, hinting that the user should enter the profile's name here.</comment>
   </data>
-  <data name="Profile_Section_VisualUI.Text" xml:space="preserve">
-    <value>Visual/UI Affordance</value>
+  <data name="Profile_Section_TabAppearance.Text" xml:space="preserve">
+    <value>Tab Appearance</value>
     <comment>Title of a section in a profile page that groups visual and UI settings (tab title, icon, tab color, etc.).</comment>
   </data>
   <data name="Profile_AppearanceNavigator.Description" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -1605,6 +1605,10 @@
     <value>Profile</value>
     <comment>Header for the profile section of the profile settings page. Shown above a text box that lets the user edit the profile name.</comment>
   </data>
+  <data name="Profile_NameBaseLayer.Header" xml:space="preserve">
+    <value>Profile Defaults</value>
+    <comment>Header for the profile section of the profile settings page, shown when editing the "defaults" that all profiles inherit from. See "Nav_ProfileDefaults.Content" for a description of what the defaults layer does in the app. Unlike "Profile_Name.Header", there is no profile name to edit here.</comment>
+  </data>
   <data name="Profile_NameBox.PlaceholderText" xml:space="preserve">
     <value>Name</value>
     <comment>Placeholder text shown inside the empty profile name text box, hinting that the user should enter the profile's name here.</comment>

--- a/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
@@ -2649,10 +2649,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>Indica el software que creó originalmente este perfil.</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>Ninguno</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>Se ha deshabilitado el inicio automático en la sección Aplicaciones de inicio de Windows configuración.</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2710,10 +2706,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>Ninguno</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>Ninguno</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>Restablecer a la configuración predeterminada</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
@@ -1241,10 +1241,6 @@
     <value>Apariencia desenfocada</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Crear apariencia</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>Eliminar</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1740,14 +1736,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Si está habilitada, muestra todas las fuentes instaladas en la lista anterior. De lo contrario, mostrar solo la lista de fuentes monoespacios.</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Crear apariencia</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Crea una apariencia no centrada para este perfil. Esta será la apariencia del perfil cuando esté inactivo.</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Eliminar apariencia</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
@@ -569,7 +569,7 @@
     <value>Permitir que OSC 777 (Desktop Notification) muestre notificaciones del sistema</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>Cuando se habilita, las aplicaciones pueden enviar la secuencia de escape de OSC 777 para desencadenar una notificación de escritorio con un título y un cuerpo personalizados.</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -930,7 +930,7 @@
     <value>Ejecutable utilizado en el perfil.</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Examinar...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1101,21 +1101,13 @@
     <value>La fuente seleccionada no tiene características de fuente.</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>Ocultar perfil de la lista desplegable</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>Si se habilita, el perfil no aparecerá en la lista de perfiles. Se puede usar para ocultar los perfiles predeterminados y los perfiles generados dinámicamente, al dejarlos en el archivo de configuración.</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>Ejecutar este perfil como Administrador</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>Si se habilita, el perfil se abrirá automáticamente en una ventana de terminal Administración. Si la ventana actual ya se está ejecutando como administrador, se abrirá en esta ventana.</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>Tamaño del historial</value>
@@ -1213,11 +1205,7 @@
     <value>Directorio de inicio</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>El directorio en el que se inicia el perfil cuando se carga.</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Examinar...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
@@ -2633,10 +2633,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>Indica el software que creó originalmente este perfil.</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>Ninguno</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>Se ha deshabilitado el inicio automático en la sección Aplicaciones de inicio de Windows configuración.</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2694,10 +2690,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>Ninguno</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>Ninguno</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>Restablecer a la configuración predeterminada</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
@@ -557,7 +557,7 @@
     <value>Permitir que OSC 777 (Desktop Notification) muestre notificaciones del sistema</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>Cuando se habilita, las aplicaciones pueden enviar la secuencia de escape de OSC 777 para desencadenar una notificación de escritorio con un título y un cuerpo personalizados.</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -918,7 +918,7 @@
     <value>Ejecutable utilizado en el perfil.</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Examinar...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1089,21 +1089,13 @@
     <value>La fuente seleccionada no tiene características de fuente.</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>Ocultar perfil de la lista desplegable</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>Si se habilita, el perfil no aparecerá en la lista de perfiles. Se puede usar para ocultar los perfiles predeterminados y los perfiles generados dinámicamente, al dejarlos en el archivo de configuración.</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>Ejecutar este perfil como Administrador</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>Si se habilita, el perfil se abrirá automáticamente en una ventana de terminal Administración. Si la ventana actual ya se está ejecutando como administrador, se abrirá en esta ventana.</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>Tamaño del historial</value>
@@ -1201,11 +1193,7 @@
     <value>Directorio de inicio</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>El directorio en el que se inicia el perfil cuando se carga.</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Examinar...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
@@ -1229,10 +1229,6 @@
     <value>Apariencia desenfocada</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Crear apariencia</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>Eliminar</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1724,14 +1720,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Si está habilitada, muestra todas las fuentes instaladas en la lista anterior. De lo contrario, mostrar solo la lista de fuentes monoespacios.</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Crear apariencia</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Crea una apariencia no centrada para este perfil. Esta será la apariencia del perfil cuando esté inactivo.</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Eliminar apariencia</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
@@ -809,7 +809,7 @@
     <value>Superior derecha</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
-  <data name="Profile_BackgroundImageBrowse.Content" xml:space="preserve">
+  <data name="Profile_BackgroundImageBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Examinar...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1129,7 +1129,7 @@
     <value>Ubicación del archivo de imagen o emoji del icono que se usa en el perfil.</value>
     <comment>A description for what the "icon" setting does. Presented near "Profile_Icon".</comment>
   </data>
-  <data name="IconPicker_IconBrowse.Content" xml:space="preserve">
+  <data name="IconPicker_IconBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Examinar...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -2101,7 +2101,7 @@
     <value>Sin color</value>
     <comment>Label for a button directing the user to opt out of choosing a color.</comment>
   </data>
-  <data name="Actions_Browse.Content" xml:space="preserve">
+  <data name="Actions_Browse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Examinar...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
@@ -1241,10 +1241,6 @@
     <value>Apparence sans focus</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Créer une apparence</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>Supprimer</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1740,14 +1736,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Si cette option est activée, toutes les polices installées sont affichées dans la liste ci-dessus. Sinon, affiche uniquement la liste des polices à espacement fixe.</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Créer une apparence</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Créez une apparence sans focus pour ce profil. Il s’agit de l’apparence du profil lorsqu’il est inactif.</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Supprimer une apparence</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
@@ -2649,10 +2649,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>Indique le logiciel qui a créé ce profil à l’origine.</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>Aucun</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>Le démarrage automatique a été désactivé dans la section Applications de démarrage de Windows paramètres.</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2710,10 +2706,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>Aucun</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>Aucun</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>Revenir aux paramètres par défaut</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
@@ -569,7 +569,7 @@
     <value>Autoriser OSC 777 (Desktop Notification) à afficher des notifications toast</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>Lorsque cette option est activée, les applications peuvent envoyer la séquence d’échappement OSC 777 pour déclencher une notification de bureau avec un titre et un corps personnalisés.</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -930,7 +930,7 @@
     <value>Exécutable de profil.</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Parcourir...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1101,21 +1101,13 @@
     <value>La police sélectionnée n’a aucune fonctionnalité de police.</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>Masquez le profil de la liste déroulante</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>Si cette option est activée, le profil n’apparaît pas dans la liste des profils. Peut être utilisé pour masquer les profils par défaut et les profils générés dynamiquement, tout en les laissant dans votre fichier de paramètres.</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>Exécuter ce profil en tant qu’administrateur</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>Si cette option est activée, le profil s’ouvre automatiquement dans une fenêtre de terminal Administration. Si la fenêtre active est déjà en cours d’exécution en tant qu’administrateur, elle s’ouvre dans cette fenêtre.</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>Taille de l’historique</value>
@@ -1213,11 +1205,7 @@
     <value>Répertoire de démarrage</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>Répertoire dans lequel le shell démarre lorsqu’il est chargé.</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Parcourir...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
@@ -2633,10 +2633,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>Indique le logiciel qui a créé ce profil à l’origine.</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>Aucun</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>Le démarrage automatique a été désactivé dans la section Applications de démarrage de Windows paramètres.</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2694,10 +2690,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>Aucun</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>Aucun</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>Revenir aux paramètres par défaut</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
@@ -809,7 +809,7 @@
     <value>En haut à droite</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
-  <data name="Profile_BackgroundImageBrowse.Content" xml:space="preserve">
+  <data name="Profile_BackgroundImageBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Parcourir...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1129,7 +1129,7 @@
     <value>Emplacement de l’image ou emoji pour l’icône du profil.</value>
     <comment>A description for what the "icon" setting does. Presented near "Profile_Icon".</comment>
   </data>
-  <data name="IconPicker_IconBrowse.Content" xml:space="preserve">
+  <data name="IconPicker_IconBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Parcourir...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -2101,7 +2101,7 @@
     <value>Aucune couleur</value>
     <comment>Label for a button directing the user to opt out of choosing a color.</comment>
   </data>
-  <data name="Actions_Browse.Content" xml:space="preserve">
+  <data name="Actions_Browse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Parcourir...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
@@ -557,7 +557,7 @@
     <value>Autoriser OSC 777 (Desktop Notification) à afficher des notifications toast</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>Lorsque cette option est activée, les applications peuvent envoyer la séquence d’échappement OSC 777 pour déclencher une notification de bureau avec un titre et un corps personnalisés.</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -918,7 +918,7 @@
     <value>Exécutable de profil.</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Parcourir...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1089,21 +1089,13 @@
     <value>La police sélectionnée n’a aucune fonctionnalité de police.</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>Masquez le profil de la liste déroulante</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>Si cette option est activée, le profil n’apparaît pas dans la liste des profils. Peut être utilisé pour masquer les profils par défaut et les profils générés dynamiquement, tout en les laissant dans votre fichier de paramètres.</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>Exécuter ce profil en tant qu’administrateur</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>Si cette option est activée, le profil s’ouvre automatiquement dans une fenêtre de terminal Administration. Si la fenêtre active est déjà en cours d’exécution en tant qu’administrateur, elle s’ouvre dans cette fenêtre.</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>Taille de l’historique</value>
@@ -1201,11 +1193,7 @@
     <value>Répertoire de démarrage</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>Répertoire dans lequel le shell démarre lorsqu’il est chargé.</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Parcourir...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
@@ -1229,10 +1229,6 @@
     <value>Apparence sans focus</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Créer une apparence</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>Supprimer</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1724,14 +1720,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Si cette option est activée, toutes les polices installées sont affichées dans la liste ci-dessus. Sinon, affiche uniquement la liste des polices à espacement fixe.</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Créer une apparence</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Créez une apparence sans focus pour ce profil. Il s’agit de l’apparence du profil lorsqu’il est inactif.</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Supprimer une apparence</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
@@ -2649,10 +2649,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>Indica il software che ha creato originariamente questo profilo.</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>Nessuno</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>L'avvio automatico è stato disabilitato nella sezione App di avvio delle impostazioni Windows.</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2710,10 +2706,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>Nessuno</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>Nessuno</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>Ripristina le impostazioni predefinite</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
@@ -569,7 +569,7 @@
     <value>Consenti a OSC 777 (Desktop Notification) di mostrare gli avvisi popup</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>Se questa opzione è abilitata, le applicazioni possono inviare la sequenza di escape OSC 777 per attivare una notifica desktop con un titolo e un corpo personalizzati.</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -930,7 +930,7 @@
     <value>Eseguibile utilizzato nel profilo.</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Sfoglia...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1101,21 +1101,13 @@
     <value>Il tipo di carattere selezionato non ha caratteristiche per i tipi di carattere.</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>Nascondi profilo da elenco a discesa</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>Se questa opzione è abilitata, il profilo non verrà visualizzato nell'elenco dei profili. Può essere usato per nascondere i profili predefiniti e i profili generati dinamicamente, lasciandoli nel file di impostazioni.</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>Esegui questo profilo come amministratore</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>Se questa opzione è abilitata, il profilo verrà aperto automaticamente in una finestra del terminale Amministrazione. Se la finestra corrente è già in esecuzione come amministratore, verrà aperta in questa finestra.</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>Dimensioni cronologia</value>
@@ -1213,11 +1205,7 @@
     <value>Directory iniziale</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>La directory che inizia il profilo durante il caricamento.</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Sfoglia...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
@@ -1241,10 +1241,6 @@
     <value>Aspetto con stato non attivo</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Crea aspetto</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>Elimina</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1740,14 +1736,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Se abilitata, mostra tutti i tipi di carattere installati nell'elenco precedente. In caso contrario, visualizza solo l'elenco dei tipi di carattere a spaziatura fissa.</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Crea aspetto</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Crea un aspetto non attivo per questo profilo. Questo sarà l'aspetto del profilo quando è inattivo.</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Elimina aspetto</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
@@ -557,7 +557,7 @@
     <value>Consenti a OSC 777 (Desktop Notification) di mostrare gli avvisi popup</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>Se questa opzione è abilitata, le applicazioni possono inviare la sequenza di escape OSC 777 per attivare una notifica desktop con un titolo e un corpo personalizzati.</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -918,7 +918,7 @@
     <value>Eseguibile utilizzato nel profilo.</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Sfoglia...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1089,21 +1089,13 @@
     <value>Il tipo di carattere selezionato non ha caratteristiche per i tipi di carattere.</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>Nascondi profilo da elenco a discesa</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>Se questa opzione è abilitata, il profilo non verrà visualizzato nell'elenco dei profili. Può essere usato per nascondere i profili predefiniti e i profili generati dinamicamente, lasciandoli nel file di impostazioni.</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>Esegui questo profilo come amministratore</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>Se questa opzione è abilitata, il profilo verrà aperto automaticamente in una finestra del terminale Amministrazione. Se la finestra corrente è già in esecuzione come amministratore, verrà aperta in questa finestra.</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>Dimensioni cronologia</value>
@@ -1201,11 +1193,7 @@
     <value>Directory iniziale</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>La directory che inizia il profilo durante il caricamento.</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Sfoglia...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
@@ -1229,10 +1229,6 @@
     <value>Aspetto con stato non attivo</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Crea aspetto</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>Elimina</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1724,14 +1720,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Se abilitata, mostra tutti i tipi di carattere installati nell'elenco precedente. In caso contrario, visualizza solo l'elenco dei tipi di carattere a spaziatura fissa.</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Crea aspetto</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Crea un aspetto non attivo per questo profilo. Questo sarà l'aspetto del profilo quando è inattivo.</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Elimina aspetto</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
@@ -2633,10 +2633,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>Indica il software che ha creato originariamente questo profilo.</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>Nessuno</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>L'avvio automatico è stato disabilitato nella sezione App di avvio delle impostazioni Windows.</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2694,10 +2690,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>Nessuno</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>Nessuno</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>Ripristina le impostazioni predefinite</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
@@ -809,7 +809,7 @@
     <value>In alto a destra</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
-  <data name="Profile_BackgroundImageBrowse.Content" xml:space="preserve">
+  <data name="Profile_BackgroundImageBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Sfoglia...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1129,7 +1129,7 @@
     <value>Posizione del file dell'emoji o dell'immagine usato per l'immagine del profilo.</value>
     <comment>A description for what the "icon" setting does. Presented near "Profile_Icon".</comment>
   </data>
-  <data name="IconPicker_IconBrowse.Content" xml:space="preserve">
+  <data name="IconPicker_IconBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Sfoglia...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -2101,7 +2101,7 @@
     <value>Nessun colore</value>
     <comment>Label for a button directing the user to opt out of choosing a color.</comment>
   </data>
-  <data name="Actions_Browse.Content" xml:space="preserve">
+  <data name="Actions_Browse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Sfoglia...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
@@ -569,7 +569,7 @@
     <value>OSC 777 (Desktop Notification) でトースト通知の表示を許可する</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>有効にすると、アプリケーションは OSC 777 エスケープ シーケンスを送信して、カスタム タイトルと本文を含むデスクトップ通知をトリガーできます。</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -930,7 +930,7 @@
     <value>プロファイルで使用される実行可能ファイル。</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>参照...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1101,21 +1101,13 @@
     <value>選択したフォントにはフォント機能がありません。</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>ドロップダウンからプロファイルを非表示にする</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>有効にした場合、プロファイルはプロファイルの一覧に表示されません。これを使用すると、既定のプロファイルや動的に生成されたプロファイルを設定ファイルに残したまま非表示にすることができます。</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>このプロファイルを管理者として実行する</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>有効にすると、プロファイルは自動的にターミナル ウィンドウ管理開きます。現在のウィンドウが既に管理者として実行されている場合は、このウィンドウで開きます。</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>履歴のサイズ</value>
@@ -1213,11 +1205,7 @@
     <value>開始ディレクトリ</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>プロファイルが読み込まれたときに開始されるディレクトリです。</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>参照...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
@@ -1241,10 +1241,6 @@
     <value>フォーカスされていない外観</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>外観の作成</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>削除</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1740,14 +1736,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>有効にすると、上の一覧にあるインストールされたすべてのフォントが表示されます。無効の場合は、等幅フォントの一覧のみが表示されます。</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>外観の作成</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>このプロファイルのフォーカスされていない外観を作成します。これは、プロファイルが非アクティブな場合の外観になります。</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>外観の削除</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
@@ -2649,10 +2649,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>このプロファイルを最初に作成したソフトウェアを示します。</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>なし</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>Windows 設定の [スタートアップ アプリ] セクションで、自動スタートアップが無効になっています。</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2710,10 +2706,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>なし</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>なし</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>初期設定にリセット</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
@@ -557,7 +557,7 @@
     <value>OSC 777 (Desktop Notification) でトースト通知の表示を許可する</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>有効にすると、アプリケーションは OSC 777 エスケープ シーケンスを送信して、カスタム タイトルと本文を含むデスクトップ通知をトリガーできます。</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -918,7 +918,7 @@
     <value>プロファイルで使用される実行可能ファイル。</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>参照...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1089,21 +1089,13 @@
     <value>選択したフォントにはフォント機能がありません。</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>ドロップダウンからプロファイルを非表示にする</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>有効にした場合、プロファイルはプロファイルの一覧に表示されません。これを使用すると、既定のプロファイルや動的に生成されたプロファイルを設定ファイルに残したまま非表示にすることができます。</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>このプロファイルを管理者として実行する</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>有効にすると、プロファイルは自動的にターミナル ウィンドウ管理開きます。現在のウィンドウが既に管理者として実行されている場合は、このウィンドウで開きます。</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>履歴のサイズ</value>
@@ -1201,11 +1193,7 @@
     <value>開始ディレクトリ</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>プロファイルが読み込まれたときに開始されるディレクトリです。</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>参照...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
@@ -1229,10 +1229,6 @@
     <value>フォーカスされていない外観</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>外観の作成</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>削除</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1724,14 +1720,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>有効にすると、上の一覧にあるインストールされたすべてのフォントが表示されます。無効の場合は、等幅フォントの一覧のみが表示されます。</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>外観の作成</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>このプロファイルのフォーカスされていない外観を作成します。これは、プロファイルが非アクティブな場合の外観になります。</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>外観の削除</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
@@ -809,7 +809,7 @@
     <value>右上</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
-  <data name="Profile_BackgroundImageBrowse.Content" xml:space="preserve">
+  <data name="Profile_BackgroundImageBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>参照...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1129,7 +1129,7 @@
     <value>プロファイルで使用されるアイコンの絵文字またはイメージ ファイルの場所です。</value>
     <comment>A description for what the "icon" setting does. Presented near "Profile_Icon".</comment>
   </data>
-  <data name="IconPicker_IconBrowse.Content" xml:space="preserve">
+  <data name="IconPicker_IconBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>参照...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -2101,7 +2101,7 @@
     <value>色なし</value>
     <comment>Label for a button directing the user to opt out of choosing a color.</comment>
   </data>
-  <data name="Actions_Browse.Content" xml:space="preserve">
+  <data name="Actions_Browse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>参照...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
@@ -2633,10 +2633,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>このプロファイルを最初に作成したソフトウェアを示します。</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>なし</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>Windows 設定の [スタートアップ アプリ] セクションで、自動スタートアップが無効になっています。</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2694,10 +2690,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>なし</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>なし</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>初期設定にリセット</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
@@ -2649,10 +2649,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>이 프로필을 원래 만든 소프트웨어를 나타냅니다.</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>없음</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>Windows 설정의 Startup Apps 섹션에서 자동 시작을 사용하지 않도록 설정했습니다.</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2710,10 +2706,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>없음</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>없음</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>기본 설정으로 초기화</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
@@ -569,7 +569,7 @@
     <value>OSC 777(Desktop Notification)이 토스트 알림을 표시하도록 허용</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>사용하도록 설정하면 애플리케이션이 OSC 777 이스케이프 시퀀스를 전송하여 사용자 지정 제목 및 본문을 사용하여 데스크톱 알림을 트리거할 수 있습니다.</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -930,7 +930,7 @@
     <value>프로필에 사용된 실행 파일입니다.</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>찾아보기...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1101,21 +1101,13 @@
     <value>선택한 글꼴에 글꼴 기능이 없습니다.</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>드롭다운에서 프로필 숨기기</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>사용하도록 설정하면 프로필이 프로필 목록에 나타나지 않습니다. 기본 프로필 및 동적으로 생성된 프로필을 설정 파일에 그대로 두는 데 사용할 수 있습니다.</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>이 프로필을 관리자 권한으로 실행</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>사용하도록 설정하면 프로필이 관리 터미널 창에서 자동으로 열립니다. 현재 창이 관리자 권한으로 이미 실행되고 있는 경우 이 창에서 열립니다.</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>기록 크기</value>
@@ -1213,11 +1205,7 @@
     <value>시작 디렉터리</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>프로필이 로드될 때 시작됩니다.</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>찾아보기...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
@@ -1241,10 +1241,6 @@
     <value>포커스되지 않는 모양</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>모양 만들기</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>삭제</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1740,14 +1736,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>사용하도록 설정된 경우 위의 목록에 설치된 모든 글꼴을 표시합니다. 그렇지 않으면 고정 폭 글꼴 목록만 표시합니다.</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>모양 만들기</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>이 프로필에 대해 할당되지 않은 모양을 만듭니다. 프로필이 비활성 상태인 경우 프로필의 모양이 됩니다.</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>모양 삭제</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
@@ -809,7 +809,7 @@
     <value>오른쪽 위</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
-  <data name="Profile_BackgroundImageBrowse.Content" xml:space="preserve">
+  <data name="Profile_BackgroundImageBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>찾아보기...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1129,7 +1129,7 @@
     <value>프로필에 사용된 아이콘의 이모지 또는 이미지 파일 위치입니다.</value>
     <comment>A description for what the "icon" setting does. Presented near "Profile_Icon".</comment>
   </data>
-  <data name="IconPicker_IconBrowse.Content" xml:space="preserve">
+  <data name="IconPicker_IconBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>찾아보기...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -2101,7 +2101,7 @@
     <value>색 없음</value>
     <comment>Label for a button directing the user to opt out of choosing a color.</comment>
   </data>
-  <data name="Actions_Browse.Content" xml:space="preserve">
+  <data name="Actions_Browse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>찾아보기...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
@@ -2633,10 +2633,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>이 프로필을 원래 만든 소프트웨어를 나타냅니다.</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>없음</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>Windows 설정의 Startup Apps 섹션에서 자동 시작을 사용하지 않도록 설정했습니다.</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2694,10 +2690,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>없음</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>없음</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>기본 설정으로 초기화</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
@@ -1229,10 +1229,6 @@
     <value>포커스되지 않는 모양</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>모양 만들기</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>삭제</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1724,14 +1720,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>사용하도록 설정된 경우 위의 목록에 설치된 모든 글꼴을 표시합니다. 그렇지 않으면 고정 폭 글꼴 목록만 표시합니다.</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>모양 만들기</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>이 프로필에 대해 할당되지 않은 모양을 만듭니다. 프로필이 비활성 상태인 경우 프로필의 모양이 됩니다.</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>모양 삭제</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
@@ -557,7 +557,7 @@
     <value>OSC 777(Desktop Notification)이 토스트 알림을 표시하도록 허용</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>사용하도록 설정하면 애플리케이션이 OSC 777 이스케이프 시퀀스를 전송하여 사용자 지정 제목 및 본문을 사용하여 데스크톱 알림을 트리거할 수 있습니다.</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -918,7 +918,7 @@
     <value>프로필에 사용된 실행 파일입니다.</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>찾아보기...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1089,21 +1089,13 @@
     <value>선택한 글꼴에 글꼴 기능이 없습니다.</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>드롭다운에서 프로필 숨기기</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>사용하도록 설정하면 프로필이 프로필 목록에 나타나지 않습니다. 기본 프로필 및 동적으로 생성된 프로필을 설정 파일에 그대로 두는 데 사용할 수 있습니다.</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>이 프로필을 관리자 권한으로 실행</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>사용하도록 설정하면 프로필이 관리 터미널 창에서 자동으로 열립니다. 현재 창이 관리자 권한으로 이미 실행되고 있는 경우 이 창에서 열립니다.</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>기록 크기</value>
@@ -1201,11 +1193,7 @@
     <value>시작 디렉터리</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>프로필이 로드될 때 시작됩니다.</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>찾아보기...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
@@ -1241,10 +1241,6 @@
     <value>Aparência sem foco</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Criar Aparência</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>Excluir</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1740,14 +1736,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Se ativado, mostra todas as fontes instaladas na lista acima. Caso contrário, mostra apenas as fontes monoespaçadas.</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Criar Aparência</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Crie uma aparência sem foco para este perfil. Esta será a aparência do perfil quando ele estiver inativo.</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Excluir Aparência</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
@@ -2649,10 +2649,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>Indica o software que criou originalmente este perfil.</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>Nenhum</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>A inicialização automática foi desabilitada na seção Aplicativos de Inicialização Windows configurações.</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2710,10 +2706,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>Nenhum</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>Nenhum</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>Redefinir para as configurações padrão</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
@@ -569,7 +569,7 @@
     <value>Permitir que OSC 777 (Desktop Notification) mostre notificações do sistema</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>Quando habilitados, os aplicativos podem enviar a sequência de escape OSC 777 para disparar uma notificação da área de trabalho com um título e corpo personalizados.</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -930,7 +930,7 @@
     <value>Arquivo executável usado no perfil.</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Procurar...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1101,21 +1101,13 @@
     <value>A fonte selecionada não tem recursos de fonte.</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>Ocultar perfil da lista suspensa</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>Se habilitado, o perfil não aparecerá na lista de perfis. Isso pode ser usado para ocultar perfis padrão e perfis gerados dinamicamente, deixando-os no arquivo de configurações.</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>Executar esse perfil como Administrador</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>Se habilitado, o perfil será aberto em uma janela Administração terminal automaticamente. Se a janela atual já estiver em execução como administrador, ela será aberta nesta janela.</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>Tamanho de histórico</value>
@@ -1213,11 +1205,7 @@
     <value>Diretório inicial</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>A pasta em que o perfil começa quando é carregado.</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Procurar...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
@@ -1229,10 +1229,6 @@
     <value>Aparência sem foco</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Criar Aparência</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>Excluir</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1724,14 +1720,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Se ativado, mostra todas as fontes instaladas na lista acima. Caso contrário, mostra apenas as fontes monoespaçadas.</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Criar Aparência</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Crie uma aparência sem foco para este perfil. Esta será a aparência do perfil quando ele estiver inativo.</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Excluir Aparência</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
@@ -557,7 +557,7 @@
     <value>Permitir que OSC 777 (Desktop Notification) mostre notificações do sistema</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>Quando habilitados, os aplicativos podem enviar a sequência de escape OSC 777 para disparar uma notificação da área de trabalho com um título e corpo personalizados.</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -918,7 +918,7 @@
     <value>Arquivo executável usado no perfil.</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Procurar...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1089,21 +1089,13 @@
     <value>A fonte selecionada não tem recursos de fonte.</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>Ocultar perfil da lista suspensa</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>Se habilitado, o perfil não aparecerá na lista de perfis. Isso pode ser usado para ocultar perfis padrão e perfis gerados dinamicamente, deixando-os no arquivo de configurações.</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>Executar esse perfil como Administrador</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>Se habilitado, o perfil será aberto em uma janela Administração terminal automaticamente. Se a janela atual já estiver em execução como administrador, ela será aberta nesta janela.</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>Tamanho de histórico</value>
@@ -1201,11 +1193,7 @@
     <value>Diretório inicial</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>A pasta em que o perfil começa quando é carregado.</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Procurar...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
@@ -809,7 +809,7 @@
     <value>Superior direito</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
-  <data name="Profile_BackgroundImageBrowse.Content" xml:space="preserve">
+  <data name="Profile_BackgroundImageBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Procurar...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1129,7 +1129,7 @@
     <value>Local do arquivo de imagem ou emoji do ícone usado no perfil.</value>
     <comment>A description for what the "icon" setting does. Presented near "Profile_Icon".</comment>
   </data>
-  <data name="IconPicker_IconBrowse.Content" xml:space="preserve">
+  <data name="IconPicker_IconBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Procurar...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -2101,7 +2101,7 @@
     <value>Sem cor</value>
     <comment>Label for a button directing the user to opt out of choosing a color.</comment>
   </data>
-  <data name="Actions_Browse.Content" xml:space="preserve">
+  <data name="Actions_Browse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Procurar...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
@@ -2633,10 +2633,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>Indica o software que criou originalmente este perfil.</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>Nenhum</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>A inicialização automática foi desabilitada na seção Aplicativos de Inicialização Windows configurações.</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2694,10 +2690,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>Nenhum</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>Nenhum</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>Redefinir para as configurações padrão</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
@@ -2653,10 +2653,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>Ĭиđĩ¢ãťēš тĥě šôƒтшǻŗέ τнăť ŏŗįģĭйάłℓў ćяэάтэð ŧћïš рŕøƒĩľє. !!! !!! !!! !!! !!! !!!</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>Ŋøиє !</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>Åΰťόмåтίĉ śţдѓтΰρ ћăş ьěёή δіѕªъľēð ïй ťĥ℮ Ŝťǻřťúφ Āρφŝ ѕěĉŧϊōη бƒ Windows ŝεтţīŋĝś. !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2714,10 +2710,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>Иθñé !</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>Ŋøπë !</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>Яєšèţ ŧθ ďēƒªũĺť śέττιŋĝş !!! !!! !</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
@@ -1241,10 +1241,6 @@
     <value>Ûηƒŏċμşεď äррėāŕαńćё !!! !!!</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Ĉřêάŧэ Δрφзάŕãñςε !!! !!</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>Ðéľėŧê !</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1740,14 +1736,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Įƒ ěлåвℓεď, šħöω ăℓŀ їήšτаļľêð ƒõņŧŝ ίл τне ľíşť ªвσνє. Öťĥέŕωíŝě, ôπľγ ŝĥσẃ ţĥэ ľíѕτ θƒ mōйǿѕφâčз ƒоņτŝ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Çřëаţë Ăφрзαѓăŉ¢έ !!! !!</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ċґêâŧέ āл ûηƒοćüšεð аφрěąґªŋčέ ƒòř тнìş φřòƒîľέ. Ţнīѕ ωïĺľ вé ťнē αррêãřªήç℮ οƒ ŧћê ρґőƒίļė ŵħėņ īŧ ίš ïńαčτîν℮. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Ďєľéтę Āρρєαяâп¢ė !!! !!</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
@@ -569,7 +569,7 @@
     <value>Άľℓôẅ OSC 777 (Desktop Notification) ťõ šђǿщ ŧôášτ ŋòţĩƒíćäťΐóйś !!! !!! !!! !!! !!! !!! !</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>Ẅђĕņ ěňāъłèð, ãφρļїčāтīòήѕ ¢аń ŝëлđ ťĥĕ OSC 777 ēśćάφз şèqüęńĉз τö ťѓĩĝĝєг ā ðĕѕќŧöρ лόтΐƒĩςªτίøп ẃìţн д сџšτõm тįŧŀé āⁿδ вόđÿ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -930,7 +930,7 @@
     <value>Эхĕçΰтдьłё ūśëď įñ ţħè рŕòƒĭŀз. !!! !!! !!!</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>ßгθшşє... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1101,21 +1101,13 @@
     <value>Τћē ŝэŀëсŧзð ƒőйť нâŝ иο ƒòиŧ ƒėäţцŕэś. !!! !!! !!! !!!</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>Ήîď℮ φябƒίļĕ ƒѓòm ďřóφδόшπ !!! !!! !</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>Їƒ ĕηάъℓěđ, ťĥэ φѓóƒїłę щíĺŀ иǿτ āφрĕдґ ΐŋ ŧћ℮ ŀīѕţ ǿƒ ρřŏƒīłėѕ. Ţђіş ςǻⁿ ъê ūšέð ťŏ ђĩðė δëƒǻūļт φґøƒíļέş аņð ďγñăмïĉâļℓÿ ģěиēяāŧεð ρřòƒίļзŝ, ẁĥιľє łэăνīⁿĝ ťĥèм ϊŉ ỳôцг śэťŧιйğŝ ƒιľë. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>Гµл тђįş φѓöƒιļэ åş Λđmįňίšтŕàтоя !!! !!! !!! </value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>Ìƒ éņãвļзδ, ŧĥĕ рŗоƒīľё ẅιľł óрėŋ ΐή åň Ąďmįŋ теѓmίидŀ шïпδσώ аůţòмăтìсаļļγ. Ĭƒ ŧĥе čцѓґ℮ⁿť ẁįлđόŵ їŝ áŀřėãďу ŕύŋņïπġ āš αðмīŉ, ϊţ ẁїłℓ òρĕй іп тħΐş ωϊⁿđоẁ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>Нíşŧôŗỳ ѕιźë !!! </value>
@@ -1213,11 +1205,7 @@
     <value>Šтдřтíⁿģ đϊŕёςŧôŗў !!! !!</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>Ţћé đĭŗéçťòŕу τħе рѓøƒĩŀе śťªřťş ïή ẅћĕл îţ ίѕ ŀбдδėď. !!! !!! !!! !!! !!! !</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Ьŕōωŝē... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
@@ -809,7 +809,7 @@
     <value>Тøρ ŕĩġћт !!!</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
-  <data name="Profile_BackgroundImageBrowse.Content" xml:space="preserve">
+  <data name="Profile_BackgroundImageBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Ьřоẅşé... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1129,7 +1129,7 @@
     <value>Ęmőĵì õř îmаĝė ƒìĺĕ ļöĉǻтïòπ ǿƒ ŧђē ісǿⁿ ùšεð іń τĥε φřôƒιľê. !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "icon" setting does. Presented near "Profile_Icon".</comment>
   </data>
-  <data name="IconPicker_IconBrowse.Content" xml:space="preserve">
+  <data name="IconPicker_IconBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>ßґóщŝę... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -2101,7 +2101,7 @@
     <value>Йό ¢ôℓǿř !!</value>
     <comment>Label for a button directing the user to opt out of choosing a color.</comment>
   </data>
-  <data name="Actions_Browse.Content" xml:space="preserve">
+  <data name="Actions_Browse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>ßřôшşе... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
@@ -1229,10 +1229,6 @@
     <value>Ûηƒŏċμşεď äррėāŕαńćё !!! !!!</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Ĉřêάŧэ Δрφзάŕãñςε !!! !!</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>Ðéľėŧê !</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1724,14 +1720,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Įƒ ěлåвℓεď, šħöω ăℓŀ їήšτаļľêð ƒõņŧŝ ίл τне ľíşť ªвσνє. Öťĥέŕωíŝě, ôπľγ ŝĥσẃ ţĥэ ľíѕτ θƒ mōйǿѕφâčз ƒоņτŝ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Çřëаţë Ăφрзαѓăŉ¢έ !!! !!</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ċґêâŧέ āл ûηƒοćüšεð аφрěąґªŋčέ ƒòř тнìş φřòƒîľέ. Ţнīѕ ωïĺľ вé ťнē αррêãřªήç℮ οƒ ŧћê ρґőƒίļė ŵħėņ īŧ ίš ïńαčτîν℮. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Ďєľéтę Āρρєαяâп¢ė !!! !!</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
@@ -557,7 +557,7 @@
     <value>Άľℓôẅ OSC 777 (Desktop Notification) ťõ šђǿщ ŧôášτ ŋòţĩƒíćäťΐóйś !!! !!! !!! !!! !!! !!! !</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>Ẅђĕņ ěňāъłèð, ãφρļїčāтīòήѕ ¢аń ŝëлđ ťĥĕ OSC 777 ēśćάφз şèqüęńĉз τö ťѓĩĝĝєг ā ðĕѕќŧöρ лόтΐƒĩςªτίøп ẃìţн д сџšτõm тįŧŀé āⁿδ вόđÿ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -918,7 +918,7 @@
     <value>Эхĕçΰтдьłё ūśëď įñ ţħè рŕòƒĭŀз. !!! !!! !!!</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>ßгθшşє... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1089,21 +1089,13 @@
     <value>Τћē ŝэŀëсŧзð ƒőйť нâŝ иο ƒòиŧ ƒėäţцŕэś. !!! !!! !!! !!!</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>Ήîď℮ φябƒίļĕ ƒѓòm ďřóφδόшπ !!! !!! !</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>Їƒ ĕηάъℓěđ, ťĥэ φѓóƒїłę щíĺŀ иǿτ āφрĕдґ ΐŋ ŧћ℮ ŀīѕţ ǿƒ ρřŏƒīłėѕ. Ţђіş ςǻⁿ ъê ūšέð ťŏ ђĩðė δëƒǻūļт φґøƒíļέş аņð ďγñăмïĉâļℓÿ ģěиēяāŧεð ρřòƒίļзŝ, ẁĥιľє łэăνīⁿĝ ťĥèм ϊŉ ỳôцг śэťŧιйğŝ ƒιľë. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>Гµл тђįş φѓöƒιļэ åş Λđmįňίšтŕàтоя !!! !!! !!! </value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>Ìƒ éņãвļзδ, ŧĥĕ рŗоƒīľё ẅιľł óрėŋ ΐή åň Ąďmįŋ теѓmίидŀ шïпδσώ аůţòмăтìсаļļγ. Ĭƒ ŧĥе čцѓґ℮ⁿť ẁįлđόŵ їŝ áŀřėãďу ŕύŋņïπġ āš αðмīŉ, ϊţ ẁїłℓ òρĕй іп тħΐş ωϊⁿđоẁ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>Нíşŧôŗỳ ѕιźë !!! </value>
@@ -1201,11 +1193,7 @@
     <value>Šтдřтíⁿģ đϊŕёςŧôŗў !!! !!</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>Ţћé đĭŗéçťòŕу τħе рѓøƒĩŀе śťªřťş ïή ẅћĕл îţ ίѕ ŀбдδėď. !!! !!! !!! !!! !!! !</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Ьŕōωŝē... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
@@ -2637,10 +2637,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>Ĭиđĩ¢ãťēš тĥě šôƒтшǻŗέ τнăť ŏŗįģĭйάłℓў ćяэάтэð ŧћïš рŕøƒĩľє. !!! !!! !!! !!! !!! !!!</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>Ŋøиє !</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>Åΰťόмåтίĉ śţдѓтΰρ ћăş ьěёή δіѕªъľēð ïй ťĥ℮ Ŝťǻřťúφ Āρφŝ ѕěĉŧϊōη бƒ Windows ŝεтţīŋĝś. !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2698,10 +2694,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>Иθñé !</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>Ŋøπë !</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>Яєšèţ ŧθ ďēƒªũĺť śέττιŋĝş !!! !!! !</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
@@ -2653,10 +2653,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>Ĭиđĩ¢ãťēš тĥě šôƒтшǻŗέ τнăť ŏŗįģĭйάłℓў ćяэάтэð ŧћïš рŕøƒĩľє. !!! !!! !!! !!! !!! !!!</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>Ŋøиє !</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>Åΰťόмåтίĉ śţдѓтΰρ ћăş ьěёή δіѕªъľēð ïй ťĥ℮ Ŝťǻřťúφ Āρφŝ ѕěĉŧϊōη бƒ Windows ŝεтţīŋĝś. !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2714,10 +2710,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>Иθñé !</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>Ŋøπë !</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>Яєšèţ ŧθ ďēƒªũĺť śέττιŋĝş !!! !!! !</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
@@ -1241,10 +1241,6 @@
     <value>Ûηƒŏċμşεď äррėāŕαńćё !!! !!!</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Ĉřêάŧэ Δрφзάŕãñςε !!! !!</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>Ðéľėŧê !</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1740,14 +1736,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Įƒ ěлåвℓεď, šħöω ăℓŀ їήšτаļľêð ƒõņŧŝ ίл τне ľíşť ªвσνє. Öťĥέŕωíŝě, ôπľγ ŝĥσẃ ţĥэ ľíѕτ θƒ mōйǿѕφâčз ƒоņτŝ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Çřëаţë Ăφрзαѓăŉ¢έ !!! !!</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ċґêâŧέ āл ûηƒοćüšεð аφрěąґªŋčέ ƒòř тнìş φřòƒîľέ. Ţнīѕ ωïĺľ вé ťнē αррêãřªήç℮ οƒ ŧћê ρґőƒίļė ŵħėņ īŧ ίš ïńαčτîν℮. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Ďєľéтę Āρρєαяâп¢ė !!! !!</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
@@ -569,7 +569,7 @@
     <value>Άľℓôẅ OSC 777 (Desktop Notification) ťõ šђǿщ ŧôášτ ŋòţĩƒíćäťΐóйś !!! !!! !!! !!! !!! !!! !</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>Ẅђĕņ ěňāъłèð, ãφρļїčāтīòήѕ ¢аń ŝëлđ ťĥĕ OSC 777 ēśćάφз şèqüęńĉз τö ťѓĩĝĝєг ā ðĕѕќŧöρ лόтΐƒĩςªτίøп ẃìţн д сџšτõm тįŧŀé āⁿδ вόđÿ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -930,7 +930,7 @@
     <value>Эхĕçΰтдьłё ūśëď įñ ţħè рŕòƒĭŀз. !!! !!! !!!</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>ßгθшşє... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1101,21 +1101,13 @@
     <value>Τћē ŝэŀëсŧзð ƒőйť нâŝ иο ƒòиŧ ƒėäţцŕэś. !!! !!! !!! !!!</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>Ήîď℮ φябƒίļĕ ƒѓòm ďřóφδόшπ !!! !!! !</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>Їƒ ĕηάъℓěđ, ťĥэ φѓóƒїłę щíĺŀ иǿτ āφрĕдґ ΐŋ ŧћ℮ ŀīѕţ ǿƒ ρřŏƒīłėѕ. Ţђіş ςǻⁿ ъê ūšέð ťŏ ђĩðė δëƒǻūļт φґøƒíļέş аņð ďγñăмïĉâļℓÿ ģěиēяāŧεð ρřòƒίļзŝ, ẁĥιľє łэăνīⁿĝ ťĥèм ϊŉ ỳôцг śэťŧιйğŝ ƒιľë. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>Гµл тђįş φѓöƒιļэ åş Λđmįňίšтŕàтоя !!! !!! !!! </value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>Ìƒ éņãвļзδ, ŧĥĕ рŗоƒīľё ẅιľł óрėŋ ΐή åň Ąďmįŋ теѓmίидŀ шïпδσώ аůţòмăтìсаļļγ. Ĭƒ ŧĥе čцѓґ℮ⁿť ẁįлđόŵ їŝ áŀřėãďу ŕύŋņïπġ āš αðмīŉ, ϊţ ẁїłℓ òρĕй іп тħΐş ωϊⁿđоẁ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>Нíşŧôŗỳ ѕιźë !!! </value>
@@ -1213,11 +1205,7 @@
     <value>Šтдřтíⁿģ đϊŕёςŧôŗў !!! !!</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>Ţћé đĭŗéçťòŕу τħе рѓøƒĩŀе śťªřťş ïή ẅћĕл îţ ίѕ ŀбдδėď. !!! !!! !!! !!! !!! !</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Ьŕōωŝē... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
@@ -809,7 +809,7 @@
     <value>Тøρ ŕĩġћт !!!</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
-  <data name="Profile_BackgroundImageBrowse.Content" xml:space="preserve">
+  <data name="Profile_BackgroundImageBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Ьřоẅşé... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1129,7 +1129,7 @@
     <value>Ęmőĵì õř îmаĝė ƒìĺĕ ļöĉǻтïòπ ǿƒ ŧђē ісǿⁿ ùšεð іń τĥε φřôƒιľê. !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "icon" setting does. Presented near "Profile_Icon".</comment>
   </data>
-  <data name="IconPicker_IconBrowse.Content" xml:space="preserve">
+  <data name="IconPicker_IconBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>ßґóщŝę... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -2101,7 +2101,7 @@
     <value>Йό ¢ôℓǿř !!</value>
     <comment>Label for a button directing the user to opt out of choosing a color.</comment>
   </data>
-  <data name="Actions_Browse.Content" xml:space="preserve">
+  <data name="Actions_Browse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>ßřôшşе... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
@@ -1229,10 +1229,6 @@
     <value>Ûηƒŏċμşεď äррėāŕαńćё !!! !!!</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Ĉřêάŧэ Δрφзάŕãñςε !!! !!</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>Ðéľėŧê !</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1724,14 +1720,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Įƒ ěлåвℓεď, šħöω ăℓŀ їήšτаļľêð ƒõņŧŝ ίл τне ľíşť ªвσνє. Öťĥέŕωíŝě, ôπľγ ŝĥσẃ ţĥэ ľíѕτ θƒ mōйǿѕφâčз ƒоņτŝ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Çřëаţë Ăφрзαѓăŉ¢έ !!! !!</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ċґêâŧέ āл ûηƒοćüšεð аφрěąґªŋčέ ƒòř тнìş φřòƒîľέ. Ţнīѕ ωïĺľ вé ťнē αррêãřªήç℮ οƒ ŧћê ρґőƒίļė ŵħėņ īŧ ίš ïńαčτîν℮. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Ďєľéтę Āρρєαяâп¢ė !!! !!</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
@@ -557,7 +557,7 @@
     <value>Άľℓôẅ OSC 777 (Desktop Notification) ťõ šђǿщ ŧôášτ ŋòţĩƒíćäťΐóйś !!! !!! !!! !!! !!! !!! !</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>Ẅђĕņ ěňāъłèð, ãφρļїčāтīòήѕ ¢аń ŝëлđ ťĥĕ OSC 777 ēśćάφз şèqüęńĉз τö ťѓĩĝĝєг ā ðĕѕќŧöρ лόтΐƒĩςªτίøп ẃìţн д сџšτõm тįŧŀé āⁿδ вόđÿ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -918,7 +918,7 @@
     <value>Эхĕçΰтдьłё ūśëď įñ ţħè рŕòƒĭŀз. !!! !!! !!!</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>ßгθшşє... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1089,21 +1089,13 @@
     <value>Τћē ŝэŀëсŧзð ƒőйť нâŝ иο ƒòиŧ ƒėäţцŕэś. !!! !!! !!! !!!</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>Ήîď℮ φябƒίļĕ ƒѓòm ďřóφδόшπ !!! !!! !</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>Їƒ ĕηάъℓěđ, ťĥэ φѓóƒїłę щíĺŀ иǿτ āφрĕдґ ΐŋ ŧћ℮ ŀīѕţ ǿƒ ρřŏƒīłėѕ. Ţђіş ςǻⁿ ъê ūšέð ťŏ ђĩðė δëƒǻūļт φґøƒíļέş аņð ďγñăмïĉâļℓÿ ģěиēяāŧεð ρřòƒίļзŝ, ẁĥιľє łэăνīⁿĝ ťĥèм ϊŉ ỳôцг śэťŧιйğŝ ƒιľë. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>Гµл тђįş φѓöƒιļэ åş Λđmįňίšтŕàтоя !!! !!! !!! </value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>Ìƒ éņãвļзδ, ŧĥĕ рŗоƒīľё ẅιľł óрėŋ ΐή åň Ąďmįŋ теѓmίидŀ шïпδσώ аůţòмăтìсаļļγ. Ĭƒ ŧĥе čцѓґ℮ⁿť ẁįлđόŵ їŝ áŀřėãďу ŕύŋņïπġ āš αðмīŉ, ϊţ ẁїłℓ òρĕй іп тħΐş ωϊⁿđоẁ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>Нíşŧôŗỳ ѕιźë !!! </value>
@@ -1201,11 +1193,7 @@
     <value>Šтдřтíⁿģ đϊŕёςŧôŗў !!! !!</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>Ţћé đĭŗéçťòŕу τħе рѓøƒĩŀе śťªřťş ïή ẅћĕл îţ ίѕ ŀбдδėď. !!! !!! !!! !!! !!! !</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Ьŕōωŝē... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
@@ -2637,10 +2637,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>Ĭиđĩ¢ãťēš тĥě šôƒтшǻŗέ τнăť ŏŗįģĭйάłℓў ćяэάтэð ŧћïš рŕøƒĩľє. !!! !!! !!! !!! !!! !!!</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>Ŋøиє !</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>Åΰťόмåтίĉ śţдѓтΰρ ћăş ьěёή δіѕªъľēð ïй ťĥ℮ Ŝťǻřťúφ Āρφŝ ѕěĉŧϊōη бƒ Windows ŝεтţīŋĝś. !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2698,10 +2694,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>Иθñé !</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>Ŋøπë !</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>Яєšèţ ŧθ ďēƒªũĺť śέττιŋĝş !!! !!! !</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
@@ -2653,10 +2653,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>Ĭиđĩ¢ãťēš тĥě šôƒтшǻŗέ τнăť ŏŗįģĭйάłℓў ćяэάтэð ŧћïš рŕøƒĩľє. !!! !!! !!! !!! !!! !!!</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>Ŋøиє !</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>Åΰťόмåтίĉ śţдѓтΰρ ћăş ьěёή δіѕªъľēð ïй ťĥ℮ Ŝťǻřťúφ Āρφŝ ѕěĉŧϊōη бƒ Windows ŝεтţīŋĝś. !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2714,10 +2710,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>Иθñé !</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>Ŋøπë !</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>Яєšèţ ŧθ ďēƒªũĺť śέττιŋĝş !!! !!! !</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
@@ -1241,10 +1241,6 @@
     <value>Ûηƒŏċμşεď äррėāŕαńćё !!! !!!</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Ĉřêάŧэ Δрφзάŕãñςε !!! !!</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>Ðéľėŧê !</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1740,14 +1736,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Įƒ ěлåвℓεď, šħöω ăℓŀ їήšτаļľêð ƒõņŧŝ ίл τне ľíşť ªвσνє. Öťĥέŕωíŝě, ôπľγ ŝĥσẃ ţĥэ ľíѕτ θƒ mōйǿѕφâčз ƒоņτŝ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Çřëаţë Ăφрзαѓăŉ¢έ !!! !!</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ċґêâŧέ āл ûηƒοćüšεð аφрěąґªŋčέ ƒòř тнìş φřòƒîľέ. Ţнīѕ ωïĺľ вé ťнē αррêãřªήç℮ οƒ ŧћê ρґőƒίļė ŵħėņ īŧ ίš ïńαčτîν℮. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Ďєľéтę Āρρєαяâп¢ė !!! !!</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
@@ -569,7 +569,7 @@
     <value>Άľℓôẅ OSC 777 (Desktop Notification) ťõ šђǿщ ŧôášτ ŋòţĩƒíćäťΐóйś !!! !!! !!! !!! !!! !!! !</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>Ẅђĕņ ěňāъłèð, ãφρļїčāтīòήѕ ¢аń ŝëлđ ťĥĕ OSC 777 ēśćάφз şèqüęńĉз τö ťѓĩĝĝєг ā ðĕѕќŧöρ лόтΐƒĩςªτίøп ẃìţн д сџšτõm тįŧŀé āⁿδ вόđÿ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -930,7 +930,7 @@
     <value>Эхĕçΰтдьłё ūśëď įñ ţħè рŕòƒĭŀз. !!! !!! !!!</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>ßгθшşє... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1101,21 +1101,13 @@
     <value>Τћē ŝэŀëсŧзð ƒőйť нâŝ иο ƒòиŧ ƒėäţцŕэś. !!! !!! !!! !!!</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>Ήîď℮ φябƒίļĕ ƒѓòm ďřóφδόшπ !!! !!! !</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>Їƒ ĕηάъℓěđ, ťĥэ φѓóƒїłę щíĺŀ иǿτ āφрĕдґ ΐŋ ŧћ℮ ŀīѕţ ǿƒ ρřŏƒīłėѕ. Ţђіş ςǻⁿ ъê ūšέð ťŏ ђĩðė δëƒǻūļт φґøƒíļέş аņð ďγñăмïĉâļℓÿ ģěиēяāŧεð ρřòƒίļзŝ, ẁĥιľє łэăνīⁿĝ ťĥèм ϊŉ ỳôцг śэťŧιйğŝ ƒιľë. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>Гµл тђįş φѓöƒιļэ åş Λđmįňίšтŕàтоя !!! !!! !!! </value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>Ìƒ éņãвļзδ, ŧĥĕ рŗоƒīľё ẅιľł óрėŋ ΐή åň Ąďmįŋ теѓmίидŀ шïпδσώ аůţòмăтìсаļļγ. Ĭƒ ŧĥе čцѓґ℮ⁿť ẁįлđόŵ їŝ áŀřėãďу ŕύŋņïπġ āš αðмīŉ, ϊţ ẁїłℓ òρĕй іп тħΐş ωϊⁿđоẁ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>Нíşŧôŗỳ ѕιźë !!! </value>
@@ -1213,11 +1205,7 @@
     <value>Šтдřтíⁿģ đϊŕёςŧôŗў !!! !!</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>Ţћé đĭŗéçťòŕу τħе рѓøƒĩŀе śťªřťş ïή ẅћĕл îţ ίѕ ŀбдδėď. !!! !!! !!! !!! !!! !</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Ьŕōωŝē... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
@@ -809,7 +809,7 @@
     <value>Тøρ ŕĩġћт !!!</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
-  <data name="Profile_BackgroundImageBrowse.Content" xml:space="preserve">
+  <data name="Profile_BackgroundImageBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Ьřоẅşé... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1129,7 +1129,7 @@
     <value>Ęmőĵì õř îmаĝė ƒìĺĕ ļöĉǻтïòπ ǿƒ ŧђē ісǿⁿ ùšεð іń τĥε φřôƒιľê. !!! !!! !!! !!! !!! !!!</value>
     <comment>A description for what the "icon" setting does. Presented near "Profile_Icon".</comment>
   </data>
-  <data name="IconPicker_IconBrowse.Content" xml:space="preserve">
+  <data name="IconPicker_IconBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>ßґóщŝę... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -2101,7 +2101,7 @@
     <value>Йό ¢ôℓǿř !!</value>
     <comment>Label for a button directing the user to opt out of choosing a color.</comment>
   </data>
-  <data name="Actions_Browse.Content" xml:space="preserve">
+  <data name="Actions_Browse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>ßřôшşе... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
@@ -1229,10 +1229,6 @@
     <value>Ûηƒŏċμşεď äррėāŕαńćё !!! !!!</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Ĉřêάŧэ Δрφзάŕãñςε !!! !!</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>Ðéľėŧê !</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1724,14 +1720,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Įƒ ěлåвℓεď, šħöω ăℓŀ їήšτаļľêð ƒõņŧŝ ίл τне ľíşť ªвσνє. Öťĥέŕωíŝě, ôπľγ ŝĥσẃ ţĥэ ľíѕτ θƒ mōйǿѕφâčз ƒоņτŝ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Çřëаţë Ăφрзαѓăŉ¢έ !!! !!</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ċґêâŧέ āл ûηƒοćüšεð аφрěąґªŋčέ ƒòř тнìş φřòƒîľέ. Ţнīѕ ωïĺľ вé ťнē αррêãřªήç℮ οƒ ŧћê ρґőƒίļė ŵħėņ īŧ ίš ïńαčτîν℮. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! </value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Ďєľéтę Āρρєαяâп¢ė !!! !!</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
@@ -557,7 +557,7 @@
     <value>Άľℓôẅ OSC 777 (Desktop Notification) ťõ šђǿщ ŧôášτ ŋòţĩƒíćäťΐóйś !!! !!! !!! !!! !!! !!! !</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>Ẅђĕņ ěňāъłèð, ãφρļїčāтīòήѕ ¢аń ŝëлđ ťĥĕ OSC 777 ēśćάφз şèqüęńĉз τö ťѓĩĝĝєг ā ðĕѕќŧöρ лόтΐƒĩςªτίøп ẃìţн д сџšτõm тįŧŀé āⁿδ вόđÿ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -918,7 +918,7 @@
     <value>Эхĕçΰтдьłё ūśëď įñ ţħè рŕòƒĭŀз. !!! !!! !!!</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>ßгθшşє... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1089,21 +1089,13 @@
     <value>Τћē ŝэŀëсŧзð ƒőйť нâŝ иο ƒòиŧ ƒėäţцŕэś. !!! !!! !!! !!!</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>Ήîď℮ φябƒίļĕ ƒѓòm ďřóφδόшπ !!! !!! !</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>Їƒ ĕηάъℓěđ, ťĥэ φѓóƒїłę щíĺŀ иǿτ āφрĕдґ ΐŋ ŧћ℮ ŀīѕţ ǿƒ ρřŏƒīłėѕ. Ţђіş ςǻⁿ ъê ūšέð ťŏ ђĩðė δëƒǻūļт φґøƒíļέş аņð ďγñăмïĉâļℓÿ ģěиēяāŧεð ρřòƒίļзŝ, ẁĥιľє łэăνīⁿĝ ťĥèм ϊŉ ỳôцг śэťŧιйğŝ ƒιľë. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>Гµл тђįş φѓöƒιļэ åş Λđmįňίšтŕàтоя !!! !!! !!! </value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>Ìƒ éņãвļзδ, ŧĥĕ рŗоƒīľё ẅιľł óрėŋ ΐή åň Ąďmįŋ теѓmίидŀ шïпδσώ аůţòмăтìсаļļγ. Ĭƒ ŧĥе čцѓґ℮ⁿť ẁįлđόŵ їŝ áŀřėãďу ŕύŋņïπġ āš αðмīŉ, ϊţ ẁїłℓ òρĕй іп тħΐş ωϊⁿđоẁ. !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>Нíşŧôŗỳ ѕιźë !!! </value>
@@ -1201,11 +1193,7 @@
     <value>Šтдřтíⁿģ đϊŕёςŧôŗў !!! !!</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>Ţћé đĭŗéçťòŕу τħе рѓøƒĩŀе śťªřťş ïή ẅћĕл îţ ίѕ ŀбдδėď. !!! !!! !!! !!! !!! !</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Ьŕōωŝē... !!!</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
@@ -2637,10 +2637,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>Ĭиđĩ¢ãťēš тĥě šôƒтшǻŗέ τнăť ŏŗįģĭйάłℓў ćяэάтэð ŧћïš рŕøƒĩľє. !!! !!! !!! !!! !!! !!!</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>Ŋøиє !</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>Åΰťόмåтίĉ śţдѓтΰρ ћăş ьěёή δіѕªъľēð ïй ťĥ℮ Ŝťǻřťúφ Āρφŝ ѕěĉŧϊōη бƒ Windows ŝεтţīŋĝś. !!! !!! !!! !!! !!! !!! !!! !!! !</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2698,10 +2694,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>Иθñé !</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>Ŋøπë !</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>Яєšèţ ŧθ ďēƒªũĺť śέττιŋĝş !!! !!! !</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
@@ -2649,10 +2649,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>Указывает программное обеспечение, которое изначально создало этот профиль.</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>Нет</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>Автоматическая загрузка отключена в разделе "Приложения запуска" Windows параметрах.</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2710,10 +2706,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>Нет</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>Нет</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>Восстановить параметры по умолчанию</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
@@ -569,7 +569,7 @@
     <value>Разрешить OSC 777 (Desktop Notification) отображать всплывающие уведомления</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>При включении этого параметра приложения могут отправлять управляющую последовательность OSC 777 для запуска уведомления рабочего стола с произвольными заголовком и текстом.</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -930,7 +930,7 @@
     <value>Исполняемый файл, используемый в профиле.</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Открыть...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1101,21 +1101,13 @@
     <value>В выбранном шрифте нет компонентов.</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>Скрытие профиля из выпадающего списка</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>Если этот параметр включен, профиль не будет отображаться в списке профилей. Используется для скрытия профилей по умолчанию и динамического создания профилей, которые при этом остаются в файле настроек.</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>Запустить этот профиль от имени администратора</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>Если этот параметр включен, профиль будет автоматически открываться в Администратор терминала. Если текущее окно уже запущено от имени администратора, оно откроется в этом окне.</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>Размер журнала</value>
@@ -1213,11 +1205,7 @@
     <value>Начальный каталог</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>Каталог, запускаемый профилем при загрузке.</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Открыть...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
@@ -1241,10 +1241,6 @@
     <value>Внешний вид без фокуса</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Создать внешний вид</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>Удалить</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1740,14 +1736,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Если этот параметр включен, отобразятся все установленные шрифты в приведенном выше списке. В противном случае будет показан только список моноширинных шрифтов.</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Создать внешний вид</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Добавление настроек внешнего вида профиля, когда он не используется. Эти параметры будут применяться к профилю, когда он не активен.</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Удалить внешний вид</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
@@ -809,7 +809,7 @@
     <value>Сверху справа</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
-  <data name="Profile_BackgroundImageBrowse.Content" xml:space="preserve">
+  <data name="Profile_BackgroundImageBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Открыть...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1129,7 +1129,7 @@
     <value>Расположение эмодзи или файла изображения для значка, используемого в профиле.</value>
     <comment>A description for what the "icon" setting does. Presented near "Profile_Icon".</comment>
   </data>
-  <data name="IconPicker_IconBrowse.Content" xml:space="preserve">
+  <data name="IconPicker_IconBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Открыть...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -2101,7 +2101,7 @@
     <value>Без цвета</value>
     <comment>Label for a button directing the user to opt out of choosing a color.</comment>
   </data>
-  <data name="Actions_Browse.Content" xml:space="preserve">
+  <data name="Actions_Browse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Открыть...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
@@ -2633,10 +2633,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>Указывает программное обеспечение, которое изначально создало этот профиль.</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>Нет</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>Автоматическая загрузка отключена в разделе "Приложения запуска" Windows параметрах.</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2694,10 +2690,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>Нет</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>Нет</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>Восстановить параметры по умолчанию</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
@@ -1229,10 +1229,6 @@
     <value>Внешний вид без фокуса</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Создать внешний вид</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>Удалить</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1724,14 +1720,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Если этот параметр включен, отобразятся все установленные шрифты в приведенном выше списке. В противном случае будет показан только список моноширинных шрифтов.</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Создать внешний вид</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Добавление настроек внешнего вида профиля, когда он не используется. Эти параметры будут применяться к профилю, когда он не активен.</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Удалить внешний вид</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
@@ -557,7 +557,7 @@
     <value>Разрешить OSC 777 (Desktop Notification) отображать всплывающие уведомления</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>При включении этого параметра приложения могут отправлять управляющую последовательность OSC 777 для запуска уведомления рабочего стола с произвольными заголовком и текстом.</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -918,7 +918,7 @@
     <value>Исполняемый файл, используемый в профиле.</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Открыть...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1089,21 +1089,13 @@
     <value>В выбранном шрифте нет компонентов.</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>Скрытие профиля из выпадающего списка</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>Если этот параметр включен, профиль не будет отображаться в списке профилей. Используется для скрытия профилей по умолчанию и динамического создания профилей, которые при этом остаются в файле настроек.</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>Запустить этот профиль от имени администратора</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>Если этот параметр включен, профиль будет автоматически открываться в Администратор терминала. Если текущее окно уже запущено от имени администратора, оно откроется в этом окне.</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>Размер журнала</value>
@@ -1201,11 +1193,7 @@
     <value>Начальный каталог</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>Каталог, запускаемый профилем при загрузке.</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Открыть...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
@@ -2586,10 +2586,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>Означава софтвер који је оригинално креирао овај профил.</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>Ништа</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>У Startup Apps одељку Windows подешавања је искључено покретање.</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2647,10 +2643,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>Ништа</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>Ништа</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>Ресетуј на подразумевана подешавања</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
@@ -1206,10 +1206,6 @@
     <value>Изглед ван фокуса</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Креирај изглед</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>Обриши</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1701,14 +1697,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Ако је укључено, горња листа приказује све инсталиране фонтове. У супротном, приказује се само листа фонтова фиксне ширине.</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Креирај изглед</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Креира за овај профил изглед када није у фокусу. То ће бити изглед профила када није активан.</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Обриши изглед</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
@@ -895,7 +895,7 @@
     <value>Извршни фајл који се користи у профилу.</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Прегледај...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1066,21 +1066,13 @@
     <value>Изабрани фонт нема ниједну особину фонта.</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>Сакриј профил из падајуће листе</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>Ако је укључено, овај профил се неће појављивати у листи профила. Ово може да се употреби за сакривање подразумеваних профила и динамички генерисаних профила, мада се још увек чувају у фајлу подешавања.</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>Покрећи овај профил као администратор</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>Ако је укључено, профил ће се аутоматски отварати у Админ терминалском прозору. Ако се текући прозор већ извршава као админ, отвориће се у том прозору.</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>Величина историје</value>
@@ -1178,11 +1170,7 @@
     <value>Почетни директоријум</value>
     <comment>Name for a control to determine the directory the session opens it at launch. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>Директоријум у којем профил почиње онда када се учита.</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Прегледај...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
@@ -1194,10 +1194,6 @@
     <value>Изглед ван фокуса</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Креирај изглед</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>Обриши</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1685,14 +1681,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Ако је укључено, горња листа приказује све инсталиране фонтове. У супротном, приказује се само листа фонтова фиксне ширине.</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Креирај изглед</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Креира за овај профил изглед када није у фокусу. То ће бити изглед профила када није активан.</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Обриши изглед</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
@@ -2570,10 +2570,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>Означава софтвер који је оригинално креирао овај профил.</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>Ништа</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>У Startup Apps одељку Windows подешавања је искључено покретање.</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2631,10 +2627,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>Ништа</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>Ништа</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>Ресетуј на подразумевана подешавања</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
@@ -774,7 +774,7 @@
     <value>Горе десно</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
-  <data name="Profile_BackgroundImageBrowse.Content" xml:space="preserve">
+  <data name="Profile_BackgroundImageBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Прегледај...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -883,7 +883,7 @@
     <value>Извршни фајл који се користи у профилу.</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Прегледај...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1054,21 +1054,13 @@
     <value>Изабрани фонт нема ниједну особину фонта.</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>Сакриј профил из падајуће листе</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>Ако је укључено, овај профил се неће појављивати у листи профила. Ово може да се употреби за сакривање подразумеваних профила и динамички генерисаних профила, мада се још увек чувају у фајлу подешавања.</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>Покрећи овај профил као администратор</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>Ако је укључено, профил ће се аутоматски отварати у Админ терминалском прозору. Ако се текући прозор већ извршава као админ, отвориће се у том прозору.</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>Величина историје</value>
@@ -1102,7 +1094,7 @@
     <value>Емођи или локација фајла слике иконе која се користи у профилу.</value>
     <comment>A description for what the "icon" setting does. Presented near "Profile_Icon".</comment>
   </data>
-  <data name="IconPicker_IconBrowse.Content" xml:space="preserve">
+  <data name="IconPicker_IconBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Прегледај...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1166,11 +1158,7 @@
     <value>Почетни директоријум</value>
     <comment>Name for a control to determine the directory the session opens it at launch. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>Директоријум у којем профил почиње онда када се учита.</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Прегледај...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1205,10 +1193,6 @@
   <data name="Profile_UnfocusedAppearanceTextBlock.Text" xml:space="preserve">
     <value>Изглед ван фокуса</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
-  </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Креирај изглед</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
   </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>Обриши</value>
@@ -1698,14 +1682,6 @@
     <value>Ако је укључено, горња листа приказује све инсталиране фонтове. У супротном, приказује се само листа фонтова фиксне ширине.</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
   </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Креирај изглед</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Креира за овај профил изглед када није у фокусу. То ће бити изглед профила када није активан.</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
-  </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Обриши изглед</value>
     <comment>Name for a control which deletes the unfocused appearance settings for this profile.</comment>
@@ -2078,7 +2054,7 @@
     <value>Без боје</value>
     <comment>Label for a button directing the user to opt out of choosing a color.</comment>
   </data>
-  <data name="Actions_Browse.Content" xml:space="preserve">
+  <data name="Actions_Browse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Прегледај...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -2582,10 +2558,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>Означава софтвер који је оригинално креирао овај профил.</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>Ништа</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>У Startup Apps одељку Windows подешавања је искључено покретање.</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2643,10 +2615,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>Ништа</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>Ништа</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>Ресетуј на подразумевана подешавања</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
@@ -774,7 +774,7 @@
     <value>Горе десно</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
-  <data name="Profile_BackgroundImageBrowse.Content" xml:space="preserve">
+  <data name="Profile_BackgroundImageBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Прегледај...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1094,7 +1094,7 @@
     <value>Емођи или локација фајла слике иконе која се користи у профилу.</value>
     <comment>A description for what the "icon" setting does. Presented near "Profile_Icon".</comment>
   </data>
-  <data name="IconPicker_IconBrowse.Content" xml:space="preserve">
+  <data name="IconPicker_IconBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Прегледај...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -2054,7 +2054,7 @@
     <value>Без боје</value>
     <comment>Label for a button directing the user to opt out of choosing a color.</comment>
   </data>
-  <data name="Actions_Browse.Content" xml:space="preserve">
+  <data name="Actions_Browse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Прегледај...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
@@ -883,7 +883,7 @@
     <value>Извршни фајл који се користи у профилу.</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Прегледај...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1054,21 +1054,13 @@
     <value>Изабрани фонт нема ниједну особину фонта.</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>Сакриј профил из падајуће листе</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>Ако је укључено, овај профил се неће појављивати у листи профила. Ово може да се употреби за сакривање подразумеваних профила и динамички генерисаних профила, мада се још увек чувају у фајлу подешавања.</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>Покрећи овај профил као администратор</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>Ако је укључено, профил ће се аутоматски отварати у Админ терминалском прозору. Ако се текући прозор већ извршава као админ, отвориће се у том прозору.</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>Величина историје</value>
@@ -1166,11 +1158,7 @@
     <value>Почетни директоријум</value>
     <comment>Name for a control to determine the directory the session opens it at launch. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>Директоријум у којем профил почиње онда када се учита.</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Прегледај...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
@@ -1241,10 +1241,6 @@
     <value>Зовнішній вигляд несфокусованого вікна</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Створення зовнішнього вигляду</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>Видалити</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1767,14 +1763,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Якщо ввімкнено, показувати всі встановлені шрифти у списку вище. В іншому випадку відобразити лише список моноширинних шрифтів.</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Створення зовнішнього вигляду</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Створити вигляд для цього профілю коли він не фокусі. Так виглядатиме профіль, коли він неактивний.</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Видалити зовнішній вигляд</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
@@ -2352,10 +2352,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>Вказує програмне забезпечення, яке початково створило цей профіль.</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>Жодного</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>Автоматичний запуск вимкнено в розділі "Програми для запуску" налаштувань Windows.</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2413,10 +2409,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>Жодного</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>Жодного</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>Скинути налаштування до типових</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
@@ -914,7 +914,7 @@
     <value>Виконуваний файл, який використовувати в профілі.</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Огляд...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1089,21 +1089,13 @@
     <value>Загальні</value>
     <comment>Header for a sub-page of profile settings focused on more general scenarios.</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>Приховати профіль із спадного меню</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>Якщо ввімкнено, профіль не відображатиметься у списку профілів. Це можна використовувати, щоб приховати типові і динамічно створені профілі, залишивши їх у файлі налаштувань.</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>Запускати цей профіль як Адміністратор</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>Якщо ввімкнено, профіль автоматично відкриватиметься у вікні терміналу Адміністратора. Якщо поточне вікно вже запущено від імені Адміністратора, воно відкриється в цьому вікні.</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>Розмір історії</value>
@@ -1205,11 +1197,7 @@
     <value>Каталог при запуску</value>
     <comment>Name for a control to determine the directory the session opens it at launch. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>Початковий каталог при відкритті профілю.</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Огляд...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
@@ -2330,10 +2330,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>Вказує програмне забезпечення, яке початково створило цей профіль.</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>Жодного</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>Автоматичний запуск вимкнено в розділі "Програми для запуску" налаштувань Windows.</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2391,10 +2387,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>Жодного</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>Жодного</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>Скинути налаштування до типових</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
@@ -896,7 +896,7 @@
     <value>Виконуваний файл, який використовувати в профілі.</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Огляд...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1071,21 +1071,13 @@
     <value>Загальні</value>
     <comment>Header for a sub-page of profile settings focused on more general scenarios.</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>Приховати профіль із спадного меню</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>Якщо ввімкнено, профіль не відображатиметься у списку профілів. Це можна використовувати, щоб приховати типові і динамічно створені профілі, залишивши їх у файлі налаштувань.</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>Запускати цей профіль як Адміністратор</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>Якщо ввімкнено, профіль автоматично відкриватиметься у вікні терміналу Адміністратора. Якщо поточне вікно вже запущено від імені Адміністратора, воно відкриється в цьому вікні.</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>Розмір історії</value>
@@ -1187,11 +1179,7 @@
     <value>Каталог при запуску</value>
     <comment>Name for a control to determine the directory the session opens it at launch. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>Початковий каталог при відкритті профілю.</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Огляд...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
@@ -1223,10 +1223,6 @@
     <value>Зовнішній вигляд несфокусованого вікна</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Створення зовнішнього вигляду</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>Видалити</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1745,14 +1741,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Якщо ввімкнено, показувати всі встановлені шрифти у списку вище. В іншому випадку відобразити лише список моноширинних шрифтів.</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Створення зовнішнього вигляду</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Створити вигляд для цього профілю коли він не фокусі. Так виглядатиме профіль, коли він неактивний.</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Видалити зовнішній вигляд</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
@@ -790,7 +790,7 @@
     <value>Вгорі справа</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
-  <data name="Profile_BackgroundImageBrowse.Content" xml:space="preserve">
+  <data name="Profile_BackgroundImageBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Огляд...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
@@ -790,7 +790,7 @@
     <value>Вгорі справа</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
-  <data name="Profile_BackgroundImageBrowse.Content" xml:space="preserve">
+  <data name="Profile_BackgroundImageBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Огляд...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -896,7 +896,7 @@
     <value>Виконуваний файл, який використовувати в профілі.</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Огляд...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1071,21 +1071,13 @@
     <value>Загальні</value>
     <comment>Header for a sub-page of profile settings focused on more general scenarios.</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>Приховати профіль із спадного меню</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>Якщо ввімкнено, профіль не відображатиметься у списку профілів. Це можна використовувати, щоб приховати типові і динамічно створені профілі, залишивши їх у файлі налаштувань.</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>Запускати цей профіль як Адміністратор</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>Якщо ввімкнено, профіль автоматично відкриватиметься у вікні терміналу Адміністратора. Якщо поточне вікно вже запущено від імені Адміністратора, воно відкриється в цьому вікні.</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>Розмір історії</value>
@@ -1187,11 +1179,7 @@
     <value>Каталог при запуску</value>
     <comment>Name for a control to determine the directory the session opens it at launch. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>Початковий каталог при відкритті профілю.</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Огляд...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1234,10 +1222,6 @@
   <data name="Profile_UnfocusedAppearanceTextBlock.Text" xml:space="preserve">
     <value>Зовнішній вигляд несфокусованого вікна</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
-  </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>Створення зовнішнього вигляду</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
   </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>Видалити</value>
@@ -1757,14 +1741,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Якщо ввімкнено, показувати всі встановлені шрифти у списку вище. В іншому випадку відобразити лише список моноширинних шрифтів.</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Створення зовнішнього вигляду</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Створити вигляд для цього профілю коли він не фокусі. Так виглядатиме профіль, коли він неактивний.</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Видалити зовнішній вигляд</value>
@@ -2342,10 +2318,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>Вказує програмне забезпечення, яке початково створило цей профіль.</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>Жодного</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>Автоматичний запуск вимкнено в розділі "Програми для запуску" налаштувань Windows.</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2403,10 +2375,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>Жодного</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>Жодного</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>Скинути налаштування до типових</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
@@ -569,7 +569,7 @@
     <value>允许 OSC 777 (Desktop Notification)显示 toast 通知</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>启用后，应用程序可以发送 OSC 777 转义序列以触发具有自定义标题和正文的桌面通知。</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -930,7 +930,7 @@
     <value>在配置文件中所使用的可执行文件。</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>浏览……</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1101,21 +1101,13 @@
     <value>所选字体没有字体功能。</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>从下拉菜单中隐藏</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>如果启用，配置文件将不会显示在配置文件列表中。这可用于隐藏默认配置文件和动态生成的配置文件，同时将它们保留在设置文件中。</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>以管理员身份运行此配置文件</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>如果启用，配置文件将在管理员终端窗口中自动打开。如果当前窗口已以管理员身份运行，它将在此窗口中打开。</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>历史记录大小</value>
@@ -1213,11 +1205,7 @@
     <value>正在启动目录</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>加载配置文件时启动的目录。</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>浏览……</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
@@ -1241,10 +1241,6 @@
     <value>无焦点外观</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>创建外观</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>删除</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1740,14 +1736,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>如果启用，则在上面的列表中显示所有已安装的字体。否则，仅显示等宽字体列表。</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>创建外观</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>创建此配置文件的无焦点外观。这将是配置文件处于非活动状态时的外观。</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>删除外观</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
@@ -2649,10 +2649,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>指示最初创建此配置文件的软件。</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>无</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>已在 Windows 设置的“启动应用”部分禁用自动启动。</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2710,10 +2706,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>无</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>无</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>重置为默认设置</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
@@ -2633,10 +2633,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>指示最初创建此配置文件的软件。</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>无</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>已在 Windows 设置的“启动应用”部分禁用自动启动。</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2694,10 +2690,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>无</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>无</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>重置为默认设置</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
@@ -809,7 +809,7 @@
     <value>右上角</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
-  <data name="Profile_BackgroundImageBrowse.Content" xml:space="preserve">
+  <data name="Profile_BackgroundImageBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>浏览……</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1129,7 +1129,7 @@
     <value>配置文件中所使用图标的表情符号或图像文件位置。</value>
     <comment>A description for what the "icon" setting does. Presented near "Profile_Icon".</comment>
   </data>
-  <data name="IconPicker_IconBrowse.Content" xml:space="preserve">
+  <data name="IconPicker_IconBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>浏览……</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -2101,7 +2101,7 @@
     <value>无颜色</value>
     <comment>Label for a button directing the user to opt out of choosing a color.</comment>
   </data>
-  <data name="Actions_Browse.Content" xml:space="preserve">
+  <data name="Actions_Browse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>浏览……</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
@@ -557,7 +557,7 @@
     <value>允许 OSC 777 (Desktop Notification)显示 toast 通知</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>启用后，应用程序可以发送 OSC 777 转义序列以触发具有自定义标题和正文的桌面通知。</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -918,7 +918,7 @@
     <value>在配置文件中所使用的可执行文件。</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>浏览……</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1089,21 +1089,13 @@
     <value>所选字体没有字体功能。</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>从下拉菜单中隐藏</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>如果启用，配置文件将不会显示在配置文件列表中。这可用于隐藏默认配置文件和动态生成的配置文件，同时将它们保留在设置文件中。</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>以管理员身份运行此配置文件</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>如果启用，配置文件将在管理员终端窗口中自动打开。如果当前窗口已以管理员身份运行，它将在此窗口中打开。</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>历史记录大小</value>
@@ -1201,11 +1193,7 @@
     <value>正在启动目录</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>加载配置文件时启动的目录。</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>浏览……</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
@@ -1229,10 +1229,6 @@
     <value>无焦点外观</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>创建外观</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>删除</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1724,14 +1720,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>如果启用，则在上面的列表中显示所有已安装的字体。否则，仅显示等宽字体列表。</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>创建外观</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>创建此配置文件的无焦点外观。这将是配置文件处于非活动状态时的外观。</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>删除外观</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
@@ -2649,10 +2649,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>指示原始建立此配置檔的軟體。</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>無</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>已在 Windows 設定的 [啟動應用程式] 區段中停用自動啟動。</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2710,10 +2706,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>無</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>無</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>重設至預設設定</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
@@ -1241,10 +1241,6 @@
     <value>非焦點外觀</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>建立外觀</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>刪除</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1740,14 +1736,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>如果啟用，顯示上述清單中所有已安裝的字型。否則，僅顯示等寬字型清單。</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>建立外觀</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>立此設定檔的非焦點外觀。這會是設定檔處於非使用中狀態時的外觀。</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>刪除外觀</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
@@ -569,7 +569,7 @@
     <value>允許 OSC 777 (Desktop Notification) 顯示快顯通知</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>啟用時，應用程式可以傳送 OSC 777 逸出序列，以觸發具有自訂標題和本文的桌面通知。</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -930,7 +930,7 @@
     <value>用於設定檔中的可執行檔。</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>瀏覽...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1101,21 +1101,13 @@
     <value>選取的字型沒有字型功能。</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>在下拉式清單中隱藏設定檔</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>如果啟用，設定檔將不會顯示在設定檔清單中。這可用來隱藏預設設定檔和動態產生的設定檔，同時將它們留在您的設定檔案中。</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>以系統管理員身分執行此設定檔</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>如果啟用，配置檔將會自動在 管理員 終端機視窗中開啟。如果目前的視窗已以系統管理員身分執行，則會在此視窗中開啟。</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>歷史大小</value>
@@ -1213,11 +1205,7 @@
     <value>起始目錄</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>載入時，設定檔起始的目錄。</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>瀏覽...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
@@ -557,7 +557,7 @@
     <value>允許 OSC 777 (Desktop Notification) 顯示快顯通知</value>
     <comment>{Locked="OSC 777"}{Locked="Desktop Notification"}Header for a control to toggle support for applications to display desktop toast notifications via the OSC 777 escape sequence.</comment>
   </data>
-  <data name="Profile_AllowOscNotifications.HelpText" xml:space="preserve">
+  <data name="Profile_AllowOscNotifications.Description" xml:space="preserve">
     <value>啟用時，應用程式可以傳送 OSC 777 逸出序列，以觸發具有自訂標題和本文的桌面通知。</value>
     <comment>{Locked="OSC 777"}Help text for the OSC 777 desktop notification toggle.</comment>
   </data>
@@ -918,7 +918,7 @@
     <value>用於設定檔中的可執行檔。</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
   </data>
-  <data name="Profile_CommandlineBrowse.Content" xml:space="preserve">
+  <data name="Profile_CommandlineBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>瀏覽...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1089,21 +1089,13 @@
     <value>選取的字型沒有字型功能。</value>
     <comment>A description provided when the font features setting is disabled. Presented near "Profile_FontFeatures".</comment>
   </data>
-  <data name="Profile_Hidden.Header" xml:space="preserve">
+  <data name="Profile_Hidden.Content" xml:space="preserve">
     <value>在下拉式清單中隱藏設定檔</value>
     <comment>Header for a control to toggle whether the profile is shown in a dropdown menu, or not.</comment>
   </data>
-  <data name="Profile_Hidden.Description" xml:space="preserve">
-    <value>如果啟用，設定檔將不會顯示在設定檔清單中。這可用來隱藏預設設定檔和動態產生的設定檔，同時將它們留在您的設定檔案中。</value>
-    <comment>A description for what the "hidden" setting does. Presented near "Profile_Hidden".</comment>
-  </data>
-  <data name="Profile_Elevate.Header" xml:space="preserve">
+  <data name="Profile_Elevate.Content" xml:space="preserve">
     <value>以系統管理員身分執行此設定檔</value>
     <comment>Header for a control to toggle whether the profile should always open elevated (in an admin window)</comment>
-  </data>
-  <data name="Profile_Elevate.Description" xml:space="preserve">
-    <value>如果啟用，配置檔將會自動在 管理員 終端機視窗中開啟。如果目前的視窗已以系統管理員身分執行，則會在此視窗中開啟。</value>
-    <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>歷史大小</value>
@@ -1201,11 +1193,7 @@
     <value>起始目錄</value>
     <comment>Name for a control to determine the session's initial directory. This is on a text box that accepts folder paths.</comment>
   </data>
-  <data name="Profile_StartingDirectory.Description" xml:space="preserve">
-    <value>載入時，設定檔起始的目錄。</value>
-    <comment>A description for what the "starting directory" setting does. Presented near "Profile_StartingDirectory".</comment>
-  </data>
-  <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
+  <data name="Profile_StartingDirectoryBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>瀏覽...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
@@ -809,7 +809,7 @@
     <value>右上</value>
     <comment>This is the formal name for a visual alignment.</comment>
   </data>
-  <data name="Profile_BackgroundImageBrowse.Content" xml:space="preserve">
+  <data name="Profile_BackgroundImageBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>瀏覽...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -1129,7 +1129,7 @@
     <value>設定檔中所用圖示的表情圖示或影像檔案位置。</value>
     <comment>A description for what the "icon" setting does. Presented near "Profile_Icon".</comment>
   </data>
-  <data name="IconPicker_IconBrowse.Content" xml:space="preserve">
+  <data name="IconPicker_IconBrowse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>瀏覽...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>
@@ -2101,7 +2101,7 @@
     <value>無色彩</value>
     <comment>Label for a button directing the user to opt out of choosing a color.</comment>
   </data>
-  <data name="Actions_Browse.Content" xml:space="preserve">
+  <data name="Actions_Browse.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>瀏覽...</value>
     <comment>Button label that opens a file picker in a new window. The "..." is standard to mean it will open a new window.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
@@ -2633,10 +2633,6 @@
   <data name="Profile_Source_Orphaned.Description" xml:space="preserve">
     <value>指示原始建立此配置檔的軟體。</value>
   </data>
-  <data name="Profile_TabTitleNone" xml:space="preserve">
-    <value>無</value>
-    <comment>Text displayed when the tab title is not defined.</comment>
-  </data>
   <data name="Globals_StartOnUserLogin_DisabledByUser" xml:space="preserve">
     <value>已在 Windows 設定的 [啟動應用程式] 區段中停用自動啟動。</value>
     <comment>{Locked="Windows"}This is displayed in concordance with Globals_StartOnUserLogin if the user has disabled the setting outside of the application.</comment>
@@ -2694,10 +2690,6 @@
   <data name="Appearance_BackgroundImageNone" xml:space="preserve">
     <value>無</value>
     <comment>Text displayed when the background image path is not defined.</comment>
-  </data>
-  <data name="Profile_AnswerbackMessageNone" xml:space="preserve">
-    <value>無</value>
-    <comment>Text displayed when the answerback message is not defined.</comment>
   </data>
   <data name="Settings_ResetToDefaultSettings.Header" xml:space="preserve">
     <value>重設至預設設定</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
@@ -1229,10 +1229,6 @@
     <value>非焦點外觀</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
   </data>
-  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
-    <value>建立外觀</value>
-    <comment>Button label that adds an unfocused appearance for this profile.</comment>
-  </data>
   <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
     <value>刪除</value>
     <comment>Button label that deletes the unfocused appearance for this profile.</comment>
@@ -1724,14 +1720,6 @@
   <data name="Profile_FontFaceShowAllFonts.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>如果啟用，顯示上述清單中所有已安裝的字型。否則，僅顯示等寬字型清單。</value>
     <comment>A description for what the supplementary "show all fonts" setting does. Presented near "Profile_FontFaceShowAllFonts".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>建立外觀</value>
-    <comment>Name for a control which creates the unfocused appearance settings for this profile. Text must match that of "Profile_AddAppearanceButton.Text".</comment>
-  </data>
-  <data name="Profile_CreateUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>立此設定檔的非焦點外觀。這會是設定檔處於非使用中狀態時的外觀。</value>
-    <comment>A description for what the create unfocused appearance button does.</comment>
   </data>
   <data name="Profile_DeleteUnfocusedAppearanceButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>刪除外觀</value>

--- a/src/cascadia/TerminalSettingsEditor/SearchIndex.cpp
+++ b/src/cascadia/TerminalSettingsEditor/SearchIndex.cpp
@@ -254,6 +254,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 LocalizedIndexEntry localizedEntry;
                 localizedEntry.Entry = &entry;
                 localizedEntry.DisplayTextLocalized = GetLibraryResourceString(entry.ResourceName);
+                if (!entry.SecondaryResourceName.empty())
+                {
+                    localizedEntry.SecondaryLabelLocalized = GetLibraryResourceString(entry.SecondaryResourceName);
+                }
                 if (shouldIncludeLanguageNeutralResources)
                 {
                     localizedEntry.DisplayTextNeutral = EnglishOnlyResourceLoader().GetLocalizedString(entry.ResourceName);
@@ -342,7 +346,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
             if (bestScore >= MinimumMatchScore)
             {
-                scoredResults.emplace_back(bestScore, winrt::make<FilteredSearchResult>(index, &entry));
+                scoredResults.emplace_back(bestScore, winrt::make<FilteredSearchResult>(index, &entry, nullptr, std::nullopt, entry.SecondaryLabelLocalized));
             }
         }
 

--- a/src/cascadia/TerminalSettingsEditor/SearchIndex.cpp
+++ b/src/cascadia/TerminalSettingsEditor/SearchIndex.cpp
@@ -254,10 +254,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 LocalizedIndexEntry localizedEntry;
                 localizedEntry.Entry = &entry;
                 localizedEntry.DisplayTextLocalized = GetLibraryResourceString(entry.ResourceName);
-                if (!entry.SecondaryResourceName.empty())
-                {
-                    localizedEntry.SecondaryLabelLocalized = GetLibraryResourceString(entry.SecondaryResourceName);
-                }
                 if (shouldIncludeLanguageNeutralResources)
                 {
                     localizedEntry.DisplayTextNeutral = EnglishOnlyResourceLoader().GetLocalizedString(entry.ResourceName);

--- a/src/cascadia/TerminalSettingsEditor/SearchIndex.cpp
+++ b/src/cascadia/TerminalSettingsEditor/SearchIndex.cpp
@@ -254,6 +254,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 LocalizedIndexEntry localizedEntry;
                 localizedEntry.Entry = &entry;
                 localizedEntry.DisplayTextLocalized = GetLibraryResourceString(entry.ResourceName);
+                if (!entry.SecondaryResourceName.empty())
+                {
+                    localizedEntry.SecondaryLabelLocalized = GetLibraryResourceString(entry.SecondaryResourceName);
+                }
                 if (shouldIncludeLanguageNeutralResources)
                 {
                     localizedEntry.DisplayTextNeutral = EnglishOnlyResourceLoader().GetLocalizedString(entry.ResourceName);

--- a/src/cascadia/TerminalSettingsEditor/SearchIndex.h
+++ b/src/cascadia/TerminalSettingsEditor/SearchIndex.h
@@ -20,6 +20,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         winrt::hstring DisplayTextLocalized;
         std::optional<winrt::hstring> DisplayTextNeutral = std::nullopt;
+        winrt::hstring SecondaryLabelLocalized;
         const IndexEntry* Entry = nullptr;
 
         std::array<std::pair<std::optional<winrt::hstring>, int>, 2> GetSearchableFields() const;

--- a/src/cascadia/TerminalSettingsEditor/SettingResetButton.cpp
+++ b/src/cascadia/TerminalSettingsEditor/SettingResetButton.cpp
@@ -1,0 +1,167 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
+#include "SettingResetButton.h"
+#include "SettingResetButton.g.cpp"
+
+using namespace winrt::Windows::Foundation;
+using namespace winrt::Windows::UI::Xaml;
+using namespace winrt::Windows::UI::Xaml::Automation;
+using namespace winrt::Windows::UI::Xaml::Controls;
+using namespace winrt::Windows::UI::Xaml::Data;
+using namespace winrt::Microsoft::Terminal::Settings::Model;
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
+{
+    DependencyProperty SettingResetButton::_TargetProperty{ nullptr };
+    DependencyProperty SettingResetButton::_SettingNameProperty{ nullptr };
+
+    static constexpr std::wstring_view EraserGlyph{ L"\uE75C" };
+
+    SettingResetButton::SettingResetButton()
+    {
+        _InitializeProperties();
+
+        // Build the eraser icon content. We rely on the default Button template
+        // (via the implicit style's BasedOn) for the rest of the visuals.
+        FontIcon icon{};
+        icon.Glyph(winrt::hstring{ EraserGlyph });
+        icon.FontSize(14.0);
+        Content(icon);
+
+        // Self-owned Click handler. Use a weak ref to avoid a reference cycle.
+        Click([weakThis{ get_weak() }](const IInspectable& sender, const RoutedEventArgs& args) {
+            if (const auto self{ weakThis.get() })
+            {
+                self->_OnClick(sender, args);
+            }
+        });
+
+        _Update();
+    }
+
+    void SettingResetButton::_InitializeProperties()
+    {
+        if (!_TargetProperty)
+        {
+            _TargetProperty = DependencyProperty::Register(
+                L"Target",
+                xaml_typename<Editor::IInheritableViewModel>(),
+                xaml_typename<Editor::SettingResetButton>(),
+                PropertyMetadata{ nullptr, PropertyChangedCallback{ &SettingResetButton::_OnTargetChanged } });
+        }
+        if (!_SettingNameProperty)
+        {
+            _SettingNameProperty = DependencyProperty::Register(
+                L"SettingName",
+                xaml_typename<hstring>(),
+                xaml_typename<Editor::SettingResetButton>(),
+                PropertyMetadata{ box_value(L""), PropertyChangedCallback{ &SettingResetButton::_OnSettingNameChanged } });
+        }
+    }
+
+    void SettingResetButton::_OnTargetChanged(const DependencyObject& d, const DependencyPropertyChangedEventArgs& /*e*/)
+    {
+        const auto& obj{ d.try_as<Editor::SettingResetButton>() };
+        const auto self{ get_self<SettingResetButton>(obj) };
+        self->_ResubscribeToTarget();
+        self->_Update();
+    }
+
+    void SettingResetButton::_OnSettingNameChanged(const DependencyObject& d, const DependencyPropertyChangedEventArgs& /*e*/)
+    {
+        const auto& obj{ d.try_as<Editor::SettingResetButton>() };
+        get_self<SettingResetButton>(obj)->_Update();
+    }
+
+    // Subscribe to the Target's PropertyChanged so we can keep our enabled state and
+    // tooltip in sync when the underlying setting (or its inheritance) changes.
+    void SettingResetButton::_ResubscribeToTarget()
+    {
+        if (_subscribedTarget)
+        {
+            _subscribedTarget.PropertyChanged(_targetPropertyChangedToken);
+            _subscribedTarget = nullptr;
+            _targetPropertyChangedToken = {};
+        }
+
+        if (const auto target{ Target() })
+        {
+            if (const auto inpc{ target.try_as<INotifyPropertyChanged>() })
+            {
+                _subscribedTarget = inpc;
+                _targetPropertyChangedToken = inpc.PropertyChanged({ get_weak(), &SettingResetButton::_OnTargetPropertyChanged });
+            }
+        }
+    }
+
+    void SettingResetButton::_OnTargetPropertyChanged(const IInspectable& /*sender*/, const PropertyChangedEventArgs& args)
+    {
+        const auto changed{ args.PropertyName() };
+        const auto name{ SettingName() };
+        const auto hasName{ hstring{ L"Has" } + name };
+        // A bulk-refresh (empty name) or a change to either the value or its
+        // "Has<Setting>" flag should refresh our state.
+        if (changed.empty() || changed == name || changed == hasName)
+        {
+            _Update();
+        }
+    }
+
+    void SettingResetButton::_Update()
+    {
+        const auto target{ Target() };
+        const auto name{ SettingName() };
+        if (!target || name.empty())
+        {
+            IsEnabled(false);
+            return;
+        }
+
+        // The button is enabled only when the setting has a value at this layer.
+        IsEnabled(target.HasSetting(name));
+
+        // Tooltip + accessible name describe what resetting will do.
+        const auto message{ _GenerateOverrideMessage(target.SettingOverrideSource(name)) };
+        ToolTipService::SetToolTip(*this, box_value(message));
+        AutomationProperties::SetName(*this, message);
+    }
+
+    void SettingResetButton::_OnClick(const IInspectable& /*sender*/, const RoutedEventArgs& /*args*/)
+    {
+        const auto target{ Target() };
+        const auto name{ SettingName() };
+        if (target && !name.empty())
+        {
+            target.ClearSetting(name);
+        }
+    }
+
+    // Mirrors the legacy SettingContainer override message: base-layer profiles get a
+    // generic "reset to inherited value" message, while fragment/generated sources get a
+    // message naming the source they would revert to.
+    hstring SettingResetButton::_GenerateOverrideMessage(const IInspectable& settingOrigin)
+    {
+        auto originTag{ OriginTag::None };
+        winrt::hstring source;
+
+        if (const auto& profile{ settingOrigin.try_as<Profile>() })
+        {
+            source = profile.Source();
+            originTag = profile.Origin();
+        }
+        else if (const auto& appearanceConfig{ settingOrigin.try_as<AppearanceConfig>() })
+        {
+            const auto profile{ appearanceConfig.SourceProfile() };
+            source = profile.Source();
+            originTag = profile.Origin();
+        }
+
+        if (originTag == OriginTag::Fragment || originTag == OriginTag::Generated)
+        {
+            return hstring{ RS_fmt(L"SettingContainer_OverrideMessageFragmentExtension", source) };
+        }
+        return RS_(L"SettingContainer_OverrideMessageBaseLayer");
+    }
+}

--- a/src/cascadia/TerminalSettingsEditor/SettingResetButton.cpp
+++ b/src/cascadia/TerminalSettingsEditor/SettingResetButton.cpp
@@ -126,10 +126,60 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         const auto target{ Target() };
         const auto name{ SettingName() };
-        if (target && !name.empty())
+        if (!target || name.empty())
         {
-            target.ClearSetting(name);
+            return;
         }
+
+        // Clearing the setting disables this button, which makes XAML move focus to the next element.
+        // Store the focus state before that happens so that we can correct it afterwards.
+        const auto focusState{ FocusState() };
+        const auto restoreState{ focusState == FocusState::Unfocused ? FocusState::Programmatic : focusState };
+        target.ClearSetting(name);
+        if (const auto& element{ _FindFocusTarget() })
+        {
+            element.Focus(restoreState);
+        }
+    }
+
+    // Picks where focus goes after this button is disabled
+    Windows::UI::Xaml::Controls::Control SettingResetButton::_FindFocusTarget()
+    {
+        auto scope{ Media::VisualTreeHelper::GetParent(*this) };
+
+        // The alignment picker is a grid of toggle buttons acting like radio buttons.
+        // Focus the one holding the current value.
+        if (SettingName() == L"BackgroundImageAlignment")
+        {
+            if (const auto& grid{ scope.try_as<Panel>() })
+            {
+                for (const auto& child : grid.Children())
+                {
+                    const auto& toggle{ child.try_as<Primitives::ToggleButton>() };
+                    if (toggle && toggle.IsChecked().Value())
+                    {
+                        return toggle;
+                    }
+                }
+            }
+        }
+
+        // Widen outward until something can take focus.
+        // This handles cases like "use desktop wallpaper" for background image.
+        for (; scope; scope = Media::VisualTreeHelper::GetParent(scope))
+        {
+            if (const auto& candidate{ FindFirstFocusable(scope) })
+            {
+                return candidate;
+            }
+
+            // The expander is as wide as we go. Beyond it sit other settings.
+            if (scope.try_as<Editor::SettingsExpander>())
+            {
+                break;
+            }
+        }
+        return nullptr;
     }
 
     // Mirrors the legacy SettingContainer override message: base-layer profiles get a

--- a/src/cascadia/TerminalSettingsEditor/SettingResetButton.cpp
+++ b/src/cascadia/TerminalSettingsEditor/SettingResetButton.cpp
@@ -88,10 +88,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         if (const auto target{ Target() })
         {
-            if (const auto inpc{ target.try_as<INotifyPropertyChanged>() })
+            if (const auto observable{ target.try_as<INotifyPropertyChanged>() })
             {
-                _subscribedTarget = inpc;
-                _targetPropertyChangedToken = inpc.PropertyChanged({ get_weak(), &SettingResetButton::_OnTargetPropertyChanged });
+                _subscribedTarget = observable;
+                _targetPropertyChangedToken = observable.PropertyChanged({ get_weak(), &SettingResetButton::_OnTargetPropertyChanged });
             }
         }
     }

--- a/src/cascadia/TerminalSettingsEditor/SettingResetButton.cpp
+++ b/src/cascadia/TerminalSettingsEditor/SettingResetButton.cpp
@@ -79,19 +79,13 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     // tooltip in sync when the underlying setting (or its inheritance) changes.
     void SettingResetButton::_ResubscribeToTarget()
     {
-        if (_subscribedTarget)
-        {
-            _subscribedTarget.PropertyChanged(_targetPropertyChangedToken);
-            _subscribedTarget = nullptr;
-            _targetPropertyChangedToken = {};
-        }
+        _targetPropertyChangedRevoker.revoke();
 
         if (const auto target{ Target() })
         {
             if (const auto observable{ target.try_as<INotifyPropertyChanged>() })
             {
-                _subscribedTarget = observable;
-                _targetPropertyChangedToken = observable.PropertyChanged({ get_weak(), &SettingResetButton::_OnTargetPropertyChanged });
+                _targetPropertyChangedRevoker = observable.PropertyChanged(winrt::auto_revoke, { get_weak(), &SettingResetButton::_OnTargetPropertyChanged });
             }
         }
     }

--- a/src/cascadia/TerminalSettingsEditor/SettingResetButton.h
+++ b/src/cascadia/TerminalSettingsEditor/SettingResetButton.h
@@ -1,0 +1,51 @@
+/*++
+Copyright (c) Microsoft Corporation
+Licensed under the MIT license.
+
+Module Name:
+- SettingResetButton
+
+Abstract:
+- A small "reset value" button (eraser glyph) shown next to a profile setting's
+  control. When the setting has a value set at the current inheritance layer, the
+  button is enabled; clicking it clears that value so the setting reverts to its
+  inherited value. The button drives all of its state generically through the
+  IInheritableViewModel projected on the owning view model, keyed by SettingName.
+
+--*/
+
+#pragma once
+
+#include "SettingResetButton.g.h"
+#include "Utils.h"
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
+{
+    struct SettingResetButton : SettingResetButtonT<SettingResetButton>
+    {
+    public:
+        SettingResetButton();
+
+        DEPENDENCY_PROPERTY(Editor::IInheritableViewModel, Target);
+        DEPENDENCY_PROPERTY(hstring, SettingName);
+
+    private:
+        static void _InitializeProperties();
+        static void _OnTargetChanged(const Windows::UI::Xaml::DependencyObject& d, const Windows::UI::Xaml::DependencyPropertyChangedEventArgs& e);
+        static void _OnSettingNameChanged(const Windows::UI::Xaml::DependencyObject& d, const Windows::UI::Xaml::DependencyPropertyChangedEventArgs& e);
+
+        void _ResubscribeToTarget();
+        void _OnTargetPropertyChanged(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Data::PropertyChangedEventArgs& args);
+        void _Update();
+        void _OnClick(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
+        hstring _GenerateOverrideMessage(const Windows::Foundation::IInspectable& settingOrigin);
+
+        Windows::UI::Xaml::Data::INotifyPropertyChanged _subscribedTarget{ nullptr };
+        winrt::event_token _targetPropertyChangedToken{};
+    };
+}
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::factory_implementation
+{
+    BASIC_FACTORY(SettingResetButton);
+}

--- a/src/cascadia/TerminalSettingsEditor/SettingResetButton.h
+++ b/src/cascadia/TerminalSettingsEditor/SettingResetButton.h
@@ -12,6 +12,9 @@ Abstract:
   inherited value. The button drives all of its state generically through the
   IInheritableViewModel projected on the owning view model, keyed by SettingName.
 
+  Because clearing the value disables the button, it also moves focus to a nearby
+  control so keyboard users aren't dropped past the setting. See _FindFocusTarget.
+
 --*/
 
 #pragma once
@@ -39,6 +42,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void _Update();
         void _OnClick(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
         hstring _GenerateOverrideMessage(const Windows::Foundation::IInspectable& settingOrigin);
+
+        Windows::UI::Xaml::Controls::Control _FindFocusTarget();
 
         Windows::UI::Xaml::Data::INotifyPropertyChanged::PropertyChanged_revoker _targetPropertyChangedRevoker;
     };

--- a/src/cascadia/TerminalSettingsEditor/SettingResetButton.h
+++ b/src/cascadia/TerminalSettingsEditor/SettingResetButton.h
@@ -40,8 +40,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void _OnClick(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
         hstring _GenerateOverrideMessage(const Windows::Foundation::IInspectable& settingOrigin);
 
-        Windows::UI::Xaml::Data::INotifyPropertyChanged _subscribedTarget{ nullptr };
-        winrt::event_token _targetPropertyChangedToken{};
+        Windows::UI::Xaml::Data::INotifyPropertyChanged::PropertyChanged_revoker _targetPropertyChangedRevoker;
     };
 }
 

--- a/src/cascadia/TerminalSettingsEditor/SettingResetButton.idl
+++ b/src/cascadia/TerminalSettingsEditor/SettingResetButton.idl
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "MainPage.idl";
+
+namespace Microsoft.Terminal.Settings.Editor
+{
+    [default_interface] runtimeclass SettingResetButton : Windows.UI.Xaml.Controls.Button
+    {
+        SettingResetButton();
+
+        // The view model that owns the setting (e.g. ProfileViewModel / AppearanceViewModel).
+        IInheritableViewModel Target;
+        static Windows.UI.Xaml.DependencyProperty TargetProperty { get; };
+
+        // The name of the inheritable setting this button resets (e.g. "Commandline").
+        String SettingName;
+        static Windows.UI.Xaml.DependencyProperty SettingNameProperty { get; };
+    }
+}

--- a/src/cascadia/TerminalSettingsEditor/SettingsCard.cpp
+++ b/src/cascadia/TerminalSettingsEditor/SettingsCard.cpp
@@ -608,7 +608,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         const auto obj{ d.try_as<Editor::SettingsCard>() };
         const auto self = get_self<SettingsCard>(obj);
         self->_UpdateHeaderIconVisibility();
-        // HeaderIcon type may have flipped between BitmapIcon and other icon types — re-evaluate
+        // HeaderIcon type may have flipped between BitmapIcon and other icon types. Re-evaluate
         // the BitmapHeaderIcon visual state so the disabled-opacity setter is applied (or cleared).
         self->_CheckHeaderIconState();
     }

--- a/src/cascadia/TerminalSettingsEditor/SettingsControlsStyle.xaml
+++ b/src/cascadia/TerminalSettingsEditor/SettingsControlsStyle.xaml
@@ -469,6 +469,13 @@
         </Setter>
     </Style>
 
+    <!--  Used to align SettingsResetButtons when a page has a mix of SettingsCards and SettingsExpanders  -->
+    <Style x:Key="ExpanderAlignedSettingsCardStyle"
+           BasedOn="{StaticResource DefaultSettingsCardStyle}"
+           TargetType="local:SettingsCard">
+        <Setter Property="Padding" Value="16,16,44,16" />
+    </Style>
+
     <!--  ============ SettingsExpander ============  -->
 
     <Style BasedOn="{StaticResource DefaultSettingsExpanderStyle}"

--- a/src/cascadia/TerminalSettingsEditor/SettingsControlsStyle.xaml
+++ b/src/cascadia/TerminalSettingsEditor/SettingsControlsStyle.xaml
@@ -492,7 +492,7 @@
         <Setter Property="FontWeight" Value="Normal" />
         <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
         <Setter Property="ItemContainerStyleSelector" Value="{StaticResource SettingsExpanderItemStyleSelector}" />
-        <!--  Same C++-side implicit-styles injection as SettingsCard — see comment on that style.  -->
+        <!--  Same C++-side implicit-styles injection as SettingsCard. See comment on that style.  -->
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:SettingsExpander">
@@ -530,7 +530,7 @@
                                     Use ItemsControl + StackPanel rather than ItemsRepeater so every
                                     Items entry is realized eagerly. ItemsRepeater inside an Expander
                                     inside the Settings page's outer ScrollViewer only realized
-                                    index 0 — the EffectiveViewport propagated through the ScrollViewer
+                                    index 0. The EffectiveViewport propagated through the ScrollViewer
                                     was 0 px at the moment the expand storyboard ran, and StackLayout's
                                     cache length is relative to viewport so 0 * anything is still 0.
                                     Settings expanders rarely hold more than a handful of cards so

--- a/src/cascadia/TerminalSettingsEditor/TerminalColorConverters.cpp
+++ b/src/cascadia/TerminalSettingsEditor/TerminalColorConverters.cpp
@@ -25,7 +25,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     Windows::Foundation::IInspectable ColorToStringConverter::Convert(Windows::Foundation::IInspectable const& value, Windows::UI::Xaml::Interop::TypeName const& /*targetType*/, Windows::Foundation::IInspectable const& /*parameter*/, hstring const& /*language*/)
     {
         const auto color = value.as<Windows::UI::Color>();
-        return winrt::box_value(fmt::format(FMT_COMPILE(L"#{:02X}{:02X}{:02X}"), color.R, color.G, color.B));
+        return winrt::box_value(winrt::Microsoft::Terminal::Settings::ColorToHexString(color));
     }
 
     Windows::Foundation::IInspectable ColorToStringConverter::ConvertBack(Windows::Foundation::IInspectable const& /*value*/, Windows::UI::Xaml::Interop::TypeName const& /*targetType*/, Windows::Foundation::IInspectable const& /*parameter*/, hstring const& /*language*/)

--- a/src/cascadia/TerminalSettingsEditor/Utils.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Utils.cpp
@@ -137,6 +137,16 @@ namespace winrt::Microsoft::Terminal::Settings
         return GetLibraryResourceString(fmtKey);
     }
 
+    hstring ColorToHexString(const winrt::Windows::UI::Color& color)
+    {
+        return hstring{ fmt::format(FMT_COMPILE(L"#{:02X}{:02X}{:02X}"), color.R, color.G, color.B) };
+    }
+
+    hstring FormatAccessibleName(const std::wstring_view headerResourceKey, const std::wstring_view value)
+    {
+        return til::hstring_format(FMT_COMPILE(L"{}: {}"), GetLibraryResourceString(headerResourceKey), value);
+    }
+
     safe_void_coroutine ExpandAncestorsAndBringIntoView(FrameworkElement root, Controls::Control control)
     {
         if (!control)

--- a/src/cascadia/TerminalSettingsEditor/Utils.h
+++ b/src/cascadia/TerminalSettingsEditor/Utils.h
@@ -80,6 +80,8 @@ namespace winrt::Microsoft::Terminal::Settings
 {
     winrt::hstring GetSelectedItemTag(const winrt::Windows::Foundation::IInspectable& comboBoxAsInspectable);
     winrt::hstring LocalizedNameForEnumName(const std::wstring_view sectionAndType, const std::wstring_view enumValue, const std::wstring_view propertyType);
+    winrt::hstring ColorToHexString(const winrt::Windows::UI::Color& color);
+    winrt::hstring FormatAccessibleName(const std::wstring_view headerResourceKey, const std::wstring_view value);
     safe_void_coroutine ExpandAncestorsAndBringIntoView(winrt::Windows::UI::Xaml::FrameworkElement root, winrt::Windows::UI::Xaml::Controls::Control control);
     Editor::KeyChordListener FindKeyChordListener(const winrt::Windows::UI::Xaml::DependencyObject& root);
     winrt::Windows::UI::Xaml::Controls::Control FindFirstFocusable(const winrt::Windows::UI::Xaml::DependencyObject& root);

--- a/src/cascadia/TerminalSettingsModel/IInheritable.h
+++ b/src/cascadia/TerminalSettingsModel/IInheritable.h
@@ -136,7 +136,7 @@ private:                                                                    \
         return std::nullopt;                                                \
     }                                                                       \
                                                                             \
-    auto _get##name##OverrideSourceImpl() -> decltype(get_strong())         \
+    auto _get##name##OverrideSourceImpl()->decltype(get_strong())           \
     {                                                                       \
         /*we have a value*/                                                 \
         if (_##name)                                                        \
@@ -159,7 +159,7 @@ private:                                                                    \
     }                                                                       \
                                                                             \
     auto _get##name##OverrideSourceAndValueImpl()                           \
-        -> std::pair<decltype(get_strong()), storageType>                   \
+        ->std::pair<decltype(get_strong()), storageType>                    \
     {                                                                       \
         /*we have a value*/                                                 \
         if (_##name)                                                        \

--- a/tools/GenerateSettingsIndex.ps1
+++ b/tools/GenerateSettingsIndex.ps1
@@ -25,7 +25,8 @@ $ProhibitedUids = @(
     "ColorScheme_ColorsHeader",
     "ColorScheme_Rename",
     "Profile_ResetProfile",
-    "Profile_DeleteProfile"
+    "Profile_DeleteProfile",
+    "Profile_DeleteUnfocusedAppearance"
 )
 
 # Prohibited XAML files (already limited to Page root elements)
@@ -93,6 +94,11 @@ $ClassMap = @{
         NavigationParam = "GlobalProfile_Nav"
         SubPage         = "BreadcrumbSubPage::Profile_Appearance"
     }
+    "Microsoft::Terminal::Settings::Editor::Profiles_UnfocusedAppearance" = @{
+        ResourceName    = "Nav_ProfileDefaults/Content"
+        NavigationParam = "GlobalProfile_Nav"
+        SubPage         = "BreadcrumbSubPage::Profile_UnfocusedAppearance"
+    }
     "Microsoft::Terminal::Settings::Editor::Profiles_Terminal" = @{
         ResourceName    = "Nav_ProfileDefaults/Content"
         NavigationParam = "GlobalProfile_Nav"
@@ -113,6 +119,7 @@ $ClassMap = @{
 function IsProfileSubPage($pageClass)
 {
     return $pageClass -match "Editor::Profiles_Appearance" -or
+           $pageClass -match "Editor::Profiles_UnfocusedAppearance" -or
            $pageClass -match "Editor::Profiles_Terminal" -or
            $pageClass -match "Editor::Profiles_Advanced"
 }
@@ -200,9 +207,10 @@ foreach ($xamlFile in Get-ChildItem -Path $SourceDir -Filter *.xaml)
         # - no UID because we want to reuse existing resources to reduce localization burden
         # - when selected, we want to navigate to the subpage (not focus the navigator)
         $navigators = @(
-            @{ Resource = "Profile_Appearance/Header"; SubPage = "BreadcrumbSubPage::Profile_Appearance" }
-            @{ Resource = "Profile_Terminal/Header";   SubPage = "BreadcrumbSubPage::Profile_Terminal" }
-            @{ Resource = "Profile_Advanced/Header";   SubPage = "BreadcrumbSubPage::Profile_Advanced" }
+            @{ Resource = "Profile_Appearance/Header";          SubPage = "BreadcrumbSubPage::Profile_Appearance" }
+            @{ Resource = "Profile_UnfocusedAppearanceTextBlock/Text"; SubPage = "BreadcrumbSubPage::Profile_UnfocusedAppearance" }
+            @{ Resource = "Profile_Terminal/Header";            SubPage = "BreadcrumbSubPage::Profile_Terminal" }
+            @{ Resource = "Profile_Advanced/Header";            SubPage = "BreadcrumbSubPage::Profile_Advanced" }
         )
         foreach ($nav in $navigators)
         {

--- a/tools/GenerateSettingsIndex.ps1
+++ b/tools/GenerateSettingsIndex.ps1
@@ -194,6 +194,39 @@ foreach ($xamlFile in Get-ChildItem -Path $SourceDir -Filter *.xaml)
             File            = $filename
         }
     }
+    elseif ($filename -eq "Profiles_Base.xaml")
+    {
+        # The navigator cards below are special:
+        # - no UID because we want to reuse existing resources to reduce localization burden
+        # - when selected, we want to navigate to the subpage (not focus the navigator)
+        $navigators = @(
+            @{ Resource = "Profile_Appearance/Header"; SubPage = "BreadcrumbSubPage::Profile_Appearance" }
+            @{ Resource = "Profile_Terminal/Header";   SubPage = "BreadcrumbSubPage::Profile_Terminal" }
+            @{ Resource = "Profile_Advanced/Header";   SubPage = "BreadcrumbSubPage::Profile_Advanced" }
+        )
+        foreach ($nav in $navigators)
+        {
+            # Build-time entry: searchable from the profile defaults context
+            $entries += [pscustomobject]@{
+                ResourceName         = $nav.Resource
+                ParentPage           = $pageClass
+                NavigationParam      = $ClassMap[$pageClass].NavigationParam
+                SubPage              = $nav.SubPage
+                ElementName          = ""
+                SecondaryResourceName = "Nav_ProfileDefaults/Content"
+                File                 = $filename
+            }
+            # Partial entry: instantiated per profile at runtime (the navigation arg is the profile VM).
+            $entries += [pscustomobject]@{
+                ResourceName    = $nav.Resource
+                ParentPage      = $pageClass
+                NavigationParam = $null
+                SubPage         = $nav.SubPage
+                ElementName     = ""
+                File            = $filename
+            }
+        }
+    }
 
     # Iterate over all local:SettingsCard and local:SettingsExpander nodes
     foreach ($settingContainer in ($xml.SelectNodes("//local:SettingsCard", $xm) + $xml.SelectNodes("//local:SettingsExpander", $xm)))
@@ -287,8 +320,9 @@ function FormatEntry($e)
     $formattedResourceName = 'USES_RESOURCE(L"{0}")' -f $e.ResourceName
     $formattedNavigationParam = 'L"{0}"' -f $e.NavigationParam # null Navigation param resolves to empty string
     $formattedElementName = 'L"{0}"' -f $e.ElementName
+    $formattedSecondary = $e.SecondaryResourceName ? (', USES_RESOURCE(L"{0}")' -f $e.SecondaryResourceName) : ''
 
-    return "            IndexEntry{{ {0}, {1}, {2}, {3} }}, // {4}" -f ($formattedResourceName, $formattedNavigationParam, $e.SubPage, $formattedElementName, $e.File)
+    return "            IndexEntry{{ {0}, {1}, {2}, {3}{5} }}, // {4}" -f ($formattedResourceName, $formattedNavigationParam, $e.SubPage, $formattedElementName, $e.File, $formattedSecondary)
 }
 
 function FormatEntries($es) {
@@ -352,6 +386,12 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         
         // x:Name of the SettingContainer to navigate to on the page (i.e. "DefaultProfile")
         wil::zwstring_view ElementName;
+
+        // Optional resource name for a secondary label shown beneath the primary label in
+        // search results (i.e. "Nav_ProfileDefaults/Content" for the profile-defaults page links).
+        // Empty for most entries.
+        // NOTE: wrapped in USES_RESOURCE() (when set) for the same compile-time validation as ResourceName.
+        wil::zwstring_view SecondaryResourceName;
     };
 
     const std::array<IndexEntry, $($buildTimeEntries.Count)>& LoadBuildTimeIndex();

--- a/tools/GenerateSettingsIndex.ps1
+++ b/tools/GenerateSettingsIndex.ps1
@@ -30,6 +30,7 @@ $ProhibitedUids = @(
     "Profile_AdvancedNavigator",
     "Profile_AppearanceNavigator",
     "Profile_DeleteProfile",
+    "Profile_DeleteUnfocusedAppearance",
     "Profile_MissingFontFaces",
     "Profile_ProportionalFontFaces",
     "Profile_ResetProfile",
@@ -105,6 +106,11 @@ $ClassMap = @{
         NavigationParam = "GlobalProfile_Nav"
         SubPage         = "BreadcrumbSubPage::Profile_Appearance"
     }
+    "Microsoft::Terminal::Settings::Editor::Profiles_UnfocusedAppearance" = @{
+        ResourceName    = "Nav_ProfileDefaults/Content"
+        NavigationParam = "GlobalProfile_Nav"
+        SubPage         = "BreadcrumbSubPage::Profile_UnfocusedAppearance"
+    }
     "Microsoft::Terminal::Settings::Editor::Profiles_Terminal" = @{
         ResourceName    = "Nav_ProfileDefaults/Content"
         NavigationParam = "GlobalProfile_Nav"
@@ -125,6 +131,7 @@ $ClassMap = @{
 function IsProfileSubPage($pageClass)
 {
     return $pageClass -match "Editor::Profiles_Appearance" -or
+           $pageClass -match "Editor::Profiles_UnfocusedAppearance" -or
            $pageClass -match "Editor::Profiles_Terminal" -or
            $pageClass -match "Editor::Profiles_Advanced"
 }
@@ -213,9 +220,10 @@ foreach ($xamlFile in Get-ChildItem -Path $SourceDir -Filter *.xaml)
         # - no UID because we want to reuse existing resources to reduce localization burden
         # - when selected, we want to navigate to the subpage (not focus the navigator)
         $navigators = @(
-            @{ Resource = "Profile_Appearance/Header"; SubPage = "BreadcrumbSubPage::Profile_Appearance" }
-            @{ Resource = "Profile_Terminal/Header";   SubPage = "BreadcrumbSubPage::Profile_Terminal" }
-            @{ Resource = "Profile_Advanced/Header";   SubPage = "BreadcrumbSubPage::Profile_Advanced" }
+            @{ Resource = "Profile_Appearance/Header";          SubPage = "BreadcrumbSubPage::Profile_Appearance" }
+            @{ Resource = "Profile_UnfocusedAppearanceTextBlock/Text"; SubPage = "BreadcrumbSubPage::Profile_UnfocusedAppearance" }
+            @{ Resource = "Profile_Terminal/Header";            SubPage = "BreadcrumbSubPage::Profile_Terminal" }
+            @{ Resource = "Profile_Advanced/Header";            SubPage = "BreadcrumbSubPage::Profile_Advanced" }
         )
         foreach ($nav in $navigators)
         {

--- a/tools/GenerateSettingsIndex.ps1
+++ b/tools/GenerateSettingsIndex.ps1
@@ -195,6 +195,51 @@ foreach ($xamlFile in Get-ChildItem -Path $SourceDir -Filter *.xaml)
             File            = $filename
         }
     }
+    elseif ($filename -eq "AddProfile.xaml")
+    {
+        # "add new" button
+        $entries += [pscustomobject]@{
+            ResourceName    = "AddProfile_AddNewTextBlock/Text"
+            ParentPage      = $pageClass
+            NavigationParam = $ClassMap[$pageClass].NavigationParam
+            SubPage         = $ClassMap[$pageClass].SubPage
+            ElementName     = "AddNewButton"
+            File            = $filename
+        }
+    }
+    elseif ($filename -eq "Profiles_Base.xaml")
+    {
+        # The navigator cards below are special:
+        # - no UID because we want to reuse existing resources to reduce localization burden
+        # - when selected, we want to navigate to the subpage (not focus the navigator)
+        $navigators = @(
+            @{ Resource = "Profile_Appearance/Header"; SubPage = "BreadcrumbSubPage::Profile_Appearance" }
+            @{ Resource = "Profile_Terminal/Header";   SubPage = "BreadcrumbSubPage::Profile_Terminal" }
+            @{ Resource = "Profile_Advanced/Header";   SubPage = "BreadcrumbSubPage::Profile_Advanced" }
+        )
+        foreach ($nav in $navigators)
+        {
+            # Build-time entry: searchable from the profile defaults context
+            $entries += [pscustomobject]@{
+                ResourceName         = $nav.Resource
+                ParentPage           = $pageClass
+                NavigationParam      = $ClassMap[$pageClass].NavigationParam
+                SubPage              = $nav.SubPage
+                ElementName          = ""
+                SecondaryLabel       = "Nav_ProfileDefaults/Content"
+                File                 = $filename
+            }
+            # Partial entry: instantiated per profile at runtime (the navigation arg is the profile VM).
+            $entries += [pscustomobject]@{
+                ResourceName    = $nav.Resource
+                ParentPage      = $pageClass
+                NavigationParam = $null
+                SubPage         = $nav.SubPage
+                ElementName     = ""
+                File            = $filename
+            }
+        }
+    }
 
     # Iterate over all local:SettingsCard and local:SettingsExpander nodes
     foreach ($settingContainer in ($xml.SelectNodes("//local:SettingsCard", $xm) + $xml.SelectNodes("//local:SettingsExpander", $xm)))


### PR DESCRIPTION
## Summary of the Pull Request
Updates the individual profile pages to include:
- icons + settings expanders/cards
- `SettingsResetButton`: a new "reset value" button
- a new "unfocused appearance" subpage with its own preview (similar to default appearance)

## Detailed Description of the Pull Request / Additional comments
- `IInheritableViewModel`: interface exposing `HasSetting()`, `ClearSetting()`, and `SettingOverrideSource()`
- To help ensure that these are updated properly, a static assert was added that checks the number of profile settings. This is intended to be a tripwire to ensure future changes also update the reset buttons.
- `Profiles_UnfocusedAppearance.h/cpp/idl/xaml`: the new unfocused appearance page
- added helper functions `FormatAccessibleName()` and `ColorToHexString()` to deduplicate code that creates accessible names for SettingsExpanders across the entire SUI

## Validation Steps Performed
- [X] settings search + deep link navigation
- [X] "reset value" button
- [X] accessibility pass with Narrator

## PR Checklist
Related to #17000