### PR TITLE
drcs: reject attempts to write a glyph that is too tall

### DIFF
--- a/src/terminal/adapter/FontBuffer.cpp
+++ b/src/terminal/adapter/FontBuffer.cpp
@@ -335,6 +335,11 @@ void FontBuffer::_addSixelValue(const VTInt value) noexcept
 void FontBuffer::_endOfSixelLine()
 {
     // Move down six rows to the get to the next sixel position.
+    if (_currentCharBuffer >= _buffer.end() || _sixelRow >= MAX_HEIGHT) [[unlikely]]
+    {
+        // Advancing the cursor beyond the last row is not OK.
+        THROW_HR(E_OUTOFMEMORY);
+    }
     std::advance(_currentCharBuffer, 6);
     _sixelRow += 6;
 

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -3979,7 +3979,15 @@ ITermDispatch::StringHandler AdaptDispatch::DownloadDRCS(const VTInt fontNumber,
         // with the constructed bit pattern.
         if (ch != AsciiChars::ESC)
         {
-            _fontBuffer->AddSixelData(ch);
+            try
+            {
+                _fontBuffer->AddSixelData(ch);
+            }
+            catch (...)
+            {
+                // Ignore all further content.
+                return false;
+            }
         }
         else if (_fontBuffer->FinalizeSixelData())
         {


### PR DESCRIPTION
We probably shouldn't walk this iterator off the end of the array. Or write into it.