### PR TITLE
Refresh hovered hyperlink on scroll

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -247,6 +247,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             [weakThis = get_weak()](const auto& update) {
                 if (auto core{ weakThis.get() }; core && !core->_IsClosing())
                 {
+                    // GH#20219: re-evaluate if we're hovering over a hyperlink after scrolling
+                    core->_refreshHoveredCell();
                     core->ScrollPositionChanged.raise(*core, update);
                 }
             });
@@ -749,6 +751,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             _terminal->UserScrollViewport(viewTop);
         }
 
+        // GH#20219: re-evaluate if we're hovering over a hyperlink after scrolling
+        _refreshHoveredCell();
+
         const auto shared = _shared.lock_shared();
         if (shared->outputIdle)
         {
@@ -835,9 +840,20 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     {
         _updateHoveredCell(std::optional<til::point>{ pos });
     }
+
     void ControlCore::ClearHoveredCell()
     {
         _updateHoveredCell(std::nullopt);
+    }
+
+    void ControlCore::_refreshHoveredCell()
+    {
+        if (_lastHoveredCell)
+        {
+            const auto cell = *_lastHoveredCell;
+            _lastHoveredCell.reset();
+            _updateHoveredCell(cell);
+        }
     }
 
     void ControlCore::_updateHoveredCell(const std::optional<til::point> terminalPosition)

--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -353,6 +353,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void _connectionOutputHandler(winrt::array_view<const char16_t> str);
         void _connectionStateChangedHandler(const TerminalConnection::ITerminalConnection&, const Windows::Foundation::IInspectable&);
         void _updateHoveredCell(const std::optional<til::point> terminalPosition);
+        void _refreshHoveredCell();
         void _setOpacity(const float opacity, const bool focused = true);
 
         bool _isBackgroundTransparent();


### PR DESCRIPTION
## Summary of the Pull Request
Updates the cached hovered hyperlink whenever a scroll occurs. All changes were made in `ControlCore`:
- Add `_refreshHoveredCell()` which simply sets the hovered cell again
- Calls the new function in `UserScrollViewport()` for user-initiated scrolling and `updateScrollBar` for non-user-initiated scrolling

## Validation Steps Performed
With multiple hyperlinks in the text buffer, the following scenarios resulted in the hovered hyperlink being updated properly:
✅ mouse wheel scrolling
✅ keyboard scrolling
✅ scroll to mark

## PR Checklist
Closes #20219

Based on #20239