### PR TITLE
Support folder paths for backgroundImage setting

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1020,10 +1020,59 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             return;
         }
 
+        auto imagePath = newAppearance.BackgroundImage();
+
+        // If the background image path is a directory, pick a random image from it.
+        // This allows users to set "backgroundImage" to a folder in settings.json
+        // and get a random image each time (including per split pane).
+        try
+        {
+            std::filesystem::path fsPath{ imagePath };
+            if (std::filesystem::is_directory(fsPath))
+            {
+                static constexpr std::wstring_view imageExtensions[] = {
+                    L".jpg", L".jpeg", L".png", L".bmp", L".gif", L".tiff", L".ico"
+                };
+                std::vector<std::wstring> imageFiles;
+                for (const auto& entry : std::filesystem::directory_iterator(fsPath))
+                {
+                    if (entry.is_regular_file())
+                    {
+                        auto ext = entry.path().extension().wstring();
+                        std::transform(ext.begin(), ext.end(), ext.begin(), ::towlower);
+                        for (const auto& validExt : imageExtensions)
+                        {
+                            if (ext == validExt)
+                            {
+                                imageFiles.push_back(entry.path().wstring());
+                                break;
+                            }
+                        }
+                    }
+                }
+                if (!imageFiles.empty())
+                {
+                    const auto idx = til::gen_random<size_t>() % imageFiles.size();
+                    imagePath = imageFiles[idx];
+                }
+                else
+                {
+                    BackgroundImage().Source(nullptr);
+                    return;
+                }
+            }
+        }
+        catch (...)
+        {
+            LOG_CAUGHT_EXCEPTION();
+            BackgroundImage().Source(nullptr);
+            return;
+        }
+
         Windows::Foundation::Uri imageUri{ nullptr };
         try
         {
-            imageUri = Windows::Foundation::Uri{ newAppearance.BackgroundImage() };
+            imageUri = Windows::Foundation::Uri{ imagePath };
         }
         catch (...)
         {

--- a/src/cascadia/TerminalControl/pch.h
+++ b/src/cascadia/TerminalControl/pch.h
@@ -74,6 +74,7 @@ TRACELOGGING_DECLARE_PROVIDER(g_hTerminalControlProvider);
 
 #include "til.h"
 #include <til/mutex.h>
+#include <til/rand.h>
 #include <til/winrt.h>
 
 #include <SafeDispatcherTimer.h>

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -612,6 +612,9 @@ static void _resolveSingleMediaResourceInner(Model::OriginTag origin, std::wstri
             return;
         }
 
+        // If the path is a directory, resolve to the directory path itself.
+        // The rendering layer (TermControl::_SetBackgroundImage) will handle
+        // picking a random image from the directory.
         resource.Resolve(winrt::hstring{ resourceAsFilesystemPath.lexically_normal().native() });
         return;
     }


### PR DESCRIPTION
Allow the backgroundImage setting in settings.json to accept a directory path instead of a direct image file path. When a folder is specified, a random image is picked from that directory each time the control is initialized.

Changes:
- CascadiaSettings.cpp: Added comment clarifying that directory paths are intentionally resolved by the existing filesystem::exists() check, delegating random selection to the rendering layer.
- TermControl.cpp: Modified _SetBackgroundImage() to detect when the resolved path is a directory, enumerate image files (jpg, jpeg, png, bmp, gif, tiff, ico), and pick one randomly using til::gen_random. Each TermControl instance (one per split pane) independently picks its own random image.
- pch.h: Added #include <til/rand.h> for til::gen_random usage.

Split panes work naturally because each pane creates its own TermControl, which independently randomizes on initialization. Settings reload also re-randomizes each pane.

## Summary of the Pull Request

## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
