### PR TITLE
Fix invalid inherited color scheme fallback

### DIFF
--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -468,14 +468,31 @@ void CascadiaSettings::_validateAllSchemesExist()
         {
             if (appearance && !colorSchemes.HasKey(appearance.DarkColorSchemeName()))
             {
-                // Clear the user set dark color scheme. We'll just fallback instead.
-                appearance.ClearDarkColorSchemeName();
+                // If the leaf owns the bad name, clear it so the system default
+                // takes effect. If the name was inherited from a parent (fragment,
+                // defaults.json, etc.), the clear would be a no-op because the
+                // leaf's optional is already nullopt. In that case we must
+                // explicitly shadow the parent's value with the system default.
+                if (appearance.HasDarkColorSchemeName())
+                {
+                    appearance.ClearDarkColorSchemeName();
+                }
+                else
+                {
+                    appearance.DarkColorSchemeName(L"Campbell");
+                }
                 foundInvalidDarkScheme = true;
             }
             if (appearance && !colorSchemes.HasKey(appearance.LightColorSchemeName()))
             {
-                // Clear the user set light color scheme. We'll just fallback instead.
-                appearance.ClearLightColorSchemeName();
+                if (appearance.HasLightColorSchemeName())
+                {
+                    appearance.ClearLightColorSchemeName();
+                }
+                else
+                {
+                    appearance.LightColorSchemeName(L"Campbell");
+                }
                 foundInvalidLightScheme = true;
             }
         }

--- a/src/cascadia/UnitTests_SettingsModel/DeserializationTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/DeserializationTests.cpp
@@ -35,6 +35,7 @@ namespace SettingsModelUnitTests
         TEST_METHOD(TestLayeringNameOnlyProfiles);
         TEST_METHOD(TestHideAllProfiles);
         TEST_METHOD(TestInvalidColorSchemeName);
+        TEST_METHOD(TestInvalidColorSchemeNameFromFragmentFallsBack);
         TEST_METHOD(TestHelperFunctions);
         TEST_METHOD(TestCloseOnExitParsing);
         TEST_METHOD(TestCloseOnExitCompatibilityShim);
@@ -741,6 +742,43 @@ namespace SettingsModelUnitTests
             VERIFY_ARE_EQUAL(L"Campbell", profile.DefaultAppearance().DarkColorSchemeName());
             VERIFY_ARE_EQUAL(L"Campbell", profile.DefaultAppearance().LightColorSchemeName());
         }
+    }
+
+    void DeserializationTests::TestInvalidColorSchemeNameFromFragmentFallsBack()
+    {
+        Log::Comment(NoThrowString().Format(
+            L"Ensure that setting a profile's scheme to a nonexistent scheme via a fragment causes a warning and falls back correctly."));
+
+        static constexpr std::string_view userJson{ R"({
+            "profiles": [
+                {
+                    "name" : "profile0"
+                }
+            ]
+        })" };
+
+        static constexpr std::string_view fragmentJson{ R"({
+            "profiles": [
+                {
+                    "name": "profile0",
+                    "colorScheme": "InvalidSchemeName"
+                }
+            ]
+        })" };
+
+        implementation::SettingsLoader loader{ userJson, implementation::LoadStringResource(IDR_DEFAULTS) };
+        loader.MergeInboxIntoUserSettings();
+        loader.MergeFragmentIntoUserSettings(L"fragment", {}, fragmentJson);
+        loader.FinalizeLayering();
+
+        auto settings = winrt::make_self<implementation::CascadiaSettings>(std::move(loader));
+        auto profile = settings->AllProfiles().GetAt(0);
+
+        VERIFY_ARE_EQUAL(1u, settings->Warnings().Size());
+        VERIFY_ARE_EQUAL(SettingsLoadWarnings::UnknownColorScheme, settings->Warnings().GetAt(0));
+
+        VERIFY_ARE_EQUAL(L"Campbell", profile.DefaultAppearance().DarkColorSchemeName());
+        VERIFY_ARE_EQUAL(L"Campbell", profile.DefaultAppearance().LightColorSchemeName());
     }
 
     void DeserializationTests::ValidateColorSchemeInCommands()


### PR DESCRIPTION
## Summary

Fixes the fallback behavior when an invalid color scheme name is inherited from a fragment parent.

## References

Fixes #20462

## Detailed Description
When `_validateAllSchemesExist()` encounters an invalid color scheme reference, it clears locally defined values so the appearance falls back to the default color scheme.

However, `ClearDarkColorSchemeName()` and `ClearLightColorSchemeName()` only clear values stored on the leaf `AppearanceConfig`. If the invalid color scheme is inherited from a fragment parent, clearing the leaf is a no-op because the leaf does not own the value, allowing the invalid inherited value to continue resolving.

This change preserves the existing behavior for locally defined values while handling inherited values separately. If the invalid color scheme is inherited, the leaf profile is assigned the default color scheme so the invalid inherited value no longer resolves during validation.

This change only affects the fallback behavior described in #20462 and does not modify warning classification.

## Validation
- Added a regression test covering an invalid color scheme inherited from a fragment using `SettingsLoader`.
- Verified that inherited invalid color schemes resolve to the default color scheme after validation.

## Checklist

- [x] Fixes #20462