### PR TITLE
build: use Terrapin for the OneBranch build too

### DIFF
--- a/build/pipelines/templates-v2/pipeline-1espt-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-1espt-full-release-build.yml
@@ -121,6 +121,9 @@ extends:
                 - template: ./build/pipelines/templates-v2/steps-setup-versioning.yml@self
 
                 - template: ./build/pipelines/templates-v2/steps-install-terrapin.yml@self
+                  parameters:
+                    useNuget: true
+                    nugetFeed: "https://pkgs.dev.azure.com/microsoft/_packaging/WindowsTerminal/nuget/v3/index.json"
 
                 - task: UniversalPackages@0
                   displayName: Download terminal-internal Universal Package

--- a/build/pipelines/templates-v2/pipeline-1espt-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-1espt-full-release-build.yml
@@ -122,7 +122,6 @@ extends:
 
                 - template: ./build/pipelines/templates-v2/steps-install-terrapin.yml@self
                   parameters:
-                    useNuget: true
                     nugetFeed: "https://pkgs.dev.azure.com/microsoft/_packaging/WindowsTerminal/nuget/v3/index.json"
 
                 - task: UniversalPackages@0

--- a/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
@@ -142,6 +142,10 @@ extends:
               beforeBuildSteps: # Right before we build, lay down the universal package and localizations
                 - template: ./build/pipelines/templates-v2/steps-setup-versioning.yml@self
 
+                - template: ./build/pipelines/templates-v2/steps-install-terrapin.yml@self
+                  parameters:
+                    useNuget: false
+
                 - task: UniversalPackages@0
                   displayName: Download terminal-internal Universal Package
                   inputs:

--- a/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
@@ -144,7 +144,7 @@ extends:
 
                 - template: ./build/pipelines/templates-v2/steps-install-terrapin.yml@self
                   parameters:
-                    useNuget: false
+                    nugetFeed: "https://pkgs.dev.azure.com/microsoft/_packaging/WindowsTerminal/nuget/v3/index.json"
 
                 - task: UniversalPackages@0
                   displayName: Download terminal-internal Universal Package

--- a/build/pipelines/templates-v2/steps-install-terrapin.yml
+++ b/build/pipelines/templates-v2/steps-install-terrapin.yml
@@ -1,6 +1,32 @@
+parameters:
+- name: useNuget
+  type: boolean
+  default: true
+- name: nugetFeed
+  type: string
+  default: unspecified
+
 steps:
+- ${{ if and(eq(parameters.useNuget, true), eq(parameters.nugetFeed, 'unspecified')) }}:
+  - "useNuget=true but nugetFeed was not specified": error
 - pwsh: |-
-    nuget install -source "https://pkgs.dev.azure.com/microsoft/_packaging/WindowsTerminal/nuget/v3/index.json" TerrapinRetrievalTool -Prerelease -OutputDirectory _trt
-    $TerrapinRetrievalToolPath = (Get-Item _trt\TerrapinRetrievalTool.*\win-x64\TerrapinRetrievalTool.exe).FullName
-    Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES]x-script,${TerrapinRetrievalToolPath} -b https://vcpkg.storage.devpackages.microsoft.io/artifacts/ -a true -u None -p {url} -s {sha512} -d {dst};x-block-origin"
-  displayName: Set up the Terrapin Retrieval Tool (vcpkg cache)
+    Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES]INVALID"
+    $TerrapinRetrievalTool = Get-ChildItem C:\nugettools\terrapinretrievaltool -Filter TerrapinRetrievalTool.exe -ErrorAction:Ignore -Recurse
+    If ($null -Ne $TerrapinRetrievalTool) {
+      $TerrapinRetrievalToolPath = $TerrapinRetrievalTool.FullName
+      Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES]x-script,${TerrapinRetrievalToolPath} -b https://vcpkg.storage.devpackages.microsoft.io/artifacts/ -a true -u None -p {url} -s {sha512} -d {dst};x-block-origin"
+    }
+  displayName: Detect installed Terrapin Retrieval Tool
+
+- ${{ if eq(parameters.useNuget, true) }}:
+  - pwsh: |-
+      nuget install -source "${{ parameters.nugetFeed }}" TerrapinRetrievalTool -Prerelease -OutputDirectory _trt
+      $TerrapinRetrievalToolPath = (Get-Item _trt\TerrapinRetrievalTool.*\win-x64\TerrapinRetrievalTool.exe).FullName
+      Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES]x-script,${TerrapinRetrievalToolPath} -b https://vcpkg.storage.devpackages.microsoft.io/artifacts/ -a true -u None -p {url} -s {sha512} -d {dst};x-block-origin"
+    displayName: Install the Terrapin Retrieval Tool (vcpkg cache)
+    condition: and(succeeded(), eq(variables['X_VCPKG_ASSET_SOURCES'], 'INVALID'))
+
+- script: |-
+    EXIT 1
+  displayName: Fail the build if Terrapin was not found
+  condition: and(succeeded(), eq(variables['X_VCPKG_ASSET_SOURCES'], 'INVALID'))

--- a/build/pipelines/templates-v2/steps-install-terrapin.yml
+++ b/build/pipelines/templates-v2/steps-install-terrapin.yml
@@ -1,32 +1,14 @@
 parameters:
-- name: useNuget
-  type: boolean
-  default: true
 - name: nugetFeed
   type: string
   default: unspecified
 
 steps:
-- ${{ if and(eq(parameters.useNuget, true), eq(parameters.nugetFeed, 'unspecified')) }}:
-  - "useNuget=true but nugetFeed was not specified": error
+- ${{ if eq(parameters.nugetFeed, 'unspecified') }}:
+  - "nugetFeed was not specified": error
+
 - pwsh: |-
-    Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES]INVALID"
-    $TerrapinRetrievalTool = Get-ChildItem C:\nugettools\terrapinretrievaltool -Filter TerrapinRetrievalTool.exe -ErrorAction:Ignore -Recurse
-    If ($null -Ne $TerrapinRetrievalTool) {
-      $TerrapinRetrievalToolPath = $TerrapinRetrievalTool.FullName
-      Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES]x-script,${TerrapinRetrievalToolPath} -b https://vcpkg.storage.devpackages.microsoft.io/artifacts/ -a true -u None -p {url} -s {sha512} -d {dst};x-block-origin"
-    }
-  displayName: Detect installed Terrapin Retrieval Tool
-
-- ${{ if eq(parameters.useNuget, true) }}:
-  - pwsh: |-
-      nuget install -source "${{ parameters.nugetFeed }}" TerrapinRetrievalTool -Prerelease -OutputDirectory _trt
-      $TerrapinRetrievalToolPath = (Get-Item _trt\TerrapinRetrievalTool.*\win-x64\TerrapinRetrievalTool.exe).FullName
-      Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES]x-script,${TerrapinRetrievalToolPath} -b https://vcpkg.storage.devpackages.microsoft.io/artifacts/ -a true -u None -p {url} -s {sha512} -d {dst};x-block-origin"
-    displayName: Install the Terrapin Retrieval Tool (vcpkg cache)
-    condition: and(succeeded(), eq(variables['X_VCPKG_ASSET_SOURCES'], 'INVALID'))
-
-- script: |-
-    EXIT 1
-  displayName: Fail the build if Terrapin was not found
-  condition: and(succeeded(), eq(variables['X_VCPKG_ASSET_SOURCES'], 'INVALID'))
+    nuget install -source "${{ parameters.nugetFeed }}" TerrapinRetrievalTool -Prerelease -OutputDirectory _trt
+    $TerrapinRetrievalToolPath = (Get-Item _trt\TerrapinRetrievalTool.*\win-x64\TerrapinRetrievalTool.exe).FullName
+    Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES]x-script,${TerrapinRetrievalToolPath} -b https://vcpkg.storage.devpackages.microsoft.io/artifacts/ -a true -u None -p {url} -s {sha512} -d {dst};x-block-origin"
+  displayName: Install the Terrapin Retrieval Tool (vcpkg cache)


### PR DESCRIPTION
It's a security requirement. Unlike 1ESPT, which fails the build if you talk to a remote server, OneBranch happily chugs along and then files a "the world is ending" work item on you.

I also made the Terrapin step template more reusable if we need to change where it downloads from.