### PR TITLE
AtlasEngine: Fix out-of-bounds row access in PaintCursor (#20269)

### DIFF
--- a/src/renderer/atlas/AtlasEngine.cpp
+++ b/src/renderer/atlas/AtlasEngine.cpp
@@ -620,7 +620,13 @@ try
         const auto cursorWidth = 1 + (options.fIsDoubleWidth & (options.cursorType != CursorType::VerticalBar));
         const auto top = options.coordCursor.y;
         const auto bottom = top + 1;
-        const auto shift = gsl::narrow_cast<u8>(_p.rows[top]->lineRendition != LineRendition::SingleWidth);
+        // coordCursor is relative to the renderer's viewport, which can momentarily
+        // disagree with our own viewport (the size of _p.rows) when the viewport
+        // dimensions change. Clamp the row index just like the other Paint*() methods
+        // before indexing into _p.rows; if the cursor really is outside the viewport,
+        // cursorRect collapses to empty below and nothing is drawn.
+        const auto row = gsl::narrow_cast<u16>(clamp<til::CoordType>(top, 0, _p.s->viewportCellCount.y - 1));
+        const auto shift = gsl::narrow_cast<u8>(_p.rows[row]->lineRendition != LineRendition::SingleWidth);
         auto left = options.coordCursor.x - (_api.viewportOffset.x >> shift);
         auto right = left + cursorWidth;
 


### PR DESCRIPTION
## Summary of the Pull Request

`AtlasEngine::PaintCursor` indexes `_p.rows[options.coordCursor.y]` without clamping the row index. `coordCursor.y` is relative to the *renderer's* viewport, which can momentarily disagree with AtlasEngine's own viewport (`_p.s->viewportCellCount.y`, the size of `_p.rows`) when the viewport dimensions change. When the renderer's viewport is taller than AtlasEngine's current one, `Renderer::_PaintCursor` still treats the cursor as in-viewport and calls `PaintCursor`, but `coordCursor.y` can exceed `_p.rows.size()`, causing an out-of-bounds read and an access violation.

Every other method in this file that indexes `_p.rows` from an external coordinate already clamps it to `[0, viewportCellCount.y - 1]` first (`PrepareLineTransform`, `PaintBufferLine`, `PaintBufferGridLines`, `PaintImageSlice`). This makes `PaintCursor` consistent with them.

## References and Relevant Issues

Fixes #20269

## Detailed Description of the Pull Request / Additional comments

- The `_p.rows` slots always point into `_p.unorderedRows` (set up in `_recreateCellCountDependentResources`), so any in-bounds index yields a valid `ShapedRow*`. Clamping the index therefore fully eliminates the out-of-bounds access — there is no remaining in-bounds-dangling case to guard against.
- Only the index used for the `_p.rows` lookup is clamped. `top`/`bottom` keep their raw values, so when the cursor is genuinely outside AtlasEngine's current viewport, `cursorRect` still collapses to an empty rect (`bottom <= top` ⇒ `til::rect::operator bool()` is `false`) and nothing is drawn — no behavioral change for the in-viewport case.

## Validation Steps Performed

- Root-caused from user crash minidumps (Windows Terminal 1.24.11321.0, Stable): the fault is `AtlasEngine::PaintCursor` reading `_p.rows[<index>]` with an out-of-range index (`index = 77` in one dump), matching the disassembly already posted in #20269.
- Built `src/renderer/atlas/atlas.vcxproj` (Debug | x64) locally with the change: compiles cleanly, 0 warnings / 0 errors.
