### PR TITLE
Pre-warm SHGetKnownFolder to avoid a deadlock in the nvidia driver

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -1139,7 +1139,7 @@ nullopts
 NUMSCROLL
 NUnit
 nupkg
-NVIDIA
+nvidia
 NVT
 OACR
 ocolor

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -550,7 +550,7 @@ void WindowEmperor::HandleCommandlineArgs(int nCmdShow)
     // under lock during application startup. See GH#20348.
     {
         wil::unique_cotaskmem_string localAppDataFolder;
-        SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &localAppDataFolder)
+        SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &localAppDataFolder);
     }
 
     _app = winrt::TerminalApp::App{};

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -544,6 +544,15 @@ void WindowEmperor::HandleCommandlineArgs(int nCmdShow)
         __assume(false);
     }
 
+    // !! LOAD BEARING !!
+    // This prevents loader lock contention with some versions of the nvidia
+    // driver, which calls SHGetKnownFolderPath triggering a delay load while
+    // under lock during application startup. See GH#20348.
+    {
+        wil::unique_cotaskmem_string localAppDataFolder;
+        SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &localAppDataFolder)
+    }
+
     _app = winrt::TerminalApp::App{};
     _app.Logic().ReloadSettings();
 

--- a/src/cascadia/WindowsTerminal/pch.h
+++ b/src/cascadia/WindowsTerminal/pch.h
@@ -32,6 +32,7 @@ Abstract:
 #include <shellscalingapi.h>
 #include <windowsx.h>
 #include <ShObjIdl.h>
+#include <shlobj_core.h>
 
 // Manually include til after we include Windows.Foundation to give it winrt superpowers
 #define BLOCK_TIL

--- a/src/host/ft_host/testmd.definition
+++ b/src/host/ft_host/testmd.definition
@@ -30,7 +30,7 @@
   "Plugins": [
     {
         "Type": "Microsoft.TestInfrastructure.UniversalTest.TestMD.Plugins.Etw.EtwPlugin",
-        "Name": "Collecting conhost logs during FTs",
+        "Name": "Collecting conhost logs during feature tests",
         "Parameters": {
             "$schema": "Microsoft.TestInfrastructure.UniversalTest.TestMD.Plugins.Etw.EtwPlugin-1.json",
             "Profiles": [


### PR DESCRIPTION
The nvidia driver attempts to use SHGetKnownFolder (which has its own lock!) under the loader lock, which occasionally triggers a deadlock when we attempt to do the same thing during settings load.

Closes #20350 (superseded)
Closes #20348
