### PR TITLE
Fix AltGr-composed characters dropped under the Kitty keyboard protocol

### DIFF
--- a/src/terminal/adapter/ut_adapter/kittyKeyboardProtocol.cpp
+++ b/src/terminal/adapter/ut_adapter/kittyKeyboardProtocol.cpp
@@ -299,4 +299,36 @@ class KittyKeyboardProtocolTests
         VERIFY_ARE_EQUAL(TerminalInput::MakeOutput(L"\x1b[98u"), process(input, true, 'B', 0x30, L'b', 0)); // different key
         VERIFY_ARE_EQUAL(TerminalInput::MakeOutput(L"\x1b[97u"), process(input, true, 'A', 0x1E, L'a', 0)); // not repeat
     }
+
+    // AltGr (RightAlt acting as a level-3 shift) composes characters such as '@'
+    // (AltGr+Q) or '{' (AltGr+7) on non-US layouts. Under the Kitty keyboard
+    // protocol these must be emitted as plain text, not mis-encoded as an
+    // "alt+<key>" CSI u sequence (which dropped the composed character entirely
+    // and broke e.g. typing '@' on a German keyboard). Windows delivers AltGr as
+    // a synthesized LeftCtrl followed by an enhanced RightAlt, so we replay that
+    // exact sequence before the character key.
+    TEST_METHOD(AltGrComposedTextIsText)
+    {
+        const auto pressAltGrChar = [](TerminalInput& input, uint16_t vk, uint16_t sc, wchar_t ch) {
+            process(input, true, VK_CONTROL, 0x1D, 0, LEFT_CTRL_PRESSED);
+            process(input, true, VK_MENU, 0x38, 0, LEFT_CTRL_PRESSED | RIGHT_ALT_PRESSED | ENHANCED_KEY);
+            return process(input, true, vk, sc, ch, LEFT_CTRL_PRESSED | RIGHT_ALT_PRESSED);
+        };
+
+        // DisambiguateEscapeCodes alone is what a line-editor style TUI typically
+        // enables; this is the case that used to turn AltGr+Q into "\x1b[113;3u".
+        {
+            auto input = createInput(D);
+            VERIFY_ARE_EQUAL(TerminalInput::MakeOutput(L"@"), pressAltGrChar(input, 'Q', 0x10, L'@'));
+        }
+        {
+            auto input = createInput(D);
+            VERIFY_ARE_EQUAL(TerminalInput::MakeOutput(L"{"), pressAltGrChar(input, '7', 0x08, L'{'));
+        }
+        // Still correct when event-type and alternate-key reporting are also on.
+        {
+            auto input = createInput(D | E | A);
+            VERIFY_ARE_EQUAL(TerminalInput::MakeOutput(L"@"), pressAltGrChar(input, 'Q', 0x10, L'@'));
+        }
+    }
 };

--- a/src/terminal/input/terminalInput.cpp
+++ b/src/terminal/input/terminalInput.cpp
@@ -341,8 +341,25 @@ TerminalInput::OutputType TerminalInput::HandleKey(const INPUT_RECORD& event)
 
     KeyboardHelper kbd;
     EncodingHelper enc;
+
+    // A genuine AltGr keypress (RightAlt acting as a level-3 shift) composes a
+    // character and must be reported as text, not as an Alt-modified key. Windows
+    // signals AltGr as RightAlt plus a *synthesized* LeftCtrl, which we already
+    // distinguish from a real Ctrl via leftCtrlIsReallyPressed. Without this guard,
+    // e.g. AltGr+Q on a German layout (= '@') gets re-encoded as a "CSI 113;3u"
+    // (alt+q) sequence under the Kitty keyboard protocol and the composed '@' is
+    // dropped. We only suppress the Alt modifier when RightAlt actually produced a
+    // printable codepoint and no real LeftAlt/LeftCtrl is held, so plain Alt+key and
+    // Ctrl+Alt+key combinations are left untouched. This mirrors how the legacy
+    // (_formatFallback) path already treats AltGr-composed characters.
+    const auto altGrComposedText =
+        WI_IsFlagSet(key.controlKeyState, RIGHT_ALT_PRESSED) &&
+        !WI_IsFlagSet(key.controlKeyState, LEFT_ALT_PRESSED) &&
+        !key.leftCtrlIsReallyPressed &&
+        key.codepoint > 0x1f && key.codepoint != 0x7f && key.codepoint < InvalidCodepoint;
+
     WI_SetFlagIf(enc.csiModifier, CSI_CTRL, key.leftCtrlIsReallyPressed || WI_IsFlagSet(key.controlKeyState, RIGHT_CTRL_PRESSED));
-    WI_SetFlagIf(enc.csiModifier, CSI_ALT, WI_IsAnyFlagSet(key.controlKeyState, ALT_PRESSED));
+    WI_SetFlagIf(enc.csiModifier, CSI_ALT, WI_IsAnyFlagSet(key.controlKeyState, ALT_PRESSED) && !altGrComposedText);
     WI_SetFlagIf(enc.csiModifier, CSI_SHIFT, WI_IsFlagSet(key.controlKeyState, SHIFT_PRESSED));
 
     if (_kittyFlags == 0 || !_encodeKitty(kbd, enc, key))


### PR DESCRIPTION
## Summary of the Pull Request

Under the Kitty keyboard protocol, AltGr-composed characters on non-US layouts (`@ { } [ ] ~ …`) are dropped: an AltGr keypress is encoded as an `alt+<key>` CSI u sequence instead of emitting the composed character. This teaches the KKP encoder to treat a genuine AltGr composition as a level-3 shift, matching the legacy input path.

## References and Relevant Issues

References #19977 — implements the `key.altGrPressed()` approach @lhecker proposed in that thread.

## Detailed Description of the Pull Request / Additional comments

On Windows, an AltGr keypress is reported as RightAlt + a synthesized LeftCtrl. The legacy path (`_formatFallback` in `src/terminal/input/terminalInput.cpp`) already accounts for this — it treats AltGr as a level-3 shift and emits the already-composed character, only applying a Ctrl/Alt modifier when a *real* extra modifier is held (both Ctrls, or a LeftCtrl distinct from the synthesized one).

The newer KKP encoder in `TerminalInput::HandleKey` did not. It saw the RightAlt/Ctrl bits in `controlKeyState` and encoded the key as an `alt+<key>` CSI u sequence, so the composed character was dropped inside any application that enables the protocol (fish 4.x, Neovim, Codex, etc.).

This change detects a genuine AltGr composition (RightAlt + the synthesized LeftCtrl, no real LeftAlt/LeftCtrl, and an actual printable codepoint) and suppresses the `CSI_ALT` modifier for it, so the key falls through to the regular text encoder and emits the composed character. Plain `Alt+key` and `Ctrl+Alt+key` are unaffected — matching the `AltGr+5 → [` cross-terminal behavior @j4james measured.

Design note: the fix applies whenever a real AltGr composition is detected, regardless of the "Report associated text" (mode 16) enhancement — so apps requesting only modes 1+4 (e.g. fish) receive the literal composed character, per @krobelus. Gating richer output (`\e[121::120;3;123u`) on mode 16 would be a follow-up on top of this. This is independent of the separate "Allow Kitty Keyboard Protocol" toggle issue @lhecker noted (the W32IM→KKP translation in ConPTY).

## Validation Steps Performed

- Added a `KittyKeyboardProtocol` regression test replaying the Windows AltGr key sequence (`AltGr+Q → @`, `AltGr+7 → {`).
- Manually verified on a physical German layout: AltGr-composed characters (`@`, `~`, …) are now delivered to protocol-enabled TUIs, and continue to work with the protocol disabled.

## PR Checklist

- [ ] Closes #xxx
- [x] Tests added
- [ ] Documentation updated
- [ ] Schema updated (if necessary)
