### PR TITLE
TerminalControl: skip whitespace-only copy-on-select

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -1398,7 +1398,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         if (suppressWhitespaceOnly &&
             std::all_of(payload.plainText.cbegin(), payload.plainText.cend(), [](const wchar_t ch) {
-                return std::iswspace(ch) != 0;
+                return ch <= L' ';
             }))
         {
             return false;

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -1372,9 +1372,11 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - withControlSequences: if enabled, the copied plain text contains color/style ANSI escape codes from the selection
     // - formats: which formats to copy (defined by action's CopyFormatting arg). nullptr
     //             if we should defer which formats are copied to the global setting
+    // - suppressWhitespaceOnly: don't raise a clipboard event if the selected plain text is empty or only whitespace
     bool ControlCore::CopySelectionToClipboard(bool singleLine,
                                                bool withControlSequences,
-                                               const CopyFormat formats)
+                                               const CopyFormat formats,
+                                               const bool suppressWhitespaceOnly)
     {
         ::Microsoft::Terminal::Core::Terminal::TextCopyData payload;
         {
@@ -1392,6 +1394,14 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             // extract text from buffer
             // RetrieveSelectedTextFromBuffer will lock while it's reading
             payload = _terminal->RetrieveSelectedTextFromBuffer(singleLine, withControlSequences, copyHtml, copyRtf);
+        }
+
+        if (suppressWhitespaceOnly &&
+            std::all_of(payload.plainText.cbegin(), payload.plainText.cend(), [](const wchar_t ch) {
+                return std::iswspace(ch) != 0;
+            }))
+        {
+            return false;
         }
 
         WriteToClipboard.raise(

--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -124,7 +124,10 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         void SendInput(std::wstring_view wstr);
         void PasteText(const winrt::hstring& hstr);
-        bool CopySelectionToClipboard(bool singleLine, bool withControlSequences, const CopyFormat formats);
+        bool CopySelectionToClipboard(bool singleLine,
+                                      bool withControlSequences,
+                                      const CopyFormat formats,
+                                      bool suppressWhitespaceOnly = false);
         void SelectAll();
         void ClearSelection();
         bool ToggleBlockSelection();

--- a/src/cascadia/TerminalControl/ControlInteractivity.cpp
+++ b/src/cascadia/TerminalControl/ControlInteractivity.cpp
@@ -214,9 +214,11 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - withControlSequences: if enabled, the copied plain text contains color/style ANSI escape codes from the selection
     // - formats: which formats to copy (defined by action's CopyFormatting arg). nullptr
     //             if we should defer which formats are copied to the global setting
+    // - suppressWhitespaceOnly: don't raise a clipboard event if the selected plain text is empty or only whitespace
     bool ControlInteractivity::CopySelectionToClipboard(bool singleLine,
                                                         bool withControlSequences,
-                                                        const CopyFormat formats)
+                                                        const CopyFormat formats,
+                                                        const bool suppressWhitespaceOnly)
     {
         if (_core)
         {
@@ -232,7 +234,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             // Mark the current selection as copied
             _selectionNeedsToBeCopied = false;
 
-            return _core->CopySelectionToClipboard(singleLine, withControlSequences, formats);
+            return _core->CopySelectionToClipboard(singleLine, withControlSequences, formats, suppressWhitespaceOnly);
         }
 
         return false;
@@ -500,7 +502,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             // IMPORTANT!
             // DO NOT clear the selection here!
             // Otherwise, the selection will be cleared immediately after you make it.
-            CopySelectionToClipboard(false, false, _core->Settings().CopyFormatting());
+            // Mark the gesture as handled even if whitespace-only text is not copied.
+            // This preserves copyOnSelect's right-click-always-pastes behavior.
+            CopySelectionToClipboard(false, false, _core->Settings().CopyFormatting(), true);
         }
 
         _singleClickTouchdownPos = std::nullopt;

--- a/src/cascadia/TerminalControl/ControlInteractivity.h
+++ b/src/cascadia/TerminalControl/ControlInteractivity.h
@@ -84,7 +84,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         bool CopySelectionToClipboard(bool singleLine,
                                       bool withControlSequences,
-                                      const CopyFormat formats);
+                                      const CopyFormat formats,
+                                      bool suppressWhitespaceOnly = false);
         void RequestPasteTextFromClipboard();
         void SetEndSelectionPoint(const Core::Point pixelPosition);
 

--- a/src/cascadia/UnitTests_Control/ControlInteractivityTests.cpp
+++ b/src/cascadia/UnitTests_Control/ControlInteractivityTests.cpp
@@ -34,6 +34,7 @@ namespace ControlUnitTests
         TEST_METHOD(ScrollWithSelection);
         TEST_METHOD(TestScrollWithTrackpad);
         TEST_METHOD(TestQuickDragOnSelect);
+        TEST_METHOD(CopyOnSelectSkipsWhitespaceOnlySelections);
 
         TEST_METHOD(TestDragSelectOutsideBounds);
 
@@ -597,6 +598,86 @@ namespace ControlUnitTests
         Log::Comment(L"Verify that it started on the first cell we clicked on, not the one we dragged to");
         til::point expectedAnchor{ 0, 0 };
         VERIFY_ARE_EQUAL(expectedAnchor, core->_terminal->GetSelectionAnchor());
+    }
+
+    void ControlInteractivityTests::CopyOnSelectSkipsWhitespaceOnlySelections()
+    {
+        auto [settings, conn] = _createSettingsAndConnection();
+        settings->CopyOnSelect(true);
+
+        auto [core, interactivity] = _createCoreAndInteractivity(*settings, *conn);
+        _standardInit(core, interactivity);
+
+        std::vector<std::wstring> clipboardWrites;
+        core->WriteToClipboard([&](auto&&, const Control::WriteToClipboardEventArgs& args) {
+            const auto plain{ args.Plain() };
+            clipboardWrites.emplace_back(plain.data(), plain.size());
+        });
+
+        auto pasteRequests = 0u;
+        interactivity->PasteFromClipboard([&](auto&&, auto&&) {
+            ++pasteRequests;
+        });
+
+        const auto select = [&](const til::point anchor, const til::point end) {
+            core->ClearSelection();
+            core->SetSelectionAnchor(anchor);
+            core->SetEndSelectionPoint(end);
+            VERIFY_IS_TRUE(core->HasSelection());
+            VERIFY_IS_TRUE(interactivity->_selectionNeedsToBeCopied);
+        };
+
+        const auto releaseSelection = [&]() {
+            const Control::MouseButtonState noMouseDown{};
+            interactivity->PointerReleased(0,
+                                           noMouseDown,
+                                           WM_LBUTTONUP,
+                                           ControlKeyStates{},
+                                           til::point{ 0, 0 }.to_core_point());
+        };
+
+        Log::Comment(L"An empty selected payload should not replace the clipboard on mouse-up");
+        select({ 0, 0 }, { 3, 0 });
+        releaseSelection();
+        VERIFY_ARE_EQUAL(0u, clipboardWrites.size());
+        VERIFY_IS_TRUE(core->HasSelection());
+        VERIFY_IS_FALSE(interactivity->_selectionNeedsToBeCopied);
+
+        Log::Comment(L"A selection containing only spaces and line breaks should not replace the clipboard");
+        select({ 0, 0 }, { 3, 1 });
+        releaseSelection();
+        VERIFY_ARE_EQUAL(0u, clipboardWrites.size());
+        VERIFY_IS_TRUE(core->HasSelection());
+        VERIFY_IS_FALSE(interactivity->_selectionNeedsToBeCopied);
+
+        Log::Comment(L"Right-click should still paste after a whitespace-only auto-copy is skipped");
+        const auto rightMouseDown{ Control::MouseButtonState::IsRightButtonDown };
+        interactivity->PointerPressed(0,
+                                      rightMouseDown,
+                                      WM_RBUTTONDOWN,
+                                      0,
+                                      ControlKeyStates{},
+                                      til::point{ 0, 0 }.to_core_point());
+        VERIFY_ARE_EQUAL(0u, clipboardWrites.size());
+        VERIFY_ARE_EQUAL(1u, pasteRequests);
+        VERIFY_IS_FALSE(core->HasSelection());
+
+        Log::Comment(L"A selection containing non-whitespace should still auto-copy");
+        conn->WriteInput(winrt_wstring_to_array_view(L"abc"));
+        select({ 0, 0 }, { 3, 0 });
+        releaseSelection();
+        VERIFY_ARE_EQUAL(1u, clipboardWrites.size());
+        const std::wstring expectedText{ L"abc" };
+        VERIFY_ARE_EQUAL(expectedText, clipboardWrites.back());
+        VERIFY_IS_FALSE(interactivity->_selectionNeedsToBeCopied);
+
+        Log::Comment(L"An explicit copy should still write a whitespace-only selection");
+        select({ 0, 1 }, { 3, 1 });
+        VERIFY_IS_TRUE(interactivity->CopySelectionToClipboard(true, false, Control::CopyFormat::None));
+        VERIFY_ARE_EQUAL(2u, clipboardWrites.size());
+        const std::wstring expectedWhitespace(3, L' ');
+        VERIFY_ARE_EQUAL(expectedWhitespace, clipboardWrites.back());
+        VERIFY_IS_FALSE(interactivity->_selectionNeedsToBeCopied);
     }
 
     void ControlInteractivityTests::TestDragSelectOutsideBounds()


### PR DESCRIPTION
## Summary of the Pull Request

Prevents `copyOnSelect` from replacing the clipboard when the selected payload is empty or contains only whitespace.

## References and Relevant Issues

Closes #11751.

## Detailed Description of the Pull Request / Additional comments

The automatic copy path now suppresses clipboard events when the extracted plain text consists entirely of whitespace. The suppression is opt-in at the internal copy helper and is enabled only for mouse-release copy-on-select, so explicit copy actions continue to copy whitespace.

The mouse selection is still marked as handled when an automatic copy is suppressed. This preserves the existing copy-on-select behavior where a subsequent right-click pastes instead of re-copying the whitespace selection.

## Validation Steps Performed

- Added `ControlInteractivity` coverage for a trimmed empty selection, multiline whitespace, the subsequent right-click paste path, non-whitespace automatic copy, and explicit whitespace copy.
- `clang-format --dry-run --Werror` passed for all changed files.
- Call-site, CRLF, and `git -c core.whitespace=cr-at-eol diff --check` validation passed.
- Restored the repository NuGet dependencies from the configured `TerminalDependencies` feed.
- Built the generated `Host.Proxy` dependency, then rebuilt `Control.UnitTests.vcxproj` in `Release|x64` with the v145 toolset: succeeded with 0 errors (4 existing PRI warnings).
- Ran `Control.Unit.Tests.dll` with TAEF: 30 passed, 0 failed, including `CopyOnSelectSkipsWhitespaceOnlySelections`.

## PR Checklist

- [x] Closes #11751
- [x] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)