### PR TITLE
atlas: only claim the soft font code points that are actually defined

### DIFF
--- a/src/renderer/atlas/AtlasEngine.cpp
+++ b/src/renderer/atlas/AtlasEngine.cpp
@@ -825,6 +825,7 @@ void AtlasEngine::_flushBufferLine()
     Expects(_api.bufferLineColumn.size() == _api.bufferLine.size() + 1);
 
     const auto builtinGlyphs = _p.s->font->builtinGlyphs;
+    const auto softFontCharCount = _p.s->font->softFontCharCount();
     const auto beg = _api.bufferLine.data();
     const auto len = _api.bufferLine.size();
     size_t segmentBeg = 0;
@@ -843,7 +844,7 @@ void AtlasEngine::_flushBufferLine()
                 codepoint = til::combine_surrogates(codepoint, beg[i++]);
             }
 
-            const auto c = (builtinGlyphs && BuiltinGlyphs::IsBuiltinGlyph(codepoint)) || BuiltinGlyphs::IsSoftFontChar(codepoint);
+            const auto c = (builtinGlyphs && BuiltinGlyphs::IsBuiltinGlyph(codepoint)) || BuiltinGlyphs::IsSoftFontChar(codepoint, softFontCharCount);
             if (custom != c)
             {
                 break;

--- a/src/renderer/atlas/BackendD3D.cpp
+++ b/src/renderer/atlas/BackendD3D.cpp
@@ -1605,7 +1605,7 @@ BackendD3D::AtlasGlyphEntry* BackendD3D::_drawBuiltinGlyph(const RenderingPayloa
         static_cast<f32>(rect.y + rect.h),
     };
 
-    if (BuiltinGlyphs::IsSoftFontChar(glyphIndex))
+    if (BuiltinGlyphs::IsSoftFontChar(glyphIndex, p.s->font->softFontCharCount()))
     {
         shadingType = _drawSoftFontGlyph(p, r, glyphIndex);
     }
@@ -1650,10 +1650,10 @@ BackendD3D::ShadingType BackendD3D::_drawSoftFontGlyph(const RenderingPayload& p
 {
     const auto width = static_cast<size_t>(p.s->font->softFontCellSize.width);
     const auto height = static_cast<size_t>(p.s->font->softFontCellSize.height);
-    const auto softFontIndex = glyphIndex - 0xEF20u;
+    const auto softFontIndex = glyphIndex - BuiltinGlyphs::SoftFont_FirstChar;
     const auto data = til::safe_slice_len(p.s->font->softFontPattern, height * softFontIndex, height);
 
-    // This happens if someone wrote a U+EF2x character (by accident), but we don't even have soft fonts enabled yet.
+    // Unreachable: _flushBufferLine() only routes code points that the soft font defines.
     if (data.empty() || data.size() != height)
     {
         return ShadingType::Default;

--- a/src/renderer/atlas/BuiltinGlyphs.h
+++ b/src/renderer/atlas/BuiltinGlyphs.h
@@ -23,9 +23,17 @@ namespace Microsoft::Console::Render::Atlas::BuiltinGlyphs
 
     i32 GetBitmapCellIndex(char32_t codepoint) noexcept;
 
+    // DECDLD soft fonts are mapped to U+EF20 and up. Only the code points the active
+    // soft font actually defines belong to us; the rest go through regular font fallback.
+    //
     // This is just an extra. It's not actually implemented as part of BuiltinGlyphs.cpp.
-    constexpr bool IsSoftFontChar(char32_t ch) noexcept
+    inline constexpr char32_t SoftFont_FirstChar = 0xEF20;
+
+    constexpr bool IsSoftFontChar(char32_t ch, u32 softFontCharCount) noexcept
     {
-        return ch >= 0xEF20 && ch < 0xEF80;
+        return ch >= SoftFont_FirstChar && ch < (SoftFont_FirstChar + softFontCharCount);
     }
+
+    static_assert(!IsSoftFontChar(SoftFont_FirstChar, 0));
+    static_assert(IsSoftFontChar(SoftFont_FirstChar + 0x0F, 0x10) && !IsSoftFontChar(SoftFont_FirstChar + 0x10, 0x10));
 }

--- a/src/renderer/atlas/common.h
+++ b/src/renderer/atlas/common.h
@@ -379,6 +379,12 @@ namespace Microsoft::Console::Render::Atlas
 
         std::vector<uint16_t> softFontPattern;
         til::size softFontCellSize;
+
+        u32 softFontCharCount() const noexcept
+        {
+            const auto height = gsl::narrow_cast<size_t>(softFontCellSize.height);
+            return height ? gsl::narrow_cast<u32>(softFontPattern.size() / height) : 0;
+        }
     };
 
     struct CursorSettings


### PR DESCRIPTION
Characters within U+EF20..U+EF7F print blank regardless of the configured font. Comments in the code say this range should only be claimed according to the size of the active soft font, and that when none is set "those code points will be treated the same as everything else".

This fix proposes to bound that range by how many glyphs the loaded soft font actually defines, so when none is loaded nothing is blocked and the characters render from the configured font.

Closes #20503

Related to #16894, which made this path memory-safe; this PR removes the reason those code points get routed there in the first place.