### PR TITLE
tsm: use the much cheaper & non-async 26100 AppExtension APIs when possible

### DIFF
--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -417,11 +417,29 @@ void SettingsLoader::FindFragmentsAndMergeIntoUserSettings(bool generateExtensio
             continue;
         }
 
-        // Likewise, getting the public folder from an extension is an async operation.
-        auto foundFolder = extractValueFromTaskWithoutMainThreadAwait(ext.GetPublicFolderAsync());
-        if (!foundFolder)
+        winrt::hstring publicFolderPath;
+        if (auto ext3{ ext.try_as<IAppExtension3>() })
         {
-            continue;
+            // Windows 11 24H2 and above support a much faster, much less
+            // Windows.Storage-y API.
+            publicFolderPath = ext3.GetPublicPath();
+            if (!publicFolderPath)
+            {
+                // No point in falling through to GetPublicFolderAsync;
+                // it won't work.
+                continue;
+            }
+        }
+        else
+        {
+            // Likewise, getting the public folder from an extension is an async operation.
+            auto foundFolder = extractValueFromTaskWithoutMainThreadAwait(ext.GetPublicFolderAsync());
+            if (!foundFolder)
+            {
+                continue;
+            }
+
+            publicFolderPath = foundFolder.Path();
         }
 
         // the StorageFolder class has its own methods for obtaining the files within the folder
@@ -429,7 +447,7 @@ void SettingsLoader::FindFragmentsAndMergeIntoUserSettings(bool generateExtensio
         // you may have noticed that we need to resort to clunky implementations for async operations
         // (they are in extractValueFromTaskWithoutMainThreadAwait)
         // so for now we will just take the folder path and access the files that way
-        const auto path = buildPath(foundFolder.Path(), FragmentsSubDirectory);
+        const auto path = buildPath(publicFolderPath, FragmentsSubDirectory);
 
         if (std::filesystem::is_directory(path))
         {

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -395,7 +395,7 @@ void SettingsLoader::FindFragmentsAndMergeIntoUserSettings(bool generateExtensio
     try
     {
         const auto catalog = AppExtensionCatalog::Open(AppExtensionHostName);
-        if (auto catalog2{ catalog.try_as<IAppExtensionCatalog2> })
+        if (auto catalog2{ catalog.try_as<IAppExtensionCatalog2>() })
         {
             extensions = catalog2.FindAll();
         }

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -395,7 +395,14 @@ void SettingsLoader::FindFragmentsAndMergeIntoUserSettings(bool generateExtensio
     try
     {
         const auto catalog = AppExtensionCatalog::Open(AppExtensionHostName);
-        extensions = extractValueFromTaskWithoutMainThreadAwait(catalog.FindAllAsync());
+        if (auto catalog2{ catalog.try_as<IAppExtensionCatalog2> })
+        {
+            extensions = catalog2.FindAll();
+        }
+        else
+        {
+            extensions = extractValueFromTaskWithoutMainThreadAwait(catalog.FindAllAsync());
+        }
     }
     CATCH_LOG();
 

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -430,7 +430,7 @@ void SettingsLoader::FindFragmentsAndMergeIntoUserSettings(bool generateExtensio
             // Windows 11 24H2 and above support a much faster, much less
             // Windows.Storage-y API.
             publicFolderPath = ext3.GetPublicPath();
-            if (!publicFolderPath)
+            if (publicFolderPath.empty())
             {
                 // No point in falling through to GetPublicFolderAsync;
                 // it won't work.

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -446,16 +446,15 @@ void SettingsLoader::FindFragmentsAndMergeIntoUserSettings(bool generateExtensio
                 continue;
             }
 
+            // the StorageFolder class has its own methods for obtaining the files within the folder
+            // however, all those methods are Async methods
+            // you may have noticed that we need to resort to clunky implementations for async operations
+            // (they are in extractValueFromTaskWithoutMainThreadAwait)
+            // so for now we will just take the folder path and access the files that way
             publicFolderPath = foundFolder.Path();
         }
 
-        // the StorageFolder class has its own methods for obtaining the files within the folder
-        // however, all those methods are Async methods
-        // you may have noticed that we need to resort to clunky implementations for async operations
-        // (they are in extractValueFromTaskWithoutMainThreadAwait)
-        // so for now we will just take the folder path and access the files that way
         const auto path = buildPath(publicFolderPath, FragmentsSubDirectory);
-
         if (std::filesystem::is_directory(path))
         {
             // MSIX does not support machine-wide scope


### PR DESCRIPTION
GetPublicPath doesn't require async _or_ Windows.Storage! FindAll is just the Sync version of FindAllAsync!