### PR TITLE
Fix icon picker file state after selecting None

### DIFF
--- a/src/cascadia/LocalTests_TerminalApp/SettingsEditorTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsEditorTests.cpp
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
+
+#include "../TerminalSettingsEditor/IconPicker.h"
+#include "CppWinrtTailored.h"
+
+using namespace WEX::Logging;
+using namespace WEX::TestExecution;
+
+namespace winrt
+{
+    namespace Editor = Microsoft::Terminal::Settings::Editor;
+}
+
+namespace TerminalAppLocalTests
+{
+    class SettingsEditorTests
+    {
+        BEGIN_TEST_CLASS(SettingsEditorTests)
+            TEST_CLASS_PROPERTY(L"RunAs", L"UAP")
+            TEST_CLASS_PROPERTY(L"UAP:AppXManifest", L"TestHostAppXManifest.xml")
+        END_TEST_CLASS()
+
+        TEST_METHOD(IconPickerKeepsFileControlsAfterNone);
+        TEST_METHOD(IconPickerRestoresLastImagePath);
+    };
+
+    void SettingsEditorTests::IconPickerKeepsFileControlsAfterNone()
+    {
+        auto result = RunOnUIThread([]() {
+            const WEX::TestExecution::DisableVerifyExceptions disableExceptionsScope;
+
+            winrt::Editor::IconPicker picker;
+            const auto noIconType = picker.IconTypes().GetAt(0);
+            const auto fileIconType = picker.IconTypes().GetAt(3);
+
+            picker.CurrentIconPath(L"none");
+            VERIFY_IS_TRUE(picker.UsingNoIcon());
+
+            Log::Comment(L"Switching from an explicit no-icon state to File, then back through None and File.");
+            picker.CurrentIconType(fileIconType);
+            VERIFY_IS_TRUE(picker.UsingImageIcon());
+
+            picker.CurrentIconType(noIconType);
+            VERIFY_IS_TRUE(picker.UsingNoIcon());
+
+            picker.CurrentIconType(fileIconType);
+            VERIFY_IS_TRUE(picker.UsingImageIcon());
+            VERIFY_ARE_EQUAL(winrt::hstring{ L"none" }, picker.CurrentIconPath());
+        });
+
+        VERIFY_SUCCEEDED(result);
+    }
+
+    void SettingsEditorTests::IconPickerRestoresLastImagePath()
+    {
+        auto result = RunOnUIThread([]() {
+            const WEX::TestExecution::DisableVerifyExceptions disableExceptionsScope;
+
+            winrt::Editor::IconPicker picker;
+            const auto noIconType = picker.IconTypes().GetAt(0);
+            const auto fileIconType = picker.IconTypes().GetAt(3);
+            const winrt::hstring imagePath{ L"C:\\icon.png" };
+
+            picker.CurrentIconPath(imagePath);
+            VERIFY_IS_TRUE(picker.UsingImageIcon());
+
+            picker.CurrentIconType(noIconType);
+            VERIFY_IS_TRUE(picker.UsingNoIcon());
+
+            picker.CurrentIconType(fileIconType);
+            VERIFY_IS_TRUE(picker.UsingImageIcon());
+            VERIFY_ARE_EQUAL(imagePath, picker.CurrentIconPath());
+        });
+
+        VERIFY_SUCCEEDED(result);
+    }
+}

--- a/src/cascadia/LocalTests_TerminalApp/TerminalApp.LocalTests.vcxproj
+++ b/src/cascadia/LocalTests_TerminalApp/TerminalApp.LocalTests.vcxproj
@@ -41,6 +41,7 @@
   <ItemGroup>
     <ClCompile Include="CommandlineTest.cpp" />
     <ClCompile Include="SettingsTests.cpp" />
+    <ClCompile Include="SettingsEditorTests.cpp" />
     <ClCompile Include="TabTests.cpp" />
 	<ClCompile Include="FilteredCommandTests.cpp" />
     <ClCompile Include="pch.cpp">

--- a/src/cascadia/TerminalSettingsEditor/IconPicker.cpp
+++ b/src/cascadia/TerminalSettingsEditor/IconPicker.cpp
@@ -74,14 +74,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         PropertyChanged([this](auto&&, const PropertyChangedEventArgs& args) {
             const auto propertyName{ args.PropertyName() };
             // "CurrentIconPath" changes are handled by _OnCurrentIconPathChanged()
-            if (propertyName == L"CurrentIconType")
-            {
-                PropertyChanged.raise(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"UsingNoIcon" });
-                PropertyChanged.raise(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"UsingBuiltInIcon" });
-                PropertyChanged.raise(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"UsingEmojiIcon" });
-                PropertyChanged.raise(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"UsingImageIcon" });
-            }
-            else if (propertyName == L"CurrentBuiltInIcon")
+            if (propertyName == L"CurrentBuiltInIcon")
             {
                 CurrentIconPath(unbox_value<hstring>(_CurrentBuiltInIcon.EnumValue()));
             }
@@ -203,7 +196,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 // Stash the current value of Icon. If the user
                 // switches out of then back to IconType::Image, we want
                 // the path that we display in the text box to remain unchanged.
-                _lastIconPath = CurrentIconPath();
+                const auto currentIconPath = CurrentIconPath();
+                _lastIconPath = _IsImageIconValue(currentIconPath) ? currentIconPath : hstring{};
             }
 
             // Set the member here instead of after setting Icon() below!
@@ -223,7 +217,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             }
             case IconType::Image:
             {
-                if (!_lastIconPath.empty())
+                if (_IsImageIconValue(_lastIconPath))
                 {
                     // Conversely, if we switch to Image,
                     // retrieve that saved value and apply it
@@ -248,7 +242,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             }
             // We're not using the VM's Icon() setter above,
             // so notify HasIcon changed manually
-            PropertyChanged.raise(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"CurrentIconType" });
+            _NotifyCurrentIconTypeChanged();
             PropertyChanged.raise(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"HasIcon" });
         }
     }
@@ -276,11 +270,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     void IconPicker::_DeduceCurrentIconType()
     {
         const auto icon = CurrentIconPath();
-        if (icon.empty() || icon == HideIconValue)
+        if (_IsNoIconValue(icon))
         {
             _currentIconType = IconTypes().GetAt(0);
         }
-        else if (icon.size() == 1 && (L'\uE700' <= til::at(icon, 0) && til::at(icon, 0) <= L'\uF8B3'))
+        else if (_IsBuiltInIconValue(icon))
         {
             _currentIconType = IconTypes().GetAt(1);
             _DeduceCurrentBuiltInIcon();
@@ -295,7 +289,33 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         {
             _currentIconType = IconTypes().GetAt(3);
         }
+        _NotifyCurrentIconTypeChanged();
+    }
+
+    bool IconPicker::_IsBuiltInIconValue(const hstring& icon) noexcept
+    {
+        return icon.size() == 1 && (L'\uE700' <= til::at(icon, 0) && til::at(icon, 0) <= L'\uF8B3');
+    }
+
+    bool IconPicker::_IsImageIconValue(const hstring& icon)
+    {
+        return !_IsNoIconValue(icon) &&
+               !_IsBuiltInIconValue(icon) &&
+               !::Microsoft::Console::Utils::IsLikelyToBeEmojiOrSymbolIcon(icon);
+    }
+
+    bool IconPicker::_IsNoIconValue(const hstring& icon) noexcept
+    {
+        return icon.empty() || icon == HideIconValue;
+    }
+
+    void IconPicker::_NotifyCurrentIconTypeChanged()
+    {
         PropertyChanged.raise(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"CurrentIconType" });
+        PropertyChanged.raise(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"UsingNoIcon" });
+        PropertyChanged.raise(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"UsingBuiltInIcon" });
+        PropertyChanged.raise(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"UsingEmojiIcon" });
+        PropertyChanged.raise(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"UsingImageIcon" });
     }
 
     void IconPicker::_DeduceCurrentBuiltInIcon()

--- a/src/cascadia/TerminalSettingsEditor/IconPicker.h
+++ b/src/cascadia/TerminalSettingsEditor/IconPicker.h
@@ -55,8 +55,13 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         static void _InitializeProperties();
         static void _OnCurrentIconPathChanged(const Windows::UI::Xaml::DependencyObject& d, const Windows::UI::Xaml::DependencyPropertyChangedEventArgs& e);
 
+        static bool _IsBuiltInIconValue(const winrt::hstring& icon) noexcept;
+        static bool _IsImageIconValue(const winrt::hstring& icon);
+        static bool _IsNoIconValue(const winrt::hstring& icon) noexcept;
+
         void _DeduceCurrentIconType();
         void _DeduceCurrentBuiltInIcon();
+        void _NotifyCurrentIconTypeChanged();
         void _updateIconFilter(std::wstring_view filter);
         void _updateFilteredIconList();
     };


### PR DESCRIPTION
## Summary of the Pull Request

Fixes the icon picker state transition when switching the profile icon type from File to None and back to File.

## References and Relevant Issues

Closes #20307

## Detailed Description of the Pull Request / Additional comments

The icon picker now only caches real image icon paths when leaving the File icon type. The `none` sentinel, built-in glyphs, and emoji values are no longer treated as restorable file paths, so selecting File after None keeps the File controls visible instead of being inferred back to None.

The control also raises the derived icon-type visibility property changes directly whenever the current icon type changes.

## Validation Steps Performed

- Added LocalTests coverage for the IconPicker File -> None -> File state transition.
- Added LocalTests coverage for restoring the last real image path after switching away from File.
- `git diff upstream/main...HEAD --check`

## PR Checklist
- [x] Closes #20307
- [x] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)