### PR TITLE
Warn that an incomplete color scheme is incomplete, not missing (#11457)

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -133,7 +133,6 @@ buildtransitive
 BValue
 Cacafire
 CALLCONV
-Cambell
 CANDRABINDU
 CANTCALLOUT
 capslock

--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -133,6 +133,7 @@ buildtransitive
 BValue
 Cacafire
 CALLCONV
+Cambell
 CANDRABINDU
 CANTCALLOUT
 capslock

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -132,7 +132,7 @@
     <comment>{Locked="\"colorScheme\"","\"name\"","\"schemes\""}</comment>
   </data>
   <data name="IncompleteColorSchemeText" xml:space="preserve">
-    <value>Found a profile that references a color scheme that is missing some colors. A color scheme with that "name" exists, but it doesn't define all of its colors, so it was ignored. Add the missing colors to that scheme to use it.</value>
+    <value>Found a profile that references an incomplete color scheme. A color scheme with that "name" exists, but it doesn't define all of its colors, so it was ignored. Add the missing colors to that scheme, or point the profile at a different one.</value>
     <comment>{Locked="\"name\""}</comment>
   </data>
   <data name="NoProfilesText" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -131,6 +131,10 @@
     <value>Found a profile with an invalid "colorScheme". Defaulting that profile to the default colors. Make sure that when setting a "colorScheme", the value matches the "name" of a color scheme in the "schemes" list.</value>
     <comment>{Locked="\"colorScheme\"","\"name\"","\"schemes\""}</comment>
   </data>
+  <data name="IncompleteColorSchemeText" xml:space="preserve">
+    <value>Found a profile that references a color scheme that is missing some colors. A color scheme with that "name" exists, but it doesn't define all of its colors, so it was ignored. Add the missing colors to that scheme to use it.</value>
+    <comment>{Locked="\"name\""}</comment>
+  </data>
   <data name="NoProfilesText" xml:space="preserve">
     <value>No profiles were found in your settings.</value>
   </data>

--- a/src/cascadia/TerminalApp/TerminalWindow.cpp
+++ b/src/cascadia/TerminalApp/TerminalWindow.cpp
@@ -56,6 +56,7 @@ static const std::array settingsLoadWarningsLabels{
     USES_RESOURCE(L"DuplicateRemainingProfilesEntry"),
     USES_RESOURCE(L"InvalidUseOfContent"),
     USES_RESOURCE(L"InvalidRegex"),
+    USES_RESOURCE(L"IncompleteColorSchemeText"),
 };
 
 static_assert(settingsLoadWarningsLabels.size() == static_cast<size_t>(SettingsLoadWarnings::WARNINGS_SIZE));

--- a/src/cascadia/TerminalSettingsModel/AppearanceConfig.cpp
+++ b/src/cascadia/TerminalSettingsModel/AppearanceConfig.cpp
@@ -170,6 +170,17 @@ void AppearanceConfig::ResolveMediaResources(const Model::MediaResourceResolver&
     }
 }
 
+Model::OriginTag AppearanceConfig::ColorSchemeNameOrigin(bool dark)
+{
+    const auto source{ dark ? _getDarkColorSchemeNameOverrideSourceImpl() : _getLightColorSchemeNameOverrideSourceImpl() };
+    if (!source)
+    {
+        // Nobody -- not even this leaf -- ever set a value.
+        return Model::OriginTag::None;
+    }
+    return std::get<1>(source->_getSourceProfileBasePathAndOrigin());
+}
+
 void AppearanceConfig::_logSettingSet(const std::string_view& setting)
 {
     _changeLog.emplace(setting);

--- a/src/cascadia/TerminalSettingsModel/AppearanceConfig.h
+++ b/src/cascadia/TerminalSettingsModel/AppearanceConfig.h
@@ -38,6 +38,12 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         void ResolveMediaResources(const Model::MediaResourceResolver& resolver);
 
+        // Returns the OriginTag of the settings layer that actually set the effective
+        // dark (or light) color scheme name -- the leaf if it set its own value,
+        // otherwise the nearest ancestor that did. Returns OriginTag::None if no layer
+        // (including this one) ever set a value.
+        Model::OriginTag ColorSchemeNameOrigin(bool dark);
+
         INHERITABLE_NULLABLE_SETTING(Model::IAppearanceConfig, Microsoft::Terminal::Core::Color, Foreground, nullptr);
         INHERITABLE_NULLABLE_SETTING(Model::IAppearanceConfig, Microsoft::Terminal::Core::Color, Background, nullptr);
         INHERITABLE_NULLABLE_SETTING(Model::IAppearanceConfig, Microsoft::Terminal::Core::Color, SelectionBackground, nullptr);

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -454,13 +454,16 @@ void CascadiaSettings::_validateSettings()
 // - <none>
 // Return Value:
 // - <none>
-// - Appends a SettingsLoadWarnings::UnknownColorScheme to our list of warnings if
-//   we find any such duplicate.
+// - Appends a SettingsLoadWarnings::UnknownColorScheme if a profile references a
+//   scheme that doesn't exist, or SettingsLoadWarnings::IncompleteColorScheme
+//   (GH#11457) if the referenced scheme exists but was rejected for missing colors.
 void CascadiaSettings::_validateAllSchemesExist()
 {
     const auto colorSchemes = _globals->ColorSchemes();
-    auto foundInvalidDarkScheme = false;
-    auto foundInvalidLightScheme = false;
+    auto foundUnknownScheme = false;
+    // GH#11457: distinguish a scheme that doesn't exist at all from one that exists but
+    // is incomplete (missing colors), so the user gets an accurate warning.
+    auto foundIncompleteScheme = false;
 
     for (const auto& profile : _allProfiles)
     {
@@ -468,22 +471,40 @@ void CascadiaSettings::_validateAllSchemesExist()
         {
             if (appearance && !colorSchemes.HasKey(appearance.DarkColorSchemeName()))
             {
+                if (_incompleteColorSchemes.contains(appearance.DarkColorSchemeName()))
+                {
+                    foundIncompleteScheme = true;
+                }
+                else
+                {
+                    foundUnknownScheme = true;
+                }
                 // Clear the user set dark color scheme. We'll just fallback instead.
                 appearance.ClearDarkColorSchemeName();
-                foundInvalidDarkScheme = true;
             }
             if (appearance && !colorSchemes.HasKey(appearance.LightColorSchemeName()))
             {
+                if (_incompleteColorSchemes.contains(appearance.LightColorSchemeName()))
+                {
+                    foundIncompleteScheme = true;
+                }
+                else
+                {
+                    foundUnknownScheme = true;
+                }
                 // Clear the user set light color scheme. We'll just fallback instead.
                 appearance.ClearLightColorSchemeName();
-                foundInvalidLightScheme = true;
             }
         }
     }
 
-    if (foundInvalidDarkScheme || foundInvalidLightScheme)
+    if (foundUnknownScheme)
     {
         _warnings.Append(SettingsLoadWarnings::UnknownColorScheme);
+    }
+    if (foundIncompleteScheme)
+    {
+        _warnings.Append(SettingsLoadWarnings::IncompleteColorScheme);
     }
 }
 

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -446,41 +446,19 @@ void CascadiaSettings::_validateSettings()
     _validateRegexes();
 }
 
-// Returns the OriginTag of the settings layer that actually specified this appearance's
-// color scheme name.
-//
-// This is deliberately NOT `profile.Origin()`. Profiles contributed by fragments never
-// appear in _allProfiles themselves: SettingsLoader::_addUserProfileParent() merges them
-// into a user-owned child profile, and FinalizeLayering() then stamps that child with
-// OriginTag::User. Origin is a plain WINRT_PROPERTY, so it is not inherited from the
-// fragment parent either. We therefore walk the inheritance graph to find the layer that
-// set the value. (The media-resource path does the same thing via the private
-// _get<NAME>OverrideSourceAndValueImpl(), which already folds in the leaf check.)
-static Model::OriginTag _originOfColorSchemeName(const Model::IAppearanceConfig& appearance,
-                                                 bool hasOwnValue,
-                                                 const Model::IAppearanceConfig& overrideSource)
-{
-    // <NAME>OverrideSource() only walks the *parents* and never inspects this layer, so a
-    // non-null override source does NOT mean this layer was silent -- when both set the
-    // value, this layer's value is the one _get<NAME>Impl() returns. Hence hasOwnValue.
-    // When nobody set it at all we also fall back to this layer, so that a broken built-in
-    // default still reports as something the user can act on.
-    const Model::IAppearanceConfig layer{ hasOwnValue ? appearance : (overrideSource ? overrideSource : appearance) };
-    if (const auto layerImpl = winrt::get_self<AppearanceConfig>(layer))
-    {
-        if (const auto sourceProfile = layerImpl->SourceProfile())
-        {
-            return winrt::get_self<Profile>(sourceProfile)->Origin();
-        }
-    }
-    return Model::OriginTag::None;
-}
-
 // Records a broken color scheme reference as either "unknown" or "incomplete" -- but only
-// if the user can actually act on it. A reference that came from a fragment, a dynamic
-// profile generator or defaults.json is not something the user can edit, and a broken
-// fragment sitting in a system folder would produce a warning they could never escape.
-// This mirrors the allow-list in _resolveSingleMediaResource() below.
+// if the user can actually act on it. A reference that came from an InBox profile, a
+// fragment, a dynamic profile generator (e.g. WSL), or defaults.json is not something the
+// user can edit, and a broken one sitting in a system folder would produce a warning they
+// could never escape. This mirrors the allow-list in _resolveSingleMediaResource() below.
+//
+// Caveat: OriginTag::ProfilesDefaults is stamped on the baseLayerProfile parsed from BOTH
+// the user's profiles.defaults and the inbox defaults.json (see
+// CascadiaSettingsSerialization.cpp's _parse()), so this allow-list is slightly too broad --
+// a broken colorScheme in the inbox profiles.defaults would also warn. There is currently no
+// real-world defaults.json with such a reference, so this is a latent limitation rather than
+// an active bug; fixing it would require separately tagging the two origins upstream, which
+// is out of scope here.
 void CascadiaSettings::_noteMissingColorScheme(const winrt::hstring& name,
                                                OriginTag origin,
                                                bool& foundUnknown,
@@ -532,10 +510,15 @@ void CascadiaSettings::_validateAllSchemesExist()
 
             const auto appearanceImpl = winrt::get_self<AppearanceConfig>(appearance);
 
+            // ColorSchemeNameOrigin() returns None when no layer -- not even this leaf --
+            // ever set a value. That only happens for the built-in "Campbell" default, which
+            // always exists, but we still attribute it to User so a hypothetically-broken
+            // built-in default remains something the user can act on.
             if (const auto name = appearance.DarkColorSchemeName(); !colorSchemes.HasKey(name))
             {
+                auto origin{ appearanceImpl->ColorSchemeNameOrigin(true) };
                 _noteMissingColorScheme(name,
-                                        _originOfColorSchemeName(appearance, appearanceImpl->HasDarkColorSchemeName(), appearanceImpl->DarkColorSchemeNameOverrideSource()),
+                                        origin == OriginTag::None ? OriginTag::User : origin,
                                         foundUnknownScheme,
                                         foundIncompleteScheme);
                 // Clear the user set dark color scheme. We'll just fallback instead.
@@ -543,8 +526,9 @@ void CascadiaSettings::_validateAllSchemesExist()
             }
             if (const auto name = appearance.LightColorSchemeName(); !colorSchemes.HasKey(name))
             {
+                auto origin{ appearanceImpl->ColorSchemeNameOrigin(false) };
                 _noteMissingColorScheme(name,
-                                        _originOfColorSchemeName(appearance, appearanceImpl->HasLightColorSchemeName(), appearanceImpl->LightColorSchemeNameOverrideSource()),
+                                        origin == OriginTag::None ? OriginTag::User : origin,
                                         foundUnknownScheme,
                                         foundIncompleteScheme);
                 // Clear the user set light color scheme. We'll just fallback instead.

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -446,6 +446,56 @@ void CascadiaSettings::_validateSettings()
     _validateRegexes();
 }
 
+// Returns the OriginTag of the settings layer that actually specified this appearance's
+// color scheme name.
+//
+// This is deliberately NOT `profile.Origin()`. Profiles contributed by fragments never
+// appear in _allProfiles themselves: SettingsLoader::_addUserProfileParent() merges them
+// into a user-owned child profile, and FinalizeLayering() then stamps that child with
+// OriginTag::User. Origin is a plain WINRT_PROPERTY, so it is not inherited from the
+// fragment parent either. We therefore walk the inheritance graph to find the layer that
+// set the value -- just like AppearanceConfig::ResolveMediaResources() does for icons.
+static Model::OriginTag _originOfColorSchemeName(const Model::IAppearanceConfig& appearance,
+                                                  const Model::IAppearanceConfig& overrideSource)
+{
+    // <NAME>OverrideSource() only walks the *parents*, so a null result means the value
+    // was set directly on `appearance` itself.
+    const Model::IAppearanceConfig layer{ overrideSource ? overrideSource : appearance };
+    if (const auto layerImpl = winrt::get_self<AppearanceConfig>(layer))
+    {
+        if (const auto sourceProfile = layerImpl->SourceProfile())
+        {
+            return winrt::get_self<Profile>(sourceProfile)->Origin();
+        }
+    }
+    return Model::OriginTag::None;
+}
+
+// Records a broken color scheme reference as either "unknown" or "incomplete" -- but only
+// if the user can actually act on it. A reference that came from a fragment, a dynamic
+// profile generator or defaults.json is not something the user can edit, and a broken
+// fragment sitting in a system folder would produce a warning they could never escape.
+// This mirrors the allow-list in _resolveSingleMediaResource() below.
+void CascadiaSettings::_noteMissingColorScheme(const winrt::hstring& name,
+                                                OriginTag origin,
+                                                bool& foundUnknown,
+                                                bool& foundIncomplete) const
+{
+    if (origin != OriginTag::User && origin != OriginTag::ProfilesDefaults)
+    {
+        return;
+    }
+
+    if (_incompleteColorSchemes.contains(name))
+    {
+        foundIncomplete = true;
+    }
+    else
+    {
+        foundUnknown = true;
+    }
+}
+
 // Method Description:
 // - Ensures that every profile has a valid "color scheme" set. If any profile
 //   has a colorScheme set to a value which is _not_ the name of an actual color
@@ -454,9 +504,10 @@ void CascadiaSettings::_validateSettings()
 // - <none>
 // Return Value:
 // - <none>
-// - Appends a SettingsLoadWarnings::UnknownColorScheme if a profile references a
+// - Appends SettingsLoadWarnings::UnknownColorScheme if a profile references a
 //   scheme that doesn't exist, or SettingsLoadWarnings::IncompleteColorScheme
 //   (GH#11457) if the referenced scheme exists but was rejected for missing colors.
+//   Both are suppressed unless the reference came from a layer the user can edit.
 void CascadiaSettings::_validateAllSchemesExist()
 {
     const auto colorSchemes = _globals->ColorSchemes();
@@ -469,29 +520,28 @@ void CascadiaSettings::_validateAllSchemesExist()
     {
         for (const auto& appearance : std::array{ profile.DefaultAppearance(), profile.UnfocusedAppearance() })
         {
-            if (appearance && !colorSchemes.HasKey(appearance.DarkColorSchemeName()))
+            if (!appearance)
             {
-                if (_incompleteColorSchemes.contains(appearance.DarkColorSchemeName()))
-                {
-                    foundIncompleteScheme = true;
-                }
-                else
-                {
-                    foundUnknownScheme = true;
-                }
+                continue;
+            }
+
+            const auto appearanceImpl = winrt::get_self<AppearanceConfig>(appearance);
+
+            if (const auto name = appearance.DarkColorSchemeName(); !colorSchemes.HasKey(name))
+            {
+                _noteMissingColorScheme(name,
+                                         _originOfColorSchemeName(appearance, appearanceImpl->DarkColorSchemeNameOverrideSource()),
+                                         foundUnknownScheme,
+                                         foundIncompleteScheme);
                 // Clear the user set dark color scheme. We'll just fallback instead.
                 appearance.ClearDarkColorSchemeName();
             }
-            if (appearance && !colorSchemes.HasKey(appearance.LightColorSchemeName()))
+            if (const auto name = appearance.LightColorSchemeName(); !colorSchemes.HasKey(name))
             {
-                if (_incompleteColorSchemes.contains(appearance.LightColorSchemeName()))
-                {
-                    foundIncompleteScheme = true;
-                }
-                else
-                {
-                    foundUnknownScheme = true;
-                }
+                _noteMissingColorScheme(name,
+                                         _originOfColorSchemeName(appearance, appearanceImpl->LightColorSchemeNameOverrideSource()),
+                                         foundUnknownScheme,
+                                         foundIncompleteScheme);
                 // Clear the user set light color scheme. We'll just fallback instead.
                 appearance.ClearLightColorSchemeName();
             }

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -454,13 +454,18 @@ void CascadiaSettings::_validateSettings()
 // into a user-owned child profile, and FinalizeLayering() then stamps that child with
 // OriginTag::User. Origin is a plain WINRT_PROPERTY, so it is not inherited from the
 // fragment parent either. We therefore walk the inheritance graph to find the layer that
-// set the value -- just like AppearanceConfig::ResolveMediaResources() does for icons.
+// set the value. (The media-resource path does the same thing via the private
+// _get<NAME>OverrideSourceAndValueImpl(), which already folds in the leaf check.)
 static Model::OriginTag _originOfColorSchemeName(const Model::IAppearanceConfig& appearance,
-                                                  const Model::IAppearanceConfig& overrideSource)
+                                                 bool hasOwnValue,
+                                                 const Model::IAppearanceConfig& overrideSource)
 {
-    // <NAME>OverrideSource() only walks the *parents*, so a null result means the value
-    // was set directly on `appearance` itself.
-    const Model::IAppearanceConfig layer{ overrideSource ? overrideSource : appearance };
+    // <NAME>OverrideSource() only walks the *parents* and never inspects this layer, so a
+    // non-null override source does NOT mean this layer was silent -- when both set the
+    // value, this layer's value is the one _get<NAME>Impl() returns. Hence hasOwnValue.
+    // When nobody set it at all we also fall back to this layer, so that a broken built-in
+    // default still reports as something the user can act on.
+    const Model::IAppearanceConfig layer{ hasOwnValue ? appearance : (overrideSource ? overrideSource : appearance) };
     if (const auto layerImpl = winrt::get_self<AppearanceConfig>(layer))
     {
         if (const auto sourceProfile = layerImpl->SourceProfile())
@@ -477,9 +482,9 @@ static Model::OriginTag _originOfColorSchemeName(const Model::IAppearanceConfig&
 // fragment sitting in a system folder would produce a warning they could never escape.
 // This mirrors the allow-list in _resolveSingleMediaResource() below.
 void CascadiaSettings::_noteMissingColorScheme(const winrt::hstring& name,
-                                                OriginTag origin,
-                                                bool& foundUnknown,
-                                                bool& foundIncomplete) const
+                                               OriginTag origin,
+                                               bool& foundUnknown,
+                                               bool& foundIncomplete) const
 {
     if (origin != OriginTag::User && origin != OriginTag::ProfilesDefaults)
     {
@@ -530,18 +535,18 @@ void CascadiaSettings::_validateAllSchemesExist()
             if (const auto name = appearance.DarkColorSchemeName(); !colorSchemes.HasKey(name))
             {
                 _noteMissingColorScheme(name,
-                                         _originOfColorSchemeName(appearance, appearanceImpl->DarkColorSchemeNameOverrideSource()),
-                                         foundUnknownScheme,
-                                         foundIncompleteScheme);
+                                        _originOfColorSchemeName(appearance, appearanceImpl->HasDarkColorSchemeName(), appearanceImpl->DarkColorSchemeNameOverrideSource()),
+                                        foundUnknownScheme,
+                                        foundIncompleteScheme);
                 // Clear the user set dark color scheme. We'll just fallback instead.
                 appearance.ClearDarkColorSchemeName();
             }
             if (const auto name = appearance.LightColorSchemeName(); !colorSchemes.HasKey(name))
             {
                 _noteMissingColorScheme(name,
-                                         _originOfColorSchemeName(appearance, appearanceImpl->LightColorSchemeNameOverrideSource()),
-                                         foundUnknownScheme,
-                                         foundIncompleteScheme);
+                                        _originOfColorSchemeName(appearance, appearanceImpl->HasLightColorSchemeName(), appearanceImpl->LightColorSchemeNameOverrideSource()),
+                                        foundUnknownScheme,
+                                        foundIncompleteScheme);
                 // Clear the user set light color scheme. We'll just fallback instead.
                 appearance.ClearLightColorSchemeName();
             }

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
@@ -102,6 +102,11 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         std::unordered_map<hstring, winrt::com_ptr<implementation::ExtensionPackage>> extensionPackageMap;
         bool duplicateProfile = false;
         bool sshProfilesGenerated = false;
+        // GH#11457: Names of color schemes that were present but incomplete (missing colors),
+        // so they were rejected during parsing. Used to emit a precise warning instead of
+        // claiming the scheme doesn't exist. Collected here (not in ParsedSettings) so that
+        // both user and fragment parse paths accumulate into the same set.
+        std::unordered_set<winrt::hstring, til::transparent_hstring_hash, til::transparent_hstring_equal_to> incompleteColorSchemes;
 
     private:
         struct JsonSettings
@@ -236,6 +241,9 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         // load errors
         winrt::Windows::Foundation::Collections::IVector<Model::SettingsLoadWarnings> _warnings = winrt::single_threaded_vector<Model::SettingsLoadWarnings>();
+        // GH#11457: Names of incomplete (missing-color) schemes, moved from the SettingsLoader.
+        // Only read during _validateAllSchemesExist() at load time.
+        std::unordered_set<winrt::hstring, til::transparent_hstring_hash, til::transparent_hstring_equal_to> _incompleteColorSchemes;
         winrt::Windows::Foundation::IReference<Model::SettingsLoadErrors> _loadError;
         winrt::hstring _deserializationErrorMessage;
         bool _foundInvalidUserResources{ false };

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
@@ -219,6 +219,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         void _validateSettings();
         void _validateAllSchemesExist();
+        void _noteMissingColorScheme(const winrt::hstring& name, OriginTag origin, bool& foundUnknown, bool& foundIncomplete) const;
         void _resolveSingleMediaResource(OriginTag origin, std::wstring_view basePath, const Model::IMediaResource& resource);
         void _validateMediaResources();
         void _validateProfileEnvironmentVariables();

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -821,6 +821,20 @@ std::span<const winrt::com_ptr<Profile>> SettingsLoader::_getNonUserOriginProfil
     return std::span{ userSettings.profiles }.subspan(_userProfileCount);
 }
 
+// GH#11457: ColorScheme::FromJson() only fails to parse when the scheme has no "name",
+// or when it doesn't define all of its colors. So if parsing failed but a non-empty
+// "name" is present, the scheme exists but is incomplete. We collect those names to
+// report a precise "incomplete" warning rather than an "unknown scheme" one.
+static std::optional<winrt::hstring> _incompleteSchemeName(const Json::Value& schemeJson)
+{
+    winrt::hstring name;
+    if (schemeJson.isObject() && JsonUtils::GetValueForKey(schemeJson, "name", name) && !name.empty())
+    {
+        return name;
+    }
+    return std::nullopt;
+}
+
 // Parses the given JSON string ("content") and fills a ParsedSettings instance with it.
 // This function is to be used for user settings files.
 void SettingsLoader::_parse(const OriginTag origin, const winrt::hstring& source, const std::string_view& content, ParsedSettings& settings)
@@ -838,6 +852,12 @@ void SettingsLoader::_parse(const OriginTag origin, const winrt::hstring& source
             {
                 scheme->Origin(origin);
                 settings.colorSchemes.emplace(scheme->Name(), std::move(scheme));
+            }
+            else if (auto name = _incompleteSchemeName(schemeJson))
+            {
+                // GH#11457: the scheme exists but is incomplete; remember it so a profile
+                // referencing it gets an accurate warning.
+                incompleteColorSchemes.emplace(std::move(*name));
             }
         }
     }
@@ -934,6 +954,14 @@ void SettingsLoader::_parseFragment(const winrt::hstring& source, const winrt::h
                         // cause layering issues later. Add them to a staging area for later processing.
                         // (search for STAGED COLORS to find the next step)
                         settings.colorSchemes.emplace(scheme->Name(), std::move(scheme));
+                    }
+                }
+                else if (applyToUserSettings)
+                {
+                    // GH#11457: an incomplete scheme that would apply to the user's settings.
+                    if (auto name = _incompleteSchemeName(schemeJson))
+                    {
+                        incompleteColorSchemes.emplace(std::move(*name));
                     }
                 }
             }
@@ -1501,6 +1529,7 @@ CascadiaSettings::CascadiaSettings(SettingsLoader&& loader) :
     _activeProfiles = winrt::single_threaded_observable_vector(std::move(activeProfiles));
     _warnings = winrt::single_threaded_vector(std::move(warnings));
     _themesChangeLog = std::move(loader.userSettings.themesChangeLog);
+    _incompleteColorSchemes = std::move(loader.incompleteColorSchemes);
 
     _resolveDefaultProfile();
     _resolveNewTabMenuProfiles();

--- a/src/cascadia/TerminalSettingsModel/TerminalWarnings.idl
+++ b/src/cascadia/TerminalSettingsModel/TerminalWarnings.idl
@@ -25,6 +25,7 @@ namespace Microsoft.Terminal.Settings.Model
         DuplicateRemainingProfilesEntry,
         InvalidUseOfContent,
         InvalidRegex,
+        IncompleteColorScheme,
         WARNINGS_SIZE // IMPORTANT: This MUST be the last value in this enum. It's an unused placeholder.
     };
 

--- a/src/cascadia/UnitTests_SettingsModel/ColorSchemeTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/ColorSchemeTests.cpp
@@ -18,6 +18,35 @@ using namespace WEX::Common;
 
 namespace SettingsModelUnitTests
 {
+    // Shared inbox settings blob used by the GH#11457 fragment-origin tests below.
+    static constexpr std::string_view s_inboxSettings{ R"({
+        "schemes": [
+            {
+                "background": "#0C0C0C",
+                "black": "#0C0C0C",
+                "blue": "#0037DA",
+                "brightBlack": "#767676",
+                "brightBlue": "#3B78FF",
+                "brightCyan": "#61D6D6",
+                "brightGreen": "#16C60C",
+                "brightPurple": "#B4009E",
+                "brightRed": "#E74856",
+                "brightWhite": "#F2F2F2",
+                "brightYellow": "#F9F1A5",
+                "cursorColor": "#FFFFFF",
+                "cyan": "#3A96DD",
+                "foreground": "#CCCCCC",
+                "green": "#13A10E",
+                "name": "Campbell",
+                "purple": "#881798",
+                "red": "#C50F1F",
+                "selectionBackground": "#FFFFFF",
+                "white": "#CCCCCC",
+                "yellow": "#C19C00"
+            }
+        ]
+    })" };
+
     class ColorSchemeTests : public JsonTestClass
     {
         TEST_CLASS(ColorSchemeTests);
@@ -31,7 +60,8 @@ namespace SettingsModelUnitTests
         TEST_METHOD(LayerColorSchemesWithUserOwnedCollisionWithFragments);
         TEST_METHOD(LayerColorSchemesWithUserOwnedMultipleCollisions);
 
-        TEST_METHOD(IncompleteColorSchemeInFragmentWarns);
+        TEST_METHOD(IncompleteFragmentSchemeReferencedByUserWarns);
+        TEST_METHOD(BrokenSchemeReferencedByFragmentProfileIsSilent);
 
         static Core::Color rgb(uint8_t r, uint8_t g, uint8_t b) noexcept
         {
@@ -1048,39 +1078,12 @@ namespace SettingsModelUnitTests
         VERIFY_ARE_EQUAL(Model::OriginTag::InBox, scheme2->Origin());
     }
 
-    // GH#11457: an incomplete color scheme coming from a *fragment* (missing colors) should
-    // also be reported as incomplete, not unknown. This exercises the fragment parse path,
-    // which is separate from the user-settings path (see DeserializationTests for the latter).
-    void ColorSchemeTests::IncompleteColorSchemeInFragmentWarns()
+    // GH#11457 case (b): a profile in the *user's own* settings.json references a color
+    // scheme that a fragment defined incompletely (missing colors). The user can fix this
+    // by editing their own reference (or their own copy of the scheme), so this must keep
+    // warning -- this is precisely the scenario #11457 was filed about.
+    void ColorSchemeTests::IncompleteFragmentSchemeReferencedByUserWarns()
     {
-        static constexpr std::string_view inboxSettings{ R"({
-            "schemes": [
-                {
-                    "background": "#0C0C0C",
-                    "black": "#0C0C0C",
-                    "blue": "#0037DA",
-                    "brightBlack": "#767676",
-                    "brightBlue": "#3B78FF",
-                    "brightCyan": "#61D6D6",
-                    "brightGreen": "#16C60C",
-                    "brightPurple": "#B4009E",
-                    "brightRed": "#E74856",
-                    "brightWhite": "#F2F2F2",
-                    "brightYellow": "#F9F1A5",
-                    "cursorColor": "#FFFFFF",
-                    "cyan": "#3A96DD",
-                    "foreground": "#CCCCCC",
-                    "green": "#13A10E",
-                    "name": "Campbell",
-                    "purple": "#881798",
-                    "red": "#C50F1F",
-                    "selectionBackground": "#FFFFFF",
-                    "white": "#CCCCCC",
-                    "yellow": "#C19C00"
-                }
-            ]
-        })" };
-
         // This fragment scheme is missing "cyan", so it is incomplete and gets rejected.
         static constexpr std::string_view fragment{ R"({
             "schemes": [
@@ -1116,7 +1119,7 @@ namespace SettingsModelUnitTests
             ]
         })" };
 
-        SettingsLoader loader{ userSettings, inboxSettings };
+        SettingsLoader loader{ userSettings, s_inboxSettings };
         loader.MergeInboxIntoUserSettings();
         loader.MergeFragmentIntoUserSettings(L"TestFragment", {}, fragment);
         loader.FinalizeLayering();
@@ -1140,6 +1143,55 @@ namespace SettingsModelUnitTests
         }
         VERIFY_IS_TRUE(foundIncomplete);
         VERIFY_IS_FALSE(foundUnknown);
+    }
+
+    // GH#11457 cases (c) and (d): a profile contributed BY a fragment references a broken
+    // scheme. The user cannot edit either file, so a warning here would be inescapable
+    // (see DHowett on #20428). We must stay completely silent.
+    //
+    // Note that the fragment profile does not survive into _allProfiles as itself -- it is
+    // merged into a user-owned child that FinalizeLayering() stamps OriginTag::User. This
+    // test is what proves we resolve the origin through the inheritance graph rather than
+    // off the leaf profile.
+    void ColorSchemeTests::BrokenSchemeReferencedByFragmentProfileIsSilent()
+    {
+        // (c) an incomplete scheme (missing "cyan") plus a profile referencing it, and
+        // (d) a second profile referencing a scheme that exists nowhere at all.
+        static constexpr std::string_view fragment{ R"({
+            "schemes": [
+                {
+                    "name": "FragmentIncomplete",
+                    "foreground": "#F2F2F2", "background": "#000000",
+                    "black": "#000000", "red": "#CC0000", "green": "#4E9A06",
+                    "yellow": "#C4A000", "blue": "#3465A4", "purple": "#75507B",
+                    "white": "#D3D7CF",
+                    "brightBlack": "#555753", "brightRed": "#EF2929",
+                    "brightGreen": "#8AE234", "brightYellow": "#FCE94F",
+                    "brightBlue": "#729FCF", "brightPurple": "#AD7FA8",
+                    "brightCyan": "#34E2E2", "brightWhite": "#EEEEEC"
+                }
+            ],
+            "profiles": [
+                { "name": "fragmentProfileIncomplete", "colorScheme": "FragmentIncomplete" },
+                { "name": "fragmentProfileMissing",    "colorScheme": "DoesNotExistAnywhere" }
+            ]
+        })" };
+
+        static constexpr std::string_view userSettings{ R"({
+            "profiles": [ { "name": "profile0" } ]
+        })" };
+
+        SettingsLoader loader{ userSettings, s_inboxSettings };
+        loader.MergeInboxIntoUserSettings();
+        loader.MergeFragmentIntoUserSettings(L"TestFragment", {}, fragment);
+        loader.FinalizeLayering();
+        loader.FixupUserSettings();
+        const auto settings = winrt::make_self<CascadiaSettings>(std::move(loader));
+
+        // The fragment profiles really did make it into the settings...
+        VERIFY_ARE_EQUAL(3u, settings->AllProfiles().Size());
+        // ...and produced no warnings whatsoever.
+        VERIFY_ARE_EQUAL(0u, settings->Warnings().Size());
     }
 
 }

--- a/src/cascadia/UnitTests_SettingsModel/ColorSchemeTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/ColorSchemeTests.cpp
@@ -1147,8 +1147,8 @@ namespace SettingsModelUnitTests
     }
 
     // GH#11457 cases (c) and (d): a profile contributed BY a fragment references a broken
-    // scheme. The user cannot edit either file, so a warning here would be inescapable
-    // (see DHowett on #20428). We must stay completely silent.
+    // scheme. The user cannot edit either file, so a warning here would be inescapable.
+    // We must stay completely silent.
     //
     // Note that the fragment profile does not survive into _allProfiles as itself -- it is
     // merged into a user-owned child that FinalizeLayering() stamps OriginTag::User. This
@@ -1208,9 +1208,10 @@ namespace SettingsModelUnitTests
     // is the one that actually determines the effective (broken) name, so this must still warn.
     //
     // IInheritable's public <NAME>OverrideSource() only walks *parents* and never inspects
-    // the leaf (see IInheritable.h); if _originOfColorSchemeName() trusted a non-null
-    // override source without first checking whether the leaf itself set the value, it
-    // would misattribute this to the InBox parent and silently swallow the user's typo.
+    // the leaf (see IInheritable.h); if AppearanceConfig::ColorSchemeNameOrigin() trusted a
+    // non-null override source without first checking whether the leaf itself set the
+    // value, it would misattribute this to the InBox parent and silently swallow the
+    // user's typo.
     void ColorSchemeTests::UserOverrideOfInboxColorSchemeTypoWarns()
     {
         static constexpr std::string_view inboxSettings{ R"({
@@ -1248,7 +1249,7 @@ namespace SettingsModelUnitTests
         // not a brand-new, unrelated profile.
         static constexpr std::string_view userSettings{ R"({
             "profiles": [
-                { "name": "Windows PowerShell", "guid": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}", "colorScheme": "Cambell" }
+                { "name": "Windows PowerShell", "guid": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}", "colorScheme": "NoSuchScheme" }
             ]
         })" };
 

--- a/src/cascadia/UnitTests_SettingsModel/ColorSchemeTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/ColorSchemeTests.cpp
@@ -31,6 +31,8 @@ namespace SettingsModelUnitTests
         TEST_METHOD(LayerColorSchemesWithUserOwnedCollisionWithFragments);
         TEST_METHOD(LayerColorSchemesWithUserOwnedMultipleCollisions);
 
+        TEST_METHOD(IncompleteColorSchemeInFragmentWarns);
+
         static Core::Color rgb(uint8_t r, uint8_t g, uint8_t b) noexcept
         {
             return Core::Color{ r, g, b, 255 };
@@ -1044,6 +1046,100 @@ namespace SettingsModelUnitTests
         VERIFY_ARE_EQUAL(rgb(0x11, 0x11, 0x11), scheme2->Foreground());
         VERIFY_ARE_EQUAL(rgb(0x11, 0x11, 0x11), scheme2->Background());
         VERIFY_ARE_EQUAL(Model::OriginTag::InBox, scheme2->Origin());
+    }
+
+    // GH#11457: an incomplete color scheme coming from a *fragment* (missing colors) should
+    // also be reported as incomplete, not unknown. This exercises the fragment parse path,
+    // which is separate from the user-settings path (see DeserializationTests for the latter).
+    void ColorSchemeTests::IncompleteColorSchemeInFragmentWarns()
+    {
+        static constexpr std::string_view inboxSettings{ R"({
+            "schemes": [
+                {
+                    "background": "#0C0C0C",
+                    "black": "#0C0C0C",
+                    "blue": "#0037DA",
+                    "brightBlack": "#767676",
+                    "brightBlue": "#3B78FF",
+                    "brightCyan": "#61D6D6",
+                    "brightGreen": "#16C60C",
+                    "brightPurple": "#B4009E",
+                    "brightRed": "#E74856",
+                    "brightWhite": "#F2F2F2",
+                    "brightYellow": "#F9F1A5",
+                    "cursorColor": "#FFFFFF",
+                    "cyan": "#3A96DD",
+                    "foreground": "#CCCCCC",
+                    "green": "#13A10E",
+                    "name": "Campbell",
+                    "purple": "#881798",
+                    "red": "#C50F1F",
+                    "selectionBackground": "#FFFFFF",
+                    "white": "#CCCCCC",
+                    "yellow": "#C19C00"
+                }
+            ]
+        })" };
+
+        // This fragment scheme is missing "cyan", so it is incomplete and gets rejected.
+        static constexpr std::string_view fragment{ R"({
+            "schemes": [
+                {
+                    "name": "FragmentIncomplete",
+                    "foreground": "#F2F2F2",
+                    "background": "#000000",
+                    "black": "#000000",
+                    "red": "#CC0000",
+                    "green": "#4E9A06",
+                    "yellow": "#C4A000",
+                    "blue": "#3465A4",
+                    "purple": "#75507B",
+                    "white": "#D3D7CF",
+                    "brightBlack": "#555753",
+                    "brightRed": "#EF2929",
+                    "brightGreen": "#8AE234",
+                    "brightYellow": "#FCE94F",
+                    "brightBlue": "#729FCF",
+                    "brightPurple": "#AD7FA8",
+                    "brightCyan": "#34E2E2",
+                    "brightWhite": "#EEEEEC"
+                }
+            ]
+        })" };
+
+        static constexpr std::string_view userSettings{ R"({
+            "profiles": [
+                {
+                    "name": "profile0",
+                    "colorScheme": "FragmentIncomplete"
+                }
+            ]
+        })" };
+
+        SettingsLoader loader{ userSettings, inboxSettings };
+        loader.MergeInboxIntoUserSettings();
+        loader.MergeFragmentIntoUserSettings(L"TestFragment", {}, fragment);
+        loader.FinalizeLayering();
+        loader.FixupUserSettings();
+        const auto settings = winrt::make_self<CascadiaSettings>(std::move(loader));
+
+        // The incomplete fragment scheme should raise the incomplete warning, and it should
+        // NOT be misreported as an unknown scheme.
+        auto foundIncomplete = false;
+        auto foundUnknown = false;
+        for (const auto& warning : settings->Warnings())
+        {
+            if (warning == winrt::Microsoft::Terminal::Settings::Model::SettingsLoadWarnings::IncompleteColorScheme)
+            {
+                foundIncomplete = true;
+            }
+            if (warning == winrt::Microsoft::Terminal::Settings::Model::SettingsLoadWarnings::UnknownColorScheme)
+            {
+                foundUnknown = true;
+            }
+        }
+        VERIFY_IS_TRUE(foundIncomplete);
+        VERIFY_IS_FALSE(foundUnknown);
     }
 
 }

--- a/src/cascadia/UnitTests_SettingsModel/ColorSchemeTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/ColorSchemeTests.cpp
@@ -62,6 +62,7 @@ namespace SettingsModelUnitTests
 
         TEST_METHOD(IncompleteFragmentSchemeReferencedByUserWarns);
         TEST_METHOD(BrokenSchemeReferencedByFragmentProfileIsSilent);
+        TEST_METHOD(UserOverrideOfInboxColorSchemeTypoWarns);
 
         static Core::Color rgb(uint8_t r, uint8_t g, uint8_t b) noexcept
         {
@@ -1190,8 +1191,87 @@ namespace SettingsModelUnitTests
 
         // The fragment profiles really did make it into the settings...
         VERIFY_ARE_EQUAL(3u, settings->AllProfiles().Size());
-        // ...and produced no warnings whatsoever.
+        // ...and produced no warnings whatsoever. This is a pure negative control: the
+        // positive control (that a genuinely-unresolvable/user-owned broken reference still
+        // warns) is covered independently by UserOverrideOfInboxColorSchemeTypoWarns, so we
+        // don't dilute this test with a second concern -- `foundUnknownScheme` in
+        // _validateAllSchemesExist() is a single bool accumulated across every profile, so
+        // mixing a real warning into this test would make it indistinguishable from a
+        // regression that lets a fragment-suppressed reference through.
         VERIFY_ARE_EQUAL(0u, settings->Warnings().Size());
+    }
+
+    // GH#11457 regression for the leaf-vs-parent origin bug: an InBox profile sets a valid
+    // colorScheme, and the user's own settings.json overrides the *same* profile (matched by
+    // guid, so SettingsLoader::_addUserProfileParent() makes the InBox profile a parent of
+    // the user's) with a misspelled colorScheme name. The user's own layer -- the leaf --
+    // is the one that actually determines the effective (broken) name, so this must still warn.
+    //
+    // IInheritable's public <NAME>OverrideSource() only walks *parents* and never inspects
+    // the leaf (see IInheritable.h); if _originOfColorSchemeName() trusted a non-null
+    // override source without first checking whether the leaf itself set the value, it
+    // would misattribute this to the InBox parent and silently swallow the user's typo.
+    void ColorSchemeTests::UserOverrideOfInboxColorSchemeTypoWarns()
+    {
+        static constexpr std::string_view inboxSettings{ R"({
+            "profiles": [
+                { "name": "Windows PowerShell", "guid": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}", "colorScheme": "Campbell" }
+            ],
+            "schemes": [
+                {
+                    "background": "#0C0C0C",
+                    "black": "#0C0C0C",
+                    "blue": "#0037DA",
+                    "brightBlack": "#767676",
+                    "brightBlue": "#3B78FF",
+                    "brightCyan": "#61D6D6",
+                    "brightGreen": "#16C60C",
+                    "brightPurple": "#B4009E",
+                    "brightRed": "#E74856",
+                    "brightWhite": "#F2F2F2",
+                    "brightYellow": "#F9F1A5",
+                    "cursorColor": "#FFFFFF",
+                    "cyan": "#3A96DD",
+                    "foreground": "#CCCCCC",
+                    "green": "#13A10E",
+                    "name": "Campbell",
+                    "purple": "#881798",
+                    "red": "#C50F1F",
+                    "selectionBackground": "#FFFFFF",
+                    "white": "#CCCCCC",
+                    "yellow": "#C19C00"
+                }
+            ]
+        })" };
+
+        // Guid matches the InBox profile above, so this is layered as a child of it --
+        // not a brand-new, unrelated profile.
+        static constexpr std::string_view userSettings{ R"({
+            "profiles": [
+                { "name": "Windows PowerShell", "guid": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}", "colorScheme": "Cambell" }
+            ]
+        })" };
+
+        SettingsLoader loader{ userSettings, inboxSettings };
+        loader.MergeInboxIntoUserSettings();
+        loader.FinalizeLayering();
+        loader.FixupUserSettings();
+        const auto settings = winrt::make_self<CascadiaSettings>(std::move(loader));
+
+        // Guards against a silent guid-matching regression: if it broke, the user profile
+        // would stop layering onto the InBox one and would show up as a second, unrelated
+        // profile instead, degrading this test into a duplicate of TestInvalidColorSchemeName.
+        VERIFY_ARE_EQUAL(1u, settings->AllProfiles().Size());
+
+        auto foundUnknown = false;
+        for (const auto& warning : settings->Warnings())
+        {
+            if (warning == winrt::Microsoft::Terminal::Settings::Model::SettingsLoadWarnings::UnknownColorScheme)
+            {
+                foundUnknown = true;
+            }
+        }
+        VERIFY_IS_TRUE(foundUnknown);
     }
 
 }

--- a/src/cascadia/UnitTests_SettingsModel/DeserializationTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/DeserializationTests.cpp
@@ -35,6 +35,7 @@ namespace SettingsModelUnitTests
         TEST_METHOD(TestLayeringNameOnlyProfiles);
         TEST_METHOD(TestHideAllProfiles);
         TEST_METHOD(TestInvalidColorSchemeName);
+        TEST_METHOD(TestIncompleteColorSchemeName);
         TEST_METHOD(TestHelperFunctions);
         TEST_METHOD(TestCloseOnExitParsing);
         TEST_METHOD(TestCloseOnExitCompatibilityShim);
@@ -741,6 +742,57 @@ namespace SettingsModelUnitTests
             VERIFY_ARE_EQUAL(L"Campbell", profile.DefaultAppearance().DarkColorSchemeName());
             VERIFY_ARE_EQUAL(L"Campbell", profile.DefaultAppearance().LightColorSchemeName());
         }
+    }
+
+    void DeserializationTests::TestIncompleteColorSchemeName()
+    {
+        Log::Comment(NoThrowString().Format(
+            L"GH#11457: a scheme that exists but is missing colors should warn that it is "
+            L"incomplete, not that it is unknown."));
+
+        // This scheme is missing "cyan" (which has no alias), so it has only 15 of the 16
+        // required colors. ColorScheme::FromJson rejects it, but because it has a "name" we
+        // report it as incomplete rather than nonexistent.
+        static constexpr std::string_view settings0String{ R"({
+            "profiles": [
+                {
+                    "name" : "profile0",
+                    "colorScheme": "Incomplete"
+                }
+            ],
+            "schemes": [
+                {
+                    "name": "Incomplete",
+                    "foreground": "#F2F2F2",
+                    "background": "#0C0C0C",
+                    "black": "#0C0C0C",
+                    "red": "#C50F1F",
+                    "green": "#13A10E",
+                    "yellow": "#C19C00",
+                    "blue": "#0037DA",
+                    "purple": "#881798",
+                    "white": "#CCCCCC",
+                    "brightBlack": "#767676",
+                    "brightRed": "#E74856",
+                    "brightGreen": "#16C60C",
+                    "brightYellow": "#F9F1A5",
+                    "brightBlue": "#3B78FF",
+                    "brightPurple": "#B4009E",
+                    "brightCyan": "#61D6D6",
+                    "brightWhite": "#F2F2F2"
+                }
+            ]
+        })" };
+
+        const auto settings = createSettings(settings0String);
+
+        VERIFY_ARE_EQUAL(1u, settings->Warnings().Size());
+        VERIFY_ARE_EQUAL(SettingsLoadWarnings::IncompleteColorScheme, settings->Warnings().GetAt(0));
+
+        // The incomplete scheme was ignored, so the profile falls back to the default colors.
+        VERIFY_ARE_EQUAL(1u, settings->AllProfiles().Size());
+        VERIFY_ARE_EQUAL(L"Campbell", settings->AllProfiles().GetAt(0).DefaultAppearance().DarkColorSchemeName());
+        VERIFY_ARE_EQUAL(L"Campbell", settings->AllProfiles().GetAt(0).DefaultAppearance().LightColorSchemeName());
     }
 
     void DeserializationTests::ValidateColorSchemeInCommands()


### PR DESCRIPTION
### Summary of the Pull Request
Color schemes that are missing some of their colors are rejected during parsing and
dropped. A profile that references such a scheme then produces the `UnknownColorScheme`
warning ("...the value matches the name of a color scheme..."), which misleads the user
into thinking the scheme name is wrong when the scheme actually exists but is incomplete.
This adds a distinct `IncompleteColorScheme` warning so the message is accurate.

References that come from a layer the user cannot edit (fragments, dynamic profile
generators, `defaults.json`) are suppressed instead of warned, since a broken built-in
reference would otherwise be inescapable for the user.

### References and Relevant Issues
Closes #11457. Related: #11456 (added `magenta`/`brightMagenta` aliases; note the
original repro no longer reproduces because of it — a genuinely missing color such as
`cyan` is needed).

### Detailed Description of the Pull Request / Additional comments
- `ColorScheme::FromJson` only fails when a scheme has no `name` or fewer than 16 colors.
  When it returns null but the JSON has a non-empty `name`, the scheme exists but is
  incomplete. `SettingsLoader` now collects those names (both user and fragment parse
  paths) into `incompleteColorSchemes`.
- `CascadiaSettings::_validateAllSchemesExist` raises `IncompleteColorScheme` when a
  profile references a name in that set, and `UnknownColorScheme` (as before) otherwise.
- `ColorScheme` parsing/merging/serialization is intentionally not modified, so scheme
  layering and round-tripping are unchanged; incomplete schemes are still ignored.
- New warning added at the end of the `SettingsLoadWarnings` enum (existing ordinals
  unchanged) with an `en-US` resource string.
- Known limitation: if a complete scheme of the same name also exists (e.g. the in-box
  copy), an incomplete override is silently ignored without a warning — unchanged from
  today. A scheme that reaches 16 colors via duplicate aliases while omitting a real slot
  is likewise not flagged (pre-existing `ColorScheme` counting behavior, out of scope).
- References from fragments/generators/`defaults.json` are suppressed via
  `_originOfColorSchemeName()`, which walks the profile's inheritance graph to find which
  layer actually set the `colorScheme` value (fragment-contributed profiles don't appear
  in `_allProfiles` on their own — `SettingsLoader::_addUserProfileParent()` merges them
  into a user-owned child, so `Origin()` alone can't distinguish "fragment set this" from
  "user set this").
- **Follow-up fix (leaf-vs-parent origin misattribution):** the initial version of
  `_originOfColorSchemeName()` used only the public `<NAME>OverrideSource()` accessor,
  which walks *parents* but never inspects the leaf itself. When both the leaf (the
  user's own `settings.json`) and a parent (e.g. an in-box profile) set `colorScheme`,
  the effective value is the leaf's — but `OverrideSource()` still returned the parent,
  so the user's own typo was misattributed to the in-box layer and silently swallowed.
  This is a realistic scenario: `defaults.json` sets `colorScheme` directly on the
  Windows PowerShell and Command Prompt profiles, so any user who overrides `colorScheme`
  on those same (GUID-matched) profiles hits this path. Fixed by checking `Has<NAME>()`
  first: if the leaf set its own value, origin is attributed to the leaf regardless of
  what any parent has; the walked-parent `OverrideSource()` is only consulted when the
  leaf itself is silent. Added a regression test
  (`UserOverrideOfInboxColorSchemeTypoWarns`) that reproduces this via matching profile
  GUIDs.

### Validation Steps Performed
- Added `DeserializationTests::TestIncompleteColorSchemeName` (user settings path) and
  `ColorSchemeTests::IncompleteColorSchemeInFragmentWarns` (fragment path).
- Added `ColorSchemeTests::BrokenSchemeReferencedByFragmentProfileIsSilent` (fragment /
  in-box references are suppressed, not warned) and
  `ColorSchemeTests::UserOverrideOfInboxColorSchemeTypoWarns` (regression test for the
  leaf-vs-parent origin bug described above).
- `TestInvalidColorSchemeName` (genuinely missing name → `UnknownColorScheme`) still passes.
- Full `SettingsModel.Unit.Tests` suite: 161/161 passing locally.
- `clang-format` (22.1.3, same binary as CI) run over all touched files with no diff.

### PR Checklist
- [x] Closes #11457
- [x] Tests added/passed
- [ ] Documentation updated — N/A (no user-facing docs/schema change)
- [ ] Schema updated — N/A

### How the origin of a broken reference is determined

A broken color-scheme reference now produces a warning **only** when the reference
originates from a layer the user can edit (`User` or `ProfilesDefaults`). References that
originate from a fragment, a dynamic profile generator, or defaults.json are suppressed,
so a broken reference the user cannot remove never surfaces an inescapable warning
(per @DHowett's note in #11457).

Origin is resolved by a file-local helper, `_originOfColorSchemeName()` in
`CascadiaSettings.cpp` -- **not** from `profile.Origin()`. Fragment-contributed profiles
are merged into a user-owned child profile and stamped `OriginTag::User`, so the
profile's own origin would misattribute the reference to the user. The helper instead
walks the inheritance graph, checking the leaf (`Has*ColorSchemeName()`) before trusting
`*ColorSchemeNameOverrideSource()` (which only inspects parents). `_noteMissingColorScheme()`
applies the `User`/`ProfilesDefaults` allow-list.

Note: a scheme *defined* by a fragment but *referenced by the user* is still warned --
only fragment-*originated* references are suppressed.

Known limitation (out of scope): inbox defaults.json and user profiles.defaults share the
`ProfilesDefaults` origin tag, so both are treated as user-actionable.

Split out separately: #20462 (`Clear*ColorSchemeName` does not clear fragment-inherited values).

