### PR TITLE
Invalidate the entire viewport when the system resumes from standby

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -46,6 +46,7 @@ APCA
 APCs
 APIENTRY
 apiset
+APMRESUMEAUTOMATIC
 APPBARDATA
 appcontainer
 appletname
@@ -738,6 +739,7 @@ hostlib
 HPA
 hpcon
 hpen
+HPOWERNOTIFY
 HPR
 HProvider
 HREDRAW

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -4,6 +4,7 @@
 #include "precomp.h"
 #include "renderer.hpp"
 
+#include <powrprof.h>
 #include <til/atomic.h>
 
 using namespace Microsoft::Console::Render;
@@ -34,11 +35,38 @@ Renderer::Renderer(RenderSettings& renderSettings, IRenderData* pData) :
         renderer._renderSettings.ToggleBlinkRendition();
         renderer.TriggerRedrawAll();
     });
+
+    DEVICE_NOTIFY_SUBSCRIBE_PARAMETERS params{
+        .Callback = &s_suspendResumeCallback,
+        .Context = this,
+    };
+    LOG_IF_WIN32_ERROR(PowerRegisterSuspendResumeNotification(DEVICE_NOTIFY_CALLBACK, &params, &_suspendResumeNotification));
 }
 
 Renderer::~Renderer()
 {
+    // This blocks until any in-flight callback has returned,
+    // so it must happen before we tear the rest of us down.
+    if (_suspendResumeNotification)
+    {
+        LOG_IF_WIN32_ERROR(PowerUnregisterSuspendResumeNotification(_suspendResumeNotification));
+    }
     TriggerTeardown();
+}
+
+// The contents of our swap chain buffers may not survive a suspend/resume cycle, while the
+// driver doesn't necessarily raise a device-loss error either. Engines which only present
+// partial dirty regions would then composite them onto stale, undefined buffer contents.
+// Queue a full invalidation for the next frame instead. (GH#20606)
+ULONG CALLBACK Renderer::s_suspendResumeCallback(void* context, ULONG type, void* /*setting*/) noexcept
+{
+    if (type == PBT_APMRESUMEAUTOMATIC)
+    {
+        const auto renderer = static_cast<Renderer*>(context);
+        renderer->_resumeRedrawQueued.store(true, std::memory_order_relaxed);
+        renderer->NotifyPaintFrame();
+    }
+    return ERROR_SUCCESS;
 }
 
 IRenderData* Renderer::GetRenderData() const noexcept
@@ -401,6 +429,14 @@ DWORD Renderer::_timerToMillis(TimerRepr t) noexcept
         // We do it before the remaining code below so that if we do have an
         // intentional call to NotifyPaintFrame(), it triggers a redraw.
         _redraw.store(false, std::memory_order_relaxed);
+
+        if (_resumeRedrawQueued.exchange(false, std::memory_order_relaxed))
+        {
+            for (const auto pEngine : _engines)
+            {
+                LOG_IF_FAILED(pEngine->InvalidateAll());
+            }
+        }
 
         // NOTE: _CheckViewportAndScroll() updates _viewport which is used by all other functions.
         _CheckViewportAndScroll();

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -98,6 +98,7 @@ namespace Microsoft::Console::Render
 
         // Base rendering loop
         static DWORD WINAPI s_renderThread(void*) noexcept;
+        static ULONG CALLBACK s_suspendResumeCallback(void* context, ULONG type, void* setting) noexcept;
         DWORD _renderThread() noexcept;
         void _waitUntilCanRender() noexcept;
 
@@ -147,7 +148,9 @@ namespace Microsoft::Console::Render
         wil::unique_handle _thread;
         wil::slim_event_manual_reset _enable;
         std::atomic<bool> _redraw;
+        std::atomic<bool> _resumeRedrawQueued{ false };
         std::atomic<bool> _threadKeepRunning{ false };
+        HPOWERNOTIFY _suspendResumeNotification = nullptr;
         til::small_vector<IRenderEngine*, 2> _engines;
         til::small_vector<TimerRoutine, 4> _timers;
         size_t _nextTimerId = 0;


### PR DESCRIPTION
## Summary of the Pull Request

After the system resumes from standby, the renderer can show stale "ghost" regions: duplicated lines at wrong offsets, fragments of older frames, doubled UI boxes. This happens because swap chain buffer contents may not survive a suspend/resume cycle while the driver does not necessarily raise a device-loss error either (observed repeatedly on Qualcomm Adreno / ARM64 / Modern Standby). Engines which only present partial dirty regions then composite them onto stale, undefined buffer contents.

This PR registers a suspend/resume notification (`PowerRegisterSuspendResumeNotification`, callback-based, no HWND required, so it covers both conhost and Windows Terminal) in `Renderer`. The callback only sets an atomic flag and wakes the render thread; the render thread itself performs `InvalidateAll()` on all engines on the next frame, mirroring what `_recreateBackend()` already does for reported device loss.

## References and Relevant Issues

#20606

## Detailed Description of the Pull Request / Additional comments

- The callback is registered in the `Renderer` constructor and unregistered first thing in the destructor (`PowerUnregisterSuspendResumeNotification` blocks until in-flight callbacks return, so it must precede teardown).
- The callback does no rendering work itself: it stores a relaxed atomic and calls `NotifyPaintFrame()`. The flag is consumed in `_PaintFrame()` under the console lock, right after `_redraw` is reset, so the invalidation happens on the render thread with no new synchronization.
- `PBT_APMRESUMEAUTOMATIC` is used because it fires on every wake, including unattended ones; `PBT_APMRESUMESUSPEND` only fires for user-initiated wakes.

## Validation Steps Performed

- Built `Host.EXE` (and its dependency tree, including `renderer/base` and `atlas`) for ARM64/Release with VS2022 Build Tools (v143); the built `OpenConsole.exe` launches and exits cleanly, i.e. registration/unregistration work.
- Verified with a standalone probe binary on the affected hardware (Snapdragon X Elite, Modern Standby) that the callback-based `PowerRegisterSuspendResumeNotification` receives `PBT_APMRESUMEAUTOMATIC` on wake. I will follow up with real standby-cycle results from the affected machine.
- On this machine, the same symptom is currently kept away by `"rendering.disablePartialInvalidation": true`, which supports the stale-partial-present diagnosis.

## PR Checklist
- [x] Closes #20606
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Schema updated (if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn1M6AXu7y2oginqHvKsGo
