### PR TITLE
Use in-class initializers for Settings scalar members (C.48)

### DIFF
--- a/src/host/settings.cpp
+++ b/src/host/settings.cpp
@@ -15,46 +15,22 @@ constexpr unsigned int DEFAULT_NUMBER_OF_BUFFERS = 4;
 using Microsoft::Console::Interactivity::ServiceLocator;
 
 Settings::Settings() :
-    _dwHotKey(0),
-    _dwStartupFlags(0),
     _wFillAttribute(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE), // White (not bright) on black by default
     _wPopupFillAttribute(FOREGROUND_RED | FOREGROUND_BLUE | BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_BLUE | BACKGROUND_INTENSITY), // Purple on white (bright) by default
     _wShowWindow(SW_SHOWNORMAL),
-    _wReserved(0),
     // dwScreenBufferSize initialized below
     // dwWindowSize initialized below
     // dwWindowOrigin initialized below
-    _nFont(0),
     // dwFontSize initialized below
-    _uFontFamily(0),
-    _uFontWeight(0),
     // FaceName initialized below
     _uCursorSize(Cursor::CURSOR_SMALL_SIZE),
-    _bFullScreen(false),
-    _bQuickEdit(true),
-    _bInsertMode(true),
-    _bAutoPosition(true),
     _uHistoryBufferSize(DEFAULT_NUMBER_OF_COMMANDS),
     _uNumberOfHistoryBuffers(DEFAULT_NUMBER_OF_BUFFERS),
-    _bHistoryNoDup(false),
     // ColorTable initialized below
     _uCodePage(ServiceLocator::LocateGlobals().uiOEMCP),
-    _uScrollScale(1),
-    _bLineSelection(true),
-    _bWrapText(true),
-    _fCtrlKeyShortcutsDisabled(false),
     _bWindowAlpha(BYTE_MAX), // 255 alpha = opaque. 0 = transparent.
-    _fFilterOnPaste(false),
-    _LaunchFaceName{},
-    _fTrimLeadingZeros(FALSE),
-    _fEnableColorSelection(FALSE),
-    _fAllowAltF4Close(true),
-    _dwVirtTermLevel(0),
-    _fUseWindowSizePixels(false),
-    // window size pixels initialized below
-    _fInterceptCopyPaste(0),
-    _fUseDx(false),
-    _fCopyColor(false)
+    _LaunchFaceName{}
+// window size pixels initialized below
 {
     _dwScreenBufferSize.X = 80;
     _dwScreenBufferSize.Y = 25;

--- a/src/host/settings.cpp
+++ b/src/host/settings.cpp
@@ -9,28 +9,10 @@
 
 #pragma hdrstop
 
-constexpr unsigned int DEFAULT_NUMBER_OF_COMMANDS = 25;
-constexpr unsigned int DEFAULT_NUMBER_OF_BUFFERS = 4;
-
 using Microsoft::Console::Interactivity::ServiceLocator;
 
 Settings::Settings() :
-    _wFillAttribute(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE), // White (not bright) on black by default
-    _wPopupFillAttribute(FOREGROUND_RED | FOREGROUND_BLUE | BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_BLUE | BACKGROUND_INTENSITY), // Purple on white (bright) by default
-    _wShowWindow(SW_SHOWNORMAL),
-    // dwScreenBufferSize initialized below
-    // dwWindowSize initialized below
-    // dwWindowOrigin initialized below
-    // dwFontSize initialized below
-    // FaceName initialized below
-    _uCursorSize(Cursor::CURSOR_SMALL_SIZE),
-    _uHistoryBufferSize(DEFAULT_NUMBER_OF_COMMANDS),
-    _uNumberOfHistoryBuffers(DEFAULT_NUMBER_OF_BUFFERS),
-    // ColorTable initialized below
-    _uCodePage(ServiceLocator::LocateGlobals().uiOEMCP),
-    _bWindowAlpha(BYTE_MAX), // 255 alpha = opaque. 0 = transparent.
-    _LaunchFaceName{}
-// window size pixels initialized below
+    _uCodePage(ServiceLocator::LocateGlobals().uiOEMCP)
 {
     _dwScreenBufferSize.X = 80;
     _dwScreenBufferSize.Y = 25;

--- a/src/host/settings.hpp
+++ b/src/host/settings.hpp
@@ -190,57 +190,57 @@ public:
 private:
     RenderSettings _renderSettings;
 
-    DWORD _dwHotKey;
-    DWORD _dwStartupFlags;
+    DWORD _dwHotKey{ 0 };
+    DWORD _dwStartupFlags{ 0 };
     WORD _wFillAttribute;
     WORD _wPopupFillAttribute;
     WORD _wShowWindow; // used when window is created
-    WORD _wReserved;
+    WORD _wReserved{ 0 };
     // START - This section filled via memcpy from shortcut properties. Do not rearrange/change.
     COORD _dwScreenBufferSize;
     COORD _dwWindowSize; // this is in characters.
     COORD _dwWindowOrigin; // used when window is created
-    DWORD _nFont;
+    DWORD _nFont{ 0 };
     COORD _dwFontSize;
-    UINT _uFontFamily;
-    UINT _uFontWeight;
+    UINT _uFontFamily{ 0 };
+    UINT _uFontWeight{ 0 };
     WCHAR _FaceName[LF_FACESIZE];
     UINT _uCursorSize;
-    BOOL _bFullScreen; // deprecated
-    BOOL _bQuickEdit;
-    BOOL _bInsertMode; // used by command line editing
-    BOOL _bAutoPosition;
+    BOOL _bFullScreen{ FALSE }; // deprecated
+    BOOL _bQuickEdit{ TRUE };
+    BOOL _bInsertMode{ TRUE }; // used by command line editing
+    BOOL _bAutoPosition{ TRUE };
     UINT _uHistoryBufferSize;
     UINT _uNumberOfHistoryBuffers;
-    BOOL _bHistoryNoDup;
+    BOOL _bHistoryNoDup{ FALSE };
     // END - memcpy
     UINT _uCodePage;
-    UINT _uScrollScale;
-    bool _fTrimLeadingZeros;
-    bool _fEnableColorSelection;
-    bool _bLineSelection;
-    bool _bWrapText; // whether to use text wrapping when resizing the window
-    bool _fCtrlKeyShortcutsDisabled; // disables Ctrl+<something> key intercepts
+    UINT _uScrollScale{ 1 };
+    bool _fTrimLeadingZeros{ false };
+    bool _fEnableColorSelection{ false };
+    bool _bLineSelection{ true };
+    bool _bWrapText{ true }; // whether to use text wrapping when resizing the window
+    bool _fCtrlKeyShortcutsDisabled{ false }; // disables Ctrl+<something> key intercepts
     BYTE _bWindowAlpha; // describes the opacity of the window
 
-    bool _fFilterOnPaste; // should we filter text when the user pastes? (e.g. remove <tab>)
+    bool _fFilterOnPaste{ false }; // should we filter text when the user pastes? (e.g. remove <tab>)
     std::wstring _LaunchFaceName;
-    bool _fAllowAltF4Close;
-    DWORD _dwVirtTermLevel;
+    bool _fAllowAltF4Close{ true };
+    DWORD _dwVirtTermLevel{ 0 };
     DWORD _msaaDelay = 100;
     DWORD _uiaDelay = 25;
     SettingsTextMeasurementMode _textMeasurement = SettingsTextMeasurementMode::Graphemes;
-    bool _fUseDx;
-    bool _fCopyColor;
+    bool _fUseDx{ false };
+    bool _fCopyColor{ false };
     bool _fEnableBuiltinGlyphs = true;
 
     // this is used for the special STARTF_USESIZE mode.
-    bool _fUseWindowSizePixels;
+    bool _fUseWindowSizePixels{ false };
     COORD _dwWindowSizePixels;
 
     CursorType _CursorType;
 
-    bool _fInterceptCopyPaste;
+    bool _fInterceptCopyPaste{ false };
 
     bool _TerminalScrolling = true;
     WCHAR _answerbackMessage[32] = {};

--- a/src/host/settings.hpp
+++ b/src/host/settings.hpp
@@ -21,8 +21,12 @@ Revision History:
 // To prevent invisible windows, set a lower threshold on window alpha channel.
 constexpr unsigned short MIN_WINDOW_OPACITY = 0x4D; // 0x4D is approximately 30% visible/opaque (70% transparent). Valid range is 0x00-0xff.
 
+constexpr unsigned int DEFAULT_NUMBER_OF_COMMANDS = 25;
+constexpr unsigned int DEFAULT_NUMBER_OF_BUFFERS = 4;
+
 #include "ConsoleArguments.hpp"
 #include "../renderer/inc/RenderSettings.hpp"
+#include "../buffer/out/cursor.h"
 
 enum class SettingsTextMeasurementMode : DWORD
 {
@@ -192,9 +196,9 @@ private:
 
     DWORD _dwHotKey{ 0 };
     DWORD _dwStartupFlags{ 0 };
-    WORD _wFillAttribute;
-    WORD _wPopupFillAttribute;
-    WORD _wShowWindow; // used when window is created
+    WORD _wFillAttribute{ FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE }; // White (not bright) on black by default
+    WORD _wPopupFillAttribute{ FOREGROUND_RED | FOREGROUND_BLUE | BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_BLUE | BACKGROUND_INTENSITY }; // Purple on white (bright) by default
+    WORD _wShowWindow{ SW_SHOWNORMAL }; // used when window is created
     WORD _wReserved{ 0 };
     // START - This section filled via memcpy from shortcut properties. Do not rearrange/change.
     COORD _dwScreenBufferSize;
@@ -205,13 +209,13 @@ private:
     UINT _uFontFamily{ 0 };
     UINT _uFontWeight{ 0 };
     WCHAR _FaceName[LF_FACESIZE];
-    UINT _uCursorSize;
+    UINT _uCursorSize{ Cursor::CURSOR_SMALL_SIZE };
     BOOL _bFullScreen{ FALSE }; // deprecated
     BOOL _bQuickEdit{ TRUE };
     BOOL _bInsertMode{ TRUE }; // used by command line editing
     BOOL _bAutoPosition{ TRUE };
-    UINT _uHistoryBufferSize;
-    UINT _uNumberOfHistoryBuffers;
+    UINT _uHistoryBufferSize{ DEFAULT_NUMBER_OF_COMMANDS };
+    UINT _uNumberOfHistoryBuffers{ DEFAULT_NUMBER_OF_BUFFERS };
     BOOL _bHistoryNoDup{ FALSE };
     // END - memcpy
     UINT _uCodePage;
@@ -221,7 +225,7 @@ private:
     bool _bLineSelection{ true };
     bool _bWrapText{ true }; // whether to use text wrapping when resizing the window
     bool _fCtrlKeyShortcutsDisabled{ false }; // disables Ctrl+<something> key intercepts
-    BYTE _bWindowAlpha; // describes the opacity of the window
+    BYTE _bWindowAlpha{ BYTE_MAX }; // describes the opacity of the window. 255 alpha = opaque. 0 = transparent.
 
     bool _fFilterOnPaste{ false }; // should we filter text when the user pastes? (e.g. remove <tab>)
     std::wstring _LaunchFaceName;


### PR DESCRIPTION
## Summary
Part of #962. Second batch of C.48 cleanups, following the approach agreed in #20449.

Moves every constant member initializer for the `Settings` class out of the constructor initializer list and into in-class member initializers, per [C.48](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c48-prefer-in-class-initializers-to-member-initializers-in-constructors-for-constant-initializers).

The only initializer left in the constructor is `_uCodePage`, which reads the runtime OEM code page from `ServiceLocator::LocateGlobals().uiOEMCP`. Assignments in the constructor body (COORD members, `_FaceName`, `_CursorType`) are unchanged.

Notes:
- `DEFAULT_NUMBER_OF_COMMANDS` / `DEFAULT_NUMBER_OF_BUFFERS` moved from settings.cpp into settings.hpp, next to `MIN_WINDOW_OPACITY`
- `Cursor::CURSOR_SMALL_SIZE`, the `FOREGROUND_*` / `BACKGROUND_*` macros, `SW_SHOWNORMAL` and `BYTE_MAX` are all visible to every consumer of settings.hpp (host and propslib precompile headers)
- Members in the memcpy shortcut-properties region only gain in-class initializers; declaration order and layout are unchanged

## Validation
- `hostlib.vcxproj` and `propslib.vcxproj` (x64 Debug): 0 errors

No behavioral change; initialization values and ordering are preserved.