### PR TITLE
Fix PGO tests

### DIFF
--- a/src/cascadia/WindowsTerminal_UIATests/Elements/TerminalApp.cs
+++ b/src/cascadia/WindowsTerminal_UIATests/Elements/TerminalApp.cs
@@ -152,12 +152,8 @@ namespace WindowsTerminal.UIA.Tests.Elements
             Actions = new Actions(Session);
             Verify.IsNotNull(Session);
 
-            Globals.WaitForLongTimeout();
-
-            UIRoot = Session.FindElementByName(WindowTitleToFind);
-
-            // Set the timeout to 15 seconds after we found the initial window.
             Session.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(15);
+            UIRoot = Session.FindElementByName(WindowTitleToFind);
         }
 
         private bool IsRunningAsAdmin()


### PR DESCRIPTION
I broke this in #20328, apparently. https://github.com/microsoft/terminal/pull/20328#issuecomment-5329356144
Seems like it would fail if the first lookup failed after 5 seconds. Removing that explicit wait causes the `FindElementByName` call to instead lookup, then poll for up to 15seconds to find the window. 

This works consistently locally?