### PR TITLE
Always open duplicated tabs next to source tab

### DIFF
--- a/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
@@ -77,6 +77,7 @@ namespace TerminalAppLocalTests
         TEST_METHOD(CreateTerminalPage);
 
         TEST_METHOD(TryDuplicateBadTab);
+        TEST_METHOD(DuplicateTabAlwaysOpensAfterCurrent);
         TEST_METHOD(TryDuplicateBadPane);
 
         TEST_METHOD(TryZoomPane);
@@ -440,6 +441,32 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(3u, page->_tabs.Size(), L"We should successfully duplicate a tab hosting a deleted profile.");
         });
         VERIFY_SUCCEEDED(result);
+    }
+
+    void TabTests::DuplicateTabAlwaysOpensAfterCurrent()
+    {
+        auto page = _commonSetup();
+        VERIFY_IS_NOT_NULL(page);
+
+        Log::Comment(L"Create three tabs with new tabs opening at the end");
+        TestOnUIThread([&page]() {
+            page->_settings.WindowSettingsDefaults().NewTabPosition(NewTabPosition::AfterLastTab);
+
+            NewTerminalArgs newTerminalArgs{ 1 };
+            page->_OpenNewTab(newTerminalArgs);
+            page->_OpenNewTab(newTerminalArgs);
+
+            VERIFY_ARE_EQUAL(3u, page->_tabs.Size());
+        });
+
+        Log::Comment(L"Duplicate the middle tab");
+        TestOnUIThread([&page]() {
+            page->_SelectTab(1);
+            page->_DuplicateFocusedTab();
+
+            VERIFY_ARE_EQUAL(4u, page->_tabs.Size());
+            VERIFY_ARE_EQUAL(2u, page->_GetFocusedTabIndex().value(), L"Duplicated tabs should open next to their source tab.");
+        });
     }
 
     void TabTests::TryDuplicateBadPane()

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -304,6 +304,7 @@ namespace winrt::TerminalApp::implementation
             // In the future, it may be preferable to just duplicate the
             // current control's live settings (which will include changes
             // made through VT).
+            // Duplicate tabs intentionally ignore NewTabPosition() and always open next to the source tab.
             const auto insertPosition = tab.TabViewIndex() + 1;
             _CreateNewTabFromPane(_MakePane(nullptr, tab, nullptr), insertPosition);
 

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -304,11 +304,7 @@ namespace winrt::TerminalApp::implementation
             // In the future, it may be preferable to just duplicate the
             // current control's live settings (which will include changes
             // made through VT).
-            uint32_t insertPosition = _tabs.Size();
-            if (_currentWindowSettings().NewTabPosition() == NewTabPosition::AfterCurrentTab)
-            {
-                insertPosition = tab.TabViewIndex() + 1;
-            }
+            const auto insertPosition = tab.TabViewIndex() + 1;
             _CreateNewTabFromPane(_MakePane(nullptr, tab, nullptr), insertPosition);
 
             const auto runtimeTabText{ tab.GetTabText() };


### PR DESCRIPTION
## Summary

Fixes duplicate tab placement so duplicated tabs always open immediately after the source tab, regardless of the configured `newTabPosition`.

Previously, when `newTabPosition` was set to `AfterLastTab`, duplicated tabs were inserted at the end of the tab list. This change keeps normal new-tab behavior unchanged while making duplicate-tab placement consistently use the source tab's position.

Fixes #20355

## Validation

- `TabTests::TryDuplicateBadTab`
- `TabTests::NextMRUTab`
- `TabTests::TestClampSwitchToTab`
- `TabTests::DuplicateTabAlwaysOpensAfterCurrent`
- Manual UI verification with `newTabPosition` set to `AfterLastTab`

## Screenshots

### Before
Duplicating `tab2` placed the duplicated tab at the end of the tab list.

<img width="779" height="110" alt="before" src="https://github.com/user-attachments/assets/62cd6a83-14e8-4088-994b-2f1b88652294" />

### After
Duplicating `tab2` now places the duplicated tab immediately after the source tab.

<img width="1656" height="77" alt="after" src="https://github.com/user-attachments/assets/be51c657-de48-4a28-9934-957c1aab5f79" />