### PR TITLE
Fix two KKP ReportEventTypes issues

### DIFF
--- a/src/terminal/adapter/ut_adapter/kittyKeyboardProtocol.cpp
+++ b/src/terminal/adapter/ut_adapter/kittyKeyboardProtocol.cpp
@@ -228,9 +228,12 @@ namespace
 
         // Enter/Tab/Backspace release without AllKeys: no output
         { L"D|E Enter press", L"\r", D | E, true, VK_RETURN, 0x1C, L'\r', 0 },
-        { L"D|E Enter release (no AllKeys)", L"", D | E, false, VK_RETURN, 0x1C, L'\r', 0 },
+        { L"D|E Enter release", L"", D | E, false, VK_RETURN, 0x1C, L'\r', 0 },
+        { L"D|E Keypad Enter release", L"\x1b[57414;1:3u", D | E, false, VK_RETURN, 0x1C, L'\r', ENHANCED_KEY },
 
         // Modifier key press/release
+        { L"D|E Left Shift press", L"", D | E, true, VK_SHIFT, 0x2A, 0, Shift },
+        { L"D|E Left Shift release", L"", D | E, false, VK_SHIFT, 0x2A, 0, 0 },
         { L"E|K Left Shift press", L"\x1b[57441;2u", E | K, true, VK_SHIFT, 0x2A, 0, Shift },
         { L"E|K Left Shift release", L"\x1b[57441;1:3u", E | K, false, VK_SHIFT, 0x2A, 0, 0 },
 
@@ -317,5 +320,11 @@ class KittyKeyboardProtocolTests
         VERIFY_ARE_EQUAL(TerminalInput::MakeOutput(L"\x1b[97u"), process(input, true, 'A', 0x10, L'a', 0));
         VERIFY_ARE_EQUAL(TerminalInput::MakeOutput(L"\x1b[98u"), process(input, true, 'B', 0x30, L'b', 0)); // different key
         VERIFY_ARE_EQUAL(TerminalInput::MakeOutput(L"\x1b[97u"), process(input, true, 'A', 0x10, L'a', 0)); // not repeat
+    }
+
+    TEST_METHOD(IgnoreDeadKey)
+    {
+        auto input = createInput(E);
+        VERIFY_ARE_EQUAL(TerminalInput::MakeOutput(L""), process(input, false, VK_OEM_6, 0x0D, L'¨', SHIFT_PRESSED));
     }
 };

--- a/src/terminal/input/terminalInput.cpp
+++ b/src/terminal/input/terminalInput.cpp
@@ -318,6 +318,16 @@ TerminalInput::OutputType TerminalInput::HandleKey(const INPUT_RECORD& event)
         }
     }
 
+    // KKP> Additionally, with [ReportAllKeysAsEscapeCodes], events for pressing modifier keys are reported.
+    //
+    // Put differently, if the mode is reset, we can early-return on modifier key events.
+    if (WI_IsFlagClear(_kittyFlags, KittyKeyboardProtocolFlags::ReportAllKeysAsEscapeCodes) &&
+        ((key.virtualKey >= VK_SHIFT && key.virtualKey <= VK_MENU) ||
+         (key.virtualKey >= VK_LSHIFT && key.virtualKey <= VK_RMENU)))
+    {
+        return _makeNoOutput();
+    }
+
     // There's a bunch of early returns we can place on key-up events,
     // before we run our more complex encoding logic below.
     if (!key.keyDown)
@@ -342,8 +352,12 @@ TerminalInput::OutputType TerminalInput::HandleKey(const INPUT_RECORD& event)
         //
         // KKP> NOTE: The Enter, Tab and Backspace keys will not have release
         // KKP> events unless Report all keys as escape codes is also set [...].
+        //
+        // Note that we have to differentiate between regular Return and Numpad Return.
         if (WI_IsFlagClear(_kittyFlags, KittyKeyboardProtocolFlags::ReportAllKeysAsEscapeCodes) &&
-            (key.virtualKey == VK_RETURN || key.virtualKey == VK_TAB || key.virtualKey == VK_BACK))
+            ((key.virtualKey == VK_RETURN && WI_IsFlagClear(key.controlKeyState, ENHANCED_KEY)) ||
+             key.virtualKey == VK_TAB ||
+             key.virtualKey == VK_BACK))
         {
             return _makeNoOutput();
         }
@@ -1245,8 +1259,11 @@ bool TerminalInput::_formatEncodingHelper(EncodingHelper& enc, const SanitizedKe
 
 void TerminalInput::_formatFallback(KeyboardHelper& kbd, const SanitizedKeyEvent& key, std::wstring& seq) const
 {
-    // If this is a modifier, it won't produce output, so we can return early.
-    if (key.virtualKey >= VK_SHIFT && key.virtualKey <= VK_MENU)
+    // With KKP ReportEventTypes set, we'll handle key up events.
+    // If the KKP logic fails to map a key it'll fall back to this function.
+    // -> This function may be called with key up events and we don't send anything for those.
+    // This happens primarily for dead keys. getKittyBaseKey fails to map it and so we get here.
+    if (!key.keyDown)
     {
         return;
     }


### PR DESCRIPTION
* Dead key releases should not be reported
* Modifier key releases should only be reported
  if `ReportAllKeysAsEscapeCodes` is also set
* (Also fixes encoding for numpad Enter)

Closes #20522

## Validation Steps Performed
* Switch to Swiss French (`0000100c`) layout
* Enable modes 0b11 (`DisambiguateEscapeCodes`, `ReportEventTypes`)
* Pressing `Shift+]` produces `!` ✅
* Pressing `] ] ] A` produces `¨¨ä` ✅