### PR TITLE
schema: Allow verbose no-argument actions in the settings schema

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -856,6 +856,64 @@
         "action"
       ]
     },
+    "NoArgsAction": {
+      "description": "An action that does not take any arguments",
+      "allOf": [
+        {
+          "$ref": "#/$defs/ShortcutAction"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "action": {
+              "enum": [
+                "clearAllMarks",
+                "clearMark",
+                "closeOtherPanes",
+                "closePane",
+                "closeWindow",
+                "duplicateTab",
+                "expandSelectionToWord",
+                "find",
+                "identifyWindow",
+                "identifyWindows",
+                "markMode",
+                "openAbout",
+                "openCWD",
+                "openNewTabDropdown",
+                "openSystemMenu",
+                "openTabColorPicker",
+                "openTabRenamer",
+                "openWindowRenamer",
+                "paste",
+                "quit",
+                "resetFontSize",
+                "restoreLastClosed",
+                "scrollDownPage",
+                "scrollToBottom",
+                "scrollToTop",
+                "scrollUpPage",
+                "selectAll",
+                "switchSelectionEndpoint",
+                "tabSearch",
+                "toggleAlwaysOnTop",
+                "toggleBlockSelection",
+                "toggleFocusMode",
+                "toggleFullscreen",
+                "togglePaneZoom",
+                "toggleReadOnlyMode",
+                "toggleShaderEffects",
+                "toggleSplitOrientation",
+                "unbound",
+                "workspaces"
+              ],
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
     "AdjustFontSizeAction": {
       "description": "Arguments corresponding to an Adjust Font Size Action",
       "allOf": [
@@ -2157,6 +2215,9 @@
               "$ref": "#/$defs/ShortcutActionName"
             },
             {
+              "$ref": "#/$defs/NoArgsAction"
+            },
+            {
               "$ref": "#/$defs/NewTabAction"
             },
             {
@@ -2164,6 +2225,9 @@
             },
             {
               "$ref": "#/$defs/ScrollToMarkAction"
+            },
+            {
+              "$ref": "#/$defs/AddMarkAction"
             },
             {
               "$ref": "#/$defs/MoveFocusAction"
@@ -2185,6 +2249,15 @@
             },
             {
               "$ref": "#/$defs/OpenSettingsAction"
+            },
+            {
+              "$ref": "#/$defs/SetFocusModeAction"
+            },
+            {
+              "$ref": "#/$defs/SetFullScreenAction"
+            },
+            {
+              "$ref": "#/$defs/SetMaximizedAction"
             },
             {
               "$ref": "#/$defs/SetTabColorAction"


### PR DESCRIPTION
## Summary of the Pull Request

- Adds a strict schema definition for verbose forms of actions that take no arguments.
- Wires four existing optional-argument action schemas into `FullCommand.command`.
- Preserves required-argument validation and rejects unexpected arguments for no-argument actions.

## References and Relevant Issues

Closes #11332

## Detailed Description of the Pull Request / Additional comments

Windows Terminal accepts both of these forms:

```json
{ "command": "toggleAlwaysOnTop" }
{ "command": { "action": "toggleAlwaysOnTop" } }
```

The settings schema only accepted the short form because `FullCommand.command`
had no object branch for actions without arguments.

This adds a strict `NoArgsAction` definition for the 39 argument-free actions.
It also connects the existing `AddMarkAction`, `SetFocusModeAction`,
`SetFullScreenAction`, and `SetMaximizedAction` definitions, which were not
referenced by `FullCommand.command`.

## Validation Steps Performed

Validated `doc/cascadia/profiles.schema.json` with PowerShell 7.6 `Test-Json`:

- All 39 no-argument actions validate in verbose form.
- Existing short forms still validate.
- Empty and populated forms of the four optional-argument actions validate.
- Actions missing required arguments remain invalid.
- Unknown actions, incorrect argument types, and unexpected arguments remain invalid.
- The schema parses successfully and `git diff --check` passes.

## PR Checklist

- [x] Closes #11332
- [x] Tests added/passed
- [ ] Documentation updated
- [x] Schema updated (if necessary)
