### PR TITLE
[1.25] Fix action name inconsistently updating in Edit Action page

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/ActionsViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ActionsViewModel.cpp
@@ -363,6 +363,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         ActionArgsVM(*actionArgsVM);
         if (!_command.HasName())
         {
+            // Invalidate the cache to make the getter recompute the display name for the "action name" field
+            _cachedDisplayName.clear();
             _NotifyChanges(L"DisplayName");
         }
     }


### PR DESCRIPTION
In the Edit Action page, the "action name" box wouldn't update sometimes when the "action type" was updated. `DisplayName()` would be refreshed, but the new name wouldn't be pulled from the model because the cache was still populated. This just invalidates it so that it's generated again.