### PR TITLE
fix: Detect pwsh installed in custom Scoop directories

### DIFF
--- a/src/cascadia/TerminalSettingsModel/PowershellCoreProfileGenerator.cpp
+++ b/src/cascadia/TerminalSettingsModel/PowershellCoreProfileGenerator.cpp
@@ -281,6 +281,24 @@ static std::vector<PowerShellInstance> _collectPowerShellInstances()
     _accumulatePwshExeInDirectory(L"%USERPROFILE%\\.dotnet\\tools", PowerShellFlags::Dotnet, versions);
     _accumulatePwshExeInDirectory(L"%USERPROFILE%\\scoop\\shims", PowerShellFlags::Scoop, versions);
 
+    // Check for custom Scoop directories via environment variables
+    // SCOOP is for user-installed apps, SCOOP_GLOBAL is for globally installed apps
+    const auto scoopEnv = wil::TryGetEnvironmentVariableW(L"SCOOP");
+    if (scoopEnv)
+    {
+        const std::filesystem::path scoopPath{ scoopEnv.get() };
+        const auto scoopShimsPath = scoopPath / L"shims";
+        _accumulatePwshExeInDirectory(scoopShimsPath.native(), PowerShellFlags::Scoop, versions);
+    }
+
+    const auto scoopGlobalEnv = wil::TryGetEnvironmentVariableW(L"SCOOP_GLOBAL");
+    if (scoopGlobalEnv)
+    {
+        const std::filesystem::path scoopGlobalPath{ scoopGlobalEnv.get() };
+        const auto scoopGlobalShimsPath = scoopGlobalPath / L"shims";
+        _accumulatePwshExeInDirectory(scoopGlobalShimsPath.native(), PowerShellFlags::Scoop, versions);
+    }
+
     std::sort(versions.rbegin(), versions.rend()); // sort in reverse (best first)
 
     return versions;


### PR DESCRIPTION
## Summary

Adds support for detecting PowerShell Core installations in custom Scoop directories.

Previously, PowerShell installations were only detected under the default `%USERPROFILE%\scoop` location. This change also checks the `SCOOP` and `SCOOP_GLOBAL` environment variables so installations using custom Scoop directories can be discovered.

## Changes

- Check the `SCOOP` environment variable for custom Scoop installations.
- Check the `SCOOP_GLOBAL` environment variable for global Scoop installations.
- Preserve the existing default `%USERPROFILE%\scoop` detection behavior.

## Validation

- Verified the updated Scoop path detection logic.
- Existing behavior for the default Scoop installation remains unchanged.

Fixes #8264