### PR TITLE
Add right-click context menu to open settings folder in Explorer

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -452,6 +452,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
     }
 
+
+    void MainPage::OpenSettingsFolder_Click(const IInspectable& /*sender*/, const Windows::UI::Xaml::RoutedEventArgs& /*args*/)
+    {
+        OpenJson.raise(nullptr, SettingsTarget::Directory);
+    }
     void MainPage::_PreNavigateHelper()
     {
         _profileViewModelChangedRevoker.revoke();

--- a/src/cascadia/TerminalSettingsEditor/MainPage.h
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.h
@@ -61,6 +61,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void SaveButton_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
         void ResetButton_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
         void BreadcrumbBar_ItemClicked(const Microsoft::UI::Xaml::Controls::BreadcrumbBar& sender, const Microsoft::UI::Xaml::Controls::BreadcrumbBarItemClickedEventArgs& args);
+        void OpenSettingsFolder_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
 
         void SetHostingWindow(uint64_t hostingWindow) noexcept;
         bool TryPropagateHostingWindow(IInspectable object) noexcept;

--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -205,7 +205,18 @@
             <muxc:NavigationViewItem x:Name="OpenJsonNavItem"
                                      x:Uid="Nav_OpenJSON"
                                      SelectsOnInvoked="False"
-                                     Tag="OpenJson_Nav" />
+                                     Tag="OpenJson_Nav" >
+                <muxc:NavigationViewItem.ContextFlyout>
+                    <MenuFlyout>
+                        <MenuFlyoutItem x:Uid="Nav_OpenSettingsFolder"
+                                        Click="OpenSettingsFolder_Click">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE838;" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                    </MenuFlyout>
+                </muxc:NavigationViewItem.ContextFlyout>
+            </muxc:NavigationViewItem>
         </muxc:NavigationView.FooterMenuItems>
 
         <Grid>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -689,6 +689,10 @@
     <value>Open JSON file</value>
     <comment>Header for a menu item. This opens the JSON file that is used to log the app's settings.</comment>
   </data>
+  <data name="Nav_OpenSettingsFolder.Text" xml:space="preserve">
+    <value>Open settings folder</value>
+    <comment>Header for a context menu item. This opens the parent folder of the settings.json file in File Explorer.</comment>
+  </data>
   <data name="Nav_ProfileDefaults.Content" xml:space="preserve">
     <value>Defaults</value>
     <comment>Header for the "defaults" menu item. This navigates to a page that lets you see and modify settings that affect profiles. This is the lowest layer of profile settings that all other profile settings are based on. If a profile doesn't define a setting, this page is responsible for figuring out what that setting is supposed to be.</comment>


### PR DESCRIPTION
## Summary of the Pull Request

Adds a right-click context menu to the "Open JSON file" button in the Settings UI. When right-clicked, it shows a menu item "Open settings folder" that opens the parent folder of the settings.json file in File Explorer.

## References

Closes #12382

## Detailed Description

The backend support for `SettingsTarget::Directory` was already fully implemented in `TerminalPage::_LaunchSettings` — it calls `openFolder()` with `CascadiaSettings::SettingsDirectory()`. This change simply adds the UI to trigger it:

1. **MainPage.xaml**: Added a `ContextFlyout` with a `MenuFlyoutItem` to the `OpenJsonNavItem`. The flyout appears on right-click and includes a folder icon (Segoe Fluent Icons glyph `&#xE838;`).

2. **MainPage.h**: Added declaration for the `OpenSettingsFolder_Click` click handler.

3. **MainPage.cpp**: Added implementation of `OpenSettingsFolder_Click` which emits the `OpenJson` event with `SettingsTarget::Directory`, reusing the existing event pipeline.

4. **Resources/en-US/Resources.resw**: Added localized string `Nav_OpenSettingsFolder.Text` with value "Open settings folder".

## PR Checklist

- [x] Closes #12382
- [ ] Tests added/passed — This is a small UI addition that reuses existing tested backend code. No new tests needed.
- [ ] Documentation updated — N/A
- [ ] Schema updated — N/A