### PR TITLE
Fix integer overflow in custom shader Time calculation

### DIFF
--- a/src/renderer/atlas/BackendD3D.cpp
+++ b/src/renderer/atlas/BackendD3D.cpp
@@ -531,7 +531,7 @@ void BackendD3D::_recreateCustomShader(const RenderingPayload& p)
         // digits not break the periodicity. For instance, with a wraparound of 1000 seconds sin(1.234*x) is still perfectly periodic.
         const auto freq = queryPerfFreq();
         _customShaderPerfTickMod = freq * 1000;
-        _customShaderSecsPerPerfTick = 1.0 / static_cast<double>(freq);
+        _customShaderSecsPerPerfTick = 1.0f / freq;
     }
 #endif
 }
@@ -2328,7 +2328,7 @@ void BackendD3D::_executeCustomShader(RenderingPayload& p)
     {
         // See the comment in _recreateCustomShader() which initializes the two members below and explains what they do.
         const auto now = queryPerfCount();
-        const float time = static_cast<float>(static_cast<double>(now % _customShaderPerfTickMod) * _customShaderSecsPerPerfTick);
+        const auto time = (now % _customShaderPerfTickMod) * _customShaderSecsPerPerfTick;
 
         const CustomConstBuffer data{
             .time = time,

--- a/src/renderer/atlas/BackendD3D.cpp
+++ b/src/renderer/atlas/BackendD3D.cpp
@@ -531,7 +531,7 @@ void BackendD3D::_recreateCustomShader(const RenderingPayload& p)
         // digits not break the periodicity. For instance, with a wraparound of 1000 seconds sin(1.234*x) is still perfectly periodic.
         const auto freq = queryPerfFreq();
         _customShaderPerfTickMod = freq * 1000;
-        _customShaderSecsPerPerfTick = 1.0f / freq;
+        _customShaderSecsPerPerfTick = 1.0 / static_cast<double>(freq);
     }
 #endif
 }
@@ -2328,7 +2328,7 @@ void BackendD3D::_executeCustomShader(RenderingPayload& p)
     {
         // See the comment in _recreateCustomShader() which initializes the two members below and explains what they do.
         const auto now = queryPerfCount();
-        const auto time = static_cast<int>(now % _customShaderPerfTickMod) * _customShaderSecsPerPerfTick;
+        const float time = static_cast<float>(static_cast<double>(now % _customShaderPerfTickMod) * _customShaderSecsPerPerfTick);
 
         const CustomConstBuffer data{
             .time = time,

--- a/src/renderer/atlas/BackendD3D.h
+++ b/src/renderer/atlas/BackendD3D.h
@@ -287,7 +287,7 @@ namespace Microsoft::Console::Render::Atlas
         wil::com_ptr<ID3D11Texture2D> _customShaderTexture;
         wil::com_ptr<ID3D11ShaderResourceView> _customShaderTextureView;
         u64 _customShaderPerfTickMod = 0;
-        double _customShaderSecsPerPerfTick = 0.0;
+        f32 _customShaderSecsPerPerfTick = 0;
 
         wil::com_ptr<ID3D11Texture2D> _backgroundBitmap;
         wil::com_ptr<ID3D11ShaderResourceView> _backgroundBitmapView;

--- a/src/renderer/atlas/BackendD3D.h
+++ b/src/renderer/atlas/BackendD3D.h
@@ -287,7 +287,7 @@ namespace Microsoft::Console::Render::Atlas
         wil::com_ptr<ID3D11Texture2D> _customShaderTexture;
         wil::com_ptr<ID3D11ShaderResourceView> _customShaderTextureView;
         u64 _customShaderPerfTickMod = 0;
-        f32 _customShaderSecsPerPerfTick = 0;
+        double _customShaderSecsPerPerfTick = 0.0;
 
         wil::com_ptr<ID3D11Texture2D> _backgroundBitmap;
         wil::com_ptr<ID3D11ShaderResourceView> _backgroundBitmapView;


### PR DESCRIPTION
## Summary of the Pull Request

Fix an integer overflow in custom shader `Time` calculation in `BackendD3D`.

## Related Issue

Related to #20226

## Details

The existing implementation computed shader time as:

```cpp
static_cast<int>(now % _customShaderPerfTickMod) * _customShaderSecsPerPerfTick
```

Since `now` is a 64-bit performance counter value and `_customShaderPerfTickMod` can exceed `INT_MAX`, the `static_cast<int>` could overflow and produce incorrect `Time` values for custom shaders.

This PR fixes the issue by removing the unnecessary 32-bit truncation and preserving the calculation entirely in 64-bit integer space while keeping the existing shader timing behavior unchanged.

## Validation

* Verified the overflow condition mathematically.
* Confirmed the issue originates from the 32-bit cast.
* Ensured the change is isolated to the custom shader time calculation path.
