### PR TITLE
Propagate foreground rights through the handoff chain

### DIFF
--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -1426,10 +1426,6 @@ void IslandWindow::_globalActivateWindow(const uint32_t dropdownDuration,
     // will be the foreground window.
     const auto oldForegroundWindow = GetForegroundWindow();
 
-    // From: https://stackoverflow.com/a/59659421
-    // > The trick is to make windows ‘think’ that our process and the target
-    // > window (hwnd) are related by attaching the threads (using
-    // > AttachThreadInput API) and using an alternative API: BringWindowToTop.
     // If the window is minimized, then restore it. We don't want to do this
     // always though, because if you SW_RESTORE a maximized window, it will
     // restore-down the window.
@@ -1457,31 +1453,24 @@ void IslandWindow::_globalActivateWindow(const uint32_t dropdownDuration,
     }
     else
     {
-        // Try first to send a message to the current foreground window. If it's not responding, it may
-        // be waiting on us to finish launching. Passing SMTO_NOTIMEOUTIFNOTHUNG means that we get the same
-        // behavior as before--that is, waiting for the message loop--but we've done an early return if
-        // it turns out that it was hung.
-        // SendMessageTimeoutW returns nonzero if it succeeds.
-        if (0 != SendMessageTimeoutW(oldForegroundWindow, WM_NULL, 0, 0, SMTO_NOTIMEOUTIFNOTHUNG | SMTO_BLOCK | SMTO_ABORTIFHUNG, 1000, nullptr))
-        {
-            const auto windowThreadProcessId = GetWindowThreadProcessId(oldForegroundWindow, nullptr);
-            const auto currentThreadId = GetCurrentThreadId();
+        LOG_IF_WIN32_BOOL_FALSE(BringWindowToTop(_window.get()));
+        ShowWindow(_window.get(), SW_SHOW);
 
-            LOG_IF_WIN32_BOOL_FALSE(AttachThreadInput(windowThreadProcessId, currentThreadId, true));
-            // Just in case, add the thread detach as a scope_exit, to make _sure_ we do it.
-            auto detachThread = wil::scope_exit([windowThreadProcessId, currentThreadId]() {
-                LOG_IF_WIN32_BOOL_FALSE(AttachThreadInput(windowThreadProcessId, currentThreadId, false));
-            });
-            LOG_IF_WIN32_BOOL_FALSE(BringWindowToTop(_window.get()));
-            ShowWindow(_window.get(), SW_SHOW);
+        // Activate the window too. This will force us to the virtual desktop this
+        // window is on, if it's on another virtual desktop.
+        LOG_LAST_ERROR_IF_NULL(SetActiveWindow(_window.get()));
 
-            // Activate the window too. This will force us to the virtual desktop this
-            // window is on, if it's on another virtual desktop.
-            LOG_LAST_ERROR_IF_NULL(SetActiveWindow(_window.get()));
+        // Throw us on the active monitor.
+        _moveToMonitor(oldForegroundWindow, toMonitor);
+    }
 
-            // Throw us on the active monitor.
-            _moveToMonitor(oldForegroundWindow, toMonitor);
-        }
+    // Foreground rights are propagated through the launch and handoff paths,
+    // so activation does not need to synchronize with another input queue.
+    if (!SetForegroundWindow(_window.get()))
+    {
+        TraceLoggingWrite(g_hWindowsTerminalProvider,
+                          "ActivateSetForegroundWindowFailed",
+                          TraceLoggingWinError(GetLastError(), "error"));
     }
 }
 

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -181,7 +181,13 @@ static wil::unique_mutex acquireMutexOrAttemptHandoff(const wchar_t* className, 
             DWORD processId = 0;
             if (GetWindowThreadProcessId(hwnd, &processId) && processId)
             {
-                AllowSetForegroundWindow(processId);
+                if (!AllowSetForegroundWindow(processId))
+                {
+                    TraceLoggingWrite(g_hWindowsTerminalProvider,
+                                      "EmperorAllowSetForegroundWindowFailed",
+                                      TraceLoggingPid(processId),
+                                      TraceLoggingWinError(GetLastError(), "error"));
+                }
             }
 
             if (SendMessageTimeoutW(hwnd, WM_COPYDATA, 0, reinterpret_cast<LPARAM>(&cds), SMTO_ABORTIFHUNG | SMTO_ERRORONEXIT, 5000, nullptr))

--- a/src/cascadia/wt/shim.cpp
+++ b/src/cascadia/wt/shim.cpp
@@ -6,10 +6,22 @@
 #include <wil/stl.h>
 #include <wil/resource.h>
 #include <wil/win32_helpers.h>
+#include <TraceLoggingProvider.h>
+
+TRACELOGGING_DEFINE_PROVIDER(
+    g_hShimProvider,
+    "Microsoft.Windows.Terminal.Shim",
+    // tl:{d295502a-ab39-5565-c342-6e6d7659a422}
+    (0xd295502a, 0xab39, 0x5565, 0xc3, 0x42, 0x6e, 0x6d, 0x76, 0x59, 0xa4, 0x22));
 
 #pragma warning(suppress : 26461) // we can't change the signature of wWinMain
 int __stdcall wWinMain(HINSTANCE, HINSTANCE, LPWSTR pCmdLine, int)
 {
+    TraceLoggingRegister(g_hShimProvider);
+    const auto unregisterProvider = wil::scope_exit([]() {
+        TraceLoggingUnregister(g_hShimProvider);
+    });
+
     std::filesystem::path module{ wil::GetModuleFileNameW<std::wstring>(nullptr) };
 
     // Cache our name (wt, wtd)
@@ -32,5 +44,31 @@ int __stdcall wWinMain(HINSTANCE, HINSTANCE, LPWSTR pCmdLine, int)
 
     // Go!
     wil::unique_process_information pi;
-    return !CreateProcessW(module.c_str(), cmdline.data(), nullptr, nullptr, FALSE, 0, nullptr, nullptr, &si, &pi);
+    if (!CreateProcessW(module.c_str(), cmdline.data(), nullptr, nullptr, FALSE, CREATE_SUSPENDED, nullptr, nullptr, &si, &pi))
+    {
+        return 1;
+    }
+
+    // Transfer any foreground right before the child gets a chance to hand off
+    // to an existing Terminal process.
+    if (!AllowSetForegroundWindow(pi.dwProcessId))
+    {
+        TraceLoggingWrite(g_hShimProvider,
+                          "ShimAllowSetForegroundWindowFailed",
+                          TraceLoggingPid(pi.dwProcessId, "processId"),
+                          TraceLoggingWinError(GetLastError(), "error"));
+    }
+
+    if (ResumeThread(pi.hThread) == static_cast<DWORD>(-1))
+    {
+        const auto error = GetLastError();
+        TerminateProcess(pi.hProcess, error);
+        TraceLoggingWrite(g_hShimProvider,
+                          "ShimResumeThreadFailed",
+                          TraceLoggingPid(pi.dwProcessId, "processId"),
+                          TraceLoggingWinError(error, "error"));
+        return 1;
+    }
+
+    return 0;
 }

--- a/src/host/exe/Host.EXE.vcxproj
+++ b/src/host/exe/Host.EXE.vcxproj
@@ -88,7 +88,7 @@
     <Link>
       <AllowIsolation>true</AllowIsolation>
       <AdditionalDependencies>winmm.lib;imm32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <DelayLoadDLLs>icu.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <DelayLoadDLLs>ext-ms-win-com-ole32-l1.dll;icu.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <!-- Careful reordering these. Some default props (contained in these files) are order sensitive. -->

--- a/src/host/srvinit.cpp
+++ b/src/host/srvinit.cpp
@@ -547,6 +547,16 @@ try
 
     myStartupInfo.wShowWindow = settings.GetShowWindow();
 
+    // Preserve an inherited foreground grant across the COM handoff when the
+    // API is available on this version of Windows.
+    if (IsApiSetImplemented("ext-ms-win-com-ole32-l1-1-1"))
+    {
+        const auto hr = CoAllowSetForegroundWindow(handoff.Get(), nullptr);
+        TraceLoggingWrite(g_hConhostV2EventTraceProvider,
+                          "PtyHandoffAllowSetForegroundWindow",
+                          TraceLoggingHResult(hr));
+    }
+
     wil::unique_handle inPipeOurSide;
     wil::unique_handle outPipeOurSide;
     RETURN_IF_FAILED(handoff->EstablishPtyHandoff(inPipeOurSide.addressof(),


### PR DESCRIPTION
Closes #19749.

The activation path currently probes the old foreground window with `SendMessageTimeoutW` before attaching its input queue. If that window is synchronously waiting for Terminal to launch, Windows can keep the call alive until its hung-window threshold, producing the reported delay.

This carries foreground authority through the launch and handoff chain instead:

- the `wt` shim creates Windows Terminal suspended, grants it foreground rights, then resumes it;
- a new Terminal process grants those rights to an existing instance before the monarch handoff;
- OpenConsole forwards inherited rights across the COM PTY handoff when the API is available; and
- window activation no longer synchronizes with the old foreground input queue and calls `SetForegroundWindow` under the propagated grant.

The shim also terminates the newly created process if `ResumeThread` fails, avoiding a suspended orphan. The COM API-set DLL is delay-loaded to preserve downlevel compatibility.

This implements the repository side of foreground-right propagation. The inbox console-host path still depends on Windows passing its inherited grant to OpenConsole before this code can forward it.

Validation:

- seven focused handoff-order invariants
- MSBuild project XML parsing
- `git diff --check`
