### PR TITLE
Fix Settings tab color mismatch with Settings page background (Dark/Light only)

### DIFF
--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -192,7 +192,7 @@
                                             ResourceKey="TabViewBackground" />
 
                             <SolidColorBrush x:Key="SettingsUiTabBrush"
-                                             Color="#0c0c0c" />
+                                             Color="#282828" />
 
                             <SolidColorBrush x:Key="BroadcastPaneBorderColor"
                                              Color="{StaticResource SystemAccentColorDark2}" />
@@ -211,7 +211,7 @@
                                             ResourceKey="TabViewBackground" />
 
                             <SolidColorBrush x:Key="SettingsUiTabBrush"
-                                             Color="#ffffff" />
+                                             Color="#F9F9F9" />
 
                             <SolidColorBrush x:Key="BroadcastPaneBorderColor"
                                              Color="{StaticResource SystemAccentColorLight2}" />


### PR DESCRIPTION
## Summary
This fixes the Settings tab color mismatch, addressing the visual inconsistency where the Settings tab appeared black while the Settings page was dark gray. 

Looking at the history of the original fix (#19999) and its subsequent revert (#20292 / #20186), it appears the accessibility/contrast concern was isolated to the HighContrast theme change (`SystemControlBackgroundBaseLowBrush` → `SystemColorWindowBrush`). 

To address the original issue while avoiding the accessibility regression, this patch reapplies **only** the Dark and Light theme softening and leaves the HighContrast theme exactly as it is on `main` today.

## Changes
- **Dark Theme:** Aligned `SettingsUiTabBrush` from `#0c0c0c` to `#282828` to match the Settings page background.
- **Light Theme:** Aligned `SettingsUiTabBrush` from `#ffffff` to `#F9F9F9`.
- **HighContrast Theme:** Left entirely unchanged.

Closes #19873