### PR TITLE
Fix KKP auto-repeat events

### DIFF
--- a/src/terminal/input/terminalInput.cpp
+++ b/src/terminal/input/terminalInput.cpp
@@ -311,11 +311,8 @@ TerminalInput::OutputType TerminalInput::HandleKey(const INPUT_RECORD& event)
             // Suppress modifier key events at all times - they aren't reported in any protocol.
             (key.virtualKey >= VK_SHIFT && key.virtualKey <= VK_MENU) ||
             (key.virtualKey >= VK_LSHIFT && key.virtualKey <= VK_RMENU) ||
-            (_kittyFlags != 0 ?
-                 // If KKP is enabled, we only report repeats if ReportEventTypes is enabled.
-                 WI_IsFlagClear(_kittyFlags, KittyKeyboardProtocolFlags::ReportEventTypes) :
-                 // Otherwise, it depends on the classic auto-repeat mode setting.
-                 !_inputMode.test(Mode::AutoRepeat)))
+            // Otherwise, it depends on the classic auto-repeat mode setting.
+            !_inputMode.test(Mode::AutoRepeat))
         {
             return _makeNoOutput();
         }


### PR DESCRIPTION
Turns out, ReportEventTypes does not control autorepeat.

Closes #20499