### PR TITLE
Preserve the DRCS font when performing a soft reset

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -86,6 +86,7 @@ backstory
 Bazz
 bbccb
 bbwe
+bcde
 bcount
 bcx
 bcz

--- a/src/host/ut_host/ScreenBufferTests.cpp
+++ b/src/host/ut_host/ScreenBufferTests.cpp
@@ -124,6 +124,7 @@ class ScreenBufferTests
 
     TEST_METHOD(VtSoftResetCursorPosition);
     TEST_METHOD(VtSoftResetAltBufferCursorState);
+    TEST_METHOD(VtSoftResetCharacterSets);
 
     TEST_METHOD(VtScrollMarginsNewlineColor);
 
@@ -1533,6 +1534,171 @@ void ScreenBufferTests::VtSoftResetAltBufferCursorState()
 
     Log::Comment(L"Returning from alt buffer should restore the main cursor position.");
     VERIFY_ARE_EQUAL(til::point(6, 3), gci.GetActiveOutputBuffer().GetTextBuffer().GetCursor().GetPosition());
+}
+
+void ScreenBufferTests::VtSoftResetCharacterSets()
+{
+    auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
+    auto& si = gci.GetActiveOutputBuffer().GetActiveBuffer();
+    auto& tbi = si.GetTextBuffer();
+    auto& stateMachine = si.GetStateMachine();
+
+    auto verifyTextTranslation = [&](auto sourceText, std::wstring_view expectedText, auto comment) {
+        tbi.GetCursor().SetPosition({ 0, 0 });
+        stateMachine.ProcessString(sourceText);
+        const auto& row = tbi.GetRowByOffset(0);
+        const auto actualText = row.GetText().substr(0, expectedText.length());
+        VERIFY_ARE_EQUAL(expectedText, actualText, comment);
+    };
+
+    Log::Comment(L"Enable GR translation");
+    stateMachine.ProcessString(L"\x1b%@");
+    auto returnToUTF8 = wil::scope_exit([&] { stateMachine.ProcessString(L"\x1b%G"); });
+
+    constexpr auto LS0 = L"\x0f";
+    constexpr auto LS1 = L"\x0e";
+    constexpr auto LS2 = L"\x1bn";
+    constexpr auto LS3 = L"\x1bo";
+    constexpr auto LS3R = L"\x1b|";
+
+    // Confirm that DECSTR resets all character sets back to the defaults.
+
+    Log::Comment(L"Designate different charsets into all the G-sets");
+    stateMachine.ProcessString(L"\x1b(0"); // Special Graphics in G0
+    stateMachine.ProcessString(L"\x1b)&4"); // Cyrillic in G1
+    stateMachine.ProcessString(L"\x1b*\"4"); // Hebrew in G2
+    stateMachine.ProcessString(L"\x1b+\"?"); // Greek in G3
+
+    Log::Comment(L"Invoke G1 into GL and G3 into GR");
+    stateMachine.ProcessString(LS1);
+    stateMachine.ProcessString(LS3R);
+    verifyTextTranslation(L"bcde", L"БЦДЕ", L"Cyrillic (G1) in GL");
+    verifyTextTranslation(L"âãäå", L"βγδε", L"Greek (G3) in GR");
+
+    Log::Comment(L"Perform a soft reset");
+    stateMachine.ProcessString(L"\x1b[!p");
+
+    Log::Comment(L"Verify ASCII is in GL, G0, G1; Latin-1 is in GR, G2, G3");
+    verifyTextTranslation(L"bcde", L"bcde", L"ASCII in GL");
+    verifyTextTranslation(L"âãäå", L"âãäå", L"Latin-1 in GR");
+    stateMachine.ProcessString(LS3);
+    verifyTextTranslation(L"bcde", L"âãäå", L"Latin-1 in G3");
+    stateMachine.ProcessString(LS2);
+    verifyTextTranslation(L"bcde", L"âãäå", L"Latin-1 in G2");
+    stateMachine.ProcessString(LS1);
+    verifyTextTranslation(L"bcde", L"bcde", L"ASCII in G1");
+    stateMachine.ProcessString(LS0);
+    verifyTextTranslation(L"bcde", L"bcde", L"ASCII in G0");
+
+    // Confirm that DECSTR does not destroy the soft font.
+
+    constexpr auto soft_bcde = L"\xEF62\xEF63\xEF64\xEF65"; // DECDLD private use codepoints
+
+    Log::Comment(L"Download a soft font into charset SP @");
+    stateMachine.ProcessString(L"\x1bP1;1;1{ @~~~~~~~/~~~~~~~\x1b\\");
+
+    Log::Comment(L"Designate it into all the G-sets");
+    stateMachine.ProcessString(L"\x1b( @"); // Designate into G0
+    stateMachine.ProcessString(L"\x1b) @"); // Designate into G1
+    stateMachine.ProcessString(L"\x1b* @"); // Designate into G2
+    stateMachine.ProcessString(L"\x1b+ @"); // Designate into G3
+
+    Log::Comment(L"Verify soft font is in GL, GR, and all the G-sets");
+    verifyTextTranslation(L"bcde", soft_bcde, L"Soft font in GL");
+    verifyTextTranslation(L"âãäå", soft_bcde, L"Soft font in GR");
+    stateMachine.ProcessString(LS3);
+    verifyTextTranslation(L"bcde", soft_bcde, L"Soft font in G3");
+    stateMachine.ProcessString(LS2);
+    verifyTextTranslation(L"bcde", soft_bcde, L"Soft font in G2");
+    stateMachine.ProcessString(LS1);
+    verifyTextTranslation(L"bcde", soft_bcde, L"Soft font in G1");
+    stateMachine.ProcessString(LS0);
+    verifyTextTranslation(L"bcde", soft_bcde, L"Soft font in G0");
+
+    Log::Comment(L"Perform a soft reset");
+    stateMachine.ProcessString(L"\x1b[!p");
+
+    Log::Comment(L"Verify ASCII is in GL, G0, G1; Latin-1 is in GR, G2, G3");
+    verifyTextTranslation(L"bcde", L"bcde", L"ASCII in GL");
+    verifyTextTranslation(L"âãäå", L"âãäå", L"Latin-1 in GR");
+    stateMachine.ProcessString(LS3);
+    verifyTextTranslation(L"bcde", L"âãäå", L"Latin-1 in G3");
+    stateMachine.ProcessString(LS2);
+    verifyTextTranslation(L"bcde", L"âãäå", L"Latin-1 in G2");
+    stateMachine.ProcessString(LS1);
+    verifyTextTranslation(L"bcde", L"bcde", L"ASCII in G1");
+    stateMachine.ProcessString(LS0);
+    verifyTextTranslation(L"bcde", L"bcde", L"ASCII in G0");
+
+    Log::Comment(L"Verify that the soft font can still be designated");
+    stateMachine.ProcessString(L"\x1b( @"); // Designate into G0 (GL)
+    stateMachine.ProcessString(L"\x1b* @"); // Designate into G2 (GR)
+    verifyTextTranslation(L"bcde", soft_bcde, L"Soft font in GL");
+    verifyTextTranslation(L"âãäå", soft_bcde, L"Soft font in GR");
+    stateMachine.ProcessString(LS3);
+    verifyTextTranslation(L"bcde", L"âãäå", L"Latin-1 in G3");
+    stateMachine.ProcessString(LS2);
+    verifyTextTranslation(L"bcde", soft_bcde, L"Soft font in G2");
+    stateMachine.ProcessString(LS1);
+    verifyTextTranslation(L"bcde", L"bcde", L"ASCII in G1");
+    stateMachine.ProcessString(LS0);
+    verifyTextTranslation(L"bcde", soft_bcde, L"Soft font in G0");
+
+    // Confirm that DECSTR uses the soft font as default when it replaces ASCII.
+
+    Log::Comment(L"Perform a soft reset");
+    stateMachine.ProcessString(L"\x1b[!p");
+
+    Log::Comment(L"Verify ASCII is in G0 and G1");
+    stateMachine.ProcessString(LS1);
+    verifyTextTranslation(L"bcde", L"bcde", L"ASCII in G1");
+    stateMachine.ProcessString(LS0);
+    verifyTextTranslation(L"bcde", L"bcde", L"ASCII in G0");
+
+    Log::Comment(L"Download a soft font into charset B (ASCII)");
+    stateMachine.ProcessString(L"\x1bP1;1;1{B~~~~~~~/~~~~~~~\x1b\\");
+
+    Log::Comment(L"Verify soft font is now in G0 and G1");
+    stateMachine.ProcessString(LS1);
+    verifyTextTranslation(L"bcde", soft_bcde, L"Soft font in G1");
+    stateMachine.ProcessString(LS0);
+    verifyTextTranslation(L"bcde", soft_bcde, L"Soft font in G0");
+
+    Log::Comment(L"Designate Special Graphics in all the G-sets");
+    stateMachine.ProcessString(L"\x1b(0"); // Designate into G0
+    stateMachine.ProcessString(L"\x1b)0"); // Designate into G1
+    stateMachine.ProcessString(L"\x1b*0"); // Designate into G2
+    stateMachine.ProcessString(L"\x1b+0"); // Designate into G3
+
+    Log::Comment(L"Verify Special Graphics is in GL, GR, and all the G-sets");
+    verifyTextTranslation(L"bcde", L"␉␌␍␊", L"Special Graphics in GL");
+    verifyTextTranslation(L"âãäå", L"␉␌␍␊", L"Special Graphics in GR");
+    stateMachine.ProcessString(LS3);
+    verifyTextTranslation(L"bcde", L"␉␌␍␊", L"Special Graphics in G3");
+    stateMachine.ProcessString(LS2);
+    verifyTextTranslation(L"bcde", L"␉␌␍␊", L"Special Graphics in G2");
+    stateMachine.ProcessString(LS1);
+    verifyTextTranslation(L"bcde", L"␉␌␍␊", L"Special Graphics in G1");
+    stateMachine.ProcessString(LS0);
+    verifyTextTranslation(L"bcde", L"␉␌␍␊", L"Special Graphics in G0");
+
+    Log::Comment(L"Perform a soft reset");
+    stateMachine.ProcessString(L"\x1b[!p");
+
+    Log::Comment(L"Verify soft font is in GL, G0, G1; Latin-1 is in GR, G2, G3");
+    verifyTextTranslation(L"bcde", soft_bcde, L"Soft font in GL");
+    verifyTextTranslation(L"âãäå", L"âãäå", L"Latin-1 in GR");
+    stateMachine.ProcessString(LS3);
+    verifyTextTranslation(L"bcde", L"âãäå", L"Latin-1 in G3");
+    stateMachine.ProcessString(LS2);
+    verifyTextTranslation(L"bcde", L"âãäå", L"Latin-1 in G2");
+    stateMachine.ProcessString(LS1);
+    verifyTextTranslation(L"bcde", soft_bcde, L"Soft font in G1");
+    stateMachine.ProcessString(LS0);
+    verifyTextTranslation(L"bcde", soft_bcde, L"Soft font in G0");
+
+    Log::Comment(L"Erase the soft font");
+    stateMachine.ProcessString(L"\x1bP0;0;2{ @\x1b\\");
 }
 
 void ScreenBufferTests::VtScrollMarginsNewlineColor()

--- a/src/host/ut_host/ScreenBufferTests.cpp
+++ b/src/host/ut_host/ScreenBufferTests.cpp
@@ -125,6 +125,7 @@ class ScreenBufferTests
     TEST_METHOD(VtSoftResetCursorPosition);
     TEST_METHOD(VtSoftResetAltBufferCursorState);
     TEST_METHOD(VtSoftResetCharacterSets);
+    TEST_METHOD(VtRestoreCharacterSets);
 
     TEST_METHOD(VtScrollMarginsNewlineColor);
 
@@ -1699,6 +1700,130 @@ void ScreenBufferTests::VtSoftResetCharacterSets()
 
     Log::Comment(L"Erase the soft font");
     stateMachine.ProcessString(L"\x1bP0;0;2{ @\x1b\\");
+}
+
+void ScreenBufferTests::VtRestoreCharacterSets()
+{
+    auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
+    auto& si = gci.GetActiveOutputBuffer().GetActiveBuffer();
+    auto& tbi = si.GetTextBuffer();
+    auto& stateMachine = si.GetStateMachine();
+
+    auto verifyTextTranslation = [&](auto sourceText, std::wstring_view expectedText, auto comment) {
+        tbi.GetCursor().SetPosition({ 0, 0 });
+        stateMachine.ProcessString(sourceText);
+        const auto& row = tbi.GetRowByOffset(0);
+        const auto actualText = row.GetText().substr(0, expectedText.length());
+        VERIFY_ARE_EQUAL(expectedText, actualText, comment);
+    };
+
+    Log::Comment(L"Enable GR translation");
+    stateMachine.ProcessString(L"\x1b%@");
+    auto returnToUTF8 = wil::scope_exit([&] { stateMachine.ProcessString(L"\x1b%G"); });
+
+    constexpr auto LS0 = L"\x0f";
+    constexpr auto LS1 = L"\x0e";
+    constexpr auto LS2 = L"\x1bn";
+    constexpr auto LS3 = L"\x1bo";
+    constexpr auto LS2R = L"\x1b}";
+    constexpr auto LS3R = L"\x1b|";
+
+    constexpr auto DECSC = L"\x1b\x37";
+    constexpr auto DECRC = L"\x1b\x38";
+
+    // Confirm that DECRC restores character sets that have been changed.
+
+    Log::Comment(L"Designate different charsets into all the G-sets");
+    stateMachine.ProcessString(L"\x1b(0"); // Special Graphics in G0
+    stateMachine.ProcessString(L"\x1b)&4"); // Cyrillic in G1
+    stateMachine.ProcessString(L"\x1b*\"4"); // Hebrew in G2
+    stateMachine.ProcessString(L"\x1b+\"?"); // Greek in G3
+
+    Log::Comment(L"Invoke G1 into GL and G3 into GR");
+    stateMachine.ProcessString(LS1);
+    stateMachine.ProcessString(LS3R);
+
+    Log::Comment(L"Save the charset state");
+    stateMachine.ProcessString(DECSC);
+
+    Log::Comment(L"Designate ASCII in all the G-sets");
+    stateMachine.ProcessString(L"\x1b(B"); // Designate into G0
+    stateMachine.ProcessString(L"\x1b)B"); // Designate into G1
+    stateMachine.ProcessString(L"\x1b*B"); // Designate into G2
+    stateMachine.ProcessString(L"\x1b+B"); // Designate into G3
+
+    Log::Comment(L"Invoke G0 into GL and G2 into GR");
+    stateMachine.ProcessString(LS0);
+    stateMachine.ProcessString(LS2R);
+
+    Log::Comment(L"Verify ASCII is in GL, GR, and all the G-sets");
+    verifyTextTranslation(L"bcde", L"bcde", L"ASCII in GL");
+    verifyTextTranslation(L"âãäå", L"bcde", L"ASCII in GR");
+    stateMachine.ProcessString(LS3);
+    verifyTextTranslation(L"bcde", L"bcde", L"ASCII in G3");
+    stateMachine.ProcessString(LS2);
+    verifyTextTranslation(L"bcde", L"bcde", L"ASCII in G2");
+    stateMachine.ProcessString(LS1);
+    verifyTextTranslation(L"bcde", L"bcde", L"ASCII in G1");
+    stateMachine.ProcessString(LS0);
+    verifyTextTranslation(L"bcde", L"bcde", L"ASCII in G0");
+
+    Log::Comment(L"Restore the charset state");
+    stateMachine.ProcessString(DECRC);
+
+    Log::Comment(L"Verify the original charsets are restored");
+    verifyTextTranslation(L"bcde", L"БЦДЕ", L"Cyrillic in GL (GL = G1)");
+    verifyTextTranslation(L"âãäå", L"βγδε", L"Greek in GR (GR = G3)");
+    stateMachine.ProcessString(LS3);
+    verifyTextTranslation(L"bcde", L"βγδε", L"Greek in G3");
+    stateMachine.ProcessString(LS2);
+    verifyTextTranslation(L"bcde", L"גדהו", L"Hebrew in G2");
+    stateMachine.ProcessString(LS1);
+    verifyTextTranslation(L"bcde", L"БЦДЕ", L"Cyrillic in G1");
+    stateMachine.ProcessString(LS0);
+    verifyTextTranslation(L"bcde", L"␉␌␍␊", L"Special Graphics in G0");
+
+    // Confirm that DECRC restores a soft font that replaced a standard character set.
+
+    constexpr auto soft_bcde = L"\xEF62\xEF63\xEF64\xEF65"; // DECDLD private use codepoints
+
+    Log::Comment(L"Invoke G2 into GL and G3 into GR");
+    stateMachine.ProcessString(LS2);
+    stateMachine.ProcessString(LS3R);
+
+    Log::Comment(L"Save the charset state");
+    stateMachine.ProcessString(DECSC);
+
+    Log::Comment(L"Designate ASCII in all the G-sets");
+    stateMachine.ProcessString(L"\x1b(B"); // Designate into G0
+    stateMachine.ProcessString(L"\x1b)B"); // Designate into G1
+    stateMachine.ProcessString(L"\x1b*B"); // Designate into G2
+    stateMachine.ProcessString(L"\x1b+B"); // Designate into G3
+
+    Log::Comment(L"Invoke G0 into GL and G2 into GR");
+    stateMachine.ProcessString(LS0);
+    stateMachine.ProcessString(LS2R);
+
+    Log::Comment(L"Download a soft font into charset \"4 (Hebrew)");
+    stateMachine.ProcessString(L"\x1bP1;1;1{\"4~~~~~~~/~~~~~~~\x1b\\");
+
+    Log::Comment(L"Restore the charset state");
+    stateMachine.ProcessString(DECRC);
+
+    Log::Comment(L"Verify original charsets are restored with a soft font replacing Hebrew");
+    verifyTextTranslation(L"bcde", soft_bcde, L"Soft font in GL (GL = G2)");
+    verifyTextTranslation(L"âãäå", L"βγδε", L"Greek in GR (GR = G3)");
+    stateMachine.ProcessString(LS3);
+    verifyTextTranslation(L"bcde", L"βγδε", L"Greek in G3");
+    stateMachine.ProcessString(LS2);
+    verifyTextTranslation(L"bcde", soft_bcde, L"Soft font in G2");
+    stateMachine.ProcessString(LS1);
+    verifyTextTranslation(L"bcde", L"БЦДЕ", L"Cyrillic in G1");
+    stateMachine.ProcessString(LS0);
+    verifyTextTranslation(L"bcde", L"␉␌␍␊", L"Special Graphics in G0");
+
+    Log::Comment(L"Restore everything with a hard reset");
+    stateMachine.ProcessString(L"\033c");
 }
 
 void ScreenBufferTests::VtScrollMarginsNewlineColor()

--- a/src/terminal/adapter/terminalOutput.cpp
+++ b/src/terminal/adapter/terminalOutput.cpp
@@ -34,7 +34,7 @@ TerminalOutput::TerminalOutput(const bool grEnabled) noexcept :
 void TerminalOutput::SoftReset() noexcept
 {
     // A soft reset is essentially the same thing as a restore from a fresh
-    // instance, but that instance must already be initalized with the current
+    // instance, but that instance must already be initialized with the current
     // GR translation state in order for the appropriate defaults to be set.
     RestoreFrom({ _grTranslationEnabled });
 }

--- a/src/terminal/adapter/terminalOutput.cpp
+++ b/src/terminal/adapter/terminalOutput.cpp
@@ -8,12 +8,10 @@
 
 using namespace Microsoft::Console::VirtualTerminal;
 
-TerminalOutput::TerminalOutput(const bool grEnabled, const VTID drcsId, const std::wstring_view drcsTranslationTable) noexcept :
+TerminalOutput::TerminalOutput(const bool grEnabled) noexcept :
     _upssId{ VTID("A") },
     _upssTranslationTable{ Latin1 },
-    _grTranslationEnabled{ grEnabled },
-    _drcsId{ drcsId },
-    _drcsTranslationTable{ drcsTranslationTable }
+    _grTranslationEnabled{ grEnabled }
 {
     // By default we set all of the G-sets to ASCII, so if someone accidentally
     // triggers a locking shift, they won't end up with UPSS in the GL table,
@@ -31,39 +29,39 @@ TerminalOutput::TerminalOutput(const bool grEnabled, const VTID drcsId, const st
     _gsetIds.at(1) = VTID("B");
     _gsetIds.at(2) = grId;
     _gsetIds.at(3) = grId;
-
-    // If this class is being reconstructed from a Soft Reset, then we may be
-    // inheriting a DRCS set. And if that set replaced ASCII or the default GR
-    // ID, we'll need to map the translation table into the relevant G-sets.
-    if (_drcsId == VTID("B"))
-    {
-        _gsetTranslationTables.at(0) = _drcsTranslationTable;
-        _gsetTranslationTables.at(1) = _drcsTranslationTable;
-        _glTranslationTable = _drcsTranslationTable;
-    }
-    if (_drcsId == grId)
-    {
-        _gsetTranslationTables.at(2) = _drcsTranslationTable;
-        _gsetTranslationTables.at(3) = _drcsTranslationTable;
-        _grTranslationTable = grEnabled ? _drcsTranslationTable : std::wstring_view{};
-    }
 }
 
 void TerminalOutput::SoftReset() noexcept
 {
-    // For a soft reset we want to reinitialize the character set designations,
-    // but retain the GR translation functionality if it's currently enabled.
-    // We also need to retain the DRCS character set if there is one applied.
-    *this = { _grTranslationEnabled, _drcsId, _drcsTranslationTable };
+    // A soft reset is essentially the same thing as a restore from a fresh
+    // instance, but that instance must already be initalized with the current
+    // GR translation state in order for the appropriate defaults to be set.
+    RestoreFrom({ _grTranslationEnabled });
 }
 
 void TerminalOutput::RestoreFrom(const TerminalOutput& savedState) noexcept
 {
-    // When restoring from a saved instance, we want to preserve the GR
-    // translation functionality if it's currently enabled.
+    // When restoring from a saved instance, we want to preserve the current GR
+    // translation state as well as the DRCS character set.
     const auto preserveGrTranslation = _grTranslationEnabled;
+    const auto preserveDrcsId = _drcsId;
+    const auto preserveDrcsSize = _drcsTranslationTable.size();
     *this = savedState;
     _grTranslationEnabled = preserveGrTranslation;
+    // We can't just set the DRCS ID and translation table directly though. We
+    // need to go through the appropriate SetDrcsDesignation method to ensure
+    // that all the affected G-sets are updated too.
+    if (preserveDrcsId)
+    {
+        if (preserveDrcsSize == 96)
+        {
+            SetDrcs96Designation(preserveDrcsId);
+        }
+        else
+        {
+            SetDrcs94Designation(preserveDrcsId);
+        }
+    }
 }
 
 void TerminalOutput::AssignUserPreferenceCharset(const VTID charset, const bool size96)

--- a/src/terminal/adapter/terminalOutput.cpp
+++ b/src/terminal/adapter/terminalOutput.cpp
@@ -31,7 +31,7 @@ TerminalOutput::TerminalOutput(const bool grEnabled) noexcept :
     _gsetIds.at(3) = grId;
 }
 
-void TerminalOutput::SoftReset() noexcept
+void TerminalOutput::SoftReset()
 {
     // A soft reset is essentially the same thing as a restore from a fresh
     // instance, but that instance must already be initialized with the current
@@ -39,7 +39,7 @@ void TerminalOutput::SoftReset() noexcept
     RestoreFrom({ _grTranslationEnabled });
 }
 
-void TerminalOutput::RestoreFrom(const TerminalOutput& savedState) noexcept
+void TerminalOutput::RestoreFrom(const TerminalOutput& savedState)
 {
     // When restoring from a saved instance, we want to preserve the current GR
     // translation state as well as the DRCS character set.

--- a/src/terminal/adapter/terminalOutput.cpp
+++ b/src/terminal/adapter/terminalOutput.cpp
@@ -8,10 +8,12 @@
 
 using namespace Microsoft::Console::VirtualTerminal;
 
-TerminalOutput::TerminalOutput(const bool grEnabled) noexcept :
+TerminalOutput::TerminalOutput(const bool grEnabled, const VTID drcsId, const std::wstring_view drcsTranslationTable) noexcept :
     _upssId{ VTID("A") },
     _upssTranslationTable{ Latin1 },
-    _grTranslationEnabled{ grEnabled }
+    _grTranslationEnabled{ grEnabled },
+    _drcsId{ drcsId },
+    _drcsTranslationTable{ drcsTranslationTable }
 {
     // By default we set all of the G-sets to ASCII, so if someone accidentally
     // triggers a locking shift, they won't end up with UPSS in the GL table,
@@ -29,13 +31,30 @@ TerminalOutput::TerminalOutput(const bool grEnabled) noexcept :
     _gsetIds.at(1) = VTID("B");
     _gsetIds.at(2) = grId;
     _gsetIds.at(3) = grId;
+
+    // If this class is being reconstructed from a Soft Reset, then we may be
+    // inheriting a DRCS set. And if that set replaced ASCII or the default GR
+    // ID, we'll need to map the translation table into the relevant G-sets.
+    if (_drcsId == VTID("B"))
+    {
+        _gsetTranslationTables.at(0) = _drcsTranslationTable;
+        _gsetTranslationTables.at(1) = _drcsTranslationTable;
+        _glTranslationTable = _drcsTranslationTable;
+    }
+    if (_drcsId == grId)
+    {
+        _gsetTranslationTables.at(2) = _drcsTranslationTable;
+        _gsetTranslationTables.at(3) = _drcsTranslationTable;
+        _grTranslationTable = grEnabled ? _drcsTranslationTable : std::wstring_view{};
+    }
 }
 
 void TerminalOutput::SoftReset() noexcept
 {
     // For a soft reset we want to reinitialize the character set designations,
     // but retain the GR translation functionality if it's currently enabled.
-    *this = { _grTranslationEnabled };
+    // We also need to retain the DRCS character set if there is one applied.
+    *this = { _grTranslationEnabled, _drcsId, _drcsTranslationTable };
 }
 
 void TerminalOutput::RestoreFrom(const TerminalOutput& savedState) noexcept

--- a/src/terminal/adapter/terminalOutput.hpp
+++ b/src/terminal/adapter/terminalOutput.hpp
@@ -25,8 +25,8 @@ namespace Microsoft::Console::VirtualTerminal
     public:
         TerminalOutput(const bool grEnabled = false) noexcept;
 
-        void SoftReset() noexcept;
-        void RestoreFrom(const TerminalOutput& savedState) noexcept;
+        void SoftReset();
+        void RestoreFrom(const TerminalOutput& savedState);
         void AssignUserPreferenceCharset(const VTID charset, const bool size96);
         VTID GetUserPreferenceCharsetId() const noexcept;
         size_t GetUserPreferenceCharsetSize() const noexcept;

--- a/src/terminal/adapter/terminalOutput.hpp
+++ b/src/terminal/adapter/terminalOutput.hpp
@@ -23,7 +23,7 @@ namespace Microsoft::Console::VirtualTerminal
     class TerminalOutput sealed
     {
     public:
-        TerminalOutput(const bool grEnabled = false) noexcept;
+        TerminalOutput(const bool grEnabled = false, const VTID drcsId = 0, const std::wstring_view drcsTranslationTable = {}) noexcept;
 
         void SoftReset() noexcept;
         void RestoreFrom(const TerminalOutput& savedState) noexcept;

--- a/src/terminal/adapter/terminalOutput.hpp
+++ b/src/terminal/adapter/terminalOutput.hpp
@@ -23,7 +23,7 @@ namespace Microsoft::Console::VirtualTerminal
     class TerminalOutput sealed
     {
     public:
-        TerminalOutput(const bool grEnabled = false, const VTID drcsId = 0, const std::wstring_view drcsTranslationTable = {}) noexcept;
+        TerminalOutput(const bool grEnabled = false) noexcept;
 
         void SoftReset() noexcept;
         void RestoreFrom(const TerminalOutput& savedState) noexcept;


### PR DESCRIPTION
## Summary of the Pull Request

When the terminal performs a soft reset (`DECSTR`), we reinitialize the
`TerminalOutput` class to reset the character set mappings, but in the
process we lose the DRCS state that tracks whether there is a soft font
available. A similar problem occurs when restoring the cursor state with
the `DECRC` sequence. This PR updates the `TerminalOutput` class's soft
reset and restore implementations to fix these issues.

## References and Relevant Issues

The original DRCS support was added in PR #10011. The soft reset of the
character sets was changed in PR #16547, but as far as I can tell this
would have already been broken in the initial implementation.

## Detailed Description of the Pull Request / Additional comments

I realized I could simplify the issue, by first reimplementing the
`SoftReset` method as a call to `Restore` with a fresh instance of the
class (although initialized with the active GR translation state, since
we don't want to lose that either). It then becomes the responsibility
of the `Restore` method to preserve the DRCS state after it replaces
everything else.

We can't just preserve the `_drcsId` and `_drcsTranslationTable` fields
though. We also need to handle the case where the DRCS font is replacing
one of the restored G-sets. But this can be achieved just by calling one
of the `SetDrcsDesignation` methods, exactly as if the font was being
newly downloaded.

## Validation Steps Performed

I've manually verified that the test case in #20581 is now working as
expected in OpenConsole. I've also added unit tests that confirm that
`DECSTR` resets the character sets as expected, and `DECRC` restores the
character sets as expected, but they also both preserve the soft font if
one has been defined.

## PR Checklist
- [x] Closes #20581
