### PR TITLE
Fix splitting pane fails when CWD is a PSDrive (#20373)

### DIFF
--- a/src/types/utils.cpp
+++ b/src/types/utils.cpp
@@ -1237,10 +1237,41 @@ plainSearch:
     return it;
 }
 
+// Returns true if `path` looks like a real Win32 filesystem path, i.e. it is
+// either a "<drive letter>:\" rooted path or a UNC ("\\server\share") path.
+//
+// This deliberately rejects strings that merely *contain* a colon, such as
+// the PSDrive provider paths PowerShell reports for $PWD (e.g. "src:\" for
+// `New-PSDrive -Name src -Root C:\src`). Those aren't real filesystem paths -
+// only the *single drive letter* form ("C:\...") is. If we don't filter
+// these out here, callers that gate "should I inherit the shell-reported
+// CWD?" on this function (e.g. when splitting/duplicating a pane) end up
+// handing the bogus provider path straight to CreateProcess's
+// lpCurrentDirectory, which then gets resolved relative to *our own*
+// process's CWD instead of failing cleanly - producing a launch failure
+// with a garbled path. See GH#20373.
+static bool _isWin32FilesystemPath(const wchar_t* path) noexcept
+{
+    // UNC path: \\server\share...
+    if (path[0] == L'\\' && path[1] == L'\\')
+    {
+        return true;
+    }
+
+    // Drive-letter path: exactly one ASCII letter, then ':', then '\' or '/'.
+    const auto isAsciiLetter = (path[0] >= L'A' && path[0] <= L'Z') || (path[0] >= L'a' && path[0] <= L'z');
+    return isAsciiLetter && path[1] == L':' && (path[2] == L'\\' || path[2] == L'/');
+}
+
 // Returns true if it's a valid path to a directory.
 bool Utils::IsValidDirectory(const wchar_t* path) noexcept
 {
     if (path == nullptr || *path == L'\0')
+    {
+        return false;
+    }
+
+    if (!_isWin32FilesystemPath(path))
     {
         return false;
     }


### PR DESCRIPTION
## Summary of the Pull Request

Fixes pane splitting failing when the active shell's working directory is a PowerShell PSDrive path instead of a real filesystem path.

## References and Relevant Issues

Fixes #20373

## Detailed Description of the Pull Request / Additional comments

When splitting a pane, TerminalPage reads the current pane's working directory from control.WorkingDirectory() and uses it as the new pane's starting directory if Utils::IsValidDirectory() returns true.

PowerShell reports its CWD through shell integration using $PWD.Path. For a PSDrive (created with New-PSDrive -Name src -Root C:\src), this returns the provider path src:\ instead of the real filesystem path. IsValidDirectory() only ran GetFileAttributesExW on the string without checking that it is a well formed Win32 path, so src:\ passed validation and was handed to ConptyConnection, then to CreateProcess's lpCurrentDirectory, where it resolved relative to the host process's own CWD instead of failing cleanly. That produced the launch error in the original report.

This PR adds a check in IsValidDirectory that requires the path to be a single drive letter path (C:\...) or a UNC path (\\server\share\...) before checking the filesystem. Provider paths like src:\ now fail validation immediately, so the split falls back to the profile's default starting directory instead of launching with a broken one.

## PR Checklist
- [x] Closes #20373
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Schema updated (if necessary)