### PR TITLE
Post WM_SETCURSOR after WM_ACTIVATE to workaround XAML island busy cursor

### DIFF
--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -518,6 +518,15 @@ void IslandWindow::_OnGetMinMaxInfo(const WPARAM /*wParam*/, const LPARAM lParam
         const bool activated = LOWORD(wparam) != 0;
         WindowActivated.raise(activated);
 
+        // GH#18662: After raising WindowActivated, XAML may be busy processing
+        // the activation (focus, layout, rendering). During this time, WM_SETCURSOR
+        // may go unanswered, causing Windows to show a busy cursor until the next
+        // mouse move. Post a WM_SETCURSOR to force re-evaluation once XAML is idle.
+        if (activated)
+        {
+            PostMessageW(GetHandle(), WM_SETCURSOR, 0, MAKELPARAM(HTCLIENT, WM_MOUSEMOVE));
+        }
+
         if (_autoHideWindow && !activated)
         {
             if (_isQuakeWindow || _minimizeToNotificationArea)


### PR DESCRIPTION
After activation, Windows Terminal may show a BUSY (IDC_APPSTARTING)
cursor because the XAML island is busy processing the activation and
does not respond to WM_SETCURSOR in time. Post a WM_SETCURSOR message
to force re-evaluation once XAML is idle.

This is a **workaround** for a limitation in WinUI XAML islands which can
block synchronous window messages while busy.

Close: https://github.com/microsoft/terminal/issues/18662

Checked only under win10. It's works.
