### PR TITLE
Fix x:Bind usage for bell sound buttons

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.xaml
@@ -168,7 +168,7 @@
                                             Click="BellSoundAudioPreview_Click"
                                             IsEnabled="{x:Bind FileExists, Mode=OneWay}"
                                             Style="{StaticResource BrowseButtonStyle}"
-                                            Tag="{Binding Mode=OneWay}">
+                                            Tag="{x:Bind}">
                                         <FontIcon FontSize="{StaticResource StandardIconSize}"
                                                   Glyph="&#xE767;" />
                                     </Button>
@@ -178,7 +178,7 @@
                                             VerticalAlignment="Stretch"
                                             Click="BellSoundDelete_Click"
                                             Style="{StaticResource DeleteButtonStyle}"
-                                            Tag="{Binding Mode=OneWay}">
+                                            Tag="{x:Bind}">
                                         <FontIcon FontSize="{StaticResource StandardIconSize}"
                                                   Glyph="&#xE74D;" />
                                     </Button>


### PR DESCRIPTION
## Description

Fix the `Tag` bindings for the bell sound preview and delete buttons by
using `x:Bind` instead of the legacy `{Binding}` syntax.

This addresses #11767.

## Changes

- Changed the bell sound preview button `Tag` to `x:Bind`
- Changed the bell sound delete button `Tag` to `x:Bind`

## Testing

- `git diff --check`