### PR TITLE
Explain implicit new-tab arguments in wt.exe help menu

### DIFF
--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -143,6 +143,7 @@ void AppCommandlineArgs::_buildParser()
     // E.g., for "wt.exe -M -d c:/", we will use -M for the launch mode, but once we will encounter -d
     // we will know that the prefix is over and try to handle the suffix as a new tab subcommand
     _app.prefix_command();
+    _app.footer(RS_A(L"CmdAppHelpFooter"));
 
     // -v,--version: Displays version info
     auto versionCallback = [this](int64_t /*count*/) {

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -1000,4 +1000,10 @@
   <data name="InvalidRegex" xml:space="preserve">
     <value>An invalid regular expression was found.</value>
   </data>
+  <data name="CmdAppHelpFooter" xml:space="preserve">
+    <value>Note: Unrecognized arguments are automatically passed to the 'new-tab' subcommand.
+For example, 'wt -p "Ubuntu" -d C:\' is equivalent to 'wt new-tab -p "Ubuntu" -d C:\'.
+For all available options, run 'wt new-tab --help'.</value>
+    <comment>{Locked="wt","new-tab","-p","-d","--help"}</comment>
+  </data>
 </root>


### PR DESCRIPTION
## Summary 
Adds a descriptive footer to the root `wt` help menu explaining that unrecognized arguments are implicitly passed to the `new-tab` subcommand. Closes #9585.

## Problem 
When users execute `wt /?` or `wt --help`, the command-line options specifically tied to tab-creation (like `-d` for starting directory or `-p` for profile) are not listed. This creates confusion because users frequently pass these arguments directly to `wt` without realizing they are actually invoking the implicit `new-tab` subcommand. 

## Root Cause 
The root CLI parser (`_app`) is configured as a prefix command to support implicit subcommand execution. `CLI11`'s help generation only lists arguments explicitly attached to the queried command, meaning arguments attached to `new-tab` are hidden when querying the root `wt` command's help.

## Solution 
Instead of duplicating argument definitions (which would break the subcommand fallback logic), this fix utilizes `CLI11`'s `footer()` API. We append a localized note to the end of the root help text clarifying the implicit `new-tab` behavior and providing an example. 

## Testing 
- **Manual Verification:** Verified that running `wt /?` displays the localized footer.
- **Localization Checks:** Added a `{Locked="..."}` comment block to `Resources.resw` to ensure automated translation tools do not mistakenly localize command-line string literals (e.g. `wt`, `new-tab`, `-d`).

## Screenshots (if applicable) 
*(N/A - CLI text change only)*

## Checklist 
- [x] Followed repository coding style
- [x] Added necessary localization locking comments
- [x] Kept commits focused and minimal
- [x] Tested command-line output locally
