### PR TITLE
[Conhost] Fix off-by-1 errors for search and color selection foreground

### DIFF
--- a/src/buffer/out/search.cpp
+++ b/src/buffer/out/search.cpp
@@ -119,11 +119,16 @@ bool Search::SelectCurrent() const
 {
     if (const auto s = GetCurrent())
     {
+        const auto& textBuffer = _renderData->GetTextBuffer();
+
+        // GH#20152: s->end is exclusive, but SelectNewRegion expects an inclusive endpoint.
+        auto inclusiveEnd = s->end;
+        textBuffer.GetSize().DecrementInBounds(inclusiveEnd);
+
         // Convert buffer selection offsets into the equivalent screen coordinates
         // required by SelectNewRegion, taking line renditions into account.
-        const auto& textBuffer = _renderData->GetTextBuffer();
         const auto selStart = textBuffer.BufferToScreenPosition(s->start);
-        const auto selEnd = textBuffer.BufferToScreenPosition(s->end);
+        const auto selEnd = textBuffer.BufferToScreenPosition(inclusiveEnd);
         _renderData->SelectNewRegion(selStart, selEnd);
         return true;
     }

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -198,9 +198,8 @@ public:
 
     struct CopyRequest
     {
-        // beg and end coordinates are inclusive
-        til::point beg;
-        til::point end;
+        til::point beg; // inclusive
+        til::point end; // exclusive
 
         til::CoordType minX;
         til::CoordType maxX;

--- a/src/host/selection.cpp
+++ b/src/host/selection.cpp
@@ -520,8 +520,8 @@ void Selection::InitializeMarkSelection()
 // Routine Description:
 // - Resets the current selection and selects a new region from the start to end coordinates
 // Arguments:
-// - coordStart - Position to start selection area from
-// - coordEnd - Position to select up to
+// - coordStart - Position to start selection area from (inclusive)
+// - coordEnd - Position to select up to (inclusive)
 // Return Value:
 // - <none>
 void Selection::SelectNewRegion(const til::point coordStart, const til::point coordEnd)

--- a/src/host/selectionInput.cpp
+++ b/src/host/selectionInput.cpp
@@ -673,9 +673,11 @@ bool Selection::_HandleColorSelection(const INPUT_KEY_INFO* const pInputKeyInfo)
         if (fShiftPressed)
         {
             // Search the selection and color *that*
+            // GH#20152: srSelectionRect.right is inclusive, but CopyRequest::end is
+            // exclusive, so it must be adjusted by one
             const auto req = TextBuffer::CopyRequest::FromConfig(textBuffer,
                                                                  til::point{ _d->srSelectionRect.left, _d->srSelectionRect.top },
-                                                                 til::point{ _d->srSelectionRect.right, _d->srSelectionRect.bottom },
+                                                                 til::point{ _d->srSelectionRect.right + 1, _d->srSelectionRect.bottom },
                                                                  true /* multi-line search doesn't make sense; concatenate all lines */,
                                                                  false /* we filtered out block search above */,
                                                                  true /* trim block selection */,
@@ -687,7 +689,10 @@ bool Selection::_HandleColorSelection(const INPUT_KEY_INFO* const pInputKeyInfo)
             const auto hits = textBuffer.SearchText(str, SearchFlag::CaseInsensitive).value_or(std::vector<til::point_span>{});
             for (const auto& s : hits)
             {
-                ColorSelection(s.start, s.end, selectionAttr);
+                // GH#20152: s.end is exclusive, but ColorSelection expects an inclusive endpoint.
+                auto inclusiveEnd = s.end;
+                textBuffer.GetSize().DecrementInBounds(inclusiveEnd);
+                ColorSelection(s.start, inclusiveEnd, selectionAttr);
             }
         }
         else
@@ -695,7 +700,8 @@ bool Selection::_HandleColorSelection(const INPUT_KEY_INFO* const pInputKeyInfo)
             const auto selection = GetSelectionSpans();
             for (auto&& sp : selection)
             {
-                sp.iterate_rows(textBuffer.GetSize().Width(), [&](til::CoordType row, til::CoordType beg, til::CoordType end) {
+                // GH#20152: GetSelectionSpans() returns exclusive-end spans
+                sp.iterate_rows_exclusive(textBuffer.GetSize().Width(), [&](til::CoordType row, til::CoordType beg, til::CoordType end) {
                     ColorSelection({ beg, row, end, row + 1 }, selectionAttr);
                 });
             }

--- a/src/host/ut_host/SearchTests.cpp
+++ b/src/host/ut_host/SearchTests.cpp
@@ -63,8 +63,9 @@ class SearchTests
     {
         const auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
 
+        // GH#20152: end is inclusive. Add 1 to point to the last column of the 2-wide match, not 1 past it.
         auto coordEndExpected = coordStartExpected;
-        coordEndExpected.x += 2;
+        coordEndExpected.x += 1;
 
         VERIFY_IS_TRUE(s.SelectCurrent());
         VERIFY_ARE_EQUAL(coordStartExpected, gci.renderData.GetSelectionAnchor());

--- a/src/host/ut_host/SelectionTests.cpp
+++ b/src/host/ut_host/SelectionTests.cpp
@@ -348,6 +348,34 @@ class SelectionTests
         VERIFY_ARE_EQUAL(srOriginal.left + sDeltaLeft, srSelection.left);
         VERIFY_ARE_EQUAL(srOriginal.right + sDeltaRight, srSelection.right);
     }
+
+    // GH#20152: verify Alt+Shift+<digit> ("search the selection and color all matches") colors
+    // every character of each match, including the last one.
+    TEST_METHOD(TestColorSelectionSearchAndColorAllMatches)
+    {
+        auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
+        auto& screenInfo = gci.GetActiveOutputBuffer();
+        auto& textBuffer = screenInfo.GetTextBuffer();
+
+        RowWriteState state{ .text = L"foo bar foo" };
+        textBuffer.GetMutableRowByOffset(0).Reset(TextAttribute{});
+        textBuffer.Replace(0, TextAttribute{}, state);
+
+        // Select the first "foo" (columns 0-2, inclusive)
+        m_pSelection->SelectNewRegion({ 0, 0 }, { 2, 0 });
+
+        // Simulate Alt+Shift+'1'
+        INPUT_KEY_INFO keyInfo{ static_cast<WORD>('1'), LEFT_ALT_PRESSED | SHIFT_PRESSED };
+        VERIFY_IS_TRUE(m_pSelection->_HandleColorSelection(&keyInfo));
+
+        // Both occurrences of "foo" (columns 0-2 and 8-10) should be fully colored
+        for (til::CoordType x = 0; x < 15; ++x)
+        {
+            const auto isColored = textBuffer.GetCellDataAt({ x, 0 })->TextAttr() != TextAttribute{};
+            const auto shouldBeColored = (x >= 0 && x <= 2) || (x >= 8 && x <= 10);
+            VERIFY_ARE_EQUAL(shouldBeColored, isColored, NoThrowString().Format(L"column %d", x));
+        }
+    }
 };
 
 class SelectionInputTests

--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -637,9 +637,8 @@ try
     if (const auto hit = _searcher.GetCurrent())
     {
         hitBeg = hit->start;
+        // GH#20152: hit->end is already exclusive, so no conversion is needed here
         hitEnd = hit->end;
-        // we need to increment the position of end because it's exclusive
-        _pData->GetTextBuffer().GetSize().IncrementInBounds(hitEnd, true);
     }
 
     if (hitBeg >= _start && hitEnd <= _end)


### PR DESCRIPTION
## Summary of the Pull Request
Fixes a number of off-by-one errors in conhost. Specifically, the issues were with search, color selection (foreground), and the UIA find text API.

To minimize risk and make a small, concentrated change, I tried making targeted fixes with concise comments explaining why the change is needed. An earlier approach was to be more explicit about inclusive/exclusive coordinates using strict typing, but that seemed more harmful than helpful.

## References and Relevant Issues
#18106

## Validation Steps Performed
- Search: 
   - prereq: `echo foo foo foo`
   - ✅ "fo"
   - ✅ "f"
- Color Selection
   - prereq:
      - ` reg add "HKCU\Console" /v EnableColorSelection /t REG_DWORD /d 1 /f`
      - `echo foo foo foo`
   - ✅ "foo" selected + invoke Alt+Shift+#
   - ✅ "fo" selected + invoke Alt+Shift+#
   - ✅ "f" selected + invoke Alt+Shift+#
   - ✅ same scenarios + invoke Alt+#
- UIA find text API
   - ✅ "exe"
   - ✅ "e"

## PR Checklist
- [X] Closes #20152 
- [X] Tests added/passed (`TestColorSelectionSearchAndColorAllMatches`)