### PR TITLE
Set COLORTERM=truecolor in the environment of new connections

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -197,6 +197,7 @@ colorspaces
 colorspec
 colortable
 colortbl
+COLORTERM
 colortest
 colortool
 COLORVALUE
@@ -1700,6 +1701,7 @@ Trd
 triaged
 triaging
 TRIMZEROHEADINGS
+truecolor
 trx
 tsa
 tsgr

--- a/src/cascadia/TerminalConnection/ConptyConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConptyConnection.cpp
@@ -63,6 +63,9 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
             // The profile Guid does include the enclosing '{}'
             environment.as_map().insert_or_assign(L"WT_PROFILE_ID", Utils::GuidToString(_profileGuid));
 
+            // Advertise 24-bit color support to client applications (GH#11057).
+            environment.as_map().insert_or_assign(L"COLORTERM", L"truecolor");
+
             // WSLENV is a colon-delimited list of environment variables (+flags) that should appear inside WSL
             // https://devblogs.microsoft.com/commandline/share-environment-vars-between-wsl-and-windows/
 
@@ -88,6 +91,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
             static constexpr std::wstring_view builtinWslEnvVars[] = {
                 L"WT_SESSION",
                 L"WT_PROFILE_ID",
+                L"COLORTERM",
             };
             // Misdiagnosis in MSVC 14.44.35207. No pointer arithmetic in sight.
 #pragma warning(suppress : 26481) // Don't use pointer arithmetic. Use span instead (bounds.1).


### PR DESCRIPTION
## Summary of the Pull Request
Sets `COLORTERM=truecolor` in the environment of every new ConPTY connection, alongside the existing `WT_SESSION` and `WT_PROFILE_ID` variables. `COLORTERM` is also added to the built-in `WSLENV` list so the variable propagates into WSL sessions, where most `COLORTERM`-aware tools run.

## References and Relevant Issues
#11057 — maintainers indicated they're on board with setting `COLORTERM` (https://github.com/microsoft/terminal/issues/11057#issuecomment-906726973). #13687 was closed as a duplicate of it.

## Detailed Description of the Pull Request / Additional comments
Many client applications (gh, oh-my-zsh, onefetch, etc.) check `COLORTERM` for the value `truecolor` to decide whether to emit 24-bit color escape sequences, and fall back to 256/16-color output when it's unset. Windows Terminal has always supported 24-bit color, so it advertises it the same way other truecolor-capable terminal emulators do (see https://github.com/termstandard/colors).

The variable is set before the profile's custom `environment` map is applied, so users can still override or clear it per-profile if they need to.

## Validation Steps Performed
Code inspection: the new variable is set via the exact code path used for `WT_SESSION`/`WT_PROFILE_ID`, and `WSLENV` handling already dedupes against user-specified entries. After building, `echo $env:COLORTERM` (PowerShell) and `echo $COLORTERM` (WSL) should both print `truecolor`.

## PR Checklist
- [x] Closes #11057
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)