### PR TITLE
Add Tango Solarized Dark color scheme

### DIFF
--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -441,6 +441,29 @@
             "selectionBackground": "#FFFFFF",
             "white": "#AAAAAA",
             "yellow": "#C47E00"
+        },
+        {
+            "name": "Tango Solarized Dark",
+            "foreground": "#839496",
+            "background": "#002B36",
+            "cursorColor": "#808080",
+            "selectionBackground": "#808080",
+            "black": "#2E3436",
+            "red": "#CC0000",
+            "green": "#4E9A06",
+            "yellow": "#C4A000",
+            "blue": "#3465A4",
+            "purple": "#75507B",
+            "cyan": "#06989A",
+            "white": "#D3D7CF",
+            "brightBlack": "#555753",
+            "brightRed": "#EF2929",
+            "brightGreen": "#8AE234",
+            "brightYellow": "#FCE94F",
+            "brightBlue": "#729FCF",
+            "brightPurple": "#AD7FA8",
+            "brightCyan": "#34E2E2",
+            "brightWhite": "#EEEEEC"
         }
     ],
     "themes": [


### PR DESCRIPTION
## Summary of the Pull Request
Adds the Tango Solarized Dark color scheme, a dark theme with balanced colors that is easier on the eyes.

## References and Relevant Issues
N/A

## Detailed Description of the Pull Request / Additional comments
This adds the `Tango+Solarized dark` color scheme directly to the `defaults.json` file.
Added to Docs in https://github.com/MicrosoftDocs/terminal/pull/957

## Validation Steps Performed
Tested locally to ensure the JSON is valid.

## PR Checklist
- [ ] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: MicrosoftDocs/terminal#957
- [ ] Schema updated (if necessary)