### PR TITLE
feat(terminal): add Mica Alt backdrop rendering support (#17650)

### DIFF
--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -163,6 +163,7 @@ Author(s):
     X(winrt::Microsoft::Terminal::Settings::Model::ThemeColor, UnfocusedFrame, "unfocusedFrame", nullptr)                          \
     X(bool, RainbowFrame, "experimental.rainbowFrame", false)                                                                      \
     X(bool, UseMica, "useMica", false)                                                                                             \
+    X(bool, UseMicaAlt, "useMicaAlt", false)                                                                                       \
     X(bool, ShowWorkspacesButton, "showWorkspacesButton", true)
 
 #define MTSM_THEME_SETTINGS_SETTINGS(X) \

--- a/src/cascadia/TerminalSettingsModel/Theme.idl
+++ b/src/cascadia/TerminalSettingsModel/Theme.idl
@@ -61,6 +61,7 @@ namespace Microsoft.Terminal.Settings.Model
     runtimeclass WindowTheme {
         Windows.UI.Xaml.ElementTheme RequestedTheme { get; };
         Boolean UseMica { get; };
+        Boolean UseMicaAlt { get; };
         Boolean RainbowFrame { get; };
         Boolean ShowWorkspacesButton { get; };
         ThemeColor Frame { get; };

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -1002,7 +1002,7 @@ void AppHost::_updateTheme()
     const auto colorOpacity = b ? color.A / 255.0 : 0.0;
     const auto brushOpacity = _opacityFromBrush(b);
     const auto opacity = std::min(colorOpacity, brushOpacity);
-    _window->UseMica(windowTheme ? windowTheme.UseMica() : false, opacity);
+    _window->UseMica(windowTheme ? (windowTheme.UseMica() || windowTheme.UseMicaAlt()) : false, opacity, windowTheme ? windowTheme.UseMicaAlt() : false);
 
     // This is a hack to make the window borders dark instead of light.
     // It must be done before WM_NCPAINT so that the borders are rendered with

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -1844,16 +1844,16 @@ void IslandWindow::UseDarkTheme(const bool v)
     std::ignore = DwmSetWindowAttribute(GetHandle(), DWMWA_USE_IMMERSIVE_DARK_MODE, &attribute, sizeof(attribute));
 }
 
-void IslandWindow::UseMica(const bool newValue, const double /*titlebarOpacity*/)
+void IslandWindow::UseMica(const bool newValue, const bool useMicaAlt, const double /*titlebarOpacity*/)
 {
-    // This block of code enables Mica for our window. By all accounts, this
+    // This block of code enables Mica / Mica Alt for our window. By all accounts, this
     // version of the code will only work on Windows 11, SV2. There's a slightly
     // different API surface for enabling Mica on Windows 11 22000.0.
     //
     // This API was only publicly supported as of Windows 11 SV2, 22621. Before
     // that version, this API will just return an error and do nothing silently.
 
-    const int attribute = newValue ? DWMSBT_MAINWINDOW : DWMSBT_NONE;
+    const int attribute = newValue ? (useMicaAlt ? DWMSBT_TABBEDWINDOW : DWMSBT_MAINWINDOW) : DWMSBT_NONE;
     std::ignore = DwmSetWindowAttribute(GetHandle(), DWMWA_SYSTEMBACKDROP_TYPE, &attribute, sizeof(attribute));
 }
 

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -1844,7 +1844,7 @@ void IslandWindow::UseDarkTheme(const bool v)
     std::ignore = DwmSetWindowAttribute(GetHandle(), DWMWA_USE_IMMERSIVE_DARK_MODE, &attribute, sizeof(attribute));
 }
 
-void IslandWindow::UseMica(const bool newValue, const bool useMicaAlt, const double /*titlebarOpacity*/)
+void IslandWindow::UseMica(const bool newValue, const double /*titlebarOpacity*/, const bool useMicaAlt)
 {
     // This block of code enables Mica / Mica Alt for our window. By all accounts, this
     // version of the code will only work on Windows 11, SV2. There's a slightly

--- a/src/cascadia/WindowsTerminal/IslandWindow.h
+++ b/src/cascadia/WindowsTerminal/IslandWindow.h
@@ -70,7 +70,7 @@ public:
     void RemoveFromSystemMenu(const winrt::hstring& itemLabel);
 
     void UseDarkTheme(const bool v);
-    virtual void UseMica(const bool newValue, const double titlebarOpacity);
+    virtual void UseMica(const bool newValue, const bool useMicaAlt = false, const double titlebarOpacity = 1.0);
 
     til::event<winrt::delegate<>> DragRegionClicked;
     til::event<winrt::delegate<>> WindowCloseButtonClicked;

--- a/src/cascadia/WindowsTerminal/IslandWindow.h
+++ b/src/cascadia/WindowsTerminal/IslandWindow.h
@@ -70,7 +70,7 @@ public:
     void RemoveFromSystemMenu(const winrt::hstring& itemLabel);
 
     void UseDarkTheme(const bool v);
-    virtual void UseMica(const bool newValue, const bool useMicaAlt = false, const double titlebarOpacity = 1.0);
+    virtual void UseMica(const bool newValue, const double titlebarOpacity = 1.0, const bool useMicaAlt = false);
 
     til::event<winrt::delegate<>> DragRegionClicked;
     til::event<winrt::delegate<>> WindowCloseButtonClicked;

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -1195,15 +1195,21 @@ void NonClientIslandWindow::SetTitlebarBackground(winrt::Windows::UI::Xaml::Medi
     _titlebar.Background(brush);
 }
 
-void NonClientIslandWindow::UseMica(const bool newValue, const double titlebarOpacity)
+void NonClientIslandWindow::UseMica(const bool newValue, const double titlebarOpacity, const bool useMicaAlt)
 {
+    if (_titlebar)
+    {
+        _titlebar.UseMica(newValue);
+    }
+
+    IslandWindow::UseMica(newValue, titlebarOpacity, useMicaAlt);
+
     // Stash internally if we're using Mica. If we aren't, we don't want to
     // totally blow away our titlebar with DwmExtendFrameIntoClientArea,
     // especially on Windows 10
     _useMica = newValue;
     _titlebarOpacity = titlebarOpacity;
 
-    IslandWindow::UseMica(newValue, titlebarOpacity);
 
     _UpdateFrameMargins();
 }

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.h
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.h
@@ -48,7 +48,7 @@ public:
     void SetTitlebarBackground(winrt::Windows::UI::Xaml::Media::Brush brush);
     void SetShowTabsFullscreen(const bool newShowTabsFullscreen) override;
 
-    virtual void UseMica(const bool newValue, const double titlebarOpacity) override;
+    virtual void UseMica(const bool newValue, const double titlebarOpacity = 1.0, const bool useMicaAlt = false) override;
 
 private:
     std::optional<til::point> _oldIslandPos;


### PR DESCRIPTION
## Validation Steps Performed

- Configured `useMicaAlt: true` inside window settings in `settings.json`.
- Verified window backdrop renders `DWMSBT_TABBEDWINDOW` (Mica Alt material effect) on Windows 11 Build 22621+.
- Verified default `useMica: true` continues rendering `DWMSBT_MAINWINDOW` without regression.

Closes #17650