### PR TITLE
Deliver a finished composition before the key that ended it

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1780,6 +1780,12 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             _altNumpadState = {};
         }
 
+        // If a composition just ended, its text is still queued up inside TSF. Hand it
+        // to the connection now, so that a key the IME passed through to end the
+        // composition can't overtake the text it finalized - neither by being forwarded
+        // to the PTY nor by triggering an action bound to it. GH#20244
+        GetTSFHandle().FlushPendingComposition();
+
         // GH#2235: Terminal::Settings hasn't been modified to differentiate
         // between AltGr and Ctrl+Alt yet.
         // -> Don't check for key bindings if this is an AltGr key combination.

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1780,10 +1780,10 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             _altNumpadState = {};
         }
 
-        // If a composition just ended, its text is still queued up inside TSF. Hand it
-        // to the connection now, so that a key the IME passed through to end the
-        // composition can't overtake the text it finalized - neither by being forwarded
-        // to the PTY nor by triggering an action bound to it. GH#20244
+        // If a composition just ended, its text is still queued up inside TSF. Hand it to
+        // the connection now, so that a key the IME passed on to us can't reach the
+        // connection before the text it finalized - neither by being forwarded to the PTY,
+        // nor by triggering an action bound to it. GH#20244
         GetTSFHandle().FlushPendingComposition();
 
         // GH#2235: Terminal::Settings hasn't been modified to differentiate

--- a/src/interactivity/win32/windowio.cpp
+++ b/src/interactivity/win32/windowio.cpp
@@ -130,9 +130,9 @@ void HandleKeyEvent(const HWND hWnd,
     const BOOL bKeyDown = WI_IsFlagClear(lParam, KEY_TRANSITION_UP);
     const bool IsCharacterMessage = (Message == WM_CHAR || Message == WM_SYSCHAR || Message == WM_DEADCHAR || Message == WM_SYSDEADCHAR);
 
-    // If a composition just ended, its text is still queued up inside TSF. Write it to
-    // the input buffer now, so that a key the IME passed through to end the composition
-    // can't overtake the text it finalized. GH#20244
+    // If a composition just ended, its text is still queued up inside TSF. Write it to the
+    // input buffer now, so that a key the IME passed on to us can't reach the input buffer
+    // before the text it finalized. GH#20244
     g.tsf.FlushPendingComposition();
 
     // Make sure we retrieve the key info first, or we could chew up

--- a/src/interactivity/win32/windowio.cpp
+++ b/src/interactivity/win32/windowio.cpp
@@ -130,6 +130,11 @@ void HandleKeyEvent(const HWND hWnd,
     const BOOL bKeyDown = WI_IsFlagClear(lParam, KEY_TRANSITION_UP);
     const bool IsCharacterMessage = (Message == WM_CHAR || Message == WM_SYSCHAR || Message == WM_DEADCHAR || Message == WM_SYSDEADCHAR);
 
+    // If a composition just ended, its text is still queued up inside TSF. Write it to
+    // the input buffer now, so that a key the IME passed through to end the composition
+    // can't overtake the text it finalized. GH#20244
+    g.tsf.FlushPendingComposition();
+
     // Make sure we retrieve the key info first, or we could chew up
     // unneeded space in the key info table if we bail out early.
     if (IsCharacterMessage)

--- a/src/tsf/Handle.cpp
+++ b/src/tsf/Handle.cpp
@@ -91,6 +91,14 @@ bool Handle::HasActiveComposition() const noexcept
     return _impl ? _impl->HasActiveComposition() : false;
 }
 
+void Handle::FlushPendingComposition() const noexcept
+{
+    if (_impl)
+    {
+        _impl->FlushPendingComposition();
+    }
+}
+
 void Handle::_destroy() noexcept
 {
     if (_impl)

--- a/src/tsf/Handle.h
+++ b/src/tsf/Handle.h
@@ -49,6 +49,7 @@ namespace Microsoft::Console::TSF
         void Focus(IDataProvider* provider) const;
         void Unfocus(IDataProvider* provider) const;
         bool HasActiveComposition() const noexcept;
+        void FlushPendingComposition() const noexcept;
 
     private:
         void _destroy() noexcept;

--- a/src/tsf/Implementation.cpp
+++ b/src/tsf/Implementation.cpp
@@ -224,6 +224,34 @@ bool Implementation::HasActiveComposition() const noexcept
     return _compositions > 0;
 }
 
+// A composition that has just ended doesn't hand its text to the application right
+// away: OnEndComposition() can only request the finalizing edit session with
+// TF_ES_ASYNC, so the text stays in the TSF context until that session gets its turn
+// on the message loop. A text service that ends a composition with a key it doesn't
+// consume - the Korean IME does this for Enter and for the arrow keys - gives that key
+// to the application inside the same message dispatch, so the key would otherwise
+// reach the shell ahead of the text it just finalized. GH#20244
+//
+// Key handling doesn't run inside an edit session, so here, unlike in
+// OnEndComposition(), we can ask for a synchronous one and settle the composition
+// before the caller decides what to do with the key.
+void Implementation::FlushPendingComposition() noexcept
+{
+    // Nothing to settle unless a composition has ended and its edit session is pending.
+    if (_compositions > 0 || !_editSessionCompositionUpdate.referenceCount || !_context)
+    {
+        return;
+    }
+
+    // A separate proxy is needed because the pending asynchronous request still holds
+    // a reference on _editSessionCompositionUpdate. Running _doCompositionUpdate() twice
+    // is harmless: it derives everything from the current state of the context, and by
+    // the time the asynchronous session runs there is nothing left to finalize.
+    HRESULT hr = S_OK;
+    LOG_IF_FAILED(_context->RequestEditSession(_clientId, &_editSessionCompositionFinalize, TF_ES_READWRITE | TF_ES_SYNC, &hr));
+    LOG_IF_FAILED(hr);
+}
+
 #pragma region IUnknown
 
 STDMETHODIMP Implementation::QueryInterface(REFIID riid, void** ppvObj) noexcept

--- a/src/tsf/Implementation.cpp
+++ b/src/tsf/Implementation.cpp
@@ -224,31 +224,24 @@ bool Implementation::HasActiveComposition() const noexcept
     return _compositions > 0;
 }
 
-// A composition that has just ended doesn't hand its text to the application right
-// away: OnEndComposition() can only request the finalizing edit session with
-// TF_ES_ASYNC, so the text stays in the TSF context until that session gets its turn
-// on the message loop. A text service that ends a composition with a key it doesn't
-// consume - the Korean IME does this for Enter and for the arrow keys - gives that key
-// to the application inside the same message dispatch, so the key would otherwise
-// reach the shell ahead of the text it just finalized. GH#20244
-//
-// Key handling doesn't run inside an edit session, so here, unlike in
-// OnEndComposition(), we can ask for a synchronous one and settle the composition
-// before the caller decides what to do with the key.
+// OnEndComposition() can only request TF_ES_ASYNC, because it runs from within an active
+// edit session. If the composition ended due to a relevant terminal key (arrow keys,
+// Enter, etc.), the terminal will receive and handle that key input synchronously, before
+// we got around to handling the completion asynchronously. This method allows you to
+// synchronously flush it from inside the key handler. GH#20244
 void Implementation::FlushPendingComposition() noexcept
 {
-    // Nothing to settle unless a composition has ended and its edit session is pending.
+    // Nothing to flush unless a composition has ended and its edit session is still pending.
     if (_compositions > 0 || !_editSessionCompositionUpdate.referenceCount || !_context)
     {
         return;
     }
 
-    // A separate proxy is needed because the pending asynchronous request still holds
-    // a reference on _editSessionCompositionUpdate. Running _doCompositionUpdate() twice
-    // is harmless: it derives everything from the current state of the context, and by
-    // the time the asynchronous session runs there is nothing left to finalize.
+    // NOTE: _request() would reject this, because the pending TF_ES_ASYNC request still
+    // references the proxy. Letting that request run afterwards is harmless, because
+    // _doCompositionUpdate() derives everything from the current state of the context.
     HRESULT hr = S_OK;
-    LOG_IF_FAILED(_context->RequestEditSession(_clientId, &_editSessionCompositionFinalize, TF_ES_READWRITE | TF_ES_SYNC, &hr));
+    LOG_IF_FAILED(_context->RequestEditSession(_clientId, &_editSessionCompositionUpdate, TF_ES_READWRITE | TF_ES_SYNC, &hr));
     LOG_IF_FAILED(hr);
 }
 

--- a/src/tsf/Implementation.h
+++ b/src/tsf/Implementation.h
@@ -28,6 +28,7 @@ namespace Microsoft::Console::TSF
         void Focus(IDataProvider* provider);
         void Unfocus(IDataProvider* provider);
         bool HasActiveComposition() const noexcept;
+        void FlushPendingComposition() noexcept;
 
         // IUnknown methods
         STDMETHODIMP QueryInterface(REFIID riid, void** ppvObj) noexcept override;
@@ -127,6 +128,9 @@ namespace Microsoft::Console::TSF
         TfClientId _clientId = TF_CLIENTID_NULL;
 
         EditSessionProxy<&Implementation::_doCompositionUpdate> _editSessionCompositionUpdate{ this };
+        // Only used by FlushPendingComposition(), which needs to run the session while
+        // the asynchronous request above is still holding a reference on its proxy.
+        EditSessionProxy<&Implementation::_doCompositionUpdate> _editSessionCompositionFinalize{ this };
         int _compositions = 0;
 
         AnsiInputScope _ansiInputScope{ this };

--- a/src/tsf/Implementation.h
+++ b/src/tsf/Implementation.h
@@ -128,9 +128,6 @@ namespace Microsoft::Console::TSF
         TfClientId _clientId = TF_CLIENTID_NULL;
 
         EditSessionProxy<&Implementation::_doCompositionUpdate> _editSessionCompositionUpdate{ this };
-        // Only used by FlushPendingComposition(), which needs to run the session while
-        // the asynchronous request above is still holding a reference on its proxy.
-        EditSessionProxy<&Implementation::_doCompositionUpdate> _editSessionCompositionFinalize{ this };
         int _compositions = 0;
 
         AnsiInputScope _ansiInputScope{ this };


### PR DESCRIPTION
## Summary of the Pull Request

A composition hands its text to the application from an asynchronous edit session. The key
that ended the composition is delivered inside the same message dispatch, so it reaches the
shell first and the syllable is written wherever the caret moved to. Drain the pending
finalize before the key is handled.

## References and Relevant Issues

Closes #20244. Follow-up to #20039.

## Detailed Description of the Pull Request / Additional comments

`OnEndComposition()` is itself called from inside an edit session, so it can only request
the finalizing one with `TF_ES_ASYNC`:

```cpp
_compositions--;
if (_compositions == 0)
{
    std::ignore = _request(_editSessionCompositionUpdate, TF_ES_READWRITE | TF_ES_ASYNC);
}
```

`_doCompositionUpdate()` — where `_provider->HandleOutput(finalizedString)` happens — only
runs once that session gets its turn on the message loop. Until then the finalized text is
still sitting in the TSF context.

The Korean IME ends a composition with the arrow keys and with <kbd>Enter</kbd> without
consuming them, so the application receives that key in the same message dispatch:

1. <kbd>←</kbd> is dispatched, the IME terminates the composition, the async session is queued.
2. The key is not consumed, so it is forwarded and the shell moves the caret.
3. The async session runs and `가` is written at the *new* caret position.

The guard added in #20039 does not cover this, because `_compositions` is decremented
before the session is even requested — `HasActiveComposition()` already returns `false`.

Key handling does not run inside an edit session, so unlike `OnEndComposition()` it can
request a synchronous one. `FlushPendingComposition()` does that, and the key handlers call
it before anything can act on the key, so the text is delivered first and the key is still
forwarded normally.

In `TermControl` the flush sits ahead of `_TryHandleKeyBinding()` as well, because an action
bound to the key that ended the composition runs in that same dispatch: finalizing `가` with
<kbd>Ctrl+V</kbd> would otherwise paste the clipboard before the syllable arrives.

Widening the guard to cover the pending session also stops the syllable from moving, but it
*drops* the key that ended the composition: <kbd>Enter</kbd> no longer submits the line, and
the space the Korean IME uses to commit is eaten, turning `안녕 하세요` into `안녕하세요`.
Delivering the text early keeps every keystroke.

## Validation Steps Performed

Korean IME, 2-set layout: compose `가` with `rk` and press <kbd>←</kbd> before finalizing.
The syllable stays where it was composed and the caret still moves. <kbd>Enter</kbd> and the
committing space are still delivered, and finalizing with <kbd>Ctrl+V</kbd> pastes after the
syllable instead of before it.

## PR Checklist
- [x] Closes #20244
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Schema updated (if necessary)
