### PR TITLE
Fix memory leak in scrolled-up position by ignoring UIA output notifi…

### DIFF
--- a/src/cascadia/TerminalControl/TermControlAutomationPeer.cpp
+++ b/src/cascadia/TerminalControl/TermControlAutomationPeer.cpp
@@ -211,6 +211,14 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     void TermControlAutomationPeer::NotifyNewOutput(std::wstring_view newOutput)
     {
+        if (auto control{ _termControl.get() })
+        {
+            if (control->ScrollOffset() > 0)
+            {
+                return;
+            }
+        }
+
         auto sanitized{ Sanitize(newOutput) };
         // Try to suppress any events (or event data)
         // that are just the keypresses that the user made


### PR DESCRIPTION
# Fix Explanation: Massive Memory Leak in Scrolled-Up Position (Issue #20342)

## 1. The Problem
When a console program runs in Windows Terminal and outputs text at a high rate while the terminal is in a scrolled-up position (viewing history, not locked to the bottom), the application consumes a massive amount of system memory (reaching gigabytes). 

When the user attempts to scroll back down or interact with the terminal, the UI freezes for a long delay before releasing the accumulated memory and returning to normal.

---

## 2. Root Cause Analysis
1. **High-Frequency UIA Events:** When new output is written to the terminal buffer, `UiaEngine::NotifyNewText` is called. If UI Automation (UIA) is active (e.g., due to Narrator, NVDA, or standard Windows accessibility features), it calls `NotifyNewOutput`.
2. **Asynchronous Thread Dispatching:** In `TermControlAutomationPeer::NotifyNewOutput`, the terminal schedules UIA notification events on the UI thread's dispatcher using `dispatcher.RunAsync(...)`.
3. **Queue Overflow:** Raising a UIA notification event (`RaiseNotificationEvent`) involves cross-process COM calls, which are relatively slow. Under high-frequency output, the background render thread posts lambdas to the UI dispatcher queue much faster than the UI thread can process them.
4. **Memory Accumulation:** Each posted lambda closure captures a copy of the new output text string. Because they cannot be processed as fast as they are queued, the dispatcher queue grows indefinitely, causing the massive memory leak.
5. **UI Freeze:** When the user scrolls back down, the UI thread has to process and drain the backlog of millions of queued lambdas, causing the long delay. Once the backlog is processed and the lambdas are destroyed, the memory is finally freed.

---

## 3. The Solution
We added a check in `TermControlAutomationPeer::NotifyNewOutput` to return immediately and bypass event queuing if the terminal is currently in a scrolled-up position:

```cpp
    void TermControlAutomationPeer::NotifyNewOutput(std::wstring_view newOutput)
    {
        if (auto control{ _termControl.get() })
        {
            if (control->ScrollOffset() > 0)
            {
                return;
            }
        }

        auto sanitized{ Sanitize(newOutput) };
        ...
```

### Why this is correct:
- **Prevents Memory & Queue Bloat:** When scrolled up, new output notifications are discarded, preventing the dispatcher queue from growing.
- **Usability & Accessibility Best Practices:** When a screen reader user scrolls up to read terminal history, they do not want to be interrupted by announcements of new off-screen text printed at the bottom of the buffer. Announcing off-screen text in this state is confusing.
- **Auto-Restores on Scroll Down:** As soon as the user scrolls back to the bottom, `ScrollOffset()` becomes `0`, and new output notifications are processed and announced normally.

