### PR TITLE
Fix indexed icon media resource resolution

### DIFF
--- a/src/cascadia/TerminalSettingsModel/MediaResourceSupport.h
+++ b/src/cascadia/TerminalSettingsModel/MediaResourceSupport.h
@@ -121,6 +121,33 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                 return;
             }
 
+            const std::wstring_view pathView{ path };
+            const auto commaIndex = pathView.rfind(L',');
+            if (!resource.Ok() && commaIndex != std::wstring_view::npos)
+            {
+                const auto pathWithoutIndex = pathView.substr(0, commaIndex);
+                const auto index = til::parse_signed<int>(pathView.substr(commaIndex + 1));
+                if (index &&
+                    (til::ends_with(pathWithoutIndex, L".exe") ||
+                     til::ends_with(pathWithoutIndex, L".dll") ||
+                     til::ends_with(pathWithoutIndex, L".lnk")))
+                {
+                    const auto binaryResource{ MediaResource::FromString(winrt::hstring{ pathWithoutIndex }) };
+                    resolver(origin, basePath, binaryResource);
+                    if (binaryResource.Ok())
+                    {
+                        std::wstring resolvedPath{ binaryResource.Resolved() };
+                        resolvedPath.append(pathView.substr(commaIndex));
+                        resource.Resolve(winrt::hstring{ resolvedPath });
+                    }
+                    else
+                    {
+                        resource.Reject();
+                    }
+                    return;
+                }
+            }
+
             ResolveMediaResource(origin, basePath, resource, resolver);
         }
     }

--- a/src/cascadia/UIHelpers/IconPathConverter.cpp
+++ b/src/cascadia/UIHelpers/IconPathConverter.cpp
@@ -254,7 +254,7 @@ namespace winrt::Microsoft::Terminal::UI::implementation
         const auto pathView = std::wstring_view{ iconPath };
         // Does iconPath have a comma in it? If so, split the string on the
         // comma and look for the index and extension.
-        const auto commaIndex = pathView.find(L',');
+        const auto commaIndex = pathView.rfind(L',');
 
         // split the path on the comma
         iconPathWithoutIndex = pathView.substr(0, commaIndex);

--- a/src/cascadia/UnitTests_SettingsModel/MediaResourceTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/MediaResourceTests.cpp
@@ -101,6 +101,7 @@ namespace SettingsModelUnitTests
 
         // REAL RESOLVER
         TEST_METHOD(RealResolverFilePaths);
+        TEST_METHOD(RealResolverIndexedIconPaths);
         TEST_METHOD(RealResolverSpecialKeywords);
         TEST_METHOD(RealResolverUrlCases);
         TEST_METHOD(RealResolverUNCCases);
@@ -1149,6 +1150,114 @@ namespace SettingsModelUnitTests
             VERIFY_IS_FALSE(image.Ok());
             VERIFY_ARE_EQUAL(L"", image.Resolved());
         }
+    }
+
+    void MediaResourceTests::RealResolverIndexedIconPaths()
+    {
+        WEX::TestExecution::DisableVerifyExceptions disableVerifyExceptions{};
+
+        g_mediaResolverHook = nullptr; // Use the real resolver
+
+        auto settings = createSettings(R"({
+    "profiles": {
+        "list": [
+            {
+                "icon": "C:\\Windows\\System32\\shell32.dll,210",
+                "name": "ProfileAbsoluteIndexedIcon"
+            },
+            {
+                "icon": "System32\\shell32.dll,-210",
+                "name": "ProfileRelativeIndexedIcon"
+            },
+            {
+                "icon": "%SystemRoot%\\System32\\shell32.dll,0",
+                "name": "ProfileEnvironmentVariableIndexedIcon"
+            },
+            {
+                "icon": "C:\\Windows\\System32\\shell32.dll,not-an-index",
+                "name": "ProfileInvalidIndexedIcon"
+            },
+            {
+                "backgroundImage": "C:\\Windows\\System32\\shell32.dll,210",
+                "name": "ProfileIndexedNonIconResource"
+            }
+        ]
+    }
+})");
+
+        constexpr std::wstring_view expectedShell32Path{ LR"(C:\Windows\System32\shell32.dll)" };
+
+        {
+            const auto profile{ settings->GetProfileByName(L"ProfileAbsoluteIndexedIcon") };
+            const auto icon{ profile.Icon() };
+            VERIFY_IS_TRUE(icon.Ok());
+            VERIFY_ARE_EQUAL(std::wstring{ expectedShell32Path } + L",210", icon.Resolved());
+        }
+
+        {
+            const auto profile{ settings->GetProfileByName(L"ProfileRelativeIndexedIcon") };
+            const auto icon{ profile.Icon() };
+            VERIFY_IS_TRUE(icon.Ok());
+            VERIFY_ARE_EQUAL(std::wstring{ expectedShell32Path } + L",-210", icon.Resolved());
+        }
+
+        {
+            const auto profile{ settings->GetProfileByName(L"ProfileEnvironmentVariableIndexedIcon") };
+            const auto icon{ profile.Icon() };
+            VERIFY_IS_TRUE(icon.Ok());
+            VERIFY_IS_TRUE(til::equals_insensitive_ascii(std::wstring{ expectedShell32Path } + L",0", icon.Resolved()), WEX::Common::NoThrowString{ icon.Resolved().c_str() });
+        }
+
+        {
+            const auto profile{ settings->GetProfileByName(L"ProfileInvalidIndexedIcon") };
+            const auto icon{ profile.Icon() };
+            VERIFY_IS_TRUE(icon.Ok());
+            VERIFY_ARE_EQUAL(cmdCommandline, icon.Resolved());
+        }
+
+        {
+            const auto profile{ settings->GetProfileByName(L"ProfileIndexedNonIconResource") };
+            const auto image{ profile.DefaultAppearance().BackgroundImagePath() };
+            VERIFY_IS_FALSE(image.Ok());
+            VERIFY_ARE_EQUAL(L"", image.Resolved());
+        }
+
+        const auto testRoot = std::filesystem::temp_directory_path() / fmt::format(L"WT_MediaResourceTests_{}", GetCurrentProcessId());
+        const auto folderWithComma = testRoot / L"folder,with-comma";
+        const auto iconInCommaFolder = folderWithComma / L"icon.dll";
+        const auto iconWithCommaFilename = testRoot / L"icon,with-comma.dll";
+        const auto cleanup = wil::scope_exit([&] {
+            std::error_code error;
+            std::filesystem::remove_all(testRoot, error);
+        });
+
+        std::filesystem::remove_all(testRoot);
+        std::filesystem::create_directories(folderWithComma);
+        std::filesystem::copy_file(LR"(C:\Windows\System32\shell32.dll)", iconInCommaFolder);
+        std::filesystem::copy_file(LR"(C:\Windows\System32\shell32.dll)", iconWithCommaFilename);
+
+        const MediaResourceResolver resolver{ [](auto, const auto&, const auto& resource) {
+            const std::filesystem::path path{ std::wstring_view{ resource.Path() } };
+            if (std::filesystem::exists(path))
+            {
+                resource.Resolve(winrt::hstring{ path.lexically_normal().native() });
+            }
+            else
+            {
+                resource.Reject();
+            }
+        } };
+        const auto verifyIcon = [&](const std::wstring& path) {
+            const auto icon{ implementation::MediaResource::FromString(winrt::hstring{ path }) };
+            implementation::ResolveIconMediaResource(OriginTag::User, {}, icon, resolver);
+            VERIFY_IS_TRUE(icon.Ok());
+            VERIFY_ARE_EQUAL(path, icon.Resolved());
+        };
+
+        verifyIcon(iconInCommaFolder.native());
+        verifyIcon(iconInCommaFolder.native() + L",24");
+        verifyIcon(iconWithCommaFilename.native());
+        verifyIcon(iconWithCommaFilename.native() + L",24");
     }
 
     static std::optional<winrt::hstring> _getDesktopWallpaper()


### PR DESCRIPTION
## Summary of the Pull Request

Fixes indexed `.exe`, `.dll`, and `.lnk` profile icons being rejected during media resource validation.

## References and Relevant Issues

Closes #20567

Regression from #19143. Restores the indexed icon behavior introduced by #14107 / #1504.

## Detailed Description of the Pull Request / Additional comments

Media resource validation currently checks the complete icon value, including its `,index` suffix, with `std::filesystem::exists`. For example, it checks for a file literally named `shell32.dll,210`, rejects the resource, and prevents `IconPathConverter` from extracting the requested icon.

This change:

- recognizes signed icon indexes for `.exe`, `.dll`, and `.lnk` resources;
- validates and resolves the binary path without the index;
- preserves the original index for `IconPathConverter`;
- splits on the final comma so commas in directory and file names remain valid;
- leaves non-icon media resources under strict whole-path validation.

## Validation Steps Performed

- Built the full Debug x64 solution with the repository's standard `Invoke-OpenConsoleBuild` workflow.
- Ran `SettingsModelUnitTests::MediaResourceTests::RealResolverIndexedIconPaths`.
- Verified absolute, relative, environment-expanded, positive, negative, zero, malformed, and non-icon indexed paths.
- Verified paths with commas in both directory names and file names, with and without an index.
- Registered and launched the local Windows Terminal Dev package and visually confirmed an icon loaded from `oicons.dll,24`.

## PR Checklist
- [x] Closes #20567
- [x] Tests added/passed
- [ ] Documentation updated
   - Not necessary; this restores previously supported behavior and does not change the settings schema.
- [ ] Schema updated (if necessary)
   - Not necessary.