### PR TITLE
Canary: enable STL hardening and destructor tombstoning in all builds

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -1692,6 +1692,7 @@ TMAE
 TMPF
 tmultiple
 tofrom
+tombstoning
 toolbars
 TOOLINFO
 TOOLWINDOW

--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -1693,6 +1693,8 @@ TMPF
 tmultiple
 tofrom
 tombstoning
+Tombstoning
+TOMBSTONING
 toolbars
 TOOLINFO
 TOOLWINDOW

--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -1692,9 +1692,7 @@ TMAE
 TMPF
 tmultiple
 tofrom
-tombstoning
 Tombstoning
-TOMBSTONING
 toolbars
 TOOLINFO
 TOOLWINDOW

--- a/src/common.build.post.props
+++ b/src/common.build.post.props
@@ -72,7 +72,7 @@
     We do this here rather than in pre.props so that we read the computed branding.
 
     Hardening prevents the misuse of containers more strictly than Container Debug and Iterator Debug.
-    Tombstoning prevents use-after-free by filling deleted pointers with a sentintel value.
+    Tombstoning prevents use-after-free by filling deleted pointers with a sentinel value.
   -->
   <ItemDefinitionGroup Condition="'$(WindowsTerminalBranding)'=='Canary' or '$(WindowsTerminalBranding)'=='Dev' or '$(WindowsTerminalBranding)'==''">
     <ClCompile>

--- a/src/common.build.post.props
+++ b/src/common.build.post.props
@@ -67,6 +67,19 @@
     </ClCompile>
   </ItemDefinitionGroup>
 
+  <!--
+    Enable the new STL hardening and destructor tombstones (for Canary/Dev only, for now).
+    We do this here rather than in pre.props so that we read the computed branding.
+
+    Hardening prevents the misuse of containers more strictly than Container Debug and Iterator Debug.
+    Tombstoning prevents use-after-free by filling deleted pointers with a sentintel value.
+  -->
+  <ItemDefinitionGroup Condition="'$(WindowsTerminalBranding)'=='Canary' or '$(WindowsTerminalBranding)'=='Dev' or '$(WindowsTerminalBranding)'==''">
+    <ClCompile>
+      <PreprocessorDefinitions>_MSVC_STL_HARDENING=1;_MSVC_STL_DESTRUCTOR_TOMBSTONES=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 
   <!-- Exclude our dependencies from static analysis. CAExcludePath can only be

--- a/src/common.build.pre.props
+++ b/src/common.build.pre.props
@@ -136,13 +136,6 @@
       -->
       <DisableSpecificWarnings>4201;4312;5105;26434;26445;26456;26478;26494;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <PreprocessorDefinitions>_WINDOWS;EXTERNAL_BUILD;_SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <!--
-        Enable the new STL hardening and destructor tombstones (for Canary only, for now).
-
-        Hardening prevents the misuse of containers more strictly than Container Debug and Iterator Debug.
-        Tombstoning prevents use-after-free by filling deleted pointers with a sentintel value.
-      -->
-      <PreprocessorDefinitions Condition="'$(WindowsTerminalBranding)'=='Canary'">_MSVC_STL_HARDENING=1;_MSVC_STL_DESTRUCTOR_TOMBSTONES=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <PrecompiledHeaderFile>precomp.h</PrecompiledHeaderFile>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>

--- a/src/common.build.pre.props
+++ b/src/common.build.pre.props
@@ -136,6 +136,13 @@
       -->
       <DisableSpecificWarnings>4201;4312;5105;26434;26445;26456;26478;26494;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <PreprocessorDefinitions>_WINDOWS;EXTERNAL_BUILD;_SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!--
+        Enable the new STL hardening and destructor tombstones (for Canary only, for now).
+
+        Hardening prevents the misuse of containers more strictly than Container Debug and Iterator Debug.
+        Tombstoning prevents use-after-free by filling deleted pointers with a sentintel value.
+      -->
+      <PreprocessorDefinitions Condition="'$(WindowsTerminalBranding)'=='Canary'">_MSVC_STL_HARDENING=1;_MSVC_STL_DESTRUCTOR_TOMBSTONES=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <PrecompiledHeaderFile>precomp.h</PrecompiledHeaderFile>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>


### PR DESCRIPTION
This may cause us some pain, but having a safer codebase is worth some pain.

More info at https://github.com/microsoft/STL/wiki/STL-Hardening.