### PR TITLE
Remove SettingContainer and Utils circular includes (#20441)

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/SettingContainer.h
+++ b/src/cascadia/TerminalSettingsEditor/SettingContainer.h
@@ -18,7 +18,6 @@ Author(s):
 #pragma once
 
 #include "SettingContainer.g.h"
-#include "Utils.h"
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {

--- a/src/cascadia/TerminalSettingsEditor/Utils.h
+++ b/src/cascadia/TerminalSettingsEditor/Utils.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include "SettingContainer.h"
-
 // This macro must be used alongside GETSET_BINDABLE_ENUM_SETTING.
 // Use this in your class's constructor after Initialize_Component().
 // It sorts and initializes the observable list of enum entries with the enum name


### PR DESCRIPTION
## Summary of the Pull Request
Removes the unused `#include "SettingContainer.h"` from `Utils.h` and `#include "Utils.h"` from `SettingContainer.h` in `TerminalSettingsEditor`, eliminating an unnecessary circular header dependency.

## References and Relevant Issues
Closes #20441

## Detailed Description of the Pull Request / Additional comments
- `Utils.h` included `SettingContainer.h` without ever referencing `SettingContainer` in its macros or utility structures.
- `SettingContainer.h` included `Utils.h` without using any of its helpers (`DEPENDENCY_PROPERTY` and `BASIC_FACTORY` are provided globally via `cppwinrt_utils.h` inside `pch.h`).
- Removing both includes breaks the circular dependency and restores clean header stratification with zero call-site disruptions.

## Validation Steps Performed
- Verified symbol resolution across `Utils.h` and `SettingContainer.h`.
- Confirmed direct consumers (`Appearances.h` and `SettingContainer.cpp`) maintain explicit and complete header dependencies.

## PR Checklist
- [x] Closes #20441
- [x] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
