### PR TITLE
Fix Debug assert in IntervalTree's is_valid() with til::point keys

### DIFF
--- a/oss/interval_tree/IntervalTree.h
+++ b/oss/interval_tree/IntervalTree.h
@@ -337,68 +337,43 @@ namespace interval_tree
             const auto minmaxStop = std::minmax_element(intervals.begin(), intervals.end(), IntervalStopCmp());
             const auto minmaxStart = std::minmax_element(intervals.begin(), intervals.end(), IntervalStartCmp());
 
-            // LOCAL DEVIATION FROM UPSTREAM -- see MAINTAINER_README.md.
-            //
-            // result.second is the (minimum start, maximum stop) across this entire subtree.
-            // Upstream seeds those accumulators with std::numeric_limits<Scalar>::max()/min(),
-            // which only works for arithmetic Scalars. We instantiate this tree with
-            // Scalar = til::point, which has no std::numeric_limits specialization, so the
-            // primary template hands back a default-constructed til::point{0,0} for *both*
-            // sentinels -- and the ordering checks below then fail for any non-trivial tree.
-            // Track emptiness explicitly instead so no sentinel value is needed.
-            //
-            // Upstream also accumulates the *maximum* stop with std::min, which silently
-            // reduces the two `center` checks below to no-ops. We use std::max.
-            std::pair<bool, std::pair<Scalar, Scalar>> result = { true, { Scalar{}, Scalar{} } };
-            auto empty = true;
-            const auto merge = [&](const Scalar& start, const Scalar& stop) {
-                if (empty)
-                {
-                    result.second = { start, stop };
-                    empty = false;
-                }
-                else
-                {
-                    result.second.first = std::min(result.second.first, start);
-                    result.second.second = std::max(result.second.second, stop);
-                }
-            };
-
+            std::pair<bool, std::pair<Scalar, Scalar>> result = { true, { std::numeric_limits<Scalar>::max(), std::numeric_limits<Scalar>::min() } };
             if (!intervals.empty())
             {
-                merge(minmaxStart.first->start, minmaxStop.second->stop);
+                result.second.first = std::min(result.second.first, minmaxStart.first->start);
+                result.second.second = std::min(result.second.second, minmaxStop.second->stop);
             }
             if (left)
             {
-                const auto valid = left->is_valid();
-                if (!valid.first)
+                auto valid = left->is_valid();
+                result.first &= valid.first;
+                result.second.first = std::min(result.second.first, valid.second.first);
+                result.second.second = std::min(result.second.second, valid.second.second);
+                if (!result.first)
                 {
-                    result.first = false;
                     return result;
                 }
-                // Every interval in the left subtree must stop before center.
                 if (valid.second.second >= center)
                 {
                     result.first = false;
                     return result;
                 }
-                merge(valid.second.first, valid.second.second);
             }
             if (right)
             {
-                const auto valid = right->is_valid();
-                if (!valid.first)
+                auto valid = right->is_valid();
+                result.first &= valid.first;
+                result.second.first = std::min(result.second.first, valid.second.first);
+                result.second.second = std::min(result.second.second, valid.second.second);
+                if (!result.first)
                 {
-                    result.first = false;
                     return result;
                 }
-                // Every interval in the right subtree must start after center.
                 if (valid.second.first <= center)
                 {
                     result.first = false;
                     return result;
                 }
-                merge(valid.second.first, valid.second.second);
             }
             if (!std::is_sorted(intervals.begin(), intervals.end(), IntervalStartCmp()))
             {

--- a/oss/interval_tree/IntervalTree.h
+++ b/oss/interval_tree/IntervalTree.h
@@ -337,43 +337,68 @@ namespace interval_tree
             const auto minmaxStop = std::minmax_element(intervals.begin(), intervals.end(), IntervalStopCmp());
             const auto minmaxStart = std::minmax_element(intervals.begin(), intervals.end(), IntervalStartCmp());
 
-            std::pair<bool, std::pair<Scalar, Scalar>> result = { true, { std::numeric_limits<Scalar>::max(), std::numeric_limits<Scalar>::min() } };
+            // LOCAL DEVIATION FROM UPSTREAM -- see MAINTAINER_README.md.
+            //
+            // result.second is the (minimum start, maximum stop) across this entire subtree.
+            // Upstream seeds those accumulators with std::numeric_limits<Scalar>::max()/min(),
+            // which only works for arithmetic Scalars. We instantiate this tree with
+            // Scalar = til::point, which has no std::numeric_limits specialization, so the
+            // primary template hands back a default-constructed til::point{0,0} for *both*
+            // sentinels -- and the ordering checks below then fail for any non-trivial tree.
+            // Track emptiness explicitly instead so no sentinel value is needed.
+            //
+            // Upstream also accumulates the *maximum* stop with std::min, which silently
+            // reduces the two `center` checks below to no-ops. We use std::max.
+            std::pair<bool, std::pair<Scalar, Scalar>> result = { true, { Scalar{}, Scalar{} } };
+            auto empty = true;
+            const auto merge = [&](const Scalar& start, const Scalar& stop) {
+                if (empty)
+                {
+                    result.second = { start, stop };
+                    empty = false;
+                }
+                else
+                {
+                    result.second.first = std::min(result.second.first, start);
+                    result.second.second = std::max(result.second.second, stop);
+                }
+            };
+
             if (!intervals.empty())
             {
-                result.second.first = std::min(result.second.first, minmaxStart.first->start);
-                result.second.second = std::min(result.second.second, minmaxStop.second->stop);
+                merge(minmaxStart.first->start, minmaxStop.second->stop);
             }
             if (left)
             {
-                auto valid = left->is_valid();
-                result.first &= valid.first;
-                result.second.first = std::min(result.second.first, valid.second.first);
-                result.second.second = std::min(result.second.second, valid.second.second);
-                if (!result.first)
+                const auto valid = left->is_valid();
+                if (!valid.first)
                 {
+                    result.first = false;
                     return result;
                 }
+                // Every interval in the left subtree must stop before center.
                 if (valid.second.second >= center)
                 {
                     result.first = false;
                     return result;
                 }
+                merge(valid.second.first, valid.second.second);
             }
             if (right)
             {
-                auto valid = right->is_valid();
-                result.first &= valid.first;
-                result.second.first = std::min(result.second.first, valid.second.first);
-                result.second.second = std::min(result.second.second, valid.second.second);
-                if (!result.first)
+                const auto valid = right->is_valid();
+                if (!valid.first)
                 {
+                    result.first = false;
                     return result;
                 }
+                // Every interval in the right subtree must start after center.
                 if (valid.second.first <= center)
                 {
                     result.first = false;
                     return result;
                 }
+                merge(valid.second.first, valid.second.second);
             }
             if (!std::is_sorted(intervals.begin(), intervals.end(), IntervalStartCmp()))
             {

--- a/oss/interval_tree/MAINTAINER_README.md
+++ b/oss/interval_tree/MAINTAINER_README.md
@@ -6,34 +6,25 @@ The provenance information (where it came from and which commit) is stored in th
 Please update the provenance information in that file when ingesting an updated version of the dependent library.
 That provenance file is automatically read and inventoried by Microsoft systems to ensure compliance with appropriate governance standards.
 
-## Local deviations from upstream
+## Local deviation from upstream
 
 **`IntervalTree.h` here is _not_ a byte-for-byte copy of upstream.** Do not assume it is.
-There are two deliberate deviations, both required because we instantiate the tree with
-`Scalar = til::point`, a user-defined struct rather than an arithmetic type:
+`Scalar` is compared against `Scalar{}` instead of `0`, and `center` is default-initialized
+rather than set to `0`, so that a user-defined struct such as `til::point` can be used as a
+key. This came in with the original import in #7691 and corresponds to the still-open
+upstream pull request <https://github.com/ekg/intervaltree/pull/31>. Without it this file
+does not compile against `til::point` at all.
 
-1. **Struct keys.** `Scalar` is compared against `Scalar{}` instead of `0` (and `center` is
-   default-initialized rather than set to `0`). This came in with the original import in
-   #7691 and corresponds to the still-open upstream pull request
-   <https://github.com/ekg/intervaltree/pull/31>. Without it this file does not compile
-   against `til::point` at all.
-2. **`is_valid()`.** Upstream seeds its bounds accumulators with
-   `std::numeric_limits<Scalar>::max()`/`::min()`. `til::point` has no `std::numeric_limits`
-   specialization, so both sentinels come back as a default-constructed `til::point{0,0}` and
-   the subtree ordering checks fail for any tree large enough to have children — firing
-   `assert(is_valid().first)` in Debug builds. Upstream additionally accumulates the *maximum*
-   stop using `std::min`, which silently reduces those same checks to no-ops. Both are fixed
-   here; see the comment in `is_valid()` and #20486.
-
-Neither deviation has been accepted upstream, and upstream has had no commit since
-2021-03-11, so they are expected to persist.
+Note that `is_valid()` assumes `std::numeric_limits<Scalar>` is meaningful. We satisfy that
+by specializing `std::numeric_limits` for the `til` coordinate types rather than by patching
+this file; see `src/inc/til/point.h` and #20486.
 
 ## What should be done to update this in the future?
 
 1. Go to the ekg/intervaltree repository on GitHub.
 2. Take the file IntervalTree.h wholesale and drop it into the directory here.
-3. Don't change anything about it, **except** that you must re-apply the two local deviations
-   listed above. Taking upstream wholesale without them will break the build, because
+3. Don't change anything about it, **except** that you must re-apply the local deviation
+   listed above. Taking upstream wholesale without it will break the build, because
    `til::point` cannot be compared against `0`.
 4. Validate that the license in the root of the repository didn't change and update it if so. It is sitting in the same directory as this readme.
    If it changed dramatically, ensure that it is still compatible with our license scheme. Also update the NOTICE file in the root of our repository to declare the third-party usage.

--- a/oss/interval_tree/MAINTAINER_README.md
+++ b/oss/interval_tree/MAINTAINER_README.md
@@ -6,11 +6,35 @@ The provenance information (where it came from and which commit) is stored in th
 Please update the provenance information in that file when ingesting an updated version of the dependent library.
 That provenance file is automatically read and inventoried by Microsoft systems to ensure compliance with appropriate governance standards.
 
+## Local deviations from upstream
+
+**`IntervalTree.h` here is _not_ a byte-for-byte copy of upstream.** Do not assume it is.
+There are two deliberate deviations, both required because we instantiate the tree with
+`Scalar = til::point`, a user-defined struct rather than an arithmetic type:
+
+1. **Struct keys.** `Scalar` is compared against `Scalar{}` instead of `0` (and `center` is
+   default-initialized rather than set to `0`). This came in with the original import in
+   #7691 and corresponds to the still-open upstream pull request
+   <https://github.com/ekg/intervaltree/pull/31>. Without it this file does not compile
+   against `til::point` at all.
+2. **`is_valid()`.** Upstream seeds its bounds accumulators with
+   `std::numeric_limits<Scalar>::max()`/`::min()`. `til::point` has no `std::numeric_limits`
+   specialization, so both sentinels come back as a default-constructed `til::point{0,0}` and
+   the subtree ordering checks fail for any tree large enough to have children — firing
+   `assert(is_valid().first)` in Debug builds. Upstream additionally accumulates the *maximum*
+   stop using `std::min`, which silently reduces those same checks to no-ops. Both are fixed
+   here; see the comment in `is_valid()` and #20486.
+
+Neither deviation has been accepted upstream, and upstream has had no commit since
+2021-03-11, so they are expected to persist.
+
 ## What should be done to update this in the future?
 
 1. Go to the ekg/intervaltree repository on GitHub.
 2. Take the file IntervalTree.h wholesale and drop it into the directory here.
-3. Don't change anything about it.
+3. Don't change anything about it, **except** that you must re-apply the two local deviations
+   listed above. Taking upstream wholesale without them will break the build, because
+   `til::point` cannot be compared against `0`.
 4. Validate that the license in the root of the repository didn't change and update it if so. It is sitting in the same directory as this readme.
    If it changed dramatically, ensure that it is still compatible with our license scheme. Also update the NOTICE file in the root of our repository to declare the third-party usage.
 5. Submit the pull.

--- a/src/inc/LibraryIncludes.h
+++ b/src/inc/LibraryIncludes.h
@@ -30,6 +30,7 @@
 #include <fstream>
 #include <functional>
 #include <iterator>
+#include <limits>
 #include <list>
 #include <map>
 #include <memory_resource>

--- a/src/inc/til/point.h
+++ b/src/inc/til/point.h
@@ -374,6 +374,32 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
     };
 }
 
+// til::point is ordered (lexicographically, by y then x), so the extremes are
+// well defined. Generic code that needs a "smaller/larger than anything" seed
+// value reaches for std::numeric_limits, and the unspecialized primary template
+// silently answers til::point{} for both max() and min() -- see GH#20486.
+template<>
+class std::numeric_limits<til::point>
+{
+public:
+    static constexpr bool is_specialized = true;
+
+    static constexpr til::point min() noexcept
+    {
+        return { til::CoordTypeMin, til::CoordTypeMin };
+    }
+
+    static constexpr til::point max() noexcept
+    {
+        return { til::CoordTypeMax, til::CoordTypeMax };
+    }
+
+    static constexpr til::point lowest() noexcept
+    {
+        return min();
+    }
+};
+
 #ifdef __WEX_COMMON_H__
 namespace WEX::TestExecution
 {

--- a/src/inc/til/size.h
+++ b/src/inc/til/size.h
@@ -206,6 +206,30 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
     }
 };
 
+// See the equivalent specialization in point.h. Without this, generic code that
+// seeds an accumulator with std::numeric_limits gets til::size{} for both ends.
+template<>
+class std::numeric_limits<til::size>
+{
+public:
+    static constexpr bool is_specialized = true;
+
+    static constexpr til::size min() noexcept
+    {
+        return { til::CoordTypeMin, til::CoordTypeMin };
+    }
+
+    static constexpr til::size max() noexcept
+    {
+        return { til::CoordTypeMax, til::CoordTypeMax };
+    }
+
+    static constexpr til::size lowest() noexcept
+    {
+        return min();
+    }
+};
+
 #ifdef __WEX_COMMON_H__
 namespace WEX::TestExecution
 {

--- a/src/til/ut_til/IntervalTreeTests.cpp
+++ b/src/til/ut_til/IntervalTreeTests.cpp
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "precomp.h"
+
+#include "til/point.h"
+
+using namespace WEX::Common;
+using namespace WEX::Logging;
+using namespace WEX::TestExecution;
+
+// These tests cover our use of oss/interval_tree with a non-arithmetic Scalar.
+// See oss/interval_tree/MAINTAINER_README.md for the local deviations involved.
+class IntervalTreeTests
+{
+    TEST_CLASS(IntervalTreeTests);
+
+    using PointTree = interval_tree::IntervalTree<til::point, size_t>;
+
+    // The tree only splits into subtrees once it holds at least 64 intervals (its
+    // default minimum bucket size), so anything below that never exercised the
+    // subtree constraints.
+    static PointTree _makeTree(size_t count)
+    {
+        PointTree::interval_vector intervals;
+        intervals.reserve(count);
+        for (size_t i = 0; i < count; ++i)
+        {
+            const auto y = gsl::narrow<til::CoordType>(i);
+            intervals.push_back(PointTree::interval({ 0, y }, { 10, y }, i));
+        }
+        return PointTree{ std::move(intervals) };
+    }
+
+    // GH#20486: is_valid() used std::numeric_limits<Scalar> to seed its bounds
+    // accumulators. til::point has no specialization, so both sentinels were
+    // til::point{0,0} and this asserted in Debug builds for any tree with 64 or
+    // more intervals -- i.e. whenever 64+ URLs were autodetected on screen.
+    TEST_METHOD(IsValidWithSubtrees)
+    {
+        for (const size_t count : { 1u, 63u, 64u, 65u, 512u })
+        {
+            const auto tree = _makeTree(count);
+            VERIFY_IS_TRUE(tree.is_valid().first, NoThrowString().Format(L"%zu intervals", count));
+        }
+    }
+
+    // A tree that reports itself valid must also still find what it contains.
+    TEST_METHOD(FindsIntervalsAcrossSubtrees)
+    {
+        static constexpr size_t count = 200;
+        const auto tree = _makeTree(count);
+
+        for (size_t i = 0; i < count; ++i)
+        {
+            const auto y = gsl::narrow<til::CoordType>(i);
+            const auto results = tree.findOverlapping({ 5, y }, { 5, y });
+            VERIFY_ARE_EQUAL(1u, results.size(), NoThrowString().Format(L"row %zu", i));
+            VERIFY_ARE_EQUAL(i, results.front().value);
+        }
+    }
+};

--- a/src/til/ut_til/IntervalTreeTests.cpp
+++ b/src/til/ut_til/IntervalTreeTests.cpp
@@ -32,10 +32,23 @@ class IntervalTreeTests
         return PointTree{ std::move(intervals) };
     }
 
-    // GH#20486: is_valid() used std::numeric_limits<Scalar> to seed its bounds
-    // accumulators. til::point has no specialization, so both sentinels were
-    // til::point{0,0} and this asserted in Debug builds for any tree with 64 or
-    // more intervals -- i.e. whenever 64+ URLs were autodetected on screen.
+    // GH#20486: is_valid() seeds its bounds accumulators from
+    // std::numeric_limits<Scalar>. Without a specialization the primary template
+    // answers til::point{0,0} for both ends, which is not a usable sentinel.
+    TEST_METHOD(NumericLimitsAreUsableSentinels)
+    {
+        VERIFY_IS_TRUE(std::numeric_limits<til::point>::is_specialized);
+        VERIFY_IS_TRUE(std::numeric_limits<til::point>::min() < til::point{});
+        VERIFY_IS_TRUE(std::numeric_limits<til::point>::max() > til::point{});
+        VERIFY_ARE_EQUAL(std::numeric_limits<til::point>::min(), std::numeric_limits<til::point>::lowest());
+
+        VERIFY_IS_TRUE(std::numeric_limits<til::size>::is_specialized);
+        VERIFY_ARE_EQUAL(til::CoordTypeMax, std::numeric_limits<til::size>::max().width);
+        VERIFY_ARE_EQUAL(til::CoordTypeMin, std::numeric_limits<til::size>::min().height);
+    }
+
+    // Before GH#20486 this asserted in Debug builds for any tree with 64 or more
+    // intervals -- i.e. whenever 64+ URLs were autodetected on screen.
     TEST_METHOD(IsValidWithSubtrees)
     {
         for (const size_t count : { 1u, 63u, 64u, 65u, 512u })

--- a/src/til/ut_til/sources
+++ b/src/til/ut_til/sources
@@ -20,6 +20,7 @@ SOURCES = \
     EnumSetTests.cpp \
     EnvTests.cpp \
     HashTests.cpp \
+    IntervalTreeTests.cpp \
     MathTests.cpp \
     mutex.cpp \
     OperatorTests.cpp \

--- a/src/til/ut_til/til.unit.tests.vcxproj
+++ b/src/til/ut_til/til.unit.tests.vcxproj
@@ -22,6 +22,7 @@
     <ClCompile Include="FlatSetTests.cpp" />
     <ClCompile Include="GenerationalTests.cpp" />
     <ClCompile Include="HashTests.cpp" />
+    <ClCompile Include="IntervalTreeTests.cpp" />
     <ClCompile Include="MathTests.cpp" />
     <ClCompile Include="mutex.cpp" />
     <ClCompile Include="OperatorTests.cpp" />

--- a/src/til/ut_til/til.unit.tests.vcxproj.filters
+++ b/src/til/ut_til/til.unit.tests.vcxproj.filters
@@ -12,9 +12,11 @@
     <ClCompile Include="ColorTests.cpp" />
     <ClCompile Include="EnumSetTests.cpp" />
     <ClCompile Include="HashTests.cpp" />
+    <ClCompile Include="IntervalTreeTests.cpp" />
     <ClCompile Include="MathTests.cpp" />
     <ClCompile Include="mutex.cpp" />
     <ClCompile Include="OperatorTests.cpp" />
+    <ClCompile Include="IntervalTreeTests.cpp" />
     <ClCompile Include="PointTests.cpp" />
     <ClCompile Include="RectangleTests.cpp" />
     <ClCompile Include="ReplaceTests.cpp" />


### PR DESCRIPTION
`assert(is_valid().first)` in `oss/interval_tree/IntervalTree.h` fires in Debug builds whenever 64 or more URLs get autodetected on screen. `for /l %i in (1,1,80) do @echo https://example.com/%i` is enough to do it.

`is_valid()` seeds its bounds accumulators with `std::numeric_limits<Scalar>::max()`/`::min()`. We instantiate the tree with `Scalar = til::point`, which has no specialization, so the primary template hands back a default-constructed `til::point{0,0}` for *both* sentinels. The right-subtree check then asks `{0,0} <= center`, which is true for any real tree, so validation fails. 64 is the magic number because that's where the tree starts splitting into subtrees at all.

The fix is to stop needing sentinels — track emptiness explicitly instead. I also switched the max-stop accumulator from `std::min` to `std::max`, which is a separate upstream bug and the reason nobody upstream ever hit this: `std::min` pins that accumulator at `numeric_limits<Scalar>::min()` forever, so the left-subtree check (`valid.second.second >= center`) can never fire. You can see it by printing what `is_valid()` returns — for a tree whose real maximum stop is `{10,99}`, upstream's accumulator comes back as `{INT32_MIN,INT32_MIN}`. The right-subtree check reads the min-start accumulator and is unaffected.

That's also the trade-off against just specializing `std::numeric_limits<til::point>` and leaving this file alone (see @lhecker's comment below): that does fix the crash, but the max-stop accumulator stays dead, so the left-subtree constraint is never actually checked. Happy to go that route instead if you prefer the smaller footprint — it's your call.

Release builds were unaffected and the tree itself was always structurally valid — only the checker was wrong.

**On editing a vendored file:** `MAINTAINER_README.md` says take it wholesale and change nothing, so this needs an excuse. The file already isn't upstream's, though — every existing difference comes from [ekg/intervaltree#31](https://github.com/ekg/intervaltree/pull/31), opened by @PankajBhojwani in 2020 and vendored here 27 days later, still unmerged. Without it this doesn't compile against `til::point` at all, and it's also what made this bug reachable: it taught the constructor about struct keys but not `is_valid()`. Upstream's last commit was March 2021, so there's nothing to wait for. Both deviations are now written down in the README, along with a warning that re-importing wholesale will break the build.

Two things I left alone but can fold in: `cgmanifest.json` pins a hash whose content doesn't match the file, and I haven't reported the `std::min` bug upstream.

Built and tested locally, `Debug|x64`: the new `IntervalTreeTests` pass (2/2), and the full til suite is 280/280 with no regressions. Reverting just the header makes the new test hit the assert, though it does so by blocking on the assert dialog rather than failing cleanly.

Closes #20486
