### PR TITLE
Fix context menu crash after split pane submenu

### DIFF
--- a/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
@@ -84,6 +84,7 @@ namespace TerminalAppLocalTests
         TEST_METHOD(CloseZoomedPane);
 
         TEST_METHOD(SwapPanes);
+        TEST_METHOD(ContextMenuUsesMenuFlyoutsForSplitAndSwapPane);
 
         TEST_METHOD(NextMRUTab);
         TEST_METHOD(VerifyCommandPaletteTabSwitcherOrder);
@@ -1042,6 +1043,53 @@ namespace TerminalAppLocalTests
             // Inspect the tree to make sure we swapped
             VERIFY_ARE_EQUAL(fourthId, tab->_rootPane->_secondChild->_secondChild->Id().value());
             VERIFY_ARE_EQUAL(thirdId, tab->_rootPane->_secondChild->_firstChild->Id().value());
+        });
+    }
+
+    void TabTests::ContextMenuUsesMenuFlyoutsForSplitAndSwapPane()
+    {
+        auto page = _commonSetup();
+
+        TestOnUIThread([&page]() {
+            Log::Comment(L"Create a second pane so Swap pane is present.");
+            page->_SplitPane(nullptr, SplitDirection::Right, 0.5f, page->_MakePane(nullptr, page->_GetFocusedTab(), nullptr));
+
+            const auto activeControl{ page->_GetActiveControl() };
+            VERIFY_IS_NOT_NULL(activeControl);
+
+            winrt::Microsoft::UI::Xaml::Controls::CommandBarFlyout contextMenu{};
+            page->_PopulateContextMenu(activeControl, contextMenu, false);
+
+            bool foundSplitPane = false;
+            bool foundSwapPane = false;
+
+            for (const auto& command : contextMenu.SecondaryCommands())
+            {
+                if (const auto button{ command.try_as<AppBarButton>() })
+                {
+                    if (button.Label() == RS_(L"SplitPaneText"))
+                    {
+                        foundSplitPane = true;
+                        const auto flyout{ button.Flyout() };
+                        const auto menuFlyout{ flyout.try_as<MenuFlyout>() };
+                        VERIFY_IS_NOT_NULL(menuFlyout);
+                        VERIFY_IS_GREATER_THAN(menuFlyout.Items().Size(), 0u);
+                        VERIFY_IS_NOT_NULL(menuFlyout.Items().GetAt(0).try_as<MenuFlyoutSubItem>());
+                    }
+                    else if (button.Label() == RS_(L"SwapPaneText"))
+                    {
+                        foundSwapPane = true;
+                        const auto flyout{ button.Flyout() };
+                        const auto menuFlyout{ flyout.try_as<MenuFlyout>() };
+                        VERIFY_IS_NOT_NULL(menuFlyout);
+                        VERIFY_IS_GREATER_THAN(menuFlyout.Items().Size(), 0u);
+                        VERIFY_IS_NOT_NULL(menuFlyout.Items().GetAt(0).try_as<MenuFlyoutItem>());
+                    }
+                }
+            }
+
+            VERIFY_IS_TRUE(foundSplitPane);
+            VERIFY_IS_TRUE(foundSwapPane);
         });
     }
 

--- a/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
@@ -84,7 +84,6 @@ namespace TerminalAppLocalTests
         TEST_METHOD(CloseZoomedPane);
 
         TEST_METHOD(SwapPanes);
-        TEST_METHOD(ContextMenuUsesMenuFlyoutsForSplitAndSwapPane);
 
         TEST_METHOD(NextMRUTab);
         TEST_METHOD(VerifyCommandPaletteTabSwitcherOrder);
@@ -1043,53 +1042,6 @@ namespace TerminalAppLocalTests
             // Inspect the tree to make sure we swapped
             VERIFY_ARE_EQUAL(fourthId, tab->_rootPane->_secondChild->_secondChild->Id().value());
             VERIFY_ARE_EQUAL(thirdId, tab->_rootPane->_secondChild->_firstChild->Id().value());
-        });
-    }
-
-    void TabTests::ContextMenuUsesMenuFlyoutsForSplitAndSwapPane()
-    {
-        auto page = _commonSetup();
-
-        TestOnUIThread([&page]() {
-            Log::Comment(L"Create a second pane so Swap pane is present.");
-            page->_SplitPane(nullptr, SplitDirection::Right, 0.5f, page->_MakePane(nullptr, page->_GetFocusedTab(), nullptr));
-
-            const auto activeControl{ page->_GetActiveControl() };
-            VERIFY_IS_NOT_NULL(activeControl);
-
-            winrt::Microsoft::UI::Xaml::Controls::CommandBarFlyout contextMenu{};
-            page->_PopulateContextMenu(activeControl, contextMenu, false);
-
-            bool foundSplitPane = false;
-            bool foundSwapPane = false;
-
-            for (const auto& command : contextMenu.SecondaryCommands())
-            {
-                if (const auto button{ command.try_as<AppBarButton>() })
-                {
-                    if (button.Label() == RS_(L"SplitPaneText"))
-                    {
-                        foundSplitPane = true;
-                        const auto flyout{ button.Flyout() };
-                        const auto menuFlyout{ flyout.try_as<MenuFlyout>() };
-                        VERIFY_IS_NOT_NULL(menuFlyout);
-                        VERIFY_IS_GREATER_THAN(menuFlyout.Items().Size(), 0u);
-                        VERIFY_IS_NOT_NULL(menuFlyout.Items().GetAt(0).try_as<MenuFlyoutSubItem>());
-                    }
-                    else if (button.Label() == RS_(L"SwapPaneText"))
-                    {
-                        foundSwapPane = true;
-                        const auto flyout{ button.Flyout() };
-                        const auto menuFlyout{ flyout.try_as<MenuFlyout>() };
-                        VERIFY_IS_NOT_NULL(menuFlyout);
-                        VERIFY_IS_GREATER_THAN(menuFlyout.Items().Size(), 0u);
-                        VERIFY_IS_NOT_NULL(menuFlyout.Items().GetAt(0).try_as<MenuFlyoutItem>());
-                    }
-                }
-            }
-
-            VERIFY_IS_TRUE(foundSplitPane);
-            VERIFY_IS_TRUE(foundSwapPane);
         });
     }
 

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -195,6 +195,10 @@
   <data name="SplitPaneToolTipText" xml:space="preserve">
     <value>Right click for split directions - right/down/up/left</value>
   </data>
+  <data name="SplitPaneAutomaticText" xml:space="preserve">
+    <value>Automatic</value>
+    <comment>An option in the Split pane context menu that automatically chooses the split direction.</comment>
+  </data>
   <data name="SplitPaneDownText" xml:space="preserve">
     <value>Split pane down</value>
   </data>

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -5584,33 +5584,28 @@ namespace winrt::TerminalApp::implementation
             targetMenu.SecondaryCommands().Append(button);
         };
 
-        auto makeContextItem = [&makeCallback](const winrt::hstring& label,
-                                               const winrt::hstring& icon,
-                                               const winrt::hstring& tooltip,
-                                               const auto& action,
-                                               const auto& subMenu,
-                                               auto& targetMenu) {
-            AppBarButton button{};
+        auto makeMenuFlyoutItem = [&makeCallback](const winrt::hstring& label,
+                                                  const winrt::hstring& icon,
+                                                  const auto& action,
+                                                  auto& targetMenu) {
+            WUX::Controls::MenuFlyoutItem item{};
 
             if (!icon.empty())
             {
                 auto iconElement = UI::IconPathConverter::IconWUX(icon);
                 Automation::AutomationProperties::SetAccessibilityView(iconElement, Automation::Peers::AccessibilityView::Raw);
-                button.Icon(iconElement);
+                item.Icon(iconElement);
             }
 
-            button.Label(label);
-            button.Click(makeCallback(action));
-            WUX::Controls::ToolTipService::SetToolTip(button, box_value(tooltip));
-            button.ContextFlyout(subMenu);
-            targetMenu.SecondaryCommands().Append(button);
+            item.Text(label);
+            item.Click(makeCallback(action));
+            targetMenu.Items().Append(item);
         };
 
         const auto focusedProfile = _GetFocusedTabImpl()->GetFocusedProfile();
-        auto separatorItem = AppBarSeparator{};
         auto activeProfiles = _settings.ActiveProfiles();
         auto activeProfileCount = gsl::narrow_cast<int>(activeProfiles.Size());
-        MUX::Controls::CommandBarFlyout splitPaneMenu{};
+        WUX::Controls::MenuFlyout splitPaneMenu{};
 
         // Wire up each item to the action that should be performed. By actually
         // connecting these to actions, we ensure the implementation is
@@ -5627,20 +5622,41 @@ namespace winrt::TerminalApp::implementation
         const auto splitPaneDownText = RS_(L"SplitPaneDownText");
         const auto splitPaneUpText = RS_(L"SplitPaneUpText");
         const auto splitPaneLeftText = RS_(L"SplitPaneLeftText");
-        const auto splitPaneToolTipText = RS_(L"SplitPaneToolTipText");
+        const auto splitPaneAutomaticText = RS_(L"SplitPaneAutomaticText");
 
-        MUX::Controls::CommandBarFlyout splitPaneContextMenu{};
-        makeItem(splitPaneRightText, focusedProfileIcon, ActionAndArgs{ ShortcutAction::SplitPane, SplitPaneArgs{ SplitType::Duplicate, SplitDirection::Right, .5, nullptr } }, splitPaneContextMenu);
-        makeItem(splitPaneDownText, focusedProfileIcon, ActionAndArgs{ ShortcutAction::SplitPane, SplitPaneArgs{ SplitType::Duplicate, SplitDirection::Down, .5, nullptr } }, splitPaneContextMenu);
-        makeItem(splitPaneUpText, focusedProfileIcon, ActionAndArgs{ ShortcutAction::SplitPane, SplitPaneArgs{ SplitType::Duplicate, SplitDirection::Up, .5, nullptr } }, splitPaneContextMenu);
-        makeItem(splitPaneLeftText, focusedProfileIcon, ActionAndArgs{ ShortcutAction::SplitPane, SplitPaneArgs{ SplitType::Duplicate, SplitDirection::Left, .5, nullptr } }, splitPaneContextMenu);
+        auto makeSplitSubMenu = [&](const winrt::hstring& label,
+                                    const winrt::hstring& icon,
+                                    const SplitType splitType,
+                                    const NewTerminalArgs& args) {
+            WUX::Controls::MenuFlyoutSubItem subMenu{};
 
-        makeContextItem(splitPaneDuplicateText, focusedProfileIcon, splitPaneToolTipText, ActionAndArgs{ ShortcutAction::SplitPane, SplitPaneArgs{ SplitType::Duplicate, SplitDirection::Automatic, .5, nullptr } }, splitPaneContextMenu, splitPaneMenu);
+            if (!icon.empty())
+            {
+                auto iconElement = UI::IconPathConverter::IconWUX(icon);
+                Automation::AutomationProperties::SetAccessibilityView(iconElement, Automation::Peers::AccessibilityView::Raw);
+                subMenu.Icon(iconElement);
+            }
 
-        // add menu separator
-        const auto separatorAutoItem = AppBarSeparator{};
+            subMenu.Text(label);
 
-        splitPaneMenu.SecondaryCommands().Append(separatorAutoItem);
+            WUX::Controls::MenuFlyoutItem autoItem{};
+            autoItem.Text(splitPaneAutomaticText);
+            autoItem.Click(makeCallback(ActionAndArgs{ ShortcutAction::SplitPane, SplitPaneArgs{ splitType, SplitDirection::Automatic, .5, args } }));
+            subMenu.Items().Append(autoItem);
+
+            subMenu.Items().Append(WUX::Controls::MenuFlyoutSeparator{});
+
+            makeMenuFlyoutItem(splitPaneRightText, L"", ActionAndArgs{ ShortcutAction::SplitPane, SplitPaneArgs{ splitType, SplitDirection::Right, .5, args } }, subMenu);
+            makeMenuFlyoutItem(splitPaneDownText, L"", ActionAndArgs{ ShortcutAction::SplitPane, SplitPaneArgs{ splitType, SplitDirection::Down, .5, args } }, subMenu);
+            makeMenuFlyoutItem(splitPaneUpText, L"", ActionAndArgs{ ShortcutAction::SplitPane, SplitPaneArgs{ splitType, SplitDirection::Up, .5, args } }, subMenu);
+            makeMenuFlyoutItem(splitPaneLeftText, L"", ActionAndArgs{ ShortcutAction::SplitPane, SplitPaneArgs{ splitType, SplitDirection::Left, .5, args } }, subMenu);
+
+            splitPaneMenu.Items().Append(subMenu);
+        };
+
+        makeSplitSubMenu(splitPaneDuplicateText, focusedProfileIcon, SplitType::Duplicate, nullptr);
+
+        splitPaneMenu.Items().Append(WUX::Controls::MenuFlyoutSeparator{});
 
         for (auto profileIndex = 0; profileIndex < activeProfileCount; profileIndex++)
         {
@@ -5651,13 +5667,7 @@ namespace winrt::TerminalApp::implementation
             NewTerminalArgs args{};
             args.Profile(profileName);
 
-            MUX::Controls::CommandBarFlyout splitPaneContextMenu{};
-            makeItem(splitPaneRightText, profileIcon, ActionAndArgs{ ShortcutAction::SplitPane, SplitPaneArgs{ SplitType::Manual, SplitDirection::Right, .5, args } }, splitPaneContextMenu);
-            makeItem(splitPaneDownText, profileIcon, ActionAndArgs{ ShortcutAction::SplitPane, SplitPaneArgs{ SplitType::Manual, SplitDirection::Down, .5, args } }, splitPaneContextMenu);
-            makeItem(splitPaneUpText, profileIcon, ActionAndArgs{ ShortcutAction::SplitPane, SplitPaneArgs{ SplitType::Manual, SplitDirection::Up, .5, args } }, splitPaneContextMenu);
-            makeItem(splitPaneLeftText, profileIcon, ActionAndArgs{ ShortcutAction::SplitPane, SplitPaneArgs{ SplitType::Manual, SplitDirection::Left, .5, args } }, splitPaneContextMenu);
-
-            makeContextItem(profileName, profileIcon, splitPaneToolTipText, ActionAndArgs{ ShortcutAction::SplitPane, SplitPaneArgs{ SplitType::Manual, SplitDirection::Automatic, .5, args } }, splitPaneContextMenu, splitPaneMenu);
+            makeSplitSubMenu(profileName, profileIcon, SplitType::Manual, args);
         }
 
         makeMenuItem(RS_(L"SplitPaneText"), L"\xF246", splitPaneMenu, menu);
@@ -5665,7 +5675,7 @@ namespace winrt::TerminalApp::implementation
         // Only wire up "Close Pane" if there's multiple panes.
         if (_GetFocusedTabImpl()->GetLeafPaneCount() > 1)
         {
-            MUX::Controls::CommandBarFlyout swapPaneMenu{};
+            WUX::Controls::MenuFlyout swapPaneMenu{};
             const auto rootPane = _GetFocusedTabImpl()->GetRootPane();
             const auto mruPanes = _GetFocusedTabImpl()->GetMruPanes();
             auto activePane = _GetFocusedTabImpl()->GetActivePane();
@@ -5681,22 +5691,22 @@ namespace winrt::TerminalApp::implementation
 
             if (auto neighbor = rootPane->NavigateDirection(activePane, FocusDirection::Down, mruPanes))
             {
-                makeItem(RS_(L"SwapPaneDownText"), neighbor->GetProfile().Icon().Resolved(), ActionAndArgs{ ShortcutAction::SwapPane, SwapPaneArgs{ FocusDirection::Down } }, swapPaneMenu);
+                makeMenuFlyoutItem(RS_(L"SwapPaneDownText"), neighbor->GetProfile().Icon().Resolved(), ActionAndArgs{ ShortcutAction::SwapPane, SwapPaneArgs{ FocusDirection::Down } }, swapPaneMenu);
             }
 
             if (auto neighbor = rootPane->NavigateDirection(activePane, FocusDirection::Right, mruPanes))
             {
-                makeItem(RS_(L"SwapPaneRightText"), neighbor->GetProfile().Icon().Resolved(), ActionAndArgs{ ShortcutAction::SwapPane, SwapPaneArgs{ FocusDirection::Right } }, swapPaneMenu);
+                makeMenuFlyoutItem(RS_(L"SwapPaneRightText"), neighbor->GetProfile().Icon().Resolved(), ActionAndArgs{ ShortcutAction::SwapPane, SwapPaneArgs{ FocusDirection::Right } }, swapPaneMenu);
             }
 
             if (auto neighbor = rootPane->NavigateDirection(activePane, FocusDirection::Up, mruPanes))
             {
-                makeItem(RS_(L"SwapPaneUpText"), neighbor->GetProfile().Icon().Resolved(), ActionAndArgs{ ShortcutAction::SwapPane, SwapPaneArgs{ FocusDirection::Up } }, swapPaneMenu);
+                makeMenuFlyoutItem(RS_(L"SwapPaneUpText"), neighbor->GetProfile().Icon().Resolved(), ActionAndArgs{ ShortcutAction::SwapPane, SwapPaneArgs{ FocusDirection::Up } }, swapPaneMenu);
             }
 
             if (auto neighbor = rootPane->NavigateDirection(activePane, FocusDirection::Left, mruPanes))
             {
-                makeItem(RS_(L"SwapPaneLeftText"), neighbor->GetProfile().Icon().Resolved(), ActionAndArgs{ ShortcutAction::SwapPane, SwapPaneArgs{ FocusDirection::Left } }, swapPaneMenu);
+                makeMenuFlyoutItem(RS_(L"SwapPaneLeftText"), neighbor->GetProfile().Icon().Resolved(), ActionAndArgs{ ShortcutAction::SwapPane, SwapPaneArgs{ FocusDirection::Left } }, swapPaneMenu);
             }
 
             makeMenuItem(RS_(L"SwapPaneText"), L"\xF1CB", swapPaneMenu, menu);

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -5639,11 +5639,11 @@ namespace winrt::TerminalApp::implementation
 
             subMenu.Text(label);
 
+            // A MenuFlyoutSubItem can't be clicked, so the automatic split is an explicit entry.
             WUX::Controls::MenuFlyoutItem autoItem{};
             autoItem.Text(splitPaneAutomaticText);
             autoItem.Click(makeCallback(ActionAndArgs{ ShortcutAction::SplitPane, SplitPaneArgs{ splitType, SplitDirection::Automatic, .5, args } }));
             subMenu.Items().Append(autoItem);
-
             subMenu.Items().Append(WUX::Controls::MenuFlyoutSeparator{});
 
             makeMenuFlyoutItem(splitPaneRightText, L"", ActionAndArgs{ ShortcutAction::SplitPane, SplitPaneArgs{ splitType, SplitDirection::Right, .5, args } }, subMenu);


### PR DESCRIPTION
## Summary of the Pull Request

Fixes the context menu crash reported in #20570 after interacting with the Split pane submenu and collapsing/re-expanding the root menu.

This replaces the nested `CommandBarFlyout` child menus with standard `MenuFlyout` controls.

## References and Relevant Issues

Closes #20570

Related: #20332

The repro from #20332 also no longer occurs on the patched build.

## Detailed Description of the Pull Request / Additional comments

- Replaces the nested Split pane and Swap pane `CommandBarFlyout` menus with `MenuFlyout`.
- Uses `MenuFlyoutSubItem` for duplicate/profile split entries, with an explicit `Automatic` option followed by the directional split options.
- Keeps the top-level context menu as a `CommandBarFlyout`.
- Adds the localized `Automatic` label.
- Adds a structural regression test verifying the Split and Swap child flyout types.

## Validation Steps Performed

- `ContextMenuUsesMenuFlyoutsForSplitAndSwapPane`: 1 passed, 0 failed.
- Full `TabTests`: 22 passed, 0 failed, 0 blocked, 0 skipped.
- `CascadiaPackage` Debug x64: built successfully (0 errors).
- `CascadiaPackage` Release x64: built successfully (0 errors).
- Re-tested the exact #20570 repro manually; the crash no longer reproduces.
- Verified Automatic split, directional split, profile split, Swap pane, and dismiss/reopen behavior.
- Re-tested the #20332 repro; it no longer reproduces on the patched build.

### Video

https://github.com/user-attachments/assets/69b71054-1740-4b29-aa22-c13f9f50a289


## PR Checklist
- [x] Closes #20570
- [x] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)