### PR TITLE
Fix broken image path in CONTRIBUTING and malformed link in Niksa.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ If no existing item describes your issue/feature, great - please file a new issu
 * Found an existing issue that describes yours? Great - upvote and add additional commentary / info / repro-steps / etc.
 
 When you hit "New Issue", select the type of issue closest to what you want to report/ask/request:
-![New issue types](/doc/images/new-issue-template.png)
+![New issue types](./doc/images/new-issue-template.png)
 
 ### Complete the template
 

--- a/doc/Niksa.md
+++ b/doc/Niksa.md
@@ -27,7 +27,7 @@ I would highly recommend that Gulp convert to using PowerShell scripts and that 
 
 Original Source: https://github.com/microsoft/terminal/issues/217#issuecomment-404240443
 
-_Addendum_: cmd.exe is the literal embodiment of [xkcd#1172]([url](https://xkcd.com/1172/)). Every change, no matter how small, will break _someone_.
+_Addendum_: cmd.exe is the literal embodiment of [xkcd#1172](https://xkcd.com/1172/). Every change, no matter how small, will break _someone_.
 
 ## <a name="screenPerf"></a>Why is typing-to-screen performance better than every other app?
 


### PR DESCRIPTION
## Summary of the Pull Request

Two rendering defects in docs:

- `CONTRIBUTING.md` embeds the new-issue-template screenshot as `![New issue types](/doc/images/new-issue-template.png)` — a site-absolute path that 404s on GitHub's rendered view. Now `./doc/images/new-issue-template.png` (file verified present).
- `doc/Niksa.md` contains `[xkcd#1172]([url](https://xkcd.com/1172/))` — a nested-bracket link that renders as broken literal text. Now a plain `[xkcd#1172](https://xkcd.com/1172/)`.

## Validation Steps Performed

Docs-only. A mechanical link audit resolving every relative markdown link against the filesystem reports zero broken links after the change; both fixes verified on the rendered markdown preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)