### PR TITLE
Fix outdated clang-format instructions and VS version comments

### DIFF
--- a/doc/building.md
+++ b/doc/building.md
@@ -9,13 +9,25 @@ git submodule update --init --recursive
 
 OpenConsole.slnx may be built from within Visual Studio or from the command-line using a set of convenience scripts & tools in the **/tools** directory:
 
-When using Visual Studio, be sure to set up the path for code formatting. To download the required clang-format.exe file, follow one of the building instructions below and run:
+When using Visual Studio, be sure to set up the path for code formatting. The repository no longer
+pulls a clang-format NuGet package; it uses the clang-format that ships with Visual Studio. To locate
+the version installed with your Visual Studio installation and format the code, run:
+
 ```powershell
 Import-Module .\tools\OpenConsole.psm1
-Set-MsBuildDevEnvironment
-Get-Format
+Set-MsbuildDevEnvironment
+Invoke-CodeFormat
 ```
-After, go to Tools > Options > Text Editor > C++ > Formatting and check "Use custom clang-format.exe file" in Visual Studio and choose the clang-format.exe in the repository at /packages/clang-format.win-x86.10.0.0/tools/clang-format.exe by clicking "browse" right under the check box.
+
+`Invoke-CodeFormat` discovers clang-format via `vswhere` (see `tools\OpenConsole.psm1`) and formats
+all C++/XAML sources in `src\`. If you prefer to configure Visual Studio's own formatting integration,
+open Tools > Options > Text Editor > C++ > Formatting, check "Use custom clang-format.exe file", and
+browse to the `clang-format.exe` that ships with your Visual Studio installation. You can locate it
+with the same search the module uses:
+
+```powershell
+& 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' -latest -prerelease -find "**\x64\bin\clang-format.exe"
+```
 
 ### Building in PowerShell
 

--- a/doc/building.md
+++ b/doc/building.md
@@ -9,25 +9,10 @@ git submodule update --init --recursive
 
 OpenConsole.slnx may be built from within Visual Studio or from the command-line using a set of convenience scripts & tools in the **/tools** directory:
 
-When using Visual Studio, be sure to set up the path for code formatting. The repository no longer
-pulls a clang-format NuGet package; it uses the clang-format that ships with Visual Studio. To locate
-the version installed with your Visual Studio installation and format the code, run:
-
-```powershell
-Import-Module .\tools\OpenConsole.psm1
-Set-MsbuildDevEnvironment
-Invoke-CodeFormat
-```
-
-`Invoke-CodeFormat` discovers clang-format via `vswhere` (see `tools\OpenConsole.psm1`) and formats
-all C++/XAML sources in `src\`. If you prefer to configure Visual Studio's own formatting integration,
-open Tools > Options > Text Editor > C++ > Formatting, check "Use custom clang-format.exe file", and
-browse to the `clang-format.exe` that ships with your Visual Studio installation. You can locate it
-with the same search the module uses:
-
-```powershell
-& 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' -latest -prerelease -find "**\x64\bin\clang-format.exe"
-```
+Code formatting uses the clang-format that ships with Visual Studio (Clang 19, VS 2022 17.14+).
+`Invoke-CodeFormat` (in `tools\OpenConsole.psm1`) locates it via vswhere and formats all C++/XAML
+sources under `src\`; run it before submitting. VS's own C++ formatting already uses this same
+clang-format, so no additional setup is required.
 
 ### Building in PowerShell
 

--- a/tools/razzle.cmd
+++ b/tools/razzle.cmd
@@ -50,10 +50,10 @@ if not defined VSWHERE (
 rem Add path to MSBuild Binaries
 rem
 rem We accept the latest prerelease of VS in the 17.x or 18.x range. The -version
-rem range [17.0,19.0) picks up both VS 2022 (17.x) and VS 2026 (18.x, including
-rem previews) but not a still-newer major whose toolset may be incompatible.
-rem VS 2026 (18.x) uses our v145 PlatformToolset (see src\common.build.pre.props);
-rem older VS versions default to v143.
+rem range [17.0,19.0) picks up both VS 2022 (17.x) and VS 18 (including previews)
+rem but not a still-newer major whose toolset may be incompatible. VS 18 uses our
+rem v145 PlatformToolset (see src\common.build.pre.props); older VS versions default
+rem to v143.
 rem
 for /f "usebackq tokens=*" %%B in (`"%VSWHERE%" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -version "[17.0,19.0)" -find MSBuild\**\Bin\MSBuild.exe 2^>nul`) do (
     set MSBUILD=%%B

--- a/tools/razzle.cmd
+++ b/tools/razzle.cmd
@@ -50,10 +50,10 @@ if not defined VSWHERE (
 rem Add path to MSBuild Binaries
 rem
 rem We accept the latest prerelease of VS in the 17.x or 18.x range. The -version
-rem range [17.0,19.0) picks up both VS 2022 (17.x) and VS 18 (including previews)
-rem but not a still-newer major whose toolset may be incompatible. VS 18 uses our
-rem v145 PlatformToolset (see src\common.build.pre.props); older VS versions default
-rem to v143.
+rem range [17.0,19.0) picks up both VS 2022 (17.x) and VS 2026 (18.x, including
+rem previews) but not a still-newer major whose toolset may be incompatible.
+rem VS 2026 (18.x) uses our v145 PlatformToolset (see src\common.build.pre.props);
+rem older VS versions default to v143.
 rem
 for /f "usebackq tokens=*" %%B in (`"%VSWHERE%" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -version "[17.0,19.0)" -find MSBuild\**\Bin\MSBuild.exe 2^>nul`) do (
     set MSBUILD=%%B


### PR DESCRIPTION
Three small, maintainer-friendly fixes that address "exists but easy to overlook" issues in the build docs:

## 1. `doc/building.md`: `Get-Format` does not exist anymore
The doc told users to run `Get-Format` after importing `tools\OpenConsole.psm1`, but that function was removed in #19821 (it used to download the pinned clang-format NuGet package). The current formatter entry point is **`Invoke-CodeFormat`** (exported in `OpenConsole.psm1`).

## 2. `doc/building.md`: stale clang-format NuGet path
The doc pointed Visual Studio at `/packages/clang-format.win-x86.10.0.0/tools/clang-format.exe`, a NuGet package the repository no longer pulls (it's absent from every `packages.config`). Since #19821 the repo uses the clang-format that ships with Visual Studio, discovered via `vswhere` in `Invoke-CodeFormat`, and VS's own C++ formatting already uses that same clang-format - so the obsolete "set up the path / Use custom clang-format.exe file" instructions were replaced with a short note.

## 3. ~~`tools/razzle.cmd`: VS version comment is stale~~ - dropped per review, to keep this PR scoped to `doc/building.md`.

No functional change - docs only.