### PR TITLE
Pre-warm SHGetKnownFolderPath before XAML App construction to avoid a GPU-driver loader-lock deadlock at startup

### DIFF
--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -545,40 +545,9 @@ void WindowEmperor::HandleCommandlineArgs(int nCmdShow)
     }
 
     // !! LOAD BEARING !!
-    // Resolve the settings folder path *before* we construct the XAML App, while
-    // this thread is still the only one touching the Known Folders machinery.
-    // GetBaseSettingsPath() caches its result, but the very first call goes through
-    // SHGetKnownFolderPath(), which has to delay-load
-    // api-ms-win-shlwapi-winrt-storage and populate the shell's Known Folders cache
-    // (taking that cache's lock as it does so).
-    //
-    // Constructing TerminalApp::App{} below brings up XAML, which spins up a
-    // graphics-device-init thread that creates a D3D device and loads the GPU's
-    // user-mode driver. On some machines (observed with NVIDIA's UMD) that driver's
-    // DllMain itself calls SHGetKnownFolderPath while holding the loader lock. If
-    // our first SHGetKnownFolderPath - which today happens later, in the AppLogic
-    // ctor's _setupFolderPathEnvVar - runs concurrently with that, we deadlock:
-    //   * our thread holds the Known Folders cache lock and is blocked in the loader
-    //     waiting for the delay-load to finish, while
-    //   * the driver's DllMain holds the loader lock and is blocked waiting for the
-    //     Known Folders cache lock.
-    // The process then hangs before any window is shown. Because that hung process
-    // is the monarch, it silently swallows every subsequent launch until it is
-    // killed, which is why "Open in Terminal" intermittently does nothing after a
-    // cold boot. See GH#20348.
-    //
-    // Warming the path here resolves the delay-load and populates the cache before
-    // that graphics thread can exist, so the lock-ordering inversion can't form.
-    // Both effects are permanent and process-wide - LdrResolveDelayLoadedAPI patches
-    // the IAT thunk exactly once, and the Known Folders definition-cache load is
-    // FOLDERID-independent and runs once - so no later SHGetKnownFolderPath (on any
-    // thread, for any folder) re-enters the loader while holding the cache lock.
-    // This call is therefore NOT dead code; please don't "clean it up."
-    //
-    // Caveat: in portable mode GetBaseSettingsPath() returns without calling
-    // SHGetKnownFolderPath at all, so this is a no-op there. The reported repro is a
-    // default, non-portable install; a portable + buggy-driver combo would need the
-    // warm-up routed through a path that always hits SHGetKnownFolderPath.
+    // This prevents loader lock contention with some versions of the nvidia
+    // driver, which calls SHGetKnownFolderPath triggering a delay load while
+    // under lock during application startup. See GH#20348.
     std::ignore = CascadiaSettings::SettingsPath();
 
     _app = winrt::TerminalApp::App{};

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -544,6 +544,43 @@ void WindowEmperor::HandleCommandlineArgs(int nCmdShow)
         __assume(false);
     }
 
+    // !! LOAD BEARING !!
+    // Resolve the settings folder path *before* we construct the XAML App, while
+    // this thread is still the only one touching the Known Folders machinery.
+    // GetBaseSettingsPath() caches its result, but the very first call goes through
+    // SHGetKnownFolderPath(), which has to delay-load
+    // api-ms-win-shlwapi-winrt-storage and populate the shell's Known Folders cache
+    // (taking that cache's lock as it does so).
+    //
+    // Constructing TerminalApp::App{} below brings up XAML, which spins up a
+    // graphics-device-init thread that creates a D3D device and loads the GPU's
+    // user-mode driver. On some machines (observed with NVIDIA's UMD) that driver's
+    // DllMain itself calls SHGetKnownFolderPath while holding the loader lock. If
+    // our first SHGetKnownFolderPath - which today happens later, in the AppLogic
+    // ctor's _setupFolderPathEnvVar - runs concurrently with that, we deadlock:
+    //   * our thread holds the Known Folders cache lock and is blocked in the loader
+    //     waiting for the delay-load to finish, while
+    //   * the driver's DllMain holds the loader lock and is blocked waiting for the
+    //     Known Folders cache lock.
+    // The process then hangs before any window is shown. Because that hung process
+    // is the monarch, it silently swallows every subsequent launch until it is
+    // killed, which is why "Open in Terminal" intermittently does nothing after a
+    // cold boot. See GH#20348.
+    //
+    // Warming the path here resolves the delay-load and populates the cache before
+    // that graphics thread can exist, so the lock-ordering inversion can't form.
+    // Both effects are permanent and process-wide - LdrResolveDelayLoadedAPI patches
+    // the IAT thunk exactly once, and the Known Folders definition-cache load is
+    // FOLDERID-independent and runs once - so no later SHGetKnownFolderPath (on any
+    // thread, for any folder) re-enters the loader while holding the cache lock.
+    // This call is therefore NOT dead code; please don't "clean it up."
+    //
+    // Caveat: in portable mode GetBaseSettingsPath() returns without calling
+    // SHGetKnownFolderPath at all, so this is a no-op there. The reported repro is a
+    // default, non-portable install; a portable + buggy-driver combo would need the
+    // warm-up routed through a path that always hits SHGetKnownFolderPath.
+    std::ignore = CascadiaSettings::SettingsPath();
+
     _app = winrt::TerminalApp::App{};
     _app.Logic().ReloadSettings();
 


### PR DESCRIPTION
## Summary

On some machines (reproduced with an NVIDIA GPU), Windows Terminal intermittently hangs during startup **before any window is shown**. Because the hung process is the monarch, it then silently swallows every subsequent launch — so the visible symptom is **"Open in Terminal" doing nothing after a cold boot** until the stuck process is killed.

A full crash dump pins this to a classic ABBA lock-ordering inversion. This PR is a small, deterministic app-side mitigation.

Closes #20348.

## Root cause

Two locks are involved:

- **Lock A** — the shell's Known Folders cache critical section (`windows_storage!kfapi::CFolderDefinitionCache`).
- **Lock B** — the NT loader lock / loader work queue.

| Thread | Holds | Waits on |
| --- | --- | --- |
| **Main** (`wWinMain` → `HandleCommandlineArgs` → first `SHGetKnownFolderPath`) | **Lock A** | **Lock B** — blocked in `LdrpDrainWorkQueue` resolving the delay-load of `api-ms-win-shlwapi-winrt-storage` |
| **XAML graphics-device-init** (`TerminalApp::App{}` → `D3D11CreateDevice` → NVIDIA UMD `DllMain`) | **Lock B** | **Lock A** — blocked in `CFolderDefinitionCache::Load` |

`!locks` confirms the main thread owns the contended critsec, and both stacks resolve frame-for-frame:

- **Main:** `SHGetKnownFolderPath_Internal` → delay-load tailMerge of `api-ms-win-shlwapi-winrt-storage` → `LdrResolveDelayLoadedAPI` → `LdrpDrainWorkQueue` → `NtWaitForSingleObject`.
- **Graphics:** `D3D11CreateDevice` → `nvldumdx!OpenAdapter12` → `LoadLibraryExW` → `LdrpCallInitRoutine` → NVIDIA UMD `DllMain` → `SHGetKnownFolderPath_Internal` → `CFolderDefinitionCache::Load` → `RtlEnterCriticalSection` (blocked).

**The originating fault is in the GPU driver, not Terminal:** its user-mode driver calls `SHGetKnownFolderPath` from `DllMain` under the loader lock — a loader-lock violation. Terminal's only contribution is *timing*: it issues its **first** `SHGetKnownFolderPath` (the one that triggers the delay-load and populates the cold Known Folders cache) concurrently with XAML's graphics-init thread.

## Why it's intermittent

It only deadlocks when Terminal's first `SHGetKnownFolderPath` is in flight **at the same time** as the driver's `DllMain` runs on the XAML graphics thread, with a cold cache. After a cold boot the cache is cold and the delay-load unresolved, so the window is widest then; once warm, the race effectively disappears.

## The fix

Resolve the settings folder path — Terminal's first `SHGetKnownFolderPath` — once on the main thread, **after** command-line handoff and **before** constructing the XAML `App`:

```cpp
// !! LOAD BEARING !! (see full comment in the diff)
std::ignore = CascadiaSettings::SettingsPath();

_app = winrt::TerminalApp::App{};
```

## Why it works

Nothing before this line (STA init, the null `_app{ nullptr }` member, AUMID setup, `acquireMutexOrAttemptHandoff`) constructs XAML or spins a render/device thread — the graphics-device-init thread is born only from `TerminalApp::App{}` on the next line. By the time the warm-up returns:

1. **The delay-load is resolved** — `LdrResolveDelayLoadedAPI` patches the IAT thunk, a process-wide one-shot.
2. **The Known Folders definition cache is populated** — `CFolderDefinitionCache::Load` is FOLDERID-independent and runs once.

So when the driver's `DllMain` later takes the cache lock, no thread is holding it across a loader wait. The cycle cannot close.

## Scope / caveats

- This **mitigates a third-party `DllMain` loader-lock violation**; it doesn't fix the underlying inversion. It guarantees Terminal is no longer the racing party at startup.
- It is a **no-op in portable mode** (`GetBaseSettingsPath` returns early without calling `SHGetKnownFolderPath`). The reported repro is a default non-portable install; noted for completeness.
- The `std::ignore = CascadiaSettings::SettingsPath();` line is **load-bearing** — the in-source comment documents why.
