### PR TITLE
Support optional Mica Alt variant (window.useMicaVariant)

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2052,6 +2052,12 @@
           "type": "boolean",
           "default": false
         },
+        "useMicaVariant": {
+          "description": "Optional. Variant of Mica to use. Valid values: \"mica\" (standard Mica) or \"micaAlt\" (tabbed Mica). Ignored on unsupported OS versions.",
+          "type": "string",
+          "enum": ["mica", "micaAlt"],
+          "default": "mica"
+        },
         "experimental.rainbowFrame": {
           "description": "When enabled, the frame of the window will cycle through all the colors. Enabling this will override the `frame` and `unfocusedFrame` settings.",
           "type": "boolean",

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -163,6 +163,7 @@ Author(s):
     X(winrt::Microsoft::Terminal::Settings::Model::ThemeColor, UnfocusedFrame, "unfocusedFrame", nullptr)                          \
     X(bool, RainbowFrame, "experimental.rainbowFrame", false)                                                                      \
     X(bool, UseMica, "useMica", false)                                                                                             \
+    X(winrt::hstring, UseMicaVariant, "useMicaVariant", L"")                                                                       \
     X(bool, ShowWorkspacesButton, "showWorkspacesButton", true)
 
 #define MTSM_THEME_SETTINGS_SETTINGS(X) \

--- a/src/cascadia/TerminalSettingsModel/Theme.idl
+++ b/src/cascadia/TerminalSettingsModel/Theme.idl
@@ -61,6 +61,7 @@ namespace Microsoft.Terminal.Settings.Model
     runtimeclass WindowTheme {
         Windows.UI.Xaml.ElementTheme RequestedTheme { get; };
         Boolean UseMica { get; };
+        String UseMicaVariant { get; };
         Boolean RainbowFrame { get; };
         Boolean ShowWorkspacesButton { get; };
         ThemeColor Frame { get; };

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -1002,6 +1002,8 @@ void AppHost::_updateTheme()
     const auto colorOpacity = b ? color.A / 255.0 : 0.0;
     const auto brushOpacity = _opacityFromBrush(b);
     const auto opacity = std::min(colorOpacity, brushOpacity);
+    // Set requested Mica variant (if provided) before enabling Mica.
+    _window->SetMicaVariant(windowTheme ? windowTheme.UseMicaVariant() : L"");
     _window->UseMica(windowTheme ? windowTheme.UseMica() : false, opacity);
 
     // This is a hack to make the window borders dark instead of light.

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -9,6 +9,8 @@
 #include <dwmapi.h>
 #include <TerminalThemeHelpers.h>
 #include <CoreWindow.h>
+#include <algorithm>
+#include <cwctype>
 
 extern "C" IMAGE_DOS_HEADER __ImageBase;
 
@@ -1853,8 +1855,36 @@ void IslandWindow::UseMica(const bool newValue, const double /*titlebarOpacity*/
     // This API was only publicly supported as of Windows 11 SV2, 22621. Before
     // that version, this API will just return an error and do nothing silently.
 
-    const int attribute = newValue ? DWMSBT_MAINWINDOW : DWMSBT_NONE;
+    int attribute = DWMSBT_NONE;
+    if (newValue)
+    {
+        // If a specific variant (e.g. "micaAlt") was requested, prefer that.
+        if (!_micaVariant.empty())
+        {
+            // compare case-insensitive to allow "micaAlt"/"micaalt"
+            std::wstring variantW{ _micaVariant.c_str() };
+            std::transform(variantW.begin(), variantW.end(), variantW.begin(), towlower);
+            if (variantW == L"micaalt" || variantW == L"mica-alt")
+            {
+                attribute = DWMSBT_TABBEDWINDOW;
+            }
+            else
+            {
+                attribute = DWMSBT_MAINWINDOW;
+            }
+        }
+        else
+        {
+            attribute = DWMSBT_MAINWINDOW;
+        }
+    }
+
     std::ignore = DwmSetWindowAttribute(GetHandle(), DWMWA_SYSTEMBACKDROP_TYPE, &attribute, sizeof(attribute));
+}
+
+void IslandWindow::SetMicaVariant(const winrt::hstring& variant)
+{
+    _micaVariant = variant;
 }
 
 // Method Description:

--- a/src/cascadia/WindowsTerminal/IslandWindow.h
+++ b/src/cascadia/WindowsTerminal/IslandWindow.h
@@ -71,6 +71,7 @@ public:
 
     void UseDarkTheme(const bool v);
     virtual void UseMica(const bool newValue, const double titlebarOpacity);
+    void SetMicaVariant(const winrt::hstring& variant);
 
     til::event<winrt::delegate<>> DragRegionClicked;
     til::event<winrt::delegate<>> WindowCloseButtonClicked;
@@ -154,6 +155,8 @@ protected:
     void _resetSystemMenu();
 
 private:
+    // Mica variant requested by settings (e.g. "micaAlt"). Empty == default behavior (main Mica)
+    winrt::hstring _micaVariant{ L"" };
     // This minimum width allows for width the tabs fit
     static constexpr float minimumWidth = 460;
 


### PR DESCRIPTION
Why

Add opt-in support for the "Mica Alt" backdrop variant so tabbed/titlebar scenarios can request the tabbed Mica appearance on supported Windows versions. Users/developers requested a way to pick the variant without breaking existing boolean useMica semantics.

What

- Introduces an optional settings property "window.useMicaVariant" ("mica" | "micaAlt").
- Exposes UseMicaVariant on the settings Theme/Window model.
- IslandWindow honors the variant and maps "micaAlt" to DWMSBT_TABBEDWINDOW while preserving the existing DWMSBT_MAINWINDOW default.
- AppHost passes the selected variant from the settings to the window before enabling Mica.

Approach

Kept changes incremental and backwards-compatible:
- Existing boolean "useMica" remains unchanged and still controls whether Mica is enabled.
- The new string property is optional; empty or unknown values default to the existing behavior.

Notes for reviewers / follow-ups

- This change requires a Windows build to validate the DWM constants and regenerate WinRT-generated files. CI on Windows will verify compilation.
- Consider adding a small unit test to Theme parsing for UseMicaVariant and updating the Settings Editor UI to surface the new option.
- No runtime behavior changes occur on unsupported Windows versions (DwmSetWindowAttribute is a no-op there).

Testing done

- Local code changes committed and pushed to branch bhaskar-madiredla-miniature-spoon. No additional automated tests added in this change.

N/A