### PR TITLE
Guard AtlasEngine::PaintCursor against out-of-bounds cursor rows

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -1239,16 +1239,28 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         _terminal->ClearSelection();
 
+        // GH#20406: Resize the terminal first. UserResize reflows the entire scrollback
+        // into a freshly allocated buffer and can fail (e.g. E_OUTOFMEMORY under memory
+        // pressure). If we told the engine about the new size before that failure, the
+        // renderer would keep producing cursor coordinates for the terminal's old,
+        // larger viewport while the engine's row buffer already had the new, smaller
+        // size - an out-of-bounds access on the render thread. A failed resize must
+        // leave the terminal and the engine at the same, old size.
+        const auto hr = _terminal->UserResize({ vp.Width(), vp.Height() });
+        if (FAILED(hr))
+        {
+            return;
+        }
+
         // Tell the dx engine that our window is now the new size.
         THROW_IF_FAILED(_renderEngine->SetWindowSize({ cx, cy }));
 
         // Invalidate everything
         _renderer->TriggerRedrawAll();
 
-        // If this function succeeds with S_FALSE, then the terminal didn't
-        // actually change size. No need to notify the connection of this no-op.
-        const auto hr = _terminal->UserResize({ vp.Width(), vp.Height() });
-        if (FAILED(hr) || hr == S_FALSE)
+        // If UserResize returned S_FALSE, the terminal didn't actually change size.
+        // No need to notify the connection of this no-op.
+        if (hr == S_FALSE)
         {
             return;
         }

--- a/src/cascadia/UnitTests_Control/ControlCoreTests.cpp
+++ b/src/cascadia/UnitTests_Control/ControlCoreTests.cpp
@@ -4,6 +4,7 @@
 #include "pch.h"
 #include "../TerminalControl/EventArgs.h"
 #include "../TerminalControl/ControlCore.h"
+#include "../../renderer/atlas/AtlasEngine.h"
 #include "MockControlSettings.h"
 #include "MockConnection.h"
 #include "../../inc/TestUtils.h"
@@ -27,6 +28,7 @@ namespace ControlUnitTests
         TEST_METHOD(ComPtrSettings);
         TEST_METHOD(InstantiateCore);
         TEST_METHOD(TestInitialize);
+        TEST_METHOD(TestResizeTerminalAndEngineStayInLockstep);
         TEST_METHOD(TestAdjustAcrylic);
 
         TEST_METHOD(TestFreeAfterClose);
@@ -129,6 +131,48 @@ namespace ControlUnitTests
 #endif
         VERIFY_IS_TRUE(core->_initializedTerminal);
         VERIFY_ARE_EQUAL(30, core->_terminal->GetViewport().Width());
+    }
+
+    void ControlCoreTests::TestResizeTerminalAndEngineStayInLockstep()
+    {
+        auto [settings, conn] = _createSettingsAndConnection();
+
+        auto core = createCore(*settings, *conn);
+        VERIFY_IS_NOT_NULL(core);
+        _standardInit(core);
+
+        // GH#20406: _refreshSizeUnderLock resizes the terminal first and only then
+        // informs the render engine, so that a failed scrollback reflow cannot leave
+        // the two at different sizes (the render thread would then paint the cursor
+        // at a row beyond the engine's row buffer). The failure path itself
+        // (E_OUTOFMEMORY inside Terminal::UserResize) has no fault-injection seam,
+        // so this test covers the non-failure paths: after every resize, the
+        // terminal's viewport must match the cell count the engine derives from the
+        // pixel size it was handed.
+        const auto assertSizesInLockstep = [&](til::CoordType pxWidth, til::CoordType pxHeight) {
+            const auto viewInPixels = Types::Viewport::FromDimensions({ 0, 0 }, { pxWidth, pxHeight });
+            const auto vp = core->_renderEngine->GetViewportInCharacters(viewInPixels);
+            VERIFY_ARE_EQUAL(vp.Width(), core->_terminal->GetViewport().Width());
+            VERIFY_ARE_EQUAL(vp.Height(), core->_terminal->GetViewport().Height());
+        };
+
+        Log::Comment(L"Grow the control");
+        core->SizeChanged(360, 570); // 40x30 chars at 9x19px per cell
+        VERIFY_ARE_EQUAL(40, core->_terminal->GetViewport().Width());
+        VERIFY_ARE_EQUAL(30, core->_terminal->GetViewport().Height());
+        assertSizesInLockstep(360, 570);
+
+        Log::Comment(L"Shrink the control");
+        core->SizeChanged(180, 190); // 20x10 chars
+        VERIFY_ARE_EQUAL(20, core->_terminal->GetViewport().Width());
+        VERIFY_ARE_EQUAL(10, core->_terminal->GetViewport().Height());
+        assertSizesInLockstep(180, 190);
+
+        Log::Comment(L"Change the pixel size without changing the cell count (UserResize returns S_FALSE)");
+        core->SizeChanged(184, 195); // still 20x10 chars
+        VERIFY_ARE_EQUAL(20, core->_terminal->GetViewport().Width());
+        VERIFY_ARE_EQUAL(10, core->_terminal->GetViewport().Height());
+        assertSizesInLockstep(184, 195);
     }
 
     void ControlCoreTests::TestAdjustAcrylic()

--- a/src/renderer/atlas/AtlasEngine.cpp
+++ b/src/renderer/atlas/AtlasEngine.cpp
@@ -620,6 +620,19 @@ try
         const auto cursorWidth = 1 + (options.fIsDoubleWidth & (options.cursorType != CursorType::VerticalBar));
         const auto top = options.coordCursor.y;
         const auto bottom = top + 1;
+
+        // GH#20269, GH#20406: coordCursor is computed against the renderer's viewport,
+        // while _p.rows is sized to our own viewportCellCount. The two can disagree
+        // when the terminal and engine sizes are transiently out of sync, for instance
+        // when a failed Terminal::UserResize left the terminal at its old size after
+        // we were already told the new one. Skip the cursor for this frame instead of
+        // reading out of bounds. EndPaint invalidates the previous cursor area either
+        // way, so no stale cursor pixels are left behind.
+        if (top < 0 || bottom > _p.s->viewportCellCount.y)
+        {
+            return S_OK;
+        }
+
         const auto shift = gsl::narrow_cast<u8>(_p.rows[top]->lineRendition != LineRendition::SingleWidth);
         auto left = options.coordCursor.x - (_api.viewportOffset.x >> shift);
         auto right = left + cursorWidth;


### PR DESCRIPTION
## Summary of the Pull Request

Fixes an access violation on the render thread in `AtlasEngine::PaintCursor` that takes down every window in the process (all windows share one `WindowsTerminal.exe`). Two changes:

1. `AtlasEngine::PaintCursor` bounds-checks the cursor row before indexing `_p.rows` and skips the cursor for that frame if it lies outside the engine's viewport. This is the durable fix: it makes the crash impossible regardless of which code path produced the terminal/engine size mismatch.
2. `ControlCore::_refreshSizeUnderLock` now resizes the terminal first and only informs the render engine when `Terminal::UserResize` did not fail. This removes one dump-proven producer of the mismatch: a failed scrollback reflow (`E_OUTOFMEMORY` under memory pressure) previously left the engine at the new size and the terminal at the old one.

## References and Relevant Issues

- Closes #20269 (same crash signature: `AtlasEngine::PaintCursor`, offset 0x2c924, AV reading `[rdx+0xC0]` with `rdx = 0`)
- Closes #20406 (same crash during tab drag-merge, with a symbolicated local dump and the producer chain below)
- Related: #20366 speculatively fixed a different producer of the same desync (the `EnablePainting` viewport assignment, refs #20269). That change addresses one producer; this PR guards the crash site itself and fixes a second, dump-proven producer.
- Related: #17246 / #17251 (crashes in the same drag-merge gesture family).

## Detailed Description of the Pull Request / Additional comments

### Root cause, proven from a crash dump

A local crash dump for #20406 (WER fault offset 0x2c924 in Microsoft.Terminal.Control.dll, matching #20269's report exactly) symbolicates to:

```
AtlasEngine::PaintCursor            src\renderer\atlas\AtlasEngine.cpp @ 623
Renderer::_PaintCursor (inlined)    src\renderer\base\renderer.cpp
Renderer::_PaintFrameForEngine
Renderer::_PaintFrame
RenderThread::_ThreadProc
```

Faulting instruction sequence:

```
movsxd r10, dword ptr [rdi+4]      ; r10 = options.coordCursor.y = 0x2e (46)
mov    rax, qword ptr [rbx+2B8h]   ; rax = _p.rows data pointer
mov    rdx, qword ptr [rax+r10*8]  ; _p.rows[46], read past the end -> 0
cmp    byte ptr [rdx+0C0h], r9b    ; ShapedRow::lineRendition -> AV at 0xC0
```

`options.coordCursor.y` is computed by `Renderer::_updateCursorInfo` against the terminal's viewport, and `Renderer::_PaintCursor` gates only on `inViewport && isVisible`, both derived from that same viewport. `_p.rows`, however, is sized to the engine's own `viewportCellCount.y` (`_recreateCellCountDependentResources`). The two sizes are tracked independently. When the terminal is taller than the engine's row buffer, a cursor on a bottom row indexes past the end of `_p.rows`. `Buffer<T>::operator[]` is assert-only, so release builds read out of bounds; the slot read back null and the `lineRendition` access faulted.

Every other `_p.rows` access already clamps its row to the engine's `viewportCellCount` first (`PaintBufferLine`, `PaintBufferGridLines`, `PaintImageSlice`, `PrepareLineTransform`) or iterates `rows` directly. `PaintCursor` was the only unbounded site; the clamp it does perform (for `cursorRect`) happens after the deref.

### The dump-proven producer

`ControlCore::_refreshSizeUnderLock` did, in order: `_renderEngine->SetWindowSize(new)`, `TriggerRedrawAll()`, `_terminal->UserResize(new)`, and returned early when `UserResize` failed. `Terminal::UserResize` is `noexcept try` + `CATCH_RETURN()` and reflows the entire scrollback into a freshly allocated `TextBuffer`, so it genuinely fails under memory pressure. On failure the engine had already adopted the new (smaller) size while the terminal, and therefore the renderer's cursor coordinates, kept the old (larger) one. The desync then persists: `SizeOrScaleChanged` updates `_panelWidth/_panelHeight` before the call and dedups on them, so the same dimensions are never retried.

In #20406 this fired during a tab drag-merge: the transferred control is resized to the target pane, the machine was under memory pressure (WER logged RADAR_PRE_LEAK_64 for the process 30 minutes before the crash), the reflow of a large scrollback failed, and continuous streaming output kept the cursor on the bottom row, maximizing the overshoot.

### Why skip instead of clamp in PaintCursor

A cursor clamped to the nearest valid row would be drawn at a cell where the cursor is not. Skipping produces the already-well-defined "no cursor this frame" state: `_p.cursorRect` is reset in `StartPaint` every frame and both backends skip empty rects, and `EndPaint` grows the dirty rect from `_api.invalidatedCursorArea` independently of `PaintCursor` (the same path that handles blink-off frames), so the previous cursor cell is still repainted and no stale pixels remain. The frame self-heals once the sizes reconverge.

### Behavior of the reorder in `_refreshSizeUnderLock`

For `UserResize` returning `S_OK` or `S_FALSE` the set of calls is unchanged (`SetWindowSize` still runs on `S_FALSE`, since the pixel size may change without the cell count changing; `AtlasEngine::SetWindowSize` only stores pending state and always returns `S_OK`). The only behavioral change is the failure case: both sides now stay at the old size. The whole function runs under the terminal lock, and the render thread paints under the same lock, so no frame can observe a half-applied resize.

### Residual issues, intentionally out of scope (follow-up material)

- Two more callers order engine-resize before terminal-resize and do not retry on failure: the deferred alt-buffer resize (`TerminalApi.cpp`, `UseMainScreenBuffer`) and `HwndTerminal::Refresh`. They rely on the new `PaintCursor` guard as their safety net; a follow-up PR could apply the same reordering there.
- `AtlasEngine::StartPaint` self-resizes from `GetClientRect` for HWND targets, so caller-side ordering alone can never fully rule out a transient mismatch. This is the structural reason the guard lives in the engine.
- After a failed resize the window renders at the stale old size until the next different-size event (pre-existing: `_panelWidth/_panelHeight` are updated and deduped before the resize is attempted). Strictly better than the crash it replaces, but visible.
- If a desync persists through an unfixed producer, the user sees no cursor rather than a crash.

## Validation Steps Performed

- Symbolicated the #20406 crash dump against the public symbol server and matched it to #20269's signature (stack, module offset, faulting instruction).
- Built `Control.UnitTests` and the TerminalCore `UnitTests` projects (x64 Debug, VS 2022 17.14 / MSVC 14.44) locally with the changes: both succeeded. (Local note: the vcpkg overlay triplet pins toolset v145, which this machine lacks; the dependencies were built locally with v143 for validation only, no repo change included.)
- Ran the full TAEF suites locally: `Terminal.Core.Unit.Tests.dll` 54/54 passed (includes `ScreenSizeLimitsTest`), `Control.Unit.Tests.dll` 30/30 passed (includes `ControlCoreTests`, `ControlInteractivityTests`, and the new `TestResizeTerminalAndEngineStayInLockstep`).
- clang-format produces no diff on the three touched files.
- The OOM failure path itself was not reproduced locally and has no fault-injection seam in the existing test infrastructure; the new test covers the non-failure resize paths (grow, shrink, same-cells pixel change) by asserting the terminal viewport stays in lockstep with the cell count the engine derives from the pixel size.

## PR Checklist
- [x] Closes #20269, closes #20406
- [x] Tests added/passed
- [ ] Documentation updated
- [ ] Schema updated (if necessary)
