### PR TITLE
add setting to disable drag/drop

### DIFF
--- a/.github/actions/spelling/allow/apis.txt
+++ b/.github/actions/spelling/allow/apis.txt
@@ -196,6 +196,8 @@ winstamin
 wmemcmp
 wpc
 WSF
+wts
+wtsapi
 WWH
 wwinmain
 XDocument

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2392,6 +2392,11 @@
           "description": "When set to true, tabs are always displayed. When set to false and \"showTabsInTitlebar\" is set to false, tabs only appear after opening a new tab.",
           "type": "boolean"
         },
+        "enableTabDragDrop": {
+          "default": true,
+          "description": "When set to true, tabs can be reordered and torn out into new windows by dragging them. When set to false, dragging tabs is disabled (they can still be moved with the \"moveTab\" actions). Dragging is also disabled automatically when running elevated or as a different user, where it would otherwise crash the window.",
+          "type": "boolean"
+        },
         "compatibility.enableUnfocusedAcrylic": {
           "default": true,
           "description": "When set to true, unfocused windows can have acrylic instead of opaque.",

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -318,6 +318,13 @@ namespace winrt::TerminalApp::implementation
         return true;
     }
 
+    // Tabs may be reordered/torn out only when the OS allows drag/drop (not
+    // elevated or a different user - GH#15689) and the user hasn't disabled it.
+    bool TerminalPage::_tabDragDropEnabled() const
+    {
+        return CanDragDrop() && _settings.GlobalSettings().EnableTabDragDrop();
+    }
+
     void TerminalPage::Create()
     {
         // Hookup the key bindings
@@ -328,7 +335,7 @@ namespace winrt::TerminalApp::implementation
         _tabView = _tabRow.TabView();
         _rearranging = false;
 
-        const auto canDragDrop = CanDragDrop() && _settings.GlobalSettings().EnableTabDragDrop();
+        const auto canDragDrop = _tabDragDropEnabled();
 
         _tabView.CanReorderTabs(canDragDrop);
         _tabView.CanDragTabs(canDragDrop);
@@ -4123,12 +4130,11 @@ namespace winrt::TerminalApp::implementation
 
         _tabRow.ShowElevationShield(IsRunningElevated() && _settings.GlobalSettings().ShowAdminShield());
 
-        // Re-evaluate whether tabs can be dragged so toggling the
-        // enableTabDragDrop setting takes effect on hot-reload. This stays
-        // disabled regardless when drag/drop would crash us (elevated or running
-        // as a different user - see Utils::CanUwpDragDrop, GH#15689).
+        // Re-apply on hot-reload so toggling enableTabDragDrop takes effect.
+        // Stays off when drag/drop would crash us anyway (elevated / different
+        // user - see Utils::CanUwpDragDrop). GH#15689.
         {
-            const auto canDragDrop = CanDragDrop() && _settings.GlobalSettings().EnableTabDragDrop();
+            const auto canDragDrop = _tabDragDropEnabled();
             _tabView.CanReorderTabs(canDragDrop);
             _tabView.CanDragTabs(canDragDrop);
         }
@@ -5993,15 +5999,17 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_onTabDragStarting(const winrt::Microsoft::UI::Xaml::Controls::TabView&,
                                           const winrt::Microsoft::UI::Xaml::Controls::TabViewTabDragStartingEventArgs& e)
     {
-        // Veto the drag entirely when drag/drop is disabled or unavailable.
-        // Toggling TabView.CanReorderTabs/CanDragTabs at runtime doesn't
-        // reliably propagate to the inner ListView, so the enableTabDragDrop
-        // setting wouldn't otherwise take effect until the next launch. Reading
-        // the setting here (and CanDragDrop, which stays false when a drag would
-        // fail-fast us - elevated or running as a different user, GH#15689)
-        // cancels both reorder and tear-out, since both begin with this event.
-        if (!(CanDragDrop() && _settings.GlobalSettings().EnableTabDragDrop()))
+        // CanReorderTabs/CanDragTabs don't reliably update after the TabView is
+        // live, so gate here too: this makes enableTabDragDrop take effect
+        // without a restart and blocks the drag that would fail-fast us when
+        // elevated or running as a different user. GH#15689.
+        if (!_tabDragDropEnabled())
         {
+            // _TabDragStarted (subscribed first) already set _rearranging; a
+            // cancelled drag raises no TabDragCompleted to clear it, so undo it.
+            _rearranging = false;
+            _rearrangeFrom = std::nullopt;
+            _rearrangeTo = std::nullopt;
             e.Cancel(true);
             return;
         }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -328,7 +328,7 @@ namespace winrt::TerminalApp::implementation
         _tabView = _tabRow.TabView();
         _rearranging = false;
 
-        const auto canDragDrop = CanDragDrop();
+        const auto canDragDrop = CanDragDrop() && _settings.GlobalSettings().EnableTabDragDrop();
 
         _tabView.CanReorderTabs(canDragDrop);
         _tabView.CanDragTabs(canDragDrop);
@@ -4123,6 +4123,16 @@ namespace winrt::TerminalApp::implementation
 
         _tabRow.ShowElevationShield(IsRunningElevated() && _settings.GlobalSettings().ShowAdminShield());
 
+        // Re-evaluate whether tabs can be dragged so toggling the
+        // enableTabDragDrop setting takes effect on hot-reload. This stays
+        // disabled regardless when drag/drop would crash us (elevated or running
+        // as a different user - see Utils::CanUwpDragDrop, GH#15689).
+        {
+            const auto canDragDrop = CanDragDrop() && _settings.GlobalSettings().EnableTabDragDrop();
+            _tabView.CanReorderTabs(canDragDrop);
+            _tabView.CanDragTabs(canDragDrop);
+        }
+
         // Apply the ShowWorkspacesButton theme setting.
         if (const auto theme = _settings.GlobalSettings().CurrentTheme())
         {
@@ -5983,6 +5993,19 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_onTabDragStarting(const winrt::Microsoft::UI::Xaml::Controls::TabView&,
                                           const winrt::Microsoft::UI::Xaml::Controls::TabViewTabDragStartingEventArgs& e)
     {
+        // Veto the drag entirely when drag/drop is disabled or unavailable.
+        // Toggling TabView.CanReorderTabs/CanDragTabs at runtime doesn't
+        // reliably propagate to the inner ListView, so the enableTabDragDrop
+        // setting wouldn't otherwise take effect until the next launch. Reading
+        // the setting here (and CanDragDrop, which stays false when a drag would
+        // fail-fast us - elevated or running as a different user, GH#15689)
+        // cancels both reorder and tear-out, since both begin with this event.
+        if (!(CanDragDrop() && _settings.GlobalSettings().EnableTabDragDrop()))
+        {
+            e.Cancel(true);
+            return;
+        }
+
         // Get the tab impl from this event.
         const auto eventTab = e.Tab();
         const auto tabBase = _GetTabByTabViewItem(eventTab);

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -503,6 +503,7 @@ namespace winrt::TerminalApp::implementation
 
         safe_void_coroutine _LaunchSettings(const Microsoft::Terminal::Settings::Model::SettingsTarget target);
 
+        bool _tabDragDropEnabled() const;
         void _TabDragStarted(const IInspectable& sender, const IInspectable& eventArgs);
         void _TabDragCompleted(const IInspectable& sender, const IInspectable& eventArgs);
 

--- a/src/cascadia/TerminalSettingsEditor/Interaction.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Interaction.xaml
@@ -84,6 +84,15 @@
                           Style="{StaticResource ComboBoxSettingStyle}" />
             </local:SettingContainer>
 
+            <!--  Enable Tab Drag and Drop  -->
+            <local:SettingContainer x:Name="EnableTabDragDrop"
+                                    x:Uid="Globals_EnableTabDragDrop"
+                                    HelpText="{x:Bind ViewModel.TabDragDropStatefulHelpText, Mode=OneWay}">
+                <ToggleSwitch IsEnabled="{x:Bind ViewModel.CanEnableTabDragDrop}"
+                              IsOn="{x:Bind ViewModel.EnableTabDragDrop, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
+
             <!--  Focus Follow Mouse Mode  -->
             <local:SettingContainer x:Name="FocusFollowMouse"
                                     x:Uid="Globals_FocusFollowMouse">

--- a/src/cascadia/TerminalSettingsEditor/InteractionViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/InteractionViewModel.cpp
@@ -22,18 +22,14 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         INITIALIZE_BINDABLE_ENUM_SETTING(ConfirmOnClose, ConfirmOnClose, Model::ConfirmOnClose, L"Globals_ConfirmOnClose", L"Content");
     }
 
-    // The enableTabDragDrop setting only has an effect when the OS will actually
-    // let us drag/drop tabs. When running elevated or as a different user, the
-    // drag/drop broker denies us and would crash the window, so we force it off
-    // regardless (see Utils::CanUwpDragDrop, GH#15689) - reflect that by
-    // disabling the control here.
+    // Grey out the toggle when drag/drop is forced off regardless of the setting
+    // (elevated / different user); see Utils::CanUwpDragDrop. GH#15689.
     bool InteractionViewModel::CanEnableTabDragDrop() const noexcept
     {
         return ::Microsoft::Console::Utils::CanUwpDragDrop();
     }
 
-    // When drag/drop is unavailable, replace the normal help text with an
-    // explanation of why the toggle is disabled (it's otherwise not obvious).
+    // Explain why the toggle is greyed out when drag/drop is unavailable.
     winrt::hstring InteractionViewModel::TabDragDropStatefulHelpText() const
     {
         if (!::Microsoft::Console::Utils::CanUwpDragDrop())

--- a/src/cascadia/TerminalSettingsEditor/InteractionViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/InteractionViewModel.cpp
@@ -6,6 +6,8 @@
 #include "InteractionViewModel.g.cpp"
 #include "EnumEntry.h"
 
+#include "../../types/inc/utils.hpp"
+
 using namespace winrt::Windows::UI::Xaml::Navigation;
 using namespace winrt::Windows::Foundation;
 using namespace winrt::Microsoft::Terminal::Settings::Model;
@@ -18,5 +20,26 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         INITIALIZE_BINDABLE_ENUM_SETTING(TabSwitcherMode, TabSwitcherMode, TabSwitcherMode, L"Globals_TabSwitcherMode", L"Content");
         INITIALIZE_BINDABLE_ENUM_SETTING(CopyFormat, CopyFormat, winrt::Microsoft::Terminal::Control::CopyFormat, L"Globals_CopyFormat", L"Content");
         INITIALIZE_BINDABLE_ENUM_SETTING(ConfirmOnClose, ConfirmOnClose, Model::ConfirmOnClose, L"Globals_ConfirmOnClose", L"Content");
+    }
+
+    // The enableTabDragDrop setting only has an effect when the OS will actually
+    // let us drag/drop tabs. When running elevated or as a different user, the
+    // drag/drop broker denies us and would crash the window, so we force it off
+    // regardless (see Utils::CanUwpDragDrop, GH#15689) - reflect that by
+    // disabling the control here.
+    bool InteractionViewModel::CanEnableTabDragDrop() const noexcept
+    {
+        return ::Microsoft::Console::Utils::CanUwpDragDrop();
+    }
+
+    // When drag/drop is unavailable, replace the normal help text with an
+    // explanation of why the toggle is disabled (it's otherwise not obvious).
+    winrt::hstring InteractionViewModel::TabDragDropStatefulHelpText() const
+    {
+        if (!::Microsoft::Console::Utils::CanUwpDragDrop())
+        {
+            return RS_(L"Globals_EnableTabDragDrop_Unavailable");
+        }
+        return RS_(L"Globals_EnableTabDragDrop/HelpText");
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/InteractionViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/InteractionViewModel.h
@@ -35,6 +35,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, WarnAboutLargePaste);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, WarnAboutMultiLinePaste);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, EnableColorSelection);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, EnableTabDragDrop);
+
+        bool CanEnableTabDragDrop() const noexcept;
+        winrt::hstring TabDragDropStatefulHelpText() const;
 
     private:
         Model::GlobalAppSettings _GlobalSettings;

--- a/src/cascadia/TerminalSettingsEditor/InteractionViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/InteractionViewModel.idl
@@ -34,5 +34,13 @@ namespace Microsoft.Terminal.Settings.Editor
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, WarnAboutLargePaste);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Microsoft.Terminal.Control.WarnAboutMultiLinePaste, WarnAboutMultiLinePaste);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, EnableColorSelection);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, EnableTabDragDrop);
+
+        // False when the OS would refuse drag/drop anyway (elevated or running
+        // as a different user); used to disable the EnableTabDragDrop control.
+        Boolean CanEnableTabDragDrop { get; };
+        // Help text for the EnableTabDragDrop control that explains why it is
+        // disabled when CanEnableTabDragDrop is false.
+        String TabDragDropStatefulHelpText { get; };
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -525,6 +525,18 @@
     <value>When disabled, the title bar will be 'Terminal'.</value>
     <comment>A description for what the "show title in titlebar" setting does. Presented near "Globals_ShowTitleInTitlebar.Header".{Locked="Windows"}</comment>
   </data>
+  <data name="Globals_EnableTabDragDrop.Header" xml:space="preserve">
+    <value>Reorder and tear out tabs by dragging</value>
+    <comment>Header for a control to toggle whether tabs can be dragged to reorder them or tear them out into a new window.</comment>
+  </data>
+  <data name="Globals_EnableTabDragDrop.HelpText" xml:space="preserve">
+    <value>When disabled, tabs can still be moved with the "move tab" actions.</value>
+    <comment>A description for what the "reorder and tear out tabs by dragging" setting does. Presented near "Globals_EnableTabDragDrop.Header".</comment>
+  </data>
+  <data name="Globals_EnableTabDragDrop_Unavailable" xml:space="preserve">
+    <value>Dragging tabs is unavailable because Terminal is running as administrator or as a different user, where it would crash the window. Use the "move tab" actions instead.</value>
+    <comment>Shown in place of the help text when the "reorder and tear out tabs by dragging" setting is disabled because the operating system would not allow tab dragging in this session.</comment>
+  </data>
   <data name="Globals_SnapToGridOnResize.Header" xml:space="preserve">
     <value>Snap window resizing to character grid</value>
     <comment>Header for a control to toggle whether the terminal snaps the window to the character grid when resizing, or not.</comment>

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
@@ -66,6 +66,7 @@ namespace Microsoft.Terminal.Settings.Model
         INHERITABLE_SETTING(Int32, InitialCols);
         INHERITABLE_SETTING(Boolean, AlwaysShowTabs);
         INHERITABLE_SETTING(Boolean, ShowTabsFullscreen);
+        INHERITABLE_SETTING(Boolean, EnableTabDragDrop);
         INHERITABLE_SETTING(NewTabPosition, NewTabPosition);
         INHERITABLE_SETTING(Boolean, ShowTitleInTitlebar);
         INHERITABLE_SETTING(ConfirmOnClose, ConfirmOnClose);

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -72,6 +72,7 @@ Author(s):
     X(winrt::Windows::Foundation::Collections::IVector<Model::NewTabMenuEntry>, NewTabMenu, "newTabMenu", winrt::single_threaded_vector<Model::NewTabMenuEntry>({ Model::RemainingProfilesEntry{} })) \
     X(bool, AllowHeadless, "compatibility.allowHeadless", false)                                                                                                                                      \
     X(hstring, SearchWebDefaultQueryUrl, "searchWebDefaultQueryUrl", L"https://www.bing.com/search?q=%22%s%22")                                                                                       \
+    X(bool, EnableTabDragDrop, "enableTabDragDrop", true)                                                                                                                                             \
     X(bool, ShowTabsFullscreen, "showTabsFullscreen", false)
 
 // Also add these settings to:

--- a/src/types/utils.cpp
+++ b/src/types/utils.cpp
@@ -959,30 +959,21 @@ GUID Utils::CreateV5Uuid(const GUID& namespaceGuid, const std::span<const std::b
     return EndianSwap(newGuid);
 }
 
-// Returns true if this process is running as a different user than the one
-// logged on to our session (e.g. it was launched via `runas /user:...`).
-//
-// The modern drag/drop broker (the "DataExchangeHost"/"DragExperienceHost"
-// service that XAML uses for tab drag/drop) refuses to service a process whose
-// token user doesn't match the interactive session's user: it fails with
-// E_ACCESSDENIED, which XAML turns into an uncaught exception and fail-fasts
-// the entire process. This is the same class of failure as running elevated,
-// just triggered by a different token rather than a higher integrity level.
-// See GH#15689.
+// True if this process runs as a user other than the session's logged-on user
+// (e.g. launched via `runas /user:...`). XAML's drag/drop broker denies such a
+// process with E_ACCESSDENIED and fail-fasts the process, same as elevation.
+// GH#15689.
 static bool _isRunningAsDifferentSessionUser(HANDLE processToken)
 {
     try
     {
-        // The user SID backing our process token.
         const auto tokenUser = wil::get_token_information<TOKEN_USER>(processToken);
 
-        // The Terminal Services session we belong to.
         DWORD sessionId = 0;
         THROW_IF_WIN32_BOOL_FALSE(ProcessIdToSessionId(GetCurrentProcessId(), &sessionId));
 
-        // The user logged on to that session. There's no WTS info class that
-        // hands back a SID directly, so we ask for the account name and resolve
-        // it ourselves below.
+        // WTS has no info class for the session user's SID, so fetch the account
+        // name/domain and resolve it to a SID below.
         LPWSTR wtsUserName = nullptr;
         LPWSTR wtsDomainName = nullptr;
         const auto freeWts = wil::scope_exit([&]() noexcept {
@@ -1000,8 +991,7 @@ static bool _isRunningAsDifferentSessionUser(HANDLE processToken)
         THROW_IF_WIN32_BOOL_FALSE(WTSQuerySessionInformationW(WTS_CURRENT_SERVER_HANDLE, sessionId, WTSUserName, &wtsUserName, &bytesReturned));
         THROW_IF_WIN32_BOOL_FALSE(WTSQuerySessionInformationW(WTS_CURRENT_SERVER_HANDLE, sessionId, WTSDomainName, &wtsDomainName, &bytesReturned));
 
-        // A session with no interactive user (e.g. a service session) gives us
-        // an empty name. Don't try to make a judgement in that case.
+        // No interactive user (e.g. a service session) -> empty name; can't judge.
         if (!wtsUserName || !*wtsUserName)
         {
             return false;
@@ -1015,13 +1005,11 @@ static bool _isRunningAsDifferentSessionUser(HANDLE processToken)
         }
         account.append(wtsUserName);
 
-        // Resolve the session user's name to a SID so we can compare it to our
-        // token's user by identity rather than by (spoofable) display name.
+        // Resolve to a SID and compare by identity, not by display name.
         DWORD sidSize = 0;
         DWORD domainSize = 0;
         SID_NAME_USE sidUse{};
-        // First call is expected to fail with ERROR_INSUFFICIENT_BUFFER; it
-        // just tells us how much to allocate.
+        // First call fails with ERROR_INSUFFICIENT_BUFFER and returns the sizes.
         LookupAccountNameW(nullptr, account.c_str(), nullptr, &sidSize, nullptr, &domainSize, &sidUse);
         if (sidSize == 0)
         {
@@ -1033,16 +1021,13 @@ static bool _isRunningAsDifferentSessionUser(HANDLE processToken)
         THROW_IF_WIN32_BOOL_FALSE(LookupAccountNameW(nullptr, account.c_str(), sidBuffer.data(), &sidSize, domainBuffer.data(), &domainSize, &sidUse));
 
         const auto sessionSid = reinterpret_cast<PSID>(sidBuffer.data());
-        // If the two SIDs differ, we're running as somebody other than the
-        // person sitting at this session -> drag/drop will crash us.
+        // Different SIDs -> different user -> drag/drop would crash us.
         return !EqualSid(tokenUser->User.Sid, sessionSid);
     }
     catch (...)
     {
-        // If any of this failed we genuinely can't tell, so don't claim it's a
-        // different user (that would needlessly disable drag/drop for everyone
-        // if, say, the Terminal Services APIs were unavailable). The caller's
-        // elevation checks still apply.
+        // Fail safe: report "same user" on any failure so we never disable
+        // drag/drop for the normal case. Elevation checks still apply.
         LOG_CAUGHT_EXCEPTION();
         return false;
     }
@@ -1066,10 +1051,8 @@ bool Utils::CanUwpDragDrop()
         {
             wil::unique_handle processToken{ GetCurrentProcessToken() };
 
-            // Running as a different user than the one logged into our session
-            // (e.g. via `runas /user:...`) crashes the drag/drop broker the
-            // same way elevation does. Check this first: it holds regardless of
-            // our own token's elevation state. See GH#15689.
+            // Different-user (runas) breaks drag/drop like elevation does, and
+            // independently of our own elevation. Check it first. GH#15689.
             if (_isRunningAsDifferentSessionUser(processToken.get()))
             {
                 return true;

--- a/src/types/utils.cpp
+++ b/src/types/utils.cpp
@@ -1021,7 +1021,7 @@ static bool _isRunningAsDifferentSessionUser(HANDLE processToken)
         THROW_IF_WIN32_BOOL_FALSE(LookupAccountNameW(nullptr, account.c_str(), sidBuffer.data(), &sidSize, domainBuffer.data(), &domainSize, &sidUse));
 
         const auto sessionSid = reinterpret_cast<PSID>(sidBuffer.data());
-        // Different SIDs -> different user -> drag/drop would crash us.
+        // A different SID means a different user -> drag/drop would crash us.
         return !EqualSid(tokenUser->User.Sid, sessionSid);
     }
     catch (...)

--- a/src/types/utils.cpp
+++ b/src/types/utils.cpp
@@ -6,10 +6,14 @@
 
 #include <til/string.h>
 #include <wil/token_helpers.h>
+#include <wil/resource.h>
 
 #include "inc/colorTable.hpp"
 
 #include <icu.h>
+
+#include <wtsapi32.h>
+#pragma comment(lib, "wtsapi32.lib")
 
 using namespace Microsoft::Console;
 
@@ -955,10 +959,101 @@ GUID Utils::CreateV5Uuid(const GUID& namespaceGuid, const std::span<const std::b
     return EndianSwap(newGuid);
 }
 
+// Returns true if this process is running as a different user than the one
+// logged on to our session (e.g. it was launched via `runas /user:...`).
+//
+// The modern drag/drop broker (the "DataExchangeHost"/"DragExperienceHost"
+// service that XAML uses for tab drag/drop) refuses to service a process whose
+// token user doesn't match the interactive session's user: it fails with
+// E_ACCESSDENIED, which XAML turns into an uncaught exception and fail-fasts
+// the entire process. This is the same class of failure as running elevated,
+// just triggered by a different token rather than a higher integrity level.
+// See GH#15689.
+static bool _isRunningAsDifferentSessionUser(HANDLE processToken)
+{
+    try
+    {
+        // The user SID backing our process token.
+        const auto tokenUser = wil::get_token_information<TOKEN_USER>(processToken);
+
+        // The Terminal Services session we belong to.
+        DWORD sessionId = 0;
+        THROW_IF_WIN32_BOOL_FALSE(ProcessIdToSessionId(GetCurrentProcessId(), &sessionId));
+
+        // The user logged on to that session. There's no WTS info class that
+        // hands back a SID directly, so we ask for the account name and resolve
+        // it ourselves below.
+        LPWSTR wtsUserName = nullptr;
+        LPWSTR wtsDomainName = nullptr;
+        const auto freeWts = wil::scope_exit([&]() noexcept {
+            if (wtsUserName)
+            {
+                WTSFreeMemory(wtsUserName);
+            }
+            if (wtsDomainName)
+            {
+                WTSFreeMemory(wtsDomainName);
+            }
+        });
+
+        DWORD bytesReturned = 0;
+        THROW_IF_WIN32_BOOL_FALSE(WTSQuerySessionInformationW(WTS_CURRENT_SERVER_HANDLE, sessionId, WTSUserName, &wtsUserName, &bytesReturned));
+        THROW_IF_WIN32_BOOL_FALSE(WTSQuerySessionInformationW(WTS_CURRENT_SERVER_HANDLE, sessionId, WTSDomainName, &wtsDomainName, &bytesReturned));
+
+        // A session with no interactive user (e.g. a service session) gives us
+        // an empty name. Don't try to make a judgement in that case.
+        if (!wtsUserName || !*wtsUserName)
+        {
+            return false;
+        }
+
+        std::wstring account;
+        if (wtsDomainName && *wtsDomainName)
+        {
+            account.append(wtsDomainName);
+            account.push_back(L'\\');
+        }
+        account.append(wtsUserName);
+
+        // Resolve the session user's name to a SID so we can compare it to our
+        // token's user by identity rather than by (spoofable) display name.
+        DWORD sidSize = 0;
+        DWORD domainSize = 0;
+        SID_NAME_USE sidUse{};
+        // First call is expected to fail with ERROR_INSUFFICIENT_BUFFER; it
+        // just tells us how much to allocate.
+        LookupAccountNameW(nullptr, account.c_str(), nullptr, &sidSize, nullptr, &domainSize, &sidUse);
+        if (sidSize == 0)
+        {
+            return false;
+        }
+
+        std::vector<std::byte> sidBuffer(sidSize);
+        std::vector<wchar_t> domainBuffer(domainSize);
+        THROW_IF_WIN32_BOOL_FALSE(LookupAccountNameW(nullptr, account.c_str(), sidBuffer.data(), &sidSize, domainBuffer.data(), &domainSize, &sidUse));
+
+        const auto sessionSid = reinterpret_cast<PSID>(sidBuffer.data());
+        // If the two SIDs differ, we're running as somebody other than the
+        // person sitting at this session -> drag/drop will crash us.
+        return !EqualSid(tokenUser->User.Sid, sessionSid);
+    }
+    catch (...)
+    {
+        // If any of this failed we genuinely can't tell, so don't claim it's a
+        // different user (that would needlessly disable drag/drop for everyone
+        // if, say, the Terminal Services APIs were unavailable). The caller's
+        // elevation checks still apply.
+        LOG_CAUGHT_EXCEPTION();
+        return false;
+    }
+}
+
 // * Elevated users cannot use the modern drag drop experience. This is
 //   specifically normal users running the Terminal as admin
 // * The Default Administrator, who does not have a split token, CAN drag drop
 //   perfectly fine. So in that case, we want to return false.
+// * Running as a different user than the session owner (e.g. `runas`) also
+//   breaks drag drop. See _isRunningAsDifferentSessionUser and GH#15689.
 // * This has to be kept separate from IsRunningElevated, which is exclusively
 //   used for "is this instance running as admin".
 bool Utils::CanUwpDragDrop()
@@ -970,6 +1065,16 @@ bool Utils::CanUwpDragDrop()
         try
         {
             wil::unique_handle processToken{ GetCurrentProcessToken() };
+
+            // Running as a different user than the one logged into our session
+            // (e.g. via `runas /user:...`) crashes the drag/drop broker the
+            // same way elevation does. Check this first: it holds regardless of
+            // our own token's elevation state. See GH#15689.
+            if (_isRunningAsDifferentSessionUser(processToken.get()))
+            {
+                return true;
+            }
+
             const auto elevationType = wil::get_token_information<TOKEN_ELEVATION_TYPE>(processToken.get());
             const auto elevationState = wil::get_token_information<TOKEN_ELEVATION>(processToken.get());
             if (elevationType == TokenElevationTypeDefault && elevationState.TokenIsElevated)


### PR DESCRIPTION
disable drag/drop/tear when running as other users, add settings for enable/disable functionality

## Summary of the Pull Request
- disables drag drop for /runas instances, similar to elevated instances
- adds "interaction" setting to allow enable/disable of tab drag/drop/rearrange/tear
- reflects "setting cannot be changed" if running as different user or elevated

## References and Relevant Issues
https://github.com/microsoft/terminal/issues/15689

## Detailed Description of the Pull Request / Additional comments
LLM summarized: The modern XAML drag/drop broker (DataExchangeHost) denies a process whose token user doesn't match the interactive session's user with E_ACCESSDENIED. XAML surfaces that as an uncaught error and fail-fasts the process, so it can't be caught — the only fix is to not start the drag, exactly like the existing elevated guard. Utils::CanUwpDragDrop() is extended to compare the process token SID against the session user SID (via WTS), which already gates TabView.CanReorderTabs/CanDragTabs

## Validation Steps Performed
- demonstrated crash (see end of PR)
- ran as "claude" and "admin" to verify user cannot drag/drop/tear tabs
- ran as "clint" and verified the interaction setting can be toggled on and drag/drop/tear works, and toggled off where it doesn't (gifs of both at the end)

## PR Checklist
- [x] Closes #15689
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [x] Schema updated -- doc/cascadia/profiles.schema.json updated

**REPRODUCTION**
<img width="1435" height="722" alt="repro" src="https://github.com/user-attachments/assets/57986600-646e-431f-ae4b-7d08ae170680" />


**FIX/ENHANCEMENT DEMONSTRATED**
<img width="1435" height="722" alt="fixed" src="https://github.com/user-attachments/assets/2d5d4161-f853-40e4-a6a4-2a1012aeff1c" />
