### PR TITLE
Add per-profile `confirmOnClose` setting

### DIFF
--- a/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
@@ -97,6 +97,16 @@ namespace TerminalAppLocalTests
 
         TEST_METHOD(TestClampSwitchToTab);
 
+        TEST_METHOD(TestConfirmOnCloseTabWarning);
+        TEST_METHOD(TestConfirmOnCloseWindowWarning);
+
+        TEST_METHOD(TestConfirmOnCloseProfileTriggeredInAutomatic);
+        TEST_METHOD(TestCloseFocusedPaneLastPaneProfileFlag);
+        TEST_METHOD(TestRemoveTabsWithPerProfileFlag);
+
+        TEST_METHOD(TestRemoveTabsPassesProfilesToDialog);
+        TEST_METHOD(TestCloseWindowAutomaticSinglePaneProfileTriggered);
+
         TEST_CLASS_SETUP(ClassSetup)
         {
             return true;
@@ -1525,6 +1535,361 @@ namespace TerminalAppLocalTests
             VERIFY_IS_TRUE(focusedTabIndexOpt.has_value());
             VERIFY_ARE_EQUAL(2u, focusedTabIndexOpt.value());
         });
+    }
+
+    void TabTests::TestConfirmOnCloseTabWarning()
+    {
+        // Settings: global = never, profile0 has confirmOnClose: true
+        static constexpr std::wstring_view settingsWithProfileConfirm{ LR"(
+        {
+            "defaultProfile": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
+            "warning.confirmOnClose": "never",
+            "profiles": [
+                {
+                    "name": "confirm-profile",
+                    "guid": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
+                    "confirmOnClose": true
+                }
+            ]
+        })" };
+
+        // Settings: global = never, profile has confirmOnClose: false (default)
+        static constexpr std::wstring_view settingsNoConfirm{ LR"(
+        {
+            "defaultProfile": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
+            "warning.confirmOnClose": "never",
+            "profiles": [
+                {
+                    "name": "no-confirm-profile",
+                    "guid": "{6239a42c-1111-49a3-80bd-e8fdd045185c}"
+                }
+            ]
+        })" };
+
+        // Settings: global = always (profile setting irrelevant)
+        static constexpr std::wstring_view settingsGlobalAlways{ LR"(
+        {
+            "defaultProfile": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
+            "warning.confirmOnClose": "always",
+            "profiles": [
+                {
+                    "name": "any-profile",
+                    "guid": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
+                    "confirmOnClose": false
+                }
+            ]
+        })" };
+
+        // Settings: global = automatic, profile = true (raises to always for single pane)
+        static constexpr std::wstring_view settingsAutomaticWithProfile{ LR"(
+        {
+            "defaultProfile": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
+            "warning.confirmOnClose": "automatic",
+            "profiles": [
+                {
+                    "name": "confirm-profile",
+                    "guid": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
+                    "confirmOnClose": true
+                }
+            ]
+        })" };
+
+        {
+            // Case 1: profile true + global never -> should warn
+            winrt::com_ptr<winrt::TerminalApp::implementation::TerminalPage> page{ nullptr };
+            _initializeTerminalPage(page, CascadiaSettings{ settingsWithProfileConfirm, {} });
+            TestOnUIThread([&page]() {
+                const auto tab = page->_GetTabImpl(page->_tabs.GetAt(0));
+                VERIFY_IS_TRUE(page->_ShouldWarnOnCloseTab(tab), L"profile=true, global=never should warn");
+            });
+        }
+
+        {
+            // Case 2: profile false + global never -> should not warn
+            winrt::com_ptr<winrt::TerminalApp::implementation::TerminalPage> page{ nullptr };
+            _initializeTerminalPage(page, CascadiaSettings{ settingsNoConfirm, {} });
+            TestOnUIThread([&page]() {
+                const auto tab = page->_GetTabImpl(page->_tabs.GetAt(0));
+                VERIFY_IS_FALSE(page->_ShouldWarnOnCloseTab(tab), L"profile=false, global=never should not warn");
+            });
+        }
+
+        {
+            // Case 3: global always + profile false -> should warn (global wins)
+            winrt::com_ptr<winrt::TerminalApp::implementation::TerminalPage> page{ nullptr };
+            _initializeTerminalPage(page, CascadiaSettings{ settingsGlobalAlways, {} });
+            TestOnUIThread([&page]() {
+                const auto tab = page->_GetTabImpl(page->_tabs.GetAt(0));
+                VERIFY_IS_TRUE(page->_ShouldWarnOnCloseTab(tab), L"global=always should always warn");
+            });
+        }
+
+        {
+            // Case 4: global automatic + profile true + single pane -> should warn
+            winrt::com_ptr<winrt::TerminalApp::implementation::TerminalPage> page{ nullptr };
+            _initializeTerminalPage(page, CascadiaSettings{ settingsAutomaticWithProfile, {} });
+            TestOnUIThread([&page]() {
+                const auto tab = page->_GetTabImpl(page->_tabs.GetAt(0));
+                VERIFY_ARE_EQUAL(1u, tab->GetLeafPaneCount(), L"Sanity: single pane");
+                VERIFY_IS_TRUE(page->_ShouldWarnOnCloseTab(tab), L"profile=true, global=automatic, single pane should warn");
+            });
+        }
+    }
+
+    void TabTests::TestConfirmOnCloseWindowWarning()
+    {
+        // Settings: global = never, one tab with confirmOnClose: true
+        static constexpr std::wstring_view settingsWithProfileConfirm{ LR"(
+        {
+            "defaultProfile": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
+            "warning.confirmOnClose": "never",
+            "profiles": [
+                {
+                    "name": "confirm-profile",
+                    "guid": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
+                    "confirmOnClose": true
+                }
+            ]
+        })" };
+
+        // Settings: global = never, tab with confirmOnClose: false
+        static constexpr std::wstring_view settingsNoConfirm{ LR"(
+        {
+            "defaultProfile": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
+            "warning.confirmOnClose": "never",
+            "profiles": [
+                {
+                    "name": "no-confirm-profile",
+                    "guid": "{6239a42c-1111-49a3-80bd-e8fdd045185c}"
+                }
+            ]
+        })" };
+
+        {
+            // Case 5: global = never, tab's profile = true -> window close should warn
+            winrt::com_ptr<winrt::TerminalApp::implementation::TerminalPage> page{ nullptr };
+            _initializeTerminalPage(page, CascadiaSettings{ settingsWithProfileConfirm, {} });
+            TestOnUIThread([&page]() {
+                VERIFY_IS_TRUE(page->_ShouldWarnOnClose(), L"global=never, profile=true -> window close should warn");
+            });
+        }
+
+        {
+            // Case 6: global = never, all tabs profile = false -> window close should not warn
+            winrt::com_ptr<winrt::TerminalApp::implementation::TerminalPage> page{ nullptr };
+            _initializeTerminalPage(page, CascadiaSettings{ settingsNoConfirm, {} });
+            TestOnUIThread([&page]() {
+                VERIFY_IS_FALSE(page->_ShouldWarnOnClose(), L"global=never, profile=false -> window close should not warn");
+            });
+        }
+    }
+
+    // Test I-1: When global is Automatic and a single-pane tab has confirmOnClose:true on its
+    // profile, _ShouldWarnOnCloseTab returns true AND profileTriggered should be true
+    // (profile caused the dialog, not multi-pane count).
+    void TabTests::TestConfirmOnCloseProfileTriggeredInAutomatic()
+    {
+        // Settings: global = automatic, profile has confirmOnClose: true
+        static constexpr std::wstring_view settingsAutomaticWithProfile{ LR"(
+        {
+            "defaultProfile": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
+            "warning.confirmOnClose": "automatic",
+            "profiles": [
+                {
+                    "name": "confirm-profile",
+                    "guid": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
+                    "confirmOnClose": true
+                }
+            ]
+        })" };
+
+        {
+            // global=automatic, single-pane, profile=true -> _ShouldWarnOnCloseTab returns true
+            // and profileTriggered is true (profile should be disabled, not global)
+            winrt::com_ptr<winrt::TerminalApp::implementation::TerminalPage> page{ nullptr };
+            _initializeTerminalPage(page, CascadiaSettings{ settingsAutomaticWithProfile, {} });
+            TestOnUIThread([&page]() {
+                const auto tab = page->_GetTabImpl(page->_tabs.GetAt(0));
+                VERIFY_ARE_EQUAL(1u, tab->GetLeafPaneCount(), L"Sanity: single pane");
+                VERIFY_IS_TRUE(page->_ShouldWarnOnCloseTab(tab), L"global=automatic, single pane, profile=true should warn");
+
+                // Verify profileTriggered logic: global=Automatic + single-pane + profile=true
+                // -> profileTriggered should be true (profile, not multi-pane, caused the dialog)
+                const auto globalSetting = page->_settings.GlobalSettings().ConfirmOnClose();
+                const auto profile = tab->GetFocusedProfile();
+                const auto profileTriggered = profile && profile.ConfirmOnClose() &&
+                                              globalSetting != ConfirmOnClose::Always &&
+                                              !(globalSetting == ConfirmOnClose::Automatic && tab->GetLeafPaneCount() > 1);
+                VERIFY_IS_TRUE(profileTriggered, L"profileTriggered should be true for Automatic+single-pane+profile case");
+            });
+        }
+    }
+
+    // Test C-2: When global is Never and a tab has a single pane with per-profile
+    // confirmOnClose:true, _ShouldWarnOnCloseTab returns true (the logic that _CloseFocusedPane
+    // now hooks into for the last-pane case).
+    void TabTests::TestCloseFocusedPaneLastPaneProfileFlag()
+    {
+        // Settings: global = never, profile has confirmOnClose: true
+        static constexpr std::wstring_view settingsNeverWithProfile{ LR"(
+        {
+            "defaultProfile": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
+            "warning.confirmOnClose": "never",
+            "profiles": [
+                {
+                    "name": "confirm-profile",
+                    "guid": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
+                    "confirmOnClose": true
+                }
+            ]
+        })" };
+
+        {
+            // global=never, single pane, profile=true -> _ShouldWarnOnCloseTab returns true
+            // This verifies that _CloseFocusedPane's new last-pane path will trigger.
+            winrt::com_ptr<winrt::TerminalApp::implementation::TerminalPage> page{ nullptr };
+            _initializeTerminalPage(page, CascadiaSettings{ settingsNeverWithProfile, {} });
+            TestOnUIThread([&page]() {
+                const auto tab = page->_GetTabImpl(page->_tabs.GetAt(0));
+                VERIFY_ARE_EQUAL(1u, tab->GetLeafPaneCount(), L"Sanity: single pane");
+                VERIFY_IS_TRUE(page->_ShouldWarnOnCloseTab(tab), L"global=never, single pane, profile=true -> should warn (C-2 path)");
+            });
+        }
+    }
+
+    // Test C-1: When global is Never but one of the tabs has confirmOnClose:true,
+    // _ShouldWarnOnCloseTab on that tab returns true — the condition that _RemoveTabs
+    // now uses to show a dialog even when global is Never.
+    void TabTests::TestRemoveTabsWithPerProfileFlag()
+    {
+        // Settings: global = never, profile has confirmOnClose: true
+        static constexpr std::wstring_view settingsNeverWithProfile{ LR"(
+        {
+            "defaultProfile": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
+            "warning.confirmOnClose": "never",
+            "profiles": [
+                {
+                    "name": "confirm-profile",
+                    "guid": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
+                    "confirmOnClose": true
+                }
+            ]
+        })" };
+
+        // Settings: global = never, profile has confirmOnClose: false
+        static constexpr std::wstring_view settingsNeverNoProfile{ LR"(
+        {
+            "defaultProfile": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
+            "warning.confirmOnClose": "never",
+            "profiles": [
+                {
+                    "name": "no-confirm-profile",
+                    "guid": "{6239a42c-1111-49a3-80bd-e8fdd045185c}"
+                }
+            ]
+        })" };
+
+        {
+            // global=never, profile=true -> _ShouldWarnOnCloseTab returns true for that tab.
+            // This verifies the new condition in _RemoveTabs (anyProfileConfirm = true).
+            winrt::com_ptr<winrt::TerminalApp::implementation::TerminalPage> page{ nullptr };
+            _initializeTerminalPage(page, CascadiaSettings{ settingsNeverWithProfile, {} });
+            TestOnUIThread([&page]() {
+                const auto tab = page->_GetTabImpl(page->_tabs.GetAt(0));
+                VERIFY_IS_TRUE(page->_ShouldWarnOnCloseTab(tab), L"global=never, profile=true -> tab warns (C-1 path reachable)");
+            });
+        }
+
+        {
+            // global=never, profile=false -> _ShouldWarnOnCloseTab returns false.
+            // No dialog should appear in _RemoveTabs (anyProfileConfirm = false).
+            winrt::com_ptr<winrt::TerminalApp::implementation::TerminalPage> page{ nullptr };
+            _initializeTerminalPage(page, CascadiaSettings{ settingsNeverNoProfile, {} });
+            TestOnUIThread([&page]() {
+                const auto tab = page->_GetTabImpl(page->_tabs.GetAt(0));
+                VERIFY_IS_FALSE(page->_ShouldWarnOnCloseTab(tab), L"global=never, profile=false -> no warning (C-1 path not triggered)");
+            });
+        }
+    }
+
+    // Test M-1: When global is Never and a tab in the removal set has confirmOnClose:true,
+    // _ShouldWarnOnCloseTab on that tab returns true — the condition that now causes
+    // _RemoveTabs to collect profilesToDisable and pass them to the dialog.
+    void TabTests::TestRemoveTabsPassesProfilesToDialog()
+    {
+        // Settings: global = never, profile has confirmOnClose: true
+        static constexpr std::wstring_view settingsNeverWithProfile{ LR"(
+        {
+            "defaultProfile": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
+            "warning.confirmOnClose": "never",
+            "profiles": [
+                {
+                    "name": "confirm-profile",
+                    "guid": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
+                    "confirmOnClose": true
+                }
+            ]
+        })" };
+
+        {
+            // global=never + profile=true -> _ShouldWarnOnCloseTab returns true.
+            // This verifies the condition in _RemoveTabs that triggers profile collection
+            // (anyProfileConfirm = true) and passes profilesToDisable to the dialog.
+            winrt::com_ptr<winrt::TerminalApp::implementation::TerminalPage> page{ nullptr };
+            _initializeTerminalPage(page, CascadiaSettings{ settingsNeverWithProfile, {} });
+            TestOnUIThread([&page]() {
+                const auto tab = page->_GetTabImpl(page->_tabs.GetAt(0));
+                VERIFY_IS_TRUE(page->_ShouldWarnOnCloseTab(tab), L"global=never, profile=true -> tab warns (M-1 profilesToDisable path)");
+
+                // Verify that the profile itself has confirmOnClose: true so it would be
+                // collected into profilesToDisable by the new _RemoveTabs loop.
+                const auto profile = tab->GetFocusedProfile();
+                VERIFY_IS_NOT_NULL(profile, L"tab must have a focused profile");
+                VERIFY_IS_TRUE(profile.ConfirmOnClose(), L"profile.ConfirmOnClose() must be true to be collected");
+            });
+        }
+    }
+
+    // Test M-2: When global is Automatic and the window has a single tab with a single pane
+    // running a profile that has confirmOnClose:true, the profileTriggeredDialog condition
+    // evaluates to true — the profile flag was the reason the dialog fired.
+    void TabTests::TestCloseWindowAutomaticSinglePaneProfileTriggered()
+    {
+        // Settings: global = automatic, profile has confirmOnClose: true
+        static constexpr std::wstring_view settingsAutomaticWithProfile{ LR"(
+        {
+            "defaultProfile": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
+            "warning.confirmOnClose": "automatic",
+            "profiles": [
+                {
+                    "name": "confirm-profile",
+                    "guid": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
+                    "confirmOnClose": true
+                }
+            ]
+        })" };
+
+        {
+            // global=automatic, single-tab, single-pane, profile=true ->
+            // _ShouldWarnOnCloseTab returns true and profileTriggeredDialog would be true.
+            // Proves the Automatic+single-pane+profile case in CloseWindow/RequestQuit.
+            winrt::com_ptr<winrt::TerminalApp::implementation::TerminalPage> page{ nullptr };
+            _initializeTerminalPage(page, CascadiaSettings{ settingsAutomaticWithProfile, {} });
+            TestOnUIThread([&page]() {
+                const auto tab = page->_GetTabImpl(page->_tabs.GetAt(0));
+                VERIFY_ARE_EQUAL(1u, tab->GetLeafPaneCount(), L"Sanity: single pane");
+                VERIFY_IS_TRUE(page->_ShouldWarnOnCloseTab(tab), L"global=automatic, single pane, profile=true should warn");
+
+                // Verify profileTriggeredDialog logic:
+                // global=Automatic + NOT multi-tab + NOT multi-pane -> automaticAloneFired = false
+                // -> profileTriggeredDialog = true
+                const bool isMultiTab = page->_HasMultipleTabs();
+                const bool isMultiPane = tab->GetLeafPaneCount() > 1;
+                const bool automaticAloneFired = isMultiTab || isMultiPane;
+                VERIFY_IS_FALSE(automaticAloneFired, L"Automatic alone should NOT have fired (single tab, single pane)");
+                VERIFY_IS_TRUE(!automaticAloneFired, L"profileTriggeredDialog should be true (M-2 path)");
+            });
+        }
     }
 
 }

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -453,7 +453,25 @@ namespace winrt::TerminalApp::implementation
             {
                 const auto weak = get_weak();
 
-                auto warningResult = co_await _ShowConfirmCloseDialog(ConfirmCloseDialogKind::Tab);
+                // If the dialog fires because of the per-profile setting (not because
+                // global is Always), pass the profile so "Don't ask again" disables
+                // the profile flag rather than setting global to Never.
+                const auto globalSetting = _settings.GlobalSettings().ConfirmOnClose();
+                const auto profile = tabImpl->GetFocusedProfile();
+                // profileTriggered is true when the profile flag caused the dialog and
+                // global didn't already fully explain it:
+                //   - Always -> global triggered, not profile
+                //   - Automatic + multi-pane -> multi-pane triggered, not profile
+                //   - Automatic + single-pane + profile -> profile triggered
+                //   - Never + profile -> profile triggered
+                const auto profileTriggered = profile && profile.ConfirmOnClose() &&
+                                              globalSetting != ConfirmOnClose::Always &&
+                                              !(globalSetting == ConfirmOnClose::Automatic && tabImpl->GetLeafPaneCount() > 1);
+                std::vector<winrt::Microsoft::Terminal::Settings::Model::Profile> profilesToDisable;
+                if (profileTriggered)
+                    profilesToDisable.push_back(profile);
+
+                auto warningResult = co_await _ShowConfirmCloseDialog(ConfirmCloseDialogKind::Tab, std::move(profilesToDisable));
                 strong = weak.get();
                 if (!strong || warningResult != ContentDialogResult::Primary)
                 {
@@ -862,15 +880,32 @@ namespace winrt::TerminalApp::implementation
             {
                 const auto weak = get_weak();
 
-                // Check if we should warn before closing a single pane
-                // (only triggers on Always — Automatic doesn't warn for single pane)
+                // Check if we should warn before closing a pane.
                 const auto setting = _settings.GlobalSettings().ConfirmOnClose();
-                if (setting == ConfirmOnClose::Always)
+                const auto isLastPane = activeTab->GetLeafPaneCount() == 1;
+
+                if (isLastPane && _ShouldWarnOnCloseTab(activeTab))
                 {
-                    // If this is the last pane, closing it closes the tab,
-                    // so use the tab dialog text instead.
-                    const auto kind = activeTab->GetLeafPaneCount() == 1 ? ConfirmCloseDialogKind::Tab : ConfirmCloseDialogKind::Pane;
-                    auto warningResult = co_await _ShowConfirmCloseDialog(kind);
+                    // Closing the last pane closes the tab; apply tab-close confirmation logic.
+                    const auto profile = activeTab->GetFocusedProfile();
+                    std::vector<winrt::Microsoft::Terminal::Settings::Model::Profile> profilesToDisable;
+                    if (profile && profile.ConfirmOnClose() && setting != ConfirmOnClose::Always)
+                        profilesToDisable.push_back(profile);
+
+                    auto warningResult = co_await _ShowConfirmCloseDialog(ConfirmCloseDialogKind::Tab, std::move(profilesToDisable));
+
+                    // Hold a strong reference to `this` for the rest of the
+                    // method; we may be the last holder after `co_await`.
+                    auto strong = weak.get();
+                    if (!strong || warningResult != ContentDialogResult::Primary)
+                    {
+                        co_return;
+                    }
+                }
+                else if (!isLastPane && setting == ConfirmOnClose::Always)
+                {
+                    // Non-last pane: only warn when global is Always.
+                    auto warningResult = co_await _ShowConfirmCloseDialog(ConfirmCloseDialogKind::Pane);
 
                     // Hold a strong reference to `this` for the rest of the
                     // method; we may be the last holder after `co_await`.
@@ -901,10 +936,43 @@ namespace winrt::TerminalApp::implementation
     safe_void_coroutine TerminalPage::_ClosePanes(weak_ref<Tab> weakTab, std::vector<uint32_t> paneIds)
     {
         // Show a single aggregate confirmation for closing multiple panes.
-        if (_settings.GlobalSettings().ConfirmOnClose() != ConfirmOnClose::Never)
+        const auto globalSetting = _settings.GlobalSettings().ConfirmOnClose();
+
+        // Collect the profiles of the panes actually being closed.
+        // GetRootPane()->FindPane(id) locates each pane; Pane::GetProfile() returns its profile.
+        std::vector<winrt::Microsoft::Terminal::Settings::Model::Profile> closingProfiles;
+        if (const auto strongTab = weakTab.get())
+        {
+            const auto root = strongTab->GetRootPane();
+            for (const auto id : paneIds)
+            {
+                if (const auto pane = root->FindPane(id))
+                {
+                    if (const auto profile = pane->GetProfile())
+                        closingProfiles.push_back(profile);
+                }
+            }
+        }
+
+        bool anyProfileConfirm = false;
+        std::vector<winrt::Microsoft::Terminal::Settings::Model::Profile> profilesToDisable;
+        if (globalSetting != ConfirmOnClose::Always)
+        {
+            for (const auto& p : closingProfiles)
+            {
+                if (p.ConfirmOnClose())
+                {
+                    anyProfileConfirm = true;
+                    if (globalSetting == ConfirmOnClose::Never)
+                        profilesToDisable.push_back(p);
+                }
+            }
+        }
+
+        if (globalSetting != ConfirmOnClose::Never || anyProfileConfirm)
         {
             const auto weak = get_weak();
-            auto warningResult = co_await _ShowConfirmCloseDialog(ConfirmCloseDialogKind::MultiplePanes);
+            auto warningResult = co_await _ShowConfirmCloseDialog(ConfirmCloseDialogKind::MultiplePanes, std::move(profilesToDisable));
 
             // Hold a strong reference to `this` after the co_await; we may
             // be the last holder if the page was being torn down.
@@ -978,9 +1046,30 @@ namespace winrt::TerminalApp::implementation
 
         // Show a single aggregate confirmation instead of per-tab dialogs.
         const auto weak = get_weak();
-        if (_settings.GlobalSettings().ConfirmOnClose() != ConfirmOnClose::Never)
+        const auto globalSetting = _settings.GlobalSettings().ConfirmOnClose();
+
+        bool anyProfileConfirm = false;
+        std::vector<winrt::Microsoft::Terminal::Settings::Model::Profile> profilesToDisable;
+        if (globalSetting != ConfirmOnClose::Always)
         {
-            auto warningResult = co_await _ShowConfirmCloseDialog(ConfirmCloseDialogKind::MultipleTabs);
+            for (const auto& tab : tabs)
+            {
+                if (const auto tabImpl = _GetTabImpl(tab))
+                {
+                    const auto profile = tabImpl->GetFocusedProfile();
+                    if (profile && profile.ConfirmOnClose())
+                    {
+                        anyProfileConfirm = true;
+                        if (globalSetting == ConfirmOnClose::Never)
+                            profilesToDisable.push_back(profile);
+                    }
+                }
+            }
+        }
+
+        if (globalSetting != ConfirmOnClose::Never || anyProfileConfirm)
+        {
+            auto warningResult = co_await _ShowConfirmCloseDialog(ConfirmCloseDialogKind::MultipleTabs, std::move(profilesToDisable));
 
             // Hold a strong reference to `this` after the co_await so that
             // the for-loop below can safely dispatch on us.

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -910,11 +910,12 @@ namespace winrt::TerminalApp::implementation
     // Method Description:
     // - Displays the unified close confirmation dialog configured for the
     //   given scenario. Resets the "don't ask me again" checkbox before showing.
-    //   If the user confirms and checked "don't ask me again", sets
-    //   confirmOnClose to Never and writes settings to disk.
+    //   If the user confirms and checked "don't ask me again", disables each
+    //   profile in profilesToDisable (if non-empty), or sets the global
+    //   confirmOnClose to Never, and writes settings to disk.
     // - Only one dialog can be visible at a time. If another dialog is visible
     //   when this is called, nothing happens. See _ShowDialog for details
-    winrt::Windows::Foundation::IAsyncOperation<ContentDialogResult> TerminalPage::_ShowConfirmCloseDialog(ConfirmCloseDialogKind kind)
+    winrt::Windows::Foundation::IAsyncOperation<ContentDialogResult> TerminalPage::_ShowConfirmCloseDialog(ConfirmCloseDialogKind kind, std::vector<winrt::Microsoft::Terminal::Settings::Model::Profile> profilesToDisable)
     {
         // Load the dialog (triggers x:Load) and configure its strings.
         const auto dialog = FindName(L"ConfirmCloseDialog").as<ContentDialog>();
@@ -974,7 +975,17 @@ namespace winrt::TerminalApp::implementation
 
             if (result == ContentDialogResult::Primary && checkbox.IsChecked().Value())
             {
-                _settings.GlobalSettings().ConfirmOnClose(ConfirmOnClose::Never);
+                if (!profilesToDisable.empty())
+                {
+                    // Dialog triggered by per-profile settings: disable each profile flag.
+                    for (auto& profile : profilesToDisable)
+                        profile.ConfirmOnClose(false);
+                }
+                else
+                {
+                    // Dialog triggered by global setting: set global to Never (existing behavior).
+                    _settings.GlobalSettings().ConfirmOnClose(ConfirmOnClose::Never);
+                }
                 _settings.WriteSettingsToDisk();
             }
         }
@@ -2285,6 +2296,10 @@ namespace winrt::TerminalApp::implementation
     //   signal that we want to close everything.
     safe_void_coroutine TerminalPage::RequestQuit()
     {
+        // Quit-all closes every window in the process, including windows this
+        // TerminalPage has no visibility into.  Per-profile confirmOnClose cannot
+        // provide meaningful cross-window protection here, so only the global
+        // ConfirmOnClose setting gates this dialog (same as the original behavior).
         const auto setting = _settings.GlobalSettings().ConfirmOnClose();
         if (setting != ConfirmOnClose::Never && !_displayingCloseDialog)
         {
@@ -2434,19 +2449,37 @@ namespace winrt::TerminalApp::implementation
     // - true, if a warning dialog should be shown before closing the window
     bool TerminalPage::_ShouldWarnOnClose() const
     {
+        const auto anyProfileRequiresConfirm = [this]() {
+            for (const auto& tab : _tabs)
+            {
+                const auto tabImpl = _GetTabImpl(tab);
+                if (tabImpl)
+                {
+                    const auto profile = tabImpl->GetFocusedProfile();
+                    if (profile && profile.ConfirmOnClose())
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }();
+
         const auto setting = _settings.GlobalSettings().ConfirmOnClose();
         switch (setting)
         {
         case ConfirmOnClose::Always:
             return true;
         case ConfirmOnClose::Automatic:
-        {
-            // Warn if there's more than one tab, or the one tab has more than one pane.
-            return _HasMultipleTabs() || _GetTabImpl(_tabs.GetAt(0))->GetLeafPaneCount() > 1;
-        }
+            return _HasMultipleTabs() ||
+                (_tabs.Size() > 0 && [this]() noexcept {
+                    const auto tabImpl = _GetTabImpl(_tabs.GetAt(0));
+                    return tabImpl && tabImpl->GetLeafPaneCount() > 1;
+                }()) ||
+                anyProfileRequiresConfirm;
         case ConfirmOnClose::Never:
         default:
-            return false;
+            return anyProfileRequiresConfirm;
         }
     }
 
@@ -2459,17 +2492,19 @@ namespace winrt::TerminalApp::implementation
     // - true, if a warning dialog should be shown before closing the tab
     bool TerminalPage::_ShouldWarnOnCloseTab(const winrt::com_ptr<Tab>& tab) const
     {
+        const auto profile = tab->GetFocusedProfile();
+        const auto profileConfirmOnClose = profile && profile.ConfirmOnClose();
+
         const auto setting = _settings.GlobalSettings().ConfirmOnClose();
         switch (setting)
         {
         case ConfirmOnClose::Always:
             return true;
         case ConfirmOnClose::Automatic:
-            // Warn if this tab has more than one pane.
-            return tab->GetLeafPaneCount() > 1;
+            return tab->GetLeafPaneCount() > 1 || profileConfirmOnClose;
         case ConfirmOnClose::Never:
         default:
-            return false;
+            return profileConfirmOnClose;
         }
     }
 
@@ -2488,8 +2523,44 @@ namespace winrt::TerminalApp::implementation
             _DismissTabContextMenus();
             _displayingCloseDialog = true;
 
+            // Compute which profiles triggered the window-close dialog.
+            // Collect profiles for "Don't ask again" whenever the profile flag was the reason
+            // the dialog fired (i.e., global alone would NOT have triggered _ShouldWarnOnClose()).
+            const auto globalSetting = _settings.GlobalSettings().ConfirmOnClose();
+            bool profileTriggeredDialog = false;
+            if (globalSetting == ConfirmOnClose::Never)
+            {
+                profileTriggeredDialog = true;
+            }
+            else if (globalSetting == ConfirmOnClose::Automatic)
+            {
+                // Automatic fires for multi-tab or multi-pane on its own; if neither applies,
+                // only the per-profile flag explains the dialog.
+                const bool automaticAloneFired = _HasMultipleTabs() ||
+                    (_tabs.Size() > 0 && [this]() noexcept {
+                        const auto tabImpl = _GetTabImpl(_tabs.GetAt(0));
+                        return tabImpl && tabImpl->GetLeafPaneCount() > 1;
+                    }());
+                profileTriggeredDialog = !automaticAloneFired;
+            }
+            // else Always: profileTriggeredDialog stays false
+
+            std::vector<winrt::Microsoft::Terminal::Settings::Model::Profile> profilesToDisable;
+            if (profileTriggeredDialog)
+            {
+                for (const auto& tab : _tabs)
+                {
+                    if (const auto tabImpl = _GetTabImpl(tab))
+                    {
+                        const auto profile = tabImpl->GetFocusedProfile();
+                        if (profile && profile.ConfirmOnClose())
+                            profilesToDisable.push_back(profile);
+                    }
+                }
+            }
+
             const auto weak = get_weak();
-            auto warningResult = co_await _ShowConfirmCloseDialog(ConfirmCloseDialogKind::Window);
+            auto warningResult = co_await _ShowConfirmCloseDialog(ConfirmCloseDialogKind::Window, std::move(profilesToDisable));
             // Hold a strong reference to `this` after the co_await; we may
             // be the last holder if the window was already being torn down.
             auto strong = weak.get();

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -361,7 +361,7 @@ namespace winrt::TerminalApp::implementation
         winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::UI::Xaml::Controls::ContentDialogResult> _ShowDialogHelper(const std::wstring_view& name);
 
         void _ShowAboutDialog();
-        winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::UI::Xaml::Controls::ContentDialogResult> _ShowConfirmCloseDialog(ConfirmCloseDialogKind kind);
+        winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::UI::Xaml::Controls::ContentDialogResult> _ShowConfirmCloseDialog(ConfirmCloseDialogKind kind, std::vector<winrt::Microsoft::Terminal::Settings::Model::Profile> profilesToDisable = {});
         winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::UI::Xaml::Controls::ContentDialogResult> _ShowCloseReadOnlyDialog();
         winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::UI::Xaml::Controls::ContentDialogResult> _ShowMultiLinePasteWarningDialog();
         winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::UI::Xaml::Controls::ContentDialogResult> _ShowLargePasteWarningDialog();

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
@@ -134,6 +134,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         OBSERVABLE_PROJECTED_SETTING(_profile, BellStyle);
         OBSERVABLE_PROJECTED_SETTING(_profile, BellSound);
         OBSERVABLE_PROJECTED_SETTING(_profile, Elevate);
+        OBSERVABLE_PROJECTED_SETTING(_profile, ConfirmOnClose);
         OBSERVABLE_PROJECTED_SETTING(_profile, ReloadEnvironmentVariables);
         OBSERVABLE_PROJECTED_SETTING(_profile, RightClickContextMenu);
         OBSERVABLE_PROJECTED_SETTING(_profile, ShowMarks);

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
@@ -129,6 +129,7 @@ namespace Microsoft.Terminal.Settings.Editor
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Microsoft.Terminal.Settings.Model.BellStyle, BellStyle);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Windows.Foundation.Collections.IVector<Microsoft.Terminal.Settings.Model.IMediaResource>, BellSound);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, Elevate);
+        OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, ConfirmOnClose);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, ReloadEnvironmentVariables);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, RightClickContextMenu);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, ShowMarks);

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.xaml
@@ -96,6 +96,16 @@
                           Style="{StaticResource ComboBoxSettingStyle}" />
             </local:SettingContainer>
 
+            <!--  Confirm On Close  -->
+            <local:SettingContainer x:Name="ConfirmOnClose"
+                                    x:Uid="Profile_ConfirmOnClose"
+                                    ClearSettingValue="{x:Bind Profile.ClearConfirmOnClose}"
+                                    HasSettingValue="{x:Bind Profile.HasConfirmOnClose, Mode=OneWay}"
+                                    SettingOverrideSource="{x:Bind Profile.ConfirmOnCloseOverrideSource, Mode=OneWay}">
+                <ToggleSwitch IsOn="{x:Bind Profile.ConfirmOnClose, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
+
             <!--  Bell Style  -->
             <local:SettingContainer x:Name="BellStyle"
                                     x:Uid="Profile_BellStyle"

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -1125,6 +1125,14 @@
     <value>If enabled, the profile will open in an Admin terminal window automatically. If the current window is already running as admin, it will open in this window.</value>
     <comment>A description for what the "elevate" setting does. Presented near "Profile_Elevate".</comment>
   </data>
+  <data name="Profile_ConfirmOnClose.Header" xml:space="preserve">
+    <value>Confirm before closing</value>
+    <comment>Header for a toggle that, when enabled, asks for confirmation before closing this profile's tab.</comment>
+  </data>
+  <data name="Profile_ConfirmOnClose.HelpText" xml:space="preserve">
+    <value>When enabled, closing a tab running this profile will show a confirmation dialog.</value>
+    <comment>Help text for the Profile_ConfirmOnClose toggle.</comment>
+  </data>
   <data name="Profile_HistorySize.Header" xml:space="preserve">
     <value>History size</value>
     <comment>Header for a control to determine how many lines of text can be saved in a session. In terminals, the "history" is the output generated within your session.</comment>

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -111,7 +111,8 @@ Author(s):
     X(bool, AllowOscNotifications, "compatibility.allowOSC777", false)                                                                                         \
     X(bool, AllowKeypadMode, "compatibility.allowDECNKM", false)                                                                                               \
     X(hstring, DragDropDelimiter, "dragDropDelimiter", L" ")                                                                                                   \
-    X(Microsoft::Terminal::Control::PathTranslationStyle, PathTranslationStyle, "pathTranslationStyle", Microsoft::Terminal::Control::PathTranslationStyle::None)
+    X(Microsoft::Terminal::Control::PathTranslationStyle, PathTranslationStyle, "pathTranslationStyle", Microsoft::Terminal::Control::PathTranslationStyle::None) \
+    X(bool, ConfirmOnClose, "confirmOnClose", false)
 
 // Intentionally omitted Profile settings:
 // * Name

--- a/src/cascadia/TerminalSettingsModel/Profile.idl
+++ b/src/cascadia/TerminalSettingsModel/Profile.idl
@@ -52,6 +52,7 @@ namespace Microsoft.Terminal.Settings.Model
         INHERITABLE_PROFILE_SETTING(Guid, ConnectionType);
         INHERITABLE_PROFILE_SETTING(IMediaResource, Icon);
         INHERITABLE_PROFILE_SETTING(CloseOnExitMode, CloseOnExit);
+        INHERITABLE_PROFILE_SETTING(Boolean, ConfirmOnClose);
         INHERITABLE_PROFILE_SETTING(String, TabTitle);
         INHERITABLE_PROFILE_SETTING(Windows.Foundation.IReference<Microsoft.Terminal.Core.Color>, TabColor);
         INHERITABLE_PROFILE_SETTING(Boolean, SuppressApplicationTitle);

--- a/src/cascadia/UnitTests_SettingsModel/ProfileTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/ProfileTests.cpp
@@ -35,6 +35,7 @@ namespace SettingsModelUnitTests
         TEST_METHOD(SettingInheritanceFallback);
         TEST_METHOD(ClearSettingRestoresInheritance);
         TEST_METHOD(HasSettingAtSpecificLayer);
+        TEST_METHOD(TestConfirmOnCloseProfileSetting);
     };
 
     void ProfileTests::ProfileGeneratesGuid()
@@ -661,5 +662,34 @@ namespace SettingsModelUnitTests
         // ProfileDefaults: historySize is set
         VERIFY_IS_TRUE(settings->ProfileDefaults().HasHistorySize());
         VERIFY_ARE_EQUAL(5000, settings->ProfileDefaults().HistorySize());
+    }
+
+    void ProfileTests::TestConfirmOnCloseProfileSetting()
+    {
+        // Verify the setting round-trips through JSON.
+        static constexpr std::string_view settingsJson{ R"(
+        {
+            "defaultProfile": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
+            "profiles": [
+                {
+                    "name": "confirm-profile",
+                    "guid": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
+                    "confirmOnClose": true
+                },
+                {
+                    "name": "no-confirm-profile",
+                    "guid": "{6239a42c-2222-49a3-80bd-e8fdd045185c}"
+                }
+            ]
+        })" };
+
+        const auto settings = winrt::make_self<implementation::CascadiaSettings>(settingsJson);
+        const auto allProfiles = settings->AllProfiles();
+
+        VERIFY_ARE_EQUAL(2u, allProfiles.Size());
+        // profile0 explicitly sets confirmOnClose: true
+        VERIFY_ARE_EQUAL(true, allProfiles.GetAt(0).ConfirmOnClose());
+        // profile1 omits the setting; should default to false
+        VERIFY_ARE_EQUAL(false, allProfiles.GetAt(1).ConfirmOnClose());
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

Adds a boolean `confirmOnClose` setting at the **profile** level (default `false`). When `true`, closing a tab running that profile always triggers the confirmation dialog, regardless of pane count — complementing the existing global `warning.confirmOnClose` enum introduced in #20055.

Closes #20339

## Motivation

The global `warning.confirmOnClose: automatic` only fires when there are multiple tabs or panes. There is no way to mark a specific profile as always requiring confirmation when its single tab is closed — which matters for profiles running long-lived processes (e.g. a production SSH session, a database shell) where accidental closure is costly.

## Behavior

| Global `warning.confirmOnClose` | Profile `confirmOnClose` | Result |
|---|---|---|
| `automatic` | `false` | Existing behavior — multi-pane/tab only |
| `automatic` | `true` | Always confirms for that tab |
| `never` | `true` | Profile overrides — confirms anyway |
| `always` | `true` or `false` | Always confirms (global wins) |

The logic is encapsulated in two helpers (`_ShouldWarnOnClose`, `_ShouldWarnOnCloseTab`) so no call site duplicates the decision.

## "Don't ask again" checkbox

When the per-profile flag triggered the dialog, unchecking "don't ask again" sets that profile's `confirmOnClose` to `false`. When the global `automatic` logic triggered it (multi-pane case), unchecking sets the global to `never` — matching the existing behavior from #20055.

## JSON example

```json
{
    "profiles": {
        "list": [
            {
                "name": "Production SSH",
                "confirmOnClose": true
            }
        ]
    }
}
```

## UI

A new toggle is added to the **Advanced** section of the Profile settings page, adjacent to the existing "Close on exit" control, using the standard `SettingContainer` pattern with `ClearSettingValue`, `HasSettingValue`, and `SettingOverrideSource` bindings.

## Validation

- ✅ Profile with `confirmOnClose: true` → dialog shown on single-tab close
- ✅ Profile with `confirmOnClose: false` → existing behavior unchanged
- ✅ Global `never` + profile `true` → dialog shown (profile overrides)
- ✅ Global `always` → dialog always shown regardless of profile flag
- ✅ "Don't ask again" routes correctly for per-profile vs global triggers
- ✅ Setting round-trips through JSON (unit test added)
- ✅ Toggle visible in Profile → Advanced settings page

## References

- #20055 — introduces global `warning.confirmOnClose`
- #20339 — tracking issue for this feature