### PR TITLE
Fix globalSummon with monitor:any moving to wrong monitor when desktop:toCurrent

### DIFF
--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -882,6 +882,20 @@ void AppHost::_WindowActivated(bool activated)
 
 safe_void_coroutine AppHost::HandleSummon(const winrt::TerminalApp::SummonWindowBehavior args) const
 {
+    // GH#20305: When monitor:"any" (InPlace) and desktop:"toCurrent" are both
+    // specified, MoveWindowToDesktop may reposition the window to the monitor
+    // of the current foreground window. Save the window position beforehand so
+    // we can restore it after the desktop move completes.
+    const auto isInPlace = args && args.ToMonitor() == winrt::TerminalApp::MonitorBehavior::InPlace;
+    const auto shouldRestorePosition = isInPlace && args.MoveToCurrentDesktop();
+
+    HWND hwnd = _window->GetHandle();
+    RECT savedWindowRect{};
+    if (shouldRestorePosition)
+    {
+        ::GetWindowRect(hwnd, &savedWindowRect);
+    }
+
     _window->SummonWindow(args);
 
     if (!args || !args.MoveToCurrentDesktop())
@@ -895,6 +909,10 @@ safe_void_coroutine AppHost::HandleSummon(const winrt::TerminalApp::SummonWindow
         co_return;
     }
 
+    // Capture the dispatcher on the UI thread before we switch to the
+    // background thread. We'll need it to restore the window position.
+    auto dispatcher = _windowLogic.GetRoot().Dispatcher();
+
     // Just like AppHost::GetVirtualDesktopId:
     // IVirtualDesktopManager is cross-process COM into explorer.exe,
     // and we can't use that on the UI thread.
@@ -904,7 +922,7 @@ safe_void_coroutine AppHost::HandleSummon(const winrt::TerminalApp::SummonWindow
     // we are, then don't call MoveWindowToDesktop. This is to mitigate
     // MSFT:33035972
     BOOL onCurrentDesktop{ false };
-    if (SUCCEEDED(desktopManager->IsWindowOnCurrentVirtualDesktop(_window->GetHandle(), &onCurrentDesktop)) && onCurrentDesktop)
+    if (SUCCEEDED(desktopManager->IsWindowOnCurrentVirtualDesktop(hwnd, &onCurrentDesktop)) && onCurrentDesktop)
     {
         // If we succeeded, and the window was on the current desktop, then do nothing.
     }
@@ -917,10 +935,27 @@ safe_void_coroutine AppHost::HandleSummon(const winrt::TerminalApp::SummonWindow
         GUID currentlyActiveDesktop{ 0 };
         if (VirtualDesktopUtils::GetCurrentVirtualDesktopId(&currentlyActiveDesktop))
         {
-            LOG_IF_FAILED(desktopManager->MoveWindowToDesktop(_window->GetHandle(), currentlyActiveDesktop));
+            LOG_IF_FAILED(desktopManager->MoveWindowToDesktop(hwnd, currentlyActiveDesktop));
         }
         // If GetCurrentVirtualDesktopId failed, then just leave the window
         // where it is. Nothing else to be done :/
+    }
+
+    // GH#20305: MoveWindowToDesktop may have moved our window to the
+    // foreground window's monitor. Restore the window to the monitor
+    // and position it was on before the summon.
+    if (shouldRestorePosition)
+    {
+        co_await wil::resume_foreground(dispatcher);
+
+        RECT currentRect;
+        if (::GetWindowRect(hwnd, &currentRect))
+        {
+            if (currentRect.left != savedWindowRect.left || currentRect.top != savedWindowRect.top)
+            {
+                ::SetWindowPos(hwnd, 0, savedWindowRect.left, savedWindowRect.top, 0, 0, SWP_NOZORDER | SWP_NOSIZE | SWP_NOACTIVATE);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary of the Pull Request

When `globalSummon` is invoked with `monitor:any` and `desktop:toCurrent`, `MoveWindowToDesktop` can reposition the window to the monitor of the current foreground window instead of keeping it on its original monitor. This fix saves the window position before summoning and restores it after the desktop move completes.

## References and Relevant Issues

Closes #20305

## Detailed Description of the Pull Request / Additional comments

In `AppHost::HandleSummon`, when the combination of `MonitorBehavior::InPlace` (mapped from `monitor:any`) and `MoveToCurrentDesktop=true` is detected:
1. Save the window rect before calling `SummonWindow`
2. After `MoveWindowToDesktop` runs on the background thread, dispatch back to the UI thread and compare the current window origin to the saved origin
3. If the origin changed (eg `MoveWindowToDesktop` moved the window to a different monitor), restore the saved position via `SetWindowPos`

The `HWND` handle is also extracted once at the top and reused throughout as a minor cleanup.

This approach was previously suggested by contributor @Weichenleeeee123 in the issue comments!

## Validation Steps Performed

- Build passes with 0 errors
- Code formatting verified via `Invoke-CodeFormat`

## PR Checklist
- [X] Closes #20305
- [ ] Tests added/passed (no existing summon-specific tests)
- [ ] Documentation updated
- [ ] Schema updated (if necessary)