### PR TITLE
Remove unnecessary C4430 suppressions

### DIFF
--- a/src/inc/HostAndPropsheetIncludes.h
+++ b/src/inc/HostAndPropsheetIncludes.h
@@ -18,10 +18,7 @@
 #include <winternl.h>
 #endif
 
-#pragma warning(push)
-#pragma warning(disable:4430) // Must disable 4430 "default int" warning for C++ because ntstatus.h is inflexible SDK definition.
 #include <ntstatus.h>
-#pragma warning(pop)
 
 #include <initguid.h>
 

--- a/src/propslib/precomp.h
+++ b/src/propslib/precomp.h
@@ -12,10 +12,7 @@
 
 #include <winternl.h>
 
-#pragma warning(push)
-#pragma warning(disable : 4430) // Must disable 4430 "default int" warning for C++ because ntstatus.h is inflexible SDK definition.
 #include <ntstatus.h>
-#pragma warning(pop)
 
 #ifdef EXTERNAL_BUILD
 #include <ShlObj.h>

--- a/src/server/precomp.h
+++ b/src/server/precomp.h
@@ -30,10 +30,7 @@ Abstract:
 
 #include <winternl.h>
 
-#pragma warning(push)
-#pragma warning(disable : 4430) // Must disable 4430 "default int" warning for C++ because ntstatus.h is inflexible SDK definition.
 #include <ntstatus.h>
-#pragma warning(pop)
 
 #include <winioctl.h>
 #include <intsafe.h>


### PR DESCRIPTION
## Summary of the Pull Request

These have all been fixed and no longer need to be suppressed.

## References and Relevant Issues

N/A, mirroring changes from internal PR.

## Detailed Description of the Pull Request / Additional comments

[C4430](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4430?view=msvc-170) is `missing type specifier - int assumed. Note: C++ does not support default-int`. We have been eliminating all instances of this warning in Windows.

## Validation Steps Performed

If this passes the CI build, we'll be okay.

## PR Checklist

All N/A