### PR TITLE
Fix razzle.cmd MSBuild detection silently failing on VS 2026 (18.x)

### DIFF
--- a/tools/razzle.cmd
+++ b/tools/razzle.cmd
@@ -49,15 +49,33 @@ if not defined VSWHERE (
 
 rem Add path to MSBuild Binaries
 rem
-rem We accept the latest prerelease of VS in the 17.x or 18.x range. The -version
-rem range [17.0,19.0) picks up both VS 2022 (17.x) and VS 18 (including previews)
-rem but not a still-newer major whose toolset may be incompatible. VS 18 uses our
-rem v145 PlatformToolset (see src\common.build.pre.props); older VS versions default
-rem to v143.
+rem We accept the latest prerelease of VS in the 17.x or 18.x range: -version
+rem "[17.0,19.0)" covers VS 2022 (17.x) and VS 18, but not a newer major whose
+rem toolset may be incompatible. VS 18 uses v145 PlatformToolset (see
+rem src\common.build.pre.props); older VS versions default to v143.
 rem
-for /f "usebackq tokens=*" %%B in (`"%VSWHERE%" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -version "[17.0,19.0)" -find MSBuild\**\Bin\MSBuild.exe 2^>nul`) do (
-    set MSBUILD=%%B
+rem Redirect vswhere's output to a temp file and read it back via for /f,
+rem instead of `for /f ... in (`vswhere ...`)`, to avoid cmd.exe miscounting
+rem the ')' in "[17.0,19.0)" as closing the for/f clause. pushd into %TEMP%
+rem and use a relative filename to keep any ')' in the %TEMP% path out of
+rem the for/f clause too; only popd if pushd succeeded, to avoid disturbing
+rem the caller's directory stack on failure.
+set "VSWHERE_TEMP_PUSHED=0"
+pushd "%TEMP%" >nul 2>nul
+if not errorlevel 1 set "VSWHERE_TEMP_PUSHED=1"
+
+rem Two %RANDOM% components avoid filename collisions between concurrent
+rem razzle.cmd runs.
+set "VSWHERE_MSBUILD_TMP=razzle-vswhere-msbuild-%RANDOM%%RANDOM%.txt"
+"%VSWHERE%" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -version "[17.0,19.0)" -find MSBuild\**\Bin\MSBuild.exe > "%VSWHERE_MSBUILD_TMP%" 2>nul
+rem if exist avoids a spurious "file not found" message when vswhere failed.
+if exist "%VSWHERE_MSBUILD_TMP%" (
+    for /f "usebackq delims=" %%B in ("%VSWHERE_MSBUILD_TMP%") do (set "MSBUILD=%%B")
 )
+del /q "%VSWHERE_MSBUILD_TMP%" 2>nul
+set "VSWHERE_MSBUILD_TMP="
+if "%VSWHERE_TEMP_PUSHED%"=="1" popd >nul 2>nul
+set "VSWHERE_TEMP_PUSHED="
 
 if not defined MSBUILD (
     echo Could not find MSBuild on your machine. Please set the MSBUILD variable to the location of MSBuild.exe and run razzle again.


### PR DESCRIPTION
## Summary

`razzle.cmd` could report `Could not find MSBuild` despite a valid Visual Studio installation, unless MSBuild was already available in `PATH`.

## Root Cause

MSBuild discovery used this command:

```
for /f ... in (`"%VSWHERE%" ... -version "[17.0,19.0)" ...`) do (
```

`for /f` executes the command between backticks through a nested `cmd.exe /c`. Because the command begins with a quoted executable path and also contains the quoted version range, the special quote-handling rules of `cmd.exe /c` cause the command to be parsed incorrectly.

Consequently, the `)` in `"[17.0,19.0)"` is interpreted as command syntax instead of part of the version argument. The `vswhere` command fails and leaves `MSBUILD` unset.

## How This Slipped Through Testing

During development of the previous change, an intermediate version was tested in a regular cmd:

```
for /f "usebackq tokens=*" %%B in (`%VSWHERE% -latest -prerelease -products * -requires Microsoft.Component.MSBuild -version "[17.0,19.0)" -find MSBuild\**\Bin\MSBuild.exe 2^>nul`) do
```
It worked because `%VSWHERE%` was not quoted, where there's only one pair of `"` and `cmd.exe` can parse it as expected.

I later [added quotes around `%VSWHERE%` to support paths containing spaces](https://github.com/microsoft/intelligent-terminal/pull/436#discussion_r3612829217), which caused the regression, but I did not retest the exact final command through the affected MSBuild discovery path.

Most of my local usage ran `razzle.cmd` from a Visual Studio Developer Command Prompt. Because MSBuild was already in `PATH`, the script was always successful and the affected discovery step was skipped. 

## Fix

The updated script runs `vswhere` directly and redirects its output to a temporary file. It then reads that file with `for /f`.

This removes the nested `cmd.exe /c` quoting ambiguity while continuing to support paths containing spaces or parentheses.

This issue was originally found and fixed in microsoft/intelligent-terminal#497; applying the same fix here.

## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed
Verified this PR on below 3 scenarios:

1. in a brand new environment with no Visual Studio or msbuild installed.
    It throws the expected error: 
    `Could not find vswhere on your machine ...`
    <img width="2213" height="876" alt="image" src="https://github.com/user-attachments/assets/6bbc2be2-c909-45be-a1b0-cfa2dea6a14a" />

2. in an environment with Visual Studio installed but not added into PATH.
    It finds the msbuild and set its variable as expected.
    <img width="1315" height="816" alt="image" src="https://github.com/user-attachments/assets/5370796b-1cda-4b61-b3a8-c4dfa939b6d4" />

3. in Visual Studio's Developer Command Prompt, where msbuild's already in PATH:
    It sets the msbuild variable as expected.
    <img width="1723" height="915" alt="image" src="https://github.com/user-attachments/assets/4802109f-44a7-4184-900c-f9ab3a9b56e5" />


## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
