### PR TITLE
Add a Nuget Package for UWP Control

### DIFF
--- a/src/cascadia/TerminalControl/package/TerminalControl.nuspec
+++ b/src/cascadia/TerminalControl/package/TerminalControl.nuspec
@@ -17,10 +17,10 @@
     <file src="native/Microsoft.Windows.Terminal.Control.props" target="build/native" />
     <file src="native/Microsoft.Windows.Terminal.Control.targets" target="build/native" />
 
-    <file src="../../../../bin/x64/Release/Microsoft.Terminal.Control/Microsoft.Terminal.Control.winmd" target="metadata" />
-    <file src="../../../../bin/x64/Release/Microsoft.Terminal.UI/Microsoft.Terminal.UI.winmd" target="metadata" />
-    <file src="../../../../bin/x64/Release/TerminalConnection/Microsoft.Terminal.TerminalConnection.winmd" target="metadata" />
-    <file src="../../../../bin/x64/Release/TerminalCore/Microsoft.Terminal.Core.winmd" target="metadata" />
+    <file src="../../../../bin/x64/Release/Microsoft.Terminal.Control/Microsoft.Terminal.Control.winmd" target="lib\uap10.0" />
+    <file src="../../../../bin/x64/Release/Microsoft.Terminal.UI/Microsoft.Terminal.UI.winmd" target="lib\uap10.0" />
+    <file src="../../../../bin/x64/Release/TerminalConnection/Microsoft.Terminal.TerminalConnection.winmd" target="lib\uap10.0" />
+    <file src="../../../../bin/x64/Release/TerminalCore/Microsoft.Terminal.Core.winmd" target="lib\uap10.0" />
 
     <file src="../../../../bin/Win32/Release/Microsoft.Terminal.Control/Microsoft.Terminal.Control.dll" target="runtimes/win-x86/native" />
     <file src="../../../../bin/Win32/Release/Microsoft.Terminal.Control.Lib/Microsoft.Terminal.Control.pri" target="runtimes/win-x86/native" />

--- a/src/cascadia/TerminalControl/package/TerminalControl.nuspec
+++ b/src/cascadia/TerminalControl/package/TerminalControl.nuspec
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata>
+    <id>Microsoft.Windows.Terminal.Control</id>
+    <version>0.0.1</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <projectUrl>https://github.com/microsoft/terminal</projectUrl>
+    <description>This package allows applications to host Windows Terminal sessions. It should work on all versions of Windows 10.0.17763.0 and above.</description>
+    <copyright>© Microsoft Corporation</copyright>
+    <dependencies />
+  </metadata>
+  <files>
+    <file src="managed/Microsoft.Windows.Terminal.Control.props" target="build" />
+    <file src="managed/Microsoft.Windows.Terminal.Control.targets" target="build" />
+    <file src="native/Microsoft.Windows.Terminal.Control.props" target="build/native" />
+    <file src="native/Microsoft.Windows.Terminal.Control.targets" target="build/native" />
+
+    <file src="../../../../bin/x64/Release/Microsoft.Terminal.Control/Microsoft.Terminal.Control.winmd" target="metadata" />
+    <file src="../../../../bin/x64/Release/Microsoft.Terminal.UI/Microsoft.Terminal.UI.winmd" target="metadata" />
+    <file src="../../../../bin/x64/Release/TerminalConnection/Microsoft.Terminal.TerminalConnection.winmd" target="metadata" />
+    <file src="../../../../bin/x64/Release/TerminalCore/Microsoft.Terminal.Core.winmd" target="metadata" />
+
+    <file src="../../../../bin/Win32/Release/Microsoft.Terminal.Control/Microsoft.Terminal.Control.dll" target="runtimes/win-x86/native" />
+    <file src="../../../../bin/Win32/Release/Microsoft.Terminal.Control.Lib/Microsoft.Terminal.Control.pri" target="runtimes/win-x86/native" />
+    <file src="../../../../bin/Win32/Release/Microsoft.Terminal.UI/Microsoft.Terminal.UI.dll" target="runtimes/win-x86/native" />
+    <file src="../../../../bin/Win32/Release/Microsoft.Terminal.UI/Microsoft.Terminal.UI.pri" target="runtimes/win-x86/native" />
+    <file src="../../../../bin/Win32/Release/TerminalConnection/TerminalConnection.dll" target="runtimes/win-x86/native" />
+    <file src="../../../../bin/Win32/Release/TerminalConnection/Microsoft.Terminal.TerminalConnection.pri" target="runtimes/win-x86/native" />
+    
+    <file src="../../../../bin/x64/Release/Microsoft.Terminal.Control/Microsoft.Terminal.Control.dll" target="runtimes/win-x64/native" />
+    <file src="../../../../bin/x64/Release/Microsoft.Terminal.Control.Lib/Microsoft.Terminal.Control.pri" target="runtimes/win-x64/native" />
+    <file src="../../../../bin/x64/Release/Microsoft.Terminal.UI/Microsoft.Terminal.UI.dll" target="runtimes/win-x64/native" />
+    <file src="../../../../bin/x64/Release/Microsoft.Terminal.UI/Microsoft.Terminal.UI.pri" target="runtimes/win-x64/native" />
+    <file src="../../../../bin/x64/Release/TerminalConnection/TerminalConnection.dll" target="runtimes/win-x64/native" />
+    <file src="../../../../bin/x64/Release/TerminalConnection/Microsoft.Terminal.TerminalConnection.pri" target="runtimes/win-x64/native" />
+    
+    <file src="../../../../bin/ARM64/Release/Microsoft.Terminal.Control/Microsoft.Terminal.Control.dll" target="runtimes/win-arm64/native" />
+    <file src="../../../../bin/ARM64/Release/Microsoft.Terminal.Control.Lib/Microsoft.Terminal.Control.pri" target="runtimes/win-arm64/native" />
+    <file src="../../../../bin/ARM64/Release/Microsoft.Terminal.UI/Microsoft.Terminal.UI.dll" target="runtimes/win-arm64/native" />
+    <file src="../../../../bin/ARM64/Release/Microsoft.Terminal.UI/Microsoft.Terminal.UI.pri" target="runtimes/win-arm64/native" />
+    <file src="../../../../bin/ARM64/Release/TerminalConnection/TerminalConnection.dll" target="runtimes/win-arm64/native" />
+    <file src="../../../../bin/ARM64/Release/TerminalConnection/Microsoft.Terminal.TerminalConnection.pri" target="runtimes/win-arm64/native" />
+  </files>
+</package>

--- a/src/cascadia/TerminalControl/package/managed/Microsoft.Windows.Terminal.Control.props
+++ b/src/cascadia/TerminalControl/package/managed/Microsoft.Windows.Terminal.Control.props
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- C# uses normalizes PlatformTarget, whereas C++ does not normalize Platform -->
+    <TerminalNativePlatform Condition="'$(TerminalNativePlatform)'==''">$(PlatformTarget)</TerminalNativePlatform>
+    <TerminalNativePlatform Condition="'$(TerminalNativePlatform)'==''">$(Platform)</TerminalNativePlatform>
+    <TerminalNativePlatform Condition="'$(TerminalNativePlatform)'=='Win32'">x86</TerminalNativePlatform>
+  </PropertyGroup>
+</Project>

--- a/src/cascadia/TerminalControl/package/managed/Microsoft.Windows.Terminal.Control.targets
+++ b/src/cascadia/TerminalControl/package/managed/Microsoft.Windows.Terminal.Control.targets
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <ItemGroup>
+        <Reference Include="$(MSBuildThisFileDirectory)..\metadata\Microsoft.Terminal.Core.winmd">
+            <WinMDFile>true</WinMDFile>
+            <Implementation>TerminalConnection.dll</Implementation>
+        </Reference>
+        <Reference Include="$(MSBuildThisFileDirectory)..\metadata\Microsoft.Terminal.TerminalConnection.winmd">
+            <WinMDFile>true</WinMDFile>
+            <Implementation>TerminalConnection.dll</Implementation>
+        </Reference>
+        <Reference Include="$(MSBuildThisFileDirectory)..\metadata\Microsoft.Terminal.UI.winmd">
+            <WinMDFile>true</WinMDFile>
+            <Implementation>Microsoft.Terminal.UI.dll</Implementation>
+        </Reference>
+        <Reference Include="$(MSBuildThisFileDirectory)..\metadata\Microsoft.Terminal.Control.winmd">
+            <WinMDFile>true</WinMDFile>
+            <Implementation>Microsoft.Terminal.Control.dll</Implementation>
+        </Reference>
+    </ItemGroup>
+</Project>

--- a/src/cascadia/TerminalControl/package/managed/Microsoft.Windows.Terminal.Control.targets
+++ b/src/cascadia/TerminalControl/package/managed/Microsoft.Windows.Terminal.Control.targets
@@ -1,21 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemGroup>
-        <Reference Include="$(MSBuildThisFileDirectory)..\metadata\Microsoft.Terminal.Core.winmd">
-            <WinMDFile>true</WinMDFile>
-            <Implementation>TerminalConnection.dll</Implementation>
-        </Reference>
-        <Reference Include="$(MSBuildThisFileDirectory)..\metadata\Microsoft.Terminal.TerminalConnection.winmd">
-            <WinMDFile>true</WinMDFile>
-            <Implementation>TerminalConnection.dll</Implementation>
-        </Reference>
-        <Reference Include="$(MSBuildThisFileDirectory)..\metadata\Microsoft.Terminal.UI.winmd">
-            <WinMDFile>true</WinMDFile>
-            <Implementation>Microsoft.Terminal.UI.dll</Implementation>
-        </Reference>
-        <Reference Include="$(MSBuildThisFileDirectory)..\metadata\Microsoft.Terminal.Control.winmd">
-            <WinMDFile>true</WinMDFile>
-            <Implementation>Microsoft.Terminal.Control.dll</Implementation>
-        </Reference>
     </ItemGroup>
 </Project>

--- a/src/cascadia/TerminalControl/package/native/Microsoft.Windows.Terminal.Control.props
+++ b/src/cascadia/TerminalControl/package/native/Microsoft.Windows.Terminal.Control.props
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildThisFileDirectory)..\Microsoft.Windows.Terminal.Control.props" />
+</Project>

--- a/src/cascadia/TerminalControl/package/native/Microsoft.Windows.Terminal.Control.targets
+++ b/src/cascadia/TerminalControl/package/native/Microsoft.Windows.Terminal.Control.targets
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildThisFileDirectory)..\Microsoft.Windows.Terminal.Control.targets" />
+  <ItemGroup>
+    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-$(TerminalNativePlatform)\native\*.dll" />
+    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-$(TerminalNativePlatform)\native\*.pri" />
+  </ItemGroup>
+</Project>

--- a/src/cascadia/TerminalControl/package/native/Microsoft.Windows.Terminal.Control.targets
+++ b/src/cascadia/TerminalControl/package/native/Microsoft.Windows.Terminal.Control.targets
@@ -2,6 +2,22 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildThisFileDirectory)..\Microsoft.Windows.Terminal.Control.targets" />
   <ItemGroup>
+    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Terminal.Core.winmd">
+        <WinMDFile>true</WinMDFile>
+        <Implementation>TerminalConnection.dll</Implementation>
+    </Reference>
+    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Terminal.TerminalConnection.winmd">
+        <WinMDFile>true</WinMDFile>
+        <Implementation>TerminalConnection.dll</Implementation>
+    </Reference>
+    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Terminal.UI.winmd">
+        <WinMDFile>true</WinMDFile>
+        <Implementation>Microsoft.Terminal.UI.dll</Implementation>
+    </Reference>
+    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.Terminal.Control.winmd">
+        <WinMDFile>true</WinMDFile>
+        <Implementation>Microsoft.Terminal.Control.dll</Implementation>
+    </Reference>
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-$(TerminalNativePlatform)\native\*.dll" />
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-$(TerminalNativePlatform)\native\*.pri" />
   </ItemGroup>


### PR DESCRIPTION
## Summary of the Pull Request
Add a nuget package for the UWP Control

## References and Relevant Issues
Towards #6999

## Detailed Description of the Pull Request / Additional comments
This adds a .nuspec file and the supporting files to create a Nuget Package for TerminalControl.

This Nuget Package is currently only C++ UWP projects and C++ UWP Xaml Islands. I wanted to keep the starting change small, and adding C# UWP support would require adding an extra project into the solution. 
This package doesn't have a required dependency on the ConPTY Nuget Package. That just makes Microsoft.Terminal.TerminalConnection.ConptyConnection close immediately, if the ConPTY Nuget Package isn't used as well. Some users may just want the TerminalControl and not care about ConPTY support.

## Validation Steps Performed
Use Nuget Package in a test project, and a real project.

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
