### PR TITLE
Add package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "hassanhassgit-effective-bassoon",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@azure/mcp-win32-x64": "^3.0.0-beta.35"
+      }
+    },
+    "node_modules/@azure/mcp-win32-x64": {
+      "version": "3.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@azure/mcp-win32-x64/-/mcp-win32-x64-3.0.0-beta.35.tgz",
+      "integrity": "sha512-AsHVQxmahdIsvqerkXjZsE9sjueZEmgNNyt6juJsXNL97H/SHO8BSGKRbAVa3Su90Gi3RERIaPX4UmB3ZgT07Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "azmcp-win32-x64": "dist/azmcp.exe"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@azure/mcp-win32-x64": "^3.0.0-beta.35"
+  }
+}


### PR DESCRIPTION
## Summary of the Pull Request
Add package.json and package-lock.json to record Node package metadata and lock dependencies required by local tooling/scripts.

## References and Relevant Issues

N/A

## Detailed Description of the Pull Request / Additional comments
This change introduces a minimal package.json manifest and the corresponding package-lock.json to pin dependency versions. No source-code changes were made beyond adding these files. This enables consistent installs for any Node-based tooling used by maintainers.

## Validation Steps Performed
- Verified files were created and committed locally.
- No runtime behavior changes expected; no tests required for this manifest-only addition.

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on our docs repo: #xxx
- [ ] Schema updated (if necessary)