### PR TITLE
Upgrade Cloud Shell API to 2025-09-01-preview

### DIFF
--- a/src/cascadia/TerminalConnection/AzureConnection.cpp
+++ b/src/cascadia/TerminalConnection/AzureConnection.cpp
@@ -975,7 +975,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
     // - the user's cloud shell settings
     WDJ::JsonObject AzureConnection::_GetCloudShellUserSettings()
     {
-        auto uri{ fmt::format(FMT_COMPILE(L"{}providers/Microsoft.Portal/userSettings/cloudconsole?api-version=2023-02-01-preview"), _resourceUri) };
+        auto uri{ fmt::format(FMT_COMPILE(L"{}providers/Microsoft.Portal/userSettings/cloudconsole?api-version=2025-09-01-preview"), _resourceUri) };
         return _SendRequestReturningJson(uri, nullptr);
     }
 
@@ -985,7 +985,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
     // - the uri for the cloud shell
     winrt::hstring AzureConnection::_GetCloudShell()
     {
-        auto uri{ fmt::format(FMT_COMPILE(L"{}providers/Microsoft.Portal/consoles/default?api-version=2023-02-01-preview"), _resourceUri) };
+        auto uri{ fmt::format(FMT_COMPILE(L"{}providers/Microsoft.Portal/consoles/default?api-version=2025-09-01-preview"), _resourceUri) };
 
         WWH::HttpStringContent content{
             LR"-({"properties": {"osType": "linux"}})-",


### PR DESCRIPTION
The primary Cloud Shell API is changing from `2023-02-01-preview` to `2025-09-01-preview`. This change ensures continued functionality once the 2023 API is retired. The API commands themselves are unchanged, so no additional code changes are needed.

Notes:
- Standard Cloud Shell users will be unaffected by this change (the new api-version is backward compatible with their old user settings)
- Cloud Shell in a VNet users may receive a message to visit Azure Portal to make required RBAC permission updates. This is due to the deprecation of ACI network profiles with this API version change. More details/instructions: aka.ms/cloud-shell-rbac-changes 
- Users who don't update Terminal with this commit will be unable to use Azure Cloud Shell via Terminal - Requests made with the 2023 API may start to fail after 10/1.