### PR TITLE
Remove em-dash usage

### DIFF
--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -250,9 +250,9 @@ public:
                 !singleLine || blockSelection,
 
                 /* trimTrailingWhitespace */
-                // Trim trailing whitespace if we're not in single line mode and — either
-                // we're not in block selection mode or, we're in block selection mode and
-                // trimming is allowed.
+                // Trim trailing whitespace if we're not in single line mode and either
+                // 1. we're not in block selection mode or
+                // 2. we're in block selection mode and trimming is allowed
                 !singleLine && (!blockSelection || trimBlockSelection),
 
                 /* formatWrappedRows */

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -898,7 +898,7 @@ namespace winrt::TerminalApp::implementation
     // Ask the WindowEmperor (in-process) to open or summon a named window,
     // restoring its persisted workspace if one exists. The event bubbles up
     // through TerminalWindow to AppHost, which calls into the WindowEmperor
-    // directly — no second wt.exe process is launched.
+    // directly. No second wt.exe process is launched.
     void TerminalPage::_OpenWorkspaceWindow(const winrt::hstring name)
     {
         const auto args = winrt::make<implementation::OpenWindowRequestedArgs>(name);
@@ -928,7 +928,7 @@ namespace winrt::TerminalApp::implementation
 
         // If this is a NewTerminalArgs, resolve its profile up-front so the
         // spawned window doesn't need to re-resolve it. Other content types
-        // (e.g. scratchpad) don't have profiles to evaluate — they get passed
+        // (e.g. scratchpad) don't have profiles to evaluate and get passed
         // through as-is.
         if (const auto terminalArgs{ newContentArgs.try_as<NewTerminalArgs>() })
         {

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -1079,7 +1079,7 @@ int AppCommandlineArgs::ParseArgs(winrt::array_view<const winrt::hstring> args)
     }
 
     // When a toast notification is clicked, Windows may launch a new instance
-    // with "--from-toast" as the argument. This is a no-op sentinel — the
+    // with "--from-toast" as the argument. This is a no-op sentinel. The
     // in-process Activated handler on the toast already handled activation.
     // See DesktopNotification.cpp for more details.
     if (args.size() == 2 && args[1] == L"--from-toast")

--- a/src/cascadia/TerminalApp/DesktopNotification.cpp
+++ b/src/cascadia/TerminalApp/DesktopNotification.cpp
@@ -29,7 +29,7 @@ namespace winrt::TerminalApp::implementation
             return false;
         }
 
-        // Attempt to update; if another thread beat us, that's fine — we'll skip this one.
+        // Attempt to update; if another thread beat us, that's fine. We'll skip this one.
         return _lastNotificationTime.compare_exchange_strong(last, now, std::memory_order_relaxed);
     }
 

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -843,7 +843,7 @@ namespace winrt::TerminalApp::implementation
                 const auto weak = get_weak();
 
                 // Check if we should warn before closing a single pane
-                // (only triggers on Always — Automatic doesn't warn for single pane)
+                // (only triggers on Always. Automatic doesn't warn for single pane)
                 const auto setting = _settings.GlobalSettings().ConfirmOnClose();
                 if (setting == ConfirmOnClose::Always)
                 {

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2391,9 +2391,9 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::PersistState()
     {
         // There are two persistence mechanisms in play here:
-        //   * PersistedWindowLayouts (vector) — consumed on next startup to
+        //   * PersistedWindowLayouts (vector): consumed on next startup to
         //     re-open a matching set of windows. Cleared after restore.
-        //   * PersistedWorkspaces (name-keyed map) — the full tab/buffer
+        //   * PersistedWorkspaces (name-keyed map): the full tab/buffer
         //     state of a named window, claimed by name on demand via
         //     ApplicationState::TakeWorkspace.
         //

--- a/src/cascadia/UnitTests_SettingsModel/ApplicationStateTests.cpp
+++ b/src/cascadia/UnitTests_SettingsModel/ApplicationStateTests.cpp
@@ -125,8 +125,8 @@ namespace SettingsModelUnitTests
         const auto taken = state->TakeWorkspace(L"win1");
         VERIFY_IS_NOT_NULL(taken);
 
-        // Subsequent Take for the same name must return null — this is the
-        // atomicity guarantee the startup path relies on.
+        // Subsequent Take for the same name must return null.
+        // This is the atomicity guarantee the startup path relies on.
         VERIFY_IS_NULL(state->TakeWorkspace(L"win1"));
     }
 


### PR DESCRIPTION
Removes most of the em-dashes in our repo. Any related to the Settings UI are covered in #20336.