### PR TITLE
Fix Export Tab leaking Enter via Command Palette

### DIFF
--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -347,6 +347,10 @@ namespace winrt::TerminalApp::implementation
                     // shell32 file picker manually.
                     std::wstring filename{ tab.Title() };
                     filename = til::clean_filename(filename);
+
+                    // GH#20188: yield before the dialog so that the Enter from the Command Palette doesn't leak into the terminal.
+                    // Low priority, so the Command Palette's close paints first.
+                    co_await wil::resume_foreground(Dispatcher(), CoreDispatcherPriority::Low);
                     path = co_await SaveFilePicker(*_hostingHwnd, [filename = std::move(filename)](auto&& dialog) {
                         THROW_IF_FAILED(dialog->SetClientGuid(clientGuidExportFile));
                         try


### PR DESCRIPTION
## Summary of the Pull Request
Fixes a bug where Enter would leak into the terminal session when running the export buffer command from the command palette.

Turns out this is because `_ExportTab()` opens the file picker synchronously in the key handler. The file picker spins a nested Win32 modal message loop, which pumps the queued `WM_CHAR` into the terminal.

Switching to the foreground thread gets out of the nested modal loop, resulting in the `WM_CHAR` being handled through XAML's pipeline and suppressing it normally. The low priority makes it so that the command palette is visibly dismissed before opening the file picker.

## Validation Steps Performed
Run export buffer action from the command palette.
✅ Enter does not go through to the underlying terminal.

## PR Checklist
Closes #20188 
Based on #20221 
