### PR TITLE
AtlasEngine: retry the settings update when rebuilding the buffers throws

### DIFF
--- a/src/cascadia/UnitTests_Control/AtlasEngineTests.cpp
+++ b/src/cascadia/UnitTests_Control/AtlasEngineTests.cpp
@@ -1,0 +1,170 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
+#include "../../renderer/atlas/AtlasEngine.h"
+
+#include <psapi.h> // GetProcessMemoryInfo
+
+using namespace Microsoft::Console::Render;
+using namespace Microsoft::Console::Render::Atlas;
+using namespace WEX::Logging;
+using namespace WEX::TestExecution;
+using namespace WEX::Common;
+
+namespace ControlUnitTests
+{
+    class AtlasEngineTests
+    {
+        BEGIN_TEST_CLASS(AtlasEngineTests)
+            TEST_CLASS_PROPERTY(L"TestTimeout", L"0:0:30") // 30s timeout
+        END_TEST_CLASS()
+
+        TEST_METHOD(SettingsUpdateRecoversFromAllocationFailure);
+
+    private:
+        static void initFont(AtlasEngine& engine)
+        {
+            FontInfoDesired desired{ L"Consolas", 0, FW_NORMAL, 12.0f, CP_UTF8 };
+            FontInfo actual{ L"Consolas", 0, FW_NORMAL, { 0, 12 }, CP_UTF8, false };
+            VERIFY_SUCCEEDED(engine.UpdateFont(desired, actual));
+        }
+
+        static HRESULT setViewport(AtlasEngine& engine, til::CoordType width, til::CoordType height)
+        {
+            return engine.UpdateViewport(til::inclusive_rect{ 0, 0, width - 1, height - 1 });
+        }
+
+        static CursorOptions cursorAtRow(til::CoordType row) noexcept
+        {
+            CursorOptions options{};
+            options.coordCursor = { 0, row };
+            options.cursorType = CursorType::Legacy;
+            options.ulCursorHeightPercent = 25;
+            options.isOn = true;
+            return options;
+        }
+
+        struct Ballast
+        {
+            std::vector<void*> blocks;
+            size_t bytes = 0;
+            bool exhausted = false;
+        };
+
+        // Hard stop for the ballast fill, in case the Job Object limit fails to constrain us.
+        static constexpr size_t ballastSafetyLimit = size_t{ 256 } << 20;
+
+        // Limits the process commit charge to its current usage plus `headroom` bytes.
+        // Returns an empty handle if the limit cannot be applied.
+        static wil::unique_handle capProcessCommit(size_t headroom)
+        {
+            PROCESS_MEMORY_COUNTERS counters{ .cb = sizeof(PROCESS_MEMORY_COUNTERS) };
+            if (!GetProcessMemoryInfo(GetCurrentProcess(), &counters, sizeof(counters)))
+            {
+                return {};
+            }
+
+            wil::unique_handle job{ CreateJobObjectW(nullptr, nullptr) };
+            if (!job)
+            {
+                return {};
+            }
+
+            JOBOBJECT_EXTENDED_LIMIT_INFORMATION limits{};
+            limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_PROCESS_MEMORY;
+            limits.ProcessMemoryLimit = counters.PagefileUsage + headroom;
+            if (!SetInformationJobObject(job.get(), JobObjectExtendedLimitInformation, &limits, sizeof(limits)) ||
+                !AssignProcessToJobObject(job.get(), GetCurrentProcess()))
+            {
+                return {};
+            }
+            return job;
+        }
+
+        // A process cannot leave its job, but clearing the limits makes it inert for any tests
+        // that run in this host afterwards.
+        static void uncapProcessCommit(HANDLE job) noexcept
+        {
+            JOBOBJECT_EXTENDED_LIMIT_INFORMATION limits{};
+            SetInformationJobObject(job, JobObjectExtendedLimitInformation, &limits, sizeof(limits));
+        }
+
+        // Commits memory in shrinking chunks until even a 64 KiB request fails. `blocks` is
+        // reserved up front so the squeeze itself doesn't allocate from the heap.
+        static Ballast exhaustCommitBudget()
+        {
+            Ballast ballast;
+            ballast.blocks.reserve(4096);
+            for (const auto chunk : { size_t{ 4 } << 20, size_t{ 256 } << 10, size_t{ 64 } << 10 })
+            {
+                while (ballast.bytes < ballastSafetyLimit)
+                {
+                    const auto block = VirtualAlloc(nullptr, chunk, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+                    if (!block)
+                    {
+                        break;
+                    }
+                    ballast.blocks.push_back(block);
+                    ballast.bytes += chunk;
+                }
+            }
+            ballast.exhausted = ballast.bytes < ballastSafetyLimit;
+            return ballast;
+        }
+
+        static void releaseBallast(Ballast& ballast) noexcept
+        {
+            for (const auto block : ballast.blocks)
+            {
+                VirtualFree(block, 0, MEM_RELEASE);
+            }
+            ballast.blocks.clear();
+            ballast.bytes = 0;
+        }
+    };
+
+    // GH#20269: A bad_alloc during _handleSettingsUpdate() used to leave _p.s permanently out of
+    // sync with the buffers it describes, because StartPaint()'s `_p.s != _api.s` check never
+    // retried the rebuild. A later, healthy frame then read rows that were never rebuilt.
+    void AtlasEngineTests::SettingsUpdateRecoversFromAllocationFailure()
+    {
+        AtlasEngine engine;
+        initFont(engine);
+        VERIFY_SUCCEEDED(setViewport(engine, 120, 30));
+        VERIFY_SUCCEEDED(engine.StartPaint());
+
+        // 426x113 cells = a maximized 4K window at 9x19px per cell. Its color bitmap alone
+        // (432 * 113 * 3 * sizeof(u32) after row stride padding, ~572 KiB) cannot fit into the
+        // headroom the ballast below leaves behind.
+        VERIFY_SUCCEEDED(setViewport(engine, 426, 113));
+
+        const auto job = capProcessCommit(size_t{ 64 } << 20);
+        if (!job)
+        {
+            Log::Result(TestResults::Skipped, L"cannot place the test process under a Job Object commit limit");
+            return;
+        }
+        auto uncap = wil::scope_exit([&]() noexcept { uncapProcessCommit(job.get()); });
+
+        auto ballast = exhaustCommitBudget();
+        auto releaseOnUnwind = wil::scope_exit([&]() noexcept { releaseBallast(ballast); });
+        if (!ballast.exhausted)
+        {
+            releaseBallast(ballast);
+            Log::Result(TestResults::Skipped, L"the commit limit did not constrain the process");
+            return;
+        }
+
+        // No Log::Comment and no VERIFY until the ballast is released: the test host itself
+        // cannot reliably allocate here.
+        const auto pressured = engine.StartPaint();
+        releaseBallast(ballast);
+
+        VERIFY_ARE_EQUAL(E_OUTOFMEMORY, pressured);
+
+        // The pressure has passed; the engine must retry the rebuild on its own.
+        VERIFY_SUCCEEDED(engine.StartPaint());
+        VERIFY_SUCCEEDED(engine.PaintCursor(cursorAtRow(112)));
+    }
+}

--- a/src/cascadia/UnitTests_Control/Control.UnitTests.vcxproj
+++ b/src/cascadia/UnitTests_Control/Control.UnitTests.vcxproj
@@ -28,6 +28,7 @@
 
   <!-- ========================= Cpp Files ======================== -->
   <ItemGroup>
+    <ClCompile Include="AtlasEngineTests.cpp" />
     <ClCompile Include="ControlCoreTests.cpp" />
     <ClCompile Include="ControlInteractivityTests.cpp" />
     <ClCompile Include="pch.cpp">

--- a/src/renderer/atlas/AtlasEngine.cpp
+++ b/src/renderer/atlas/AtlasEngine.cpp
@@ -698,6 +698,14 @@ void AtlasEngine::_handleSettingsUpdate()
     const auto fontChanged = _p.s->font != _api.s->font;
     const auto cellCountChanged = _p.s->viewportCellCount != _api.s->viewportCellCount;
 
+    // GH#20269: The _recreate*() calls below read _p.s, so it must be advanced first, but they
+    // also allocate and may throw. Roll _p.s back on failure so that the next StartPaint() call
+    // retries the update, otherwise we'd keep painting against buffers that were never rebuilt.
+    auto previousSettings = _p.s;
+    auto restoreSettings = wil::scope_exit([&]() noexcept {
+        _p.s = std::move(previousSettings);
+    });
+
     _p.s = _api.s;
 
     if (targetChanged)
@@ -716,6 +724,8 @@ void AtlasEngine::_handleSettingsUpdate()
     }
 
     _api.invalidatedRows = invalidatedRowsAll;
+
+    restoreSettings.release();
 }
 
 void AtlasEngine::_recreateFontDependentResources()


### PR DESCRIPTION
## Summary of the Pull Request

`_handleSettingsUpdate()` advances `_p.s` to the new settings before the `_recreate*()` calls rebuild the buffers those settings describe. The rebuilds allocate and can throw `bad_alloc`.

When that happens, `StartPaint()`'s `_p.s != _api.s` check is already satisfied, so the rebuild is never retried, as such, the engine keeps painting against buffers that never matched its settings, and a later, otherwise-healthy frame reads a row that was never rebuilt. 

That is the `AtlasEngine::PaintCursor` access violation in #20269, and it takes every window in the process down with it.

The fix rolls `_p.s` back when a rebuild throws, so the next `StartPaint()` retries the whole update. A transient allocation failure can no longer corrupt the engine for the rest of its lifetime. Ten lines in one production file, plus a test.

## References and Relevant Issues

Closes #20269 (my #20406 was closed as its duplicate). 

This crash had two independent producers, and #20366 fixed the `EnablePainting` viewport desync, and the Canary drag-testing in the thread validates that path. 

This PR removes the remaining one, which requires an allocation failure at the wrong moment, something drag-testing on a healthy machine can never probe.

@yuu61 identified this exact hole in the thread (the `_handleSettingsUpdate` exception-safety note) but never sent the rollback, and this PR is that fix, with a deterministic test :-).

## Detailed Description of the Pull Request / Additional comments

`_p.s` must hold the new settings while the rebuilds run, because the `_recreate*()` helpers read it.

The delayed crash is the point of this bug: the allocation failure only seeds the desync, and the AV lands minutes or days later on a machine that is healthy by then - which matches the "random, can't repro" reports in the thread, including mine.

## Validation Steps Performed

The new test (`AtlasEngineTests` in `UnitTests_Control`) reproduces the failure deterministically, with no test hooks in production code. It limits the test process's commit charge with a Job Object (current usage + 64 MiB), exhausts that headroom with bounded ballast, and resizes the engine to 426x113 - the rebuild genuinely cannot allocate and `StartPaint()` returns `E_OUTOFMEMORY`. The ballast is then released, and the next `StartPaint()` must recover on its own.

- Without the fix, that frame skips the rebuild behind the already-satisfied settings check and crashes with `0xC0000005`, exactly the failure bucket in every report on #20269. Reverting just the ten-line `AtlasEngine.cpp` hunk and rerunning the suite shows it.

- With the fix, the update is retried and the closing `PaintCursor` on the viewport's last row, which the exact read that crashes in the field - succeeds.

The job's limits are cleared before the test returns (the suite's other tests pass after it in the same host), and the test logs an explicit Skipped where a commit cap cannot be applied. 

Local x64 Debug runs: Control 30/30 (the new test runs end to end, no skip), TerminalCore 54/54, clang-format 19.1.5 produces no diff.

## PR Checklist

- [x] Closes #20269
- [x] Tests added/passed
- [ ] Documentation updated (n/a - no user-facing behavior change)
- [ ] Schema updated (n/a)
