### PR TITLE
Switch from __WEX_COMMON_H__ to VERIFY_ARE_EQUAL for detecting when Verify.h was included.

### DIFF
--- a/src/inc/til/color.h
+++ b/src/inc/til/color.h
@@ -230,7 +230,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
 
 static_assert(sizeof(til::color) == sizeof(uint32_t));
 
-#ifdef __WEX_COMMON_H__
+#ifdef VERIFY_ARE_EQUAL
 namespace WEX::TestExecution
 {
     template<>

--- a/src/inc/til/point.h
+++ b/src/inc/til/point.h
@@ -374,7 +374,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
     };
 }
 
-#ifdef __WEX_COMMON_H__
+#ifdef VERIFY_ARE_EQUAL
 namespace WEX::TestExecution
 {
     template<>

--- a/src/inc/til/rect.h
+++ b/src/inc/til/rect.h
@@ -778,7 +778,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
     }
 }
 
-#ifdef __WEX_COMMON_H__
+#ifdef VERIFY_ARE_EQUAL
 namespace WEX::TestExecution
 {
     template<>

--- a/src/inc/til/rle.h
+++ b/src/inc/til/rle.h
@@ -1039,7 +1039,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
     using small_rle = basic_rle<T, S, til::small_vector<rle_pair<T, S>, N>>;
 };
 
-#ifdef __WEX_COMMON_H__
+#ifdef VERIFY_ARE_EQUAL
 namespace WEX::TestExecution
 {
     template<typename T, typename S, typename Container>

--- a/src/inc/til/size.h
+++ b/src/inc/til/size.h
@@ -206,7 +206,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
     }
 };
 
-#ifdef __WEX_COMMON_H__
+#ifdef VERIFY_ARE_EQUAL
 namespace WEX::TestExecution
 {
     template<>


### PR DESCRIPTION
## Summary of the Pull Request
Some headers in src\inc\til use the `__WEX_COMMON_H__` macro to detect when it is safe to specialize the `WEX::TestExecution::VerifyOutputTraits` and `WEX::TestExecution::VerifyCompareTraits` classes. The `__WEX_COMMON_H__` macro is an internal implementation detail of TAEF that I plan to remove in an upcoming TAEF version. (I am the main dev for TAEF.) To avoid issues when you upgrade TAEF versions, I'm switching the code to check whether `VERIFY_ARE_EQUAL` is defined instead. This is a documented macro that is defined in the same header that defines the `VerifyOutputTraits` and `VerifyCompareTraits` clases.

## Validation Steps Performed
No validation other than a quick check in a different project that `#ifdef` works with macros that take parameters. The change is simple, and the PR build should catch any issues if any exist.
