### PR TITLE
Preserve ENHANCED_KEY for direct key events (Alt up, F7 down)

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -385,7 +385,7 @@ namespace winrt::TerminalApp::implementation
     // - Implements the Alt handler
     // Return value:
     // - whether the key was handled
-    bool CommandPalette::OnDirectKeyEvent(const uint32_t vkey, const uint8_t /*scanCode*/, const bool down)
+    bool CommandPalette::OnDirectKeyEvent(const uint32_t vkey, const uint8_t /*scanCode*/, const bool /*extended*/, const bool down)
     {
         auto handled = false;
         if (_currentMode == CommandPaletteMode::TabSwitchMode)

--- a/src/cascadia/TerminalApp/CommandPalette.h
+++ b/src/cascadia/TerminalApp/CommandPalette.h
@@ -34,7 +34,7 @@ namespace winrt::TerminalApp::implementation
         void SetTabs(const Windows::Foundation::Collections::IObservableVector<winrt::TerminalApp::Tab>& tabs, const Windows::Foundation::Collections::IObservableVector<winrt::TerminalApp::Tab>& mruTabs);
         void SetActionMap(const Microsoft::Terminal::Settings::Model::IActionMapView& actionMap);
 
-        bool OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool down);
+        bool OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool extended, const bool down);
 
         void SelectNextItem(const bool moveDown);
 

--- a/src/cascadia/TerminalApp/SuggestionsControl.cpp
+++ b/src/cascadia/TerminalApp/SuggestionsControl.cpp
@@ -460,7 +460,7 @@ namespace winrt::TerminalApp::implementation
     // - Implements the Alt handler
     // Return value:
     // - whether the key was handled
-    bool SuggestionsControl::OnDirectKeyEvent(const uint32_t /*vkey*/, const uint8_t /*scanCode*/, const bool /*down*/)
+    bool SuggestionsControl::OnDirectKeyEvent(const uint32_t /*vkey*/, const uint8_t /*scanCode*/, const bool /*extended*/, const bool /*down*/)
     {
         auto handled = false;
         return handled;

--- a/src/cascadia/TerminalApp/SuggestionsControl.h
+++ b/src/cascadia/TerminalApp/SuggestionsControl.h
@@ -25,7 +25,7 @@ namespace winrt::TerminalApp::implementation
 
         void SetCommands(const Windows::Foundation::Collections::IVector<Microsoft::Terminal::Settings::Model::Command>& actions);
 
-        bool OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool down);
+        bool OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool extended, const bool down);
 
         void SelectNextItem(const bool moveDown);
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1890,7 +1890,7 @@ namespace winrt::TerminalApp::implementation
         e.Handled(true);
     }
 
-    bool TerminalPage::OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool down)
+    bool TerminalPage::OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool /*extended*/, const bool down)
     {
         const auto modifiers = _GetPressedModifierKeys();
         if (vkey == VK_SPACE && modifiers.IsAltPressed() && down)

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -222,7 +222,7 @@ namespace winrt::TerminalApp::implementation
         void WindowActivated(const bool activated);
         bool FocusTab(const winrt::TerminalApp::Tab& tab);
 
-        bool OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool down);
+        bool OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool extended, const bool down);
 
         void AttachContent(Windows::Foundation::Collections::IVector<Microsoft::Terminal::Settings::Model::ActionAndArgs> args, uint32_t tabIndex);
         void SendContentToOther(winrt::TerminalApp::RequestReceiveContentArgs args);

--- a/src/cascadia/TerminalApp/TerminalWindow.cpp
+++ b/src/cascadia/TerminalApp/TerminalWindow.cpp
@@ -910,7 +910,7 @@ namespace winrt::TerminalApp::implementation
     // - Implements the Alt handler (per GH#6421)
     // Return value:
     // - whether the key was handled
-    bool TerminalWindow::OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool down)
+    bool TerminalWindow::OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool extended, const bool down)
     {
         if (_root)
         {
@@ -926,7 +926,7 @@ namespace winrt::TerminalApp::implementation
             {
                 if (auto keyListener{ focusedObject.try_as<UI::IDirectKeyListener>() })
                 {
-                    if (keyListener.OnDirectKeyEvent(vkey, scanCode, down))
+                    if (keyListener.OnDirectKeyEvent(vkey, scanCode, extended, down))
                     {
                         return true;
                     }
@@ -954,7 +954,7 @@ namespace winrt::TerminalApp::implementation
                         {
                             if (auto keyListener{ _root.try_as<UI::IDirectKeyListener>() })
                             {
-                                return keyListener.OnDirectKeyEvent(vkey, scanCode, down);
+                                return keyListener.OnDirectKeyEvent(vkey, scanCode, extended, down);
                             }
                         }
                     }

--- a/src/cascadia/TerminalApp/TerminalWindow.h
+++ b/src/cascadia/TerminalApp/TerminalWindow.h
@@ -119,7 +119,7 @@ namespace winrt::TerminalApp::implementation
 
         hstring Title();
         void TitlebarClicked();
-        bool OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool down);
+        bool OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool extended, const bool down);
 
         void CloseWindow();
         void WindowVisibilityChanged(const bool showOrHide);

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1535,9 +1535,18 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     //   normally. Namely, the keys we're concerned with are F7 down and Alt up.
     // Return value:
     // - Whether the key was handled.
-    bool TermControl::OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool down)
+    bool TermControl::OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool extended, const bool down)
     {
-        const auto modifiers{ _GetPressedModifierKeys() };
+        auto modifiers{ _GetPressedModifierKeys() };
+
+        // GH#18120: Direct key events bypass the regular _KeyHandler path,
+        // which gets the extended-key state from CorePhysicalKeyStatus.
+        // Without this, releasing e.g. RightAlt loses its ENHANCED_KEY flag.
+        if (extended)
+        {
+            modifiers |= ControlKeyStates::EnhancedKey;
+        }
+
         return _KeyHandler(gsl::narrow_cast<WORD>(vkey), gsl::narrow_cast<WORD>(scanCode), modifiers, down);
     }
 

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -144,7 +144,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         bool SearchBoxEditInFocus() const;
 
-        bool OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool down);
+        bool OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool extended, const bool down);
 
         bool OnMouseWheel(const Windows::Foundation::Point location, const winrt::Microsoft::Terminal::Core::Point delta, const bool leftButtonDown, const bool midButtonDown, const bool rightButtonDown);
 

--- a/src/cascadia/TerminalControl/TermControl.idl
+++ b/src/cascadia/TerminalControl/TermControl.idl
@@ -16,7 +16,7 @@ namespace Microsoft.Terminal.Control
     // WinRT is a trip.
     [uuid("0ddf4edc-3fda-4dee-97ca-a417ee3dd510")]
     interface IDirectKeyListener {
-        Boolean OnDirectKeyEvent(UInt32 vkey, UInt8 scanCode, Boolean down);
+        Boolean OnDirectKeyEvent(UInt32 vkey, UInt8 scanCode, Boolean extended, Boolean down);
     }
 
     enum CursorDisplayState

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -48,6 +48,7 @@ namespace TerminalCoreUnitTests
     class TerminalBufferTests;
     class TerminalApiTest;
     class ScrollTest;
+    class InputTest;
 };
 #endif
 
@@ -491,5 +492,6 @@ private:
     friend class TerminalCoreUnitTests::TerminalBufferTests;
     friend class TerminalCoreUnitTests::TerminalApiTest;
     friend class TerminalCoreUnitTests::ScrollTest;
+    friend class TerminalCoreUnitTests::InputTest;
 #endif
 };

--- a/src/cascadia/UIHelpers/IDirectKeyListener.idl
+++ b/src/cascadia/UIHelpers/IDirectKeyListener.idl
@@ -5,6 +5,6 @@ namespace Microsoft.Terminal.UI
 {
     [uuid("0ddf4edc-3fda-4dee-97ca-a417ee3dd510")]
     interface IDirectKeyListener {
-        Boolean OnDirectKeyEvent(UInt32 vkey, UInt8 scanCode, Boolean down);
+        Boolean OnDirectKeyEvent(UInt32 vkey, UInt8 scanCode, Boolean extended, Boolean down);
     }
 }

--- a/src/cascadia/UnitTests_TerminalCore/InputTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/InputTest.cpp
@@ -30,6 +30,7 @@ namespace TerminalCoreUnitTests
 
         TEST_METHOD(AltShiftKey);
         TEST_METHOD(InvalidKeyEvent);
+        TEST_METHOD(Win32KeyEventsRetainEnhancedKey);
 
         Terminal term{ Terminal::TestDummyMarker{} };
     };
@@ -51,5 +52,30 @@ namespace TerminalCoreUnitTests
         // send us key events using SendInput() whose values are outside of the valid range.
         VERIFY_ARE_EQUAL(unhandled(), term.SendKeyEvent(0, 123, {}, true));
         VERIFY_ARE_EQUAL(unhandled(), term.SendKeyEvent(255, 123, {}, true));
+    }
+
+    void InputTest::Win32KeyEventsRetainEnhancedKey()
+    {
+        // Tests GH#18120
+        // In win32-input-mode, both the press and the release of an extended
+        // key (e.g. RightAlt) must encode the ENHANCED_KEY flag (0x100) in the
+        // Cs parameter, so that the client can distinguish RightAlt from LeftAlt.
+        auto& input = term._getTerminalInput();
+        input.SetInputMode(Microsoft::Console::VirtualTerminal::TerminalInput::Mode::Win32, true);
+        const auto restore = wil::scope_exit([&]() {
+            input.SetInputMode(Microsoft::Console::VirtualTerminal::TerminalInput::Mode::Win32, false);
+        });
+
+        // RightAlt down: VK_MENU (18), scanCode 0x38 (56),
+        // Cs = RIGHT_ALT_PRESSED | ENHANCED_KEY = 0x0001 | 0x0100 = 257
+        const auto down = term.SendKeyEvent(VK_MENU, 0x38, ControlKeyStates::RightAltPressed | ControlKeyStates::EnhancedKey, true);
+        VERIFY_IS_TRUE(down.has_value());
+        VERIFY_ARE_EQUAL(L"\x1b[18;56;0;1;257;1_", *down);
+
+        // RightAlt up: the modifier itself is no longer pressed,
+        // but the key release must still carry ENHANCED_KEY = 0x0100 = 256.
+        const auto up = term.SendKeyEvent(VK_MENU, 0x38, ControlKeyStates::EnhancedKey, false);
+        VERIFY_IS_TRUE(up.has_value());
+        VERIFY_ARE_EQUAL(L"\x1b[18;56;0;0;256;1_", *up);
     }
 }

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -84,11 +84,11 @@ AppHost::AppHost(WindowEmperor* manager, const winrt::TerminalApp::AppLogic& log
     QueryPerformanceCounter(&_lastActivatedTime);
 }
 
-bool AppHost::OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool down)
+bool AppHost::OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool extended, const bool down)
 {
     if (_windowLogic)
     {
-        return _windowLogic.OnDirectKeyEvent(vkey, scanCode, down);
+        return _windowLogic.OnDirectKeyEvent(vkey, scanCode, extended, down);
     }
     return false;
 }

--- a/src/cascadia/WindowsTerminal/AppHost.h
+++ b/src/cascadia/WindowsTerminal/AppHost.h
@@ -22,7 +22,7 @@ public:
     IslandWindow* GetWindow() const noexcept;
     winrt::TerminalApp::TerminalWindow Logic();
 
-    bool OnDirectKeyEvent(uint32_t vkey, uint8_t scanCode, bool down);
+    bool OnDirectKeyEvent(uint32_t vkey, uint8_t scanCode, bool extended, bool down);
     void SetTaskbarProgress(const winrt::Windows::Foundation::IInspectable& sender, const winrt::Windows::Foundation::IInspectable& args);
     safe_void_coroutine HandleSummon(winrt::TerminalApp::SummonWindowBehavior args) const;
     void DispatchCommandline(winrt::TerminalApp::CommandlineArgs args);

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -781,8 +781,12 @@ void WindowEmperor::_dispatchSpecialKey(const MSG& msg) const
 
     const auto vkey = gsl::narrow_cast<uint32_t>(msg.wParam);
     const auto scanCode = gsl::narrow_cast<uint8_t>(msg.lParam >> 16);
+    // Bit 24 of lParam indicates an extended key (e.g. RightAlt/RightCtrl).
+    // We need to forward it, so that the key event can be translated to an
+    // INPUT_RECORD with the ENHANCED_KEY flag set (GH#18120).
+    const bool extended = (msg.lParam & 0x01000000) != 0;
     const bool keyDown = (msg.message & 1) == 0;
-    window->OnDirectKeyEvent(vkey, scanCode, keyDown);
+    window->OnDirectKeyEvent(vkey, scanCode, extended, keyDown);
 }
 
 void WindowEmperor::_dispatchCommandline(winrt::TerminalApp::CommandlineArgs args)


### PR DESCRIPTION
## Summary of the Pull Request

`WindowEmperor::_dispatchSpecialKey` intercepts Alt key-up (and F7 key-down) to handle the window menu before XAML sees them. These events get forwarded through `IDirectKeyListener::OnDirectKeyEvent`, but the extended-key bit from `lParam` was dropped along the way. Without it, `TermControl` can't distinguish RightAlt from LeftAlt on release, so a RightAlt key-up produces an `INPUT_RECORD` identical to LeftAlt. The key *press* works fine because it goes through the regular XAML `_KeyHandler` path where `CorePhysicalKeyStatus.IsExtendedKey` is available.

Fix: thread an `extended` bool through the `OnDirectKeyEvent` chain and set `ControlKeyStates::EnhancedKey` when true - same thing the regular key path already does. Changed signature: `OnDirectKeyEvent(vkey, scanCode, down, extended)`.

## References and Relevant Issues

Closes #18120

## Detailed Description of the Pull Request / Additional comments

The asymmetry happens because the emperor intercepts Alt-up for system menu handling - it needs to swallow it before XAML turns it into a menu activation. That interception path (`_dispatchSpecialKey`) only extracted the virtual key, scan code, and up/down state from `lParam`, ignoring bit 24 (the extended-key flag). This PR extracts that bit and passes it through.

## Validation Steps Performed

Built two copies locally (x64 Debug, VS 2026 / SDK 10.0.26100), registered with `Add-AppxPackage -Register`, ran on Windows 11. Used a small `ReadConsoleInputW` repro tool with win32-input-mode enabled (`\x1b[?9001h`), pressing RightAlt and LeftAlt on a Swedish keyboard layout (where RightAlt is AltGr, so Windows translates it to Ctrl+Alt - hence the `(auto)` LeftCtrl events).

**Before** (parent commit 079d1cc) - RightAlt release loses its identity:
<img width="700" height="408" alt="before" src="https://github.com/user-attachments/assets/19c44fca-0afb-4d4f-8fed-1bf05fa474e4" />

```
pressed     reported    action   EK    note
----------  ----------  -------  ----  ------
RightAlt    LeftCtrl    press    0     (auto)
RightAlt    RightAlt    press    1
RightAlt    LeftCtrl    release  0     (auto)
RightAlt    LeftAlt     release  0     <-- wrong, should be RightAlt
LeftAlt     LeftAlt     press    0
LeftAlt     LeftAlt     release  0
```

**After** (this branch) - works correctly:
<img width="700" height="408" alt="after" src="https://github.com/user-attachments/assets/a5405a8f-366d-49f1-9442-418a0af8eb55" />

```
pressed     reported    action   EK    note
----------  ----------  -------  ----  ------
RightAlt    LeftCtrl    press    0     (auto)
RightAlt    RightAlt    press    1
RightAlt    LeftCtrl    release  0     (auto)
RightAlt    RightAlt    release  1     <-- correct
LeftAlt     LeftAlt     press    0
LeftAlt     LeftAlt     release  0
```

Also added `InputTest::Win32KeyEventsRetainEnhancedKey` which checks that win32-input-mode encodes the flag correctly for both press and release of RightAlt. Passes locally.

## PR Checklist

- [x] Closes #18120
- [x] Tests added/passed
- [ ] Documentation updated
- [ ] Schema updated (if necessary)
