### PR TITLE
Add initial rendering-only BiDi support to AtlasEngine

### DIFF
--- a/src/renderer/atlas/AtlasEngine.cpp
+++ b/src/renderer/atlas/AtlasEngine.cpp
@@ -31,6 +31,31 @@
 
 using namespace Microsoft::Console::Render::Atlas;
 
+namespace
+{
+    void _debugLogBidiRuns(const std::vector<TextAnalysisBidiRun>& bidiRuns) noexcept
+    {
+        if (std::none_of(bidiRuns.begin(), bidiRuns.end(), [](const auto& run) noexcept { return (run.resolvedLevel & 1) != 0; }))
+        {
+            return;
+        }
+
+        std::wstring message{ L"[AtlasEngine] Bidi runs:" };
+        for (const auto& run : bidiRuns)
+        {
+            message += L" [pos=";
+            message += std::to_wstring(run.textPosition);
+            message += L", len=";
+            message += std::to_wstring(run.textLength);
+            message += L", level=";
+            message += std::to_wstring(run.resolvedLevel);
+            message += L"]";
+        }
+        message += L"\n";
+        OutputDebugStringW(message.c_str());
+    }
+}
+
 #pragma warning(suppress : 26455) // Default constructor may not throw. Declare it 'noexcept' (f.6).
 AtlasEngine::AtlasEngine()
 {
@@ -819,10 +844,23 @@ void AtlasEngine::_flushBufferLine()
     const auto cleanup = wil::scope_exit([this]() noexcept {
         _api.bufferLine.clear();
         _api.bufferLineColumn.clear();
+        _api.bidiLevels.clear();
+        _api.bidiRuns.clear();
     });
 
     // This would seriously blow us up otherwise.
     Expects(_api.bufferLineColumn.size() == _api.bufferLine.size() + 1);
+
+    _api.analysisResults.clear();
+    _api.bidiLevels.assign(_api.bufferLine.size(), 0);
+    _api.bidiRuns.clear();
+
+    {
+        TextAnalysisSource analysisSource{ _p.userLocaleName.c_str(), _api.bufferLine.data(), gsl::narrow<UINT32>(_api.bufferLine.size()) };
+        TextAnalysisSink analysisSink{ _api.analysisResults, _api.bidiLevels, &_api.bidiRuns };
+        THROW_IF_FAILED(_p.textAnalyzer->AnalyzeBidi(&analysisSource, 0, gsl::narrow<UINT32>(_api.bufferLine.size()), &analysisSink));
+        _debugLogBidiRuns(_api.bidiRuns);
+    }
 
     const auto builtinGlyphs = _p.s->font->builtinGlyphs;
     const auto beg = _api.bufferLine.data();
@@ -1033,12 +1071,16 @@ void AtlasEngine::_mapComplex(IDWriteFontFace2* mappedFontFace, u32 idx, u32 len
 {
     _api.analysisResults.clear();
 
+    _api.bidiLevels.assign(_api.bufferLine.size(), 0);
+
     TextAnalysisSource analysisSource{ _p.userLocaleName.c_str(), _api.bufferLine.data(), gsl::narrow<UINT32>(_api.bufferLine.size()) };
-    TextAnalysisSink analysisSink{ _api.analysisResults };
+    TextAnalysisSink analysisSink{ _api.analysisResults, _api.bidiLevels };
     THROW_IF_FAILED(_p.textAnalyzer->AnalyzeScript(&analysisSource, idx, length, &analysisSink));
+    THROW_IF_FAILED(_p.textAnalyzer->AnalyzeBidi(&analysisSource, idx, length, &analysisSink));
 
     for (const auto& a : _api.analysisResults)
     {
+        const BOOL isRightToLeft = a.textPosition < _api.bidiLevels.size() && (_api.bidiLevels[a.textPosition] & 1) != 0;
         u32 actualGlyphCount = 0;
 
 #pragma warning(push)
@@ -1076,7 +1118,7 @@ void AtlasEngine::_mapComplex(IDWriteFontFace2* mappedFontFace, u32 idx, u32 len
                 /* textLength          */ a.textLength,
                 /* fontFace            */ mappedFontFace,
                 /* isSideways          */ false,
-                /* isRightToLeft       */ 0,
+                /* isRightToLeft       */ isRightToLeft,
                 /* scriptAnalysis      */ &a.analysis,
                 /* localeName          */ _p.userLocaleName.c_str(),
                 /* numberSubstitution  */ nullptr,
@@ -1128,7 +1170,7 @@ void AtlasEngine::_mapComplex(IDWriteFontFace2* mappedFontFace, u32 idx, u32 len
             /* fontFace            */ mappedFontFace,
             /* fontEmSize          */ _p.s->font->fontSize,
             /* isSideways          */ false,
-            /* isRightToLeft       */ 0,
+            /* isRightToLeft       */ isRightToLeft,
             /* scriptAnalysis      */ &a.analysis,
             /* localeName          */ _p.userLocaleName.c_str(),
             /* features            */ &features,

--- a/src/renderer/atlas/AtlasEngine.cpp
+++ b/src/renderer/atlas/AtlasEngine.cpp
@@ -1299,6 +1299,8 @@ void AtlasEngine::_mapComplex(IDWriteFontFace2* mappedFontFace, u32 idx, u32 len
         const auto colors = _p.foregroundBitmap.begin() + _p.colorBitmapRowStride * _api.lastPaintBufferLineCoord.y;
         auto prevCluster = _api.clusterMap[0];
         size_t beg = 0;
+        std::vector<GlyphClusterRange> clusterRanges;
+        clusterRanges.reserve(a.textLength);
 
         for (size_t i = 1; i <= a.textLength; ++i)
         {
@@ -1320,15 +1322,37 @@ void AtlasEngine::_mapComplex(IDWriteFontFace2* mappedFontFace, u32 idx, u32 len
             }
             _api.glyphAdvances[nextCluster - 1] += expectedAdvance - actualAdvance;
 
-            row.colors.insert(row.colors.end(), nextCluster - prevCluster, fg);
+            clusterRanges.push_back({ prevCluster, nextCluster, fg });
 
             prevCluster = nextCluster;
             beg = i;
         }
 
-        row.glyphIndices.insert(row.glyphIndices.end(), _api.glyphIndices.begin(), _api.glyphIndices.begin() + actualGlyphCount);
-        row.glyphAdvances.insert(row.glyphAdvances.end(), _api.glyphAdvances.begin(), _api.glyphAdvances.begin() + actualGlyphCount);
-        row.glyphOffsets.insert(row.glyphOffsets.end(), _api.glyphOffsets.begin(), _api.glyphOffsets.begin() + actualGlyphCount);
+        const auto appendCluster = [&](const GlyphClusterRange& cluster) {
+            row.glyphIndices.insert(row.glyphIndices.end(), _api.glyphIndices.begin() + cluster.glyphsFrom, _api.glyphIndices.begin() + cluster.glyphsTo);
+            row.glyphAdvances.insert(row.glyphAdvances.end(), _api.glyphAdvances.begin() + cluster.glyphsFrom, _api.glyphAdvances.begin() + cluster.glyphsTo);
+            row.glyphOffsets.insert(row.glyphOffsets.end(), _api.glyphOffsets.begin() + cluster.glyphsFrom, _api.glyphOffsets.begin() + cluster.glyphsTo);
+            row.colors.insert(row.colors.end(), cluster.glyphsTo - cluster.glyphsFrom, cluster.color);
+        };
+
+        if (isRightToLeft)
+        {
+            // _flushBufferLine() handles line/span visual order with resolved bidi levels.
+            // DirectWrite shaping preserves glyph relationships within each cluster. Atlas stores
+            // glyphs in a left-to-right stream, so RTL runs emit clusters in reverse order while
+            // preserving glyph order inside each cluster.
+            for (auto it = clusterRanges.rbegin(); it != clusterRanges.rend(); ++it)
+            {
+                appendCluster(*it);
+            }
+        }
+        else
+        {
+            for (const auto& cluster : clusterRanges)
+            {
+                appendCluster(cluster);
+            }
+        }
     }
 }
 

--- a/src/renderer/atlas/AtlasEngine.cpp
+++ b/src/renderer/atlas/AtlasEngine.cpp
@@ -33,27 +33,171 @@ using namespace Microsoft::Console::Render::Atlas;
 
 namespace
 {
-    void _debugLogBidiRuns(const std::vector<TextAnalysisBidiRun>& bidiRuns) noexcept
+    struct VisualSpan
     {
-        if (std::none_of(bidiRuns.begin(), bidiRuns.end(), [](const auto& run) noexcept { return (run.resolvedLevel & 1) != 0; }))
+        size_t beg;
+        size_t end;
+        bool custom;
+        u8 resolvedLevel;
+    };
+
+    struct GlyphClusterRange
+    {
+        u16 glyphsFrom;
+        u16 glyphsTo;
+        u32 color;
+    };
+
+    bool _isWhitespaceSeparator(const wchar_t ch) noexcept
+    {
+        // U+2066..U+2069 are normalized to U+200B in PaintBufferLine().
+        if (ch == L'\u200B')
+        {
+            return true;
+        }
+
+        WORD charType = 0;
+        return GetStringTypeW(CT_CTYPE1, &ch, 1, &charType) && WI_IsFlagSet(charType, C1_SPACE);
+    }
+
+    void _appendWhitespaceSeparatedSpan(std::vector<VisualSpan>& spans, const std::span<const wchar_t> bufferLine, const size_t beg, const size_t end, const bool custom, const u8 resolvedLevel)
+    {
+        // DirectWrite may resolve an entire RTL phrase, including whitespace, to a single bidi level.
+        // Splitting same-level spans at whitespace boundaries gives the UAX #9 L2 span ordering below
+        // a useful rendering granularity. This is only render-order support and intentionally does not
+        // implement cursor, selection, copy, wrapping, punctuation, or bracket-mirroring bidi behavior.
+        auto pos = beg;
+        while (pos < end)
+        {
+            const auto separator = _isWhitespaceSeparator(bufferLine[pos]);
+            auto next = pos + 1;
+            while (next < end && _isWhitespaceSeparator(bufferLine[next]) == separator)
+            {
+                ++next;
+            }
+
+            spans.push_back({ pos, next, custom, resolvedLevel });
+            pos = next;
+        }
+    }
+
+    void _appendBidiIntersectedSpan(std::vector<VisualSpan>& spans, const std::span<const wchar_t> bufferLine, const size_t beg, const size_t end, const bool custom, const std::vector<TextAnalysisBidiRun>& bidiRuns)
+    {
+        if (bidiRuns.empty())
+        {
+            _appendWhitespaceSeparatedSpan(spans, bufferLine, beg, end, custom, 0);
+            return;
+        }
+
+        auto pos = beg;
+        for (const auto& run : bidiRuns)
+        {
+            const auto runBeg = static_cast<size_t>(run.textPosition);
+            const auto runEnd = runBeg + run.textLength;
+            if (runEnd <= pos)
+            {
+                continue;
+            }
+            if (runBeg >= end)
+            {
+                break;
+            }
+
+            if (pos < runBeg)
+            {
+                const auto spanEnd = std::min(runBeg, end);
+                _appendWhitespaceSeparatedSpan(spans, bufferLine, pos, spanEnd, custom, 0);
+                pos = spanEnd;
+            }
+
+            const auto spanBeg = std::max(pos, runBeg);
+            const auto spanEnd = std::min(end, runEnd);
+            if (spanBeg < spanEnd)
+            {
+                _appendWhitespaceSeparatedSpan(spans, bufferLine, spanBeg, spanEnd, custom, run.resolvedLevel);
+                pos = spanEnd;
+            }
+
+            if (pos == end)
+            {
+                break;
+            }
+        }
+
+        if (pos < end)
+        {
+            _appendWhitespaceSeparatedSpan(spans, bufferLine, pos, end, custom, 0);
+        }
+    }
+
+    std::vector<VisualSpan> _buildVisualSpans(const std::span<const wchar_t> bufferLine, const bool builtinGlyphs, const std::vector<TextAnalysisBidiRun>& bidiRuns)
+    {
+        std::vector<VisualSpan> spans;
+        spans.reserve(bufferLine.size());
+        size_t segmentBeg = 0;
+        size_t segmentEnd = 0;
+        bool custom = false;
+
+        while (segmentBeg < bufferLine.size())
+        {
+            segmentEnd = segmentBeg;
+            do
+            {
+                auto i = segmentEnd;
+                char32_t codepoint = bufferLine[i++];
+                if (til::is_leading_surrogate(codepoint) && i < bufferLine.size())
+                {
+                    codepoint = til::combine_surrogates(codepoint, bufferLine[i++]);
+                }
+
+                const auto c = (builtinGlyphs && BuiltinGlyphs::IsBuiltinGlyph(codepoint)) || BuiltinGlyphs::IsSoftFontChar(codepoint);
+                if (custom != c)
+                {
+                    break;
+                }
+
+                segmentEnd = i;
+            } while (segmentEnd < bufferLine.size());
+
+            if (segmentBeg != segmentEnd)
+            {
+                _appendBidiIntersectedSpan(spans, bufferLine, segmentBeg, segmentEnd, custom, bidiRuns);
+            }
+
+            segmentBeg = segmentEnd;
+            custom = !custom;
+        }
+
+        return spans;
+    }
+
+    void _applyBidiLevelOrdering(std::vector<VisualSpan>& spans)
+    {
+        if (spans.empty())
         {
             return;
         }
 
-        std::wstring message{ L"[AtlasEngine] Bidi runs:" };
-        for (const auto& run : bidiRuns)
+        const auto maxLevel = std::max_element(spans.begin(), spans.end(), [](const auto& lhs, const auto& rhs) noexcept {
+            return lhs.resolvedLevel < rhs.resolvedLevel;
+        })->resolvedLevel;
+
+        for (auto level = maxLevel; level > 0; --level)
         {
-            message += L" [pos=";
-            message += std::to_wstring(run.textPosition);
-            message += L", len=";
-            message += std::to_wstring(run.textLength);
-            message += L", level=";
-            message += std::to_wstring(run.resolvedLevel);
-            message += L"]";
+            for (auto it = spans.begin(); it != spans.end();)
+            {
+                it = std::find_if(it, spans.end(), [level](const auto& span) noexcept {
+                    return span.resolvedLevel >= level;
+                });
+                const auto revBeg = it;
+                it = std::find_if(it, spans.end(), [level](const auto& span) noexcept {
+                    return span.resolvedLevel < level;
+                });
+                std::reverse(revBeg, it);
+            }
         }
-        message += L"\n";
-        OutputDebugStringW(message.c_str());
     }
+
 }
 
 #pragma warning(suppress : 26455) // Default constructor may not throw. Declare it 'noexcept' (f.6).
@@ -859,51 +1003,21 @@ void AtlasEngine::_flushBufferLine()
         TextAnalysisSource analysisSource{ _p.userLocaleName.c_str(), _api.bufferLine.data(), gsl::narrow<UINT32>(_api.bufferLine.size()) };
         TextAnalysisSink analysisSink{ _api.analysisResults, _api.bidiLevels, &_api.bidiRuns };
         THROW_IF_FAILED(_p.textAnalyzer->AnalyzeBidi(&analysisSource, 0, gsl::narrow<UINT32>(_api.bufferLine.size()), &analysisSink));
-        _debugLogBidiRuns(_api.bidiRuns);
     }
 
-    const auto builtinGlyphs = _p.s->font->builtinGlyphs;
-    const auto beg = _api.bufferLine.data();
-    const auto len = _api.bufferLine.size();
-    size_t segmentBeg = 0;
-    size_t segmentEnd = 0;
-    bool custom = false;
+    auto spans = _buildVisualSpans(_api.bufferLine, _p.s->font->builtinGlyphs, _api.bidiRuns);
+    _applyBidiLevelOrdering(spans);
 
-    while (segmentBeg < len)
+    for (const auto& span : spans)
     {
-        segmentEnd = segmentBeg;
-        do
+        if (span.custom)
         {
-            auto i = segmentEnd;
-            char32_t codepoint = beg[i++];
-            if (til::is_leading_surrogate(codepoint) && i < len)
-            {
-                codepoint = til::combine_surrogates(codepoint, beg[i++]);
-            }
-
-            const auto c = (builtinGlyphs && BuiltinGlyphs::IsBuiltinGlyph(codepoint)) || BuiltinGlyphs::IsSoftFontChar(codepoint);
-            if (custom != c)
-            {
-                break;
-            }
-
-            segmentEnd = i;
-        } while (segmentEnd < len);
-
-        if (segmentBeg != segmentEnd)
-        {
-            if (custom)
-            {
-                _mapBuiltinGlyphs(segmentBeg, segmentEnd);
-            }
-            else
-            {
-                _mapRegularText(segmentBeg, segmentEnd);
-            }
+            _mapBuiltinGlyphs(span.beg, span.end);
         }
-
-        segmentBeg = segmentEnd;
-        custom = !custom;
+        else
+        {
+            _mapRegularText(span.beg, span.end);
+        }
     }
 }
 

--- a/src/renderer/atlas/AtlasEngine.h
+++ b/src/renderer/atlas/AtlasEngine.h
@@ -12,6 +12,7 @@
 namespace Microsoft::Console::Render::Atlas
 {
     struct TextAnalysisSinkResult;
+    struct TextAnalysisBidiRun;
 
     class AtlasEngine final : public IRenderEngine
     {
@@ -144,6 +145,8 @@ namespace Microsoft::Console::Render::Atlas
 
             std::array<Buffer<DWRITE_FONT_AXIS_VALUE>, 4> textFormatAxes;
             std::vector<TextAnalysisSinkResult> analysisResults;
+            std::vector<u8> bidiLevels;
+            std::vector<TextAnalysisBidiRun> bidiRuns;
             Buffer<u16> clusterMap;
             Buffer<DWRITE_SHAPING_TEXT_PROPERTIES> textProps;
             Buffer<u16> glyphIndices;

--- a/src/renderer/atlas/DWriteTextAnalysis.cpp
+++ b/src/renderer/atlas/DWriteTextAnalysis.cpp
@@ -104,8 +104,10 @@ HRESULT TextAnalysisSource::GetNumberSubstitution(UINT32 textPosition, UINT32* t
     return E_NOTIMPL;
 }
 
-TextAnalysisSink::TextAnalysisSink(std::vector<TextAnalysisSinkResult>& results) noexcept :
-    _results{ results }
+TextAnalysisSink::TextAnalysisSink(std::vector<TextAnalysisSinkResult>& results, std::vector<u8>& bidiLevels, std::vector<TextAnalysisBidiRun>* bidiRuns) noexcept :
+    _results{ results },
+    _bidiLevels{ bidiLevels },
+    _bidiRuns{ bidiRuns }
 {
 }
 
@@ -168,7 +170,37 @@ HRESULT TextAnalysisSink::SetLineBreakpoints(UINT32 textPosition, UINT32 textLen
 
 HRESULT TextAnalysisSink::SetBidiLevel(UINT32 textPosition, UINT32 textLength, UINT8 explicitLevel, UINT8 resolvedLevel) noexcept
 {
-    return E_NOTIMPL;
+    UNREFERENCED_PARAMETER(explicitLevel);
+
+    if (_bidiRuns && textLength != 0)
+    {
+        if (!_bidiRuns->empty())
+        {
+            auto& back = _bidiRuns->back();
+            const auto backEnd = back.textPosition + back.textLength;
+            if (backEnd == textPosition && back.resolvedLevel == resolvedLevel)
+            {
+                back.textLength += textLength;
+            }
+            else
+            {
+                _bidiRuns->push_back({ textPosition, textLength, resolvedLevel });
+            }
+        }
+        else
+        {
+            _bidiRuns->push_back({ textPosition, textLength, resolvedLevel });
+        }
+    }
+
+    if (textPosition >= _bidiLevels.size())
+    {
+        return S_OK;
+    }
+
+    const auto end = std::min<size_t>(static_cast<size_t>(textPosition) + textLength, _bidiLevels.size());
+    std::fill(_bidiLevels.begin() + textPosition, _bidiLevels.begin() + end, resolvedLevel);
+    return S_OK;
 }
 
 HRESULT TextAnalysisSink::SetNumberSubstitution(UINT32 textPosition, UINT32 textLength, IDWriteNumberSubstitution* numberSubstitution) noexcept

--- a/src/renderer/atlas/DWriteTextAnalysis.h
+++ b/src/renderer/atlas/DWriteTextAnalysis.h
@@ -34,7 +34,7 @@ namespace Microsoft::Console::Render::Atlas
 
     struct TextAnalysisSink final : IDWriteTextAnalysisSink
     {
-        TextAnalysisSink(std::vector<TextAnalysisSinkResult>& results) noexcept;
+        TextAnalysisSink(std::vector<TextAnalysisSinkResult>& results, std::vector<u8>& bidiLevels, std::vector<TextAnalysisBidiRun>* bidiRuns = nullptr) noexcept;
 #ifndef NDEBUG
         ~TextAnalysisSink();
 #endif
@@ -49,6 +49,8 @@ namespace Microsoft::Console::Render::Atlas
 
     private:
         std::vector<TextAnalysisSinkResult>& _results;
+        std::vector<u8>& _bidiLevels;
+        std::vector<TextAnalysisBidiRun>* _bidiRuns;
 #ifndef NDEBUG
         ULONG _refCount = 1;
 #endif

--- a/src/renderer/atlas/common.h
+++ b/src/renderer/atlas/common.h
@@ -315,6 +315,13 @@ namespace Microsoft::Console::Render::Atlas
         DWRITE_SCRIPT_ANALYSIS analysis;
     };
 
+    struct TextAnalysisBidiRun
+    {
+        uint32_t textPosition;
+        uint32_t textLength;
+        uint8_t resolvedLevel;
+    };
+
     enum class GraphicsAPI
     {
         Automatic,


### PR DESCRIPTION
## Summary

This PR adds initial rendering-only bidirectional text support to AtlasEngine.

The change improves visual ordering and shaping for RTL scripts such as Arabic, Persian, and Hebrew by using DirectWrite BiDi analysis in the Atlas text shaping path, ordering visual spans by resolved embedding levels, and emitting RTL shaped clusters in visual order.

This intentionally does **not** implement full terminal BiDi support. The scope of this PR is limited to rendered text ordering inside AtlasEngine.

---

## Implementation

- Capture DirectWrite BiDi levels during text analysis.
- Run line-level `IDWriteTextAnalyzer::AnalyzeBidi`.
- Store resolved BiDi runs for the current rendered line.
- Build visual spans by intersecting renderer spans with resolved BiDi runs.
- Split same-level spans at whitespace boundaries to improve RTL phrase ordering.
- Apply UAX #9 L2-style level ordering before rendering.
- Emit RTL shaped clusters in visual order while preserving glyph order inside each cluster.

---

## Validation

Built locally:

- `src/renderer/atlas/atlas.vcxproj`

Validated manually using a local Windows Terminal Dev package with:

- Arabic words
- Arabic multi-word phrases
- Persian phrases
- Hebrew phrases
- RTL text after an LTR PowerShell prompt
- Mixed LTR/RTL text
- Existing LTR rendering

---

## Known Limitations

This is intentionally a rendering-only implementation.

The following are out of scope for this PR:

- BiDi-aware cursor/caret movement
- Editable input navigation
- Selection and hit testing
- Copy/paste logical ↔ visual mapping
- Wrapping and reflow
- Bracket mirroring
- Paragraph/base direction handling

Current known issues:

- Neutral punctuation around RTL editable input (quotes, brackets, colons, etc.) can still produce incorrect caret behavior.
- Cursor/editing remains logical-cell based.
- Combining marks and diacritics are not yet fully correct in all cases.

---

## Follow-up Work

Future work should address:

- Caret movement
- Selection and hit testing
- Copy/paste mapping
- Wrapping/reflow
- Neutral punctuation
- Paragraph direction
- Combining mark placement

**This PR is intended as an initial rendering improvement and as a foundation for future BiDi work, rather than a complete RTL terminal implementation.**