### PR TITLE
Report the IME caret rect relative to the client area

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -207,19 +207,27 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             return {};
         }
 
+        // TSF wants screen coordinates, and localOrigin below is relative to the XAML island, which sits at
+        // the origin of our client area. GH#20318: GetWindowRect() is not that origin. _OnNcCalcSize() only
+        // pushes the client area's top edge past the resize borders while the window is maximized, so the
+        // rect would then be a resize handle height too high, which is enough for the IME candidate window
+        // to cover the text being composed.
         const auto hwnd = reinterpret_cast<HWND>(_termControl->OwningHwnd());
-        RECT clientRect;
-        GetWindowRect(hwnd, &clientRect);
+        POINT islandOrigin{};
+        ClientToScreen(hwnd, &islandOrigin);
 
-        const auto scaleFactor = static_cast<float>(DisplayInformation::GetForCurrentView().RawPixelsPerViewPixel());
+        // DisplayInformation::GetForCurrentView() describes the hidden dummy CoreWindow that XAML islands run
+        // on, not necessarily the display we're on. fontSize below is in pixels derived from the SwapChainPanel's
+        // composition scale (see ControlCore::FontSizeInDips), so use that here as well to keep both in sync.
+        const auto scaleFactor = _termControl->SwapChainPanel().CompositionScaleX();
         const auto localOrigin = _termControl->TransformToVisual(nullptr).TransformPoint({});
         const auto padding = _termControl->GetPadding();
         const auto cursorPosition = core->CursorPosition();
         const auto fontSize = core->FontSize();
 
         // fontSize is not in DIPs, so we need to first multiply by scaleFactor and then do the rest.
-        const auto left = clientRect.left + (localOrigin.X + static_cast<float>(padding.Left)) * scaleFactor + cursorPosition.X * fontSize.Width;
-        const auto top = clientRect.top + (localOrigin.Y + static_cast<float>(padding.Top)) * scaleFactor + cursorPosition.Y * fontSize.Height;
+        const auto left = islandOrigin.x + (localOrigin.X + static_cast<float>(padding.Left)) * scaleFactor + cursorPosition.X * fontSize.Width;
+        const auto top = islandOrigin.y + (localOrigin.Y + static_cast<float>(padding.Top)) * scaleFactor + cursorPosition.Y * fontSize.Height;
         const auto right = left + fontSize.Width;
         const auto bottom = top + fontSize.Height;
 

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -207,14 +207,14 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             return {};
         }
 
-        // TSF wants screen coordinates, and localOrigin below is relative to the XAML island, which sits at
-        // the origin of our client area. GH#20318: GetWindowRect() is not that origin. _OnNcCalcSize() only
-        // pushes the client area's top edge past the resize borders while the window is maximized, so the
-        // rect would then be a resize handle height too high, which is enough for the IME candidate window
+        // TSF wants screen coordinates, and localOrigin below is relative to the root of our visual tree,
+        // which sits at the origin of the owning window's client area. GH#20318: GetWindowRect() is not
+        // that origin. While the window is maximized the client area starts below the resize borders, so
+        // the rect ended up a resize handle height too high, which is enough for the IME candidate window
         // to cover the text being composed.
         const auto hwnd = reinterpret_cast<HWND>(_termControl->OwningHwnd());
-        POINT islandOrigin{};
-        ClientToScreen(hwnd, &islandOrigin);
+        POINT windowOrigin{};
+        ClientToScreen(hwnd, &windowOrigin);
 
         const auto scaleFactor = _termControl->SwapChainPanel().CompositionScaleX();
         const auto localOrigin = _termControl->TransformToVisual(nullptr).TransformPoint({});
@@ -223,8 +223,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         const auto fontSize = core->FontSize();
 
         // fontSize is not in DIPs, so we need to first multiply by scaleFactor and then do the rest.
-        const auto left = islandOrigin.x + (localOrigin.X + static_cast<float>(padding.Left)) * scaleFactor + cursorPosition.X * fontSize.Width;
-        const auto top = islandOrigin.y + (localOrigin.Y + static_cast<float>(padding.Top)) * scaleFactor + cursorPosition.Y * fontSize.Height;
+        const auto left = windowOrigin.x + (localOrigin.X + static_cast<float>(padding.Left)) * scaleFactor + cursorPosition.X * fontSize.Width;
+        const auto top = windowOrigin.y + (localOrigin.Y + static_cast<float>(padding.Top)) * scaleFactor + cursorPosition.Y * fontSize.Height;
         const auto right = left + fontSize.Width;
         const auto bottom = top + fontSize.Height;
 

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -216,9 +216,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         POINT islandOrigin{};
         ClientToScreen(hwnd, &islandOrigin);
 
-        // DisplayInformation::GetForCurrentView() describes the hidden dummy CoreWindow that XAML islands run
-        // on, not necessarily the display we're on. fontSize below is in pixels derived from the SwapChainPanel's
-        // composition scale (see ControlCore::FontSizeInDips), so use that here as well to keep both in sync.
         const auto scaleFactor = _termControl->SwapChainPanel().CompositionScaleX();
         const auto localOrigin = _termControl->TransformToVisual(nullptr).TransformPoint({});
         const auto padding = _termControl->GetPadding();


### PR DESCRIPTION
## Summary of the Pull Request

`TsfDataProvider::GetCursorPosition()` tells the IME where the composition is. It built that rectangle from `GetWindowRect()`, so while the window is maximized the rectangle sits above the actual caret by the height of the resize handle. The IME anchors the candidate window to that rectangle, so the candidate window ends up covering the text that is being composed.

## References and Relevant Issues

Closes #20318

## Detailed Description of the Pull Request / Additional comments

`GetCursorPosition()` is what `Implementation::GetTextExt()` (`ITfContextOwner::GetTextExt`) hands to the IME, in screen coordinates. It computed:

```cpp
RECT clientRect;
GetWindowRect(hwnd, &clientRect);
...
const auto top = clientRect.top + (localOrigin.Y + static_cast<float>(padding.Top)) * scaleFactor + cursorPosition.Y * fontSize.Height;
```

`localOrigin` comes from `TransformToVisual(nullptr)`, so it is relative to the XAML island, which `NonClientIslandWindow::_UpdateIslandPosition()` places at the origin of the *client* area. `GetWindowRect()` returns the *window* rect, and the two do not line up the same way in every window state, because `NonClientIslandWindow::_OnNcCalcSize()` keeps the client area's top edge at the window rect's top edge for a restored window, but moves it down by `_GetResizeHandleHeight()` while the window is maximized:

| window state | client origin minus window origin |
| --- | --- |
| restored | (frame, **0**) |
| maximized | (frame, **frame**) |
| fullscreen (`WS_POPUP`) | (0, 0) |

So while maximized the reported rectangle is one resize handle height above the actual caret. I instrumented a local build to measure it, on a single display at 150%:

```
[maximized]  window=(-11,-11) client=(0,0) delta=(11,11)
             localOrigin=(0.00,32.00) padding=(8.00,8.00) cursor=(2,2) font=(11.00,26.00)
             reported top=101, actual top=112

[restored]   window=(65,76) client=(76,76) delta=(11,0)
             reported top=148, actual top=148
```

11px against a 26px cell is 42% of a row, and the IME places the candidate window right below the rectangle it was given, so the candidate window covers the bottom of the row being composed. That matches the issue in that it happens wherever the caret is on screen, not only at the bottom edge of the display. This uses `ClientToScreen()` instead, which is also what the other two `IDataProvider` implementations do (`src/interactivity/win32/windowproc.cpp` and `HwndTerminal::TsfDataProvider::GetCursorPosition()`). As a side effect the rectangle is no longer built from an uninitialized `RECT` when `OwningHwnd()` has not been set yet, since `GetWindowRect()` leaves its output untouched when it fails.

The second change is `DisplayInformation::GetForCurrentView().RawPixelsPerViewPixel()` to `SwapChainPanel().CompositionScaleX()`. XAML islands run on a thread whose `CoreWindow` is a hidden dummy window, so `DisplayInformation::GetForCurrentView()` is not a reliable source for the scale factor of the display this window is on. The same expression adds `ControlCore::FontSize()`, which is in pixels derived from the SwapChainPanel's composition scale (see `ControlCore::FontSizeInDips()`), so the two terms are not guaranteed to use the same scale. `CompositionScaleX()` is already what `TermControl::_toTerminalOrigin()` and `TermControl::_coreFontSizeChanged()` use for DIP to pixel conversions.

I could not verify that second part: on the single 150% display I tested on, `RawPixelsPerViewPixel()` and `CompositionScaleX()` both measured 1.5, so it is a no-op there. I am including it because the terms of that expression should use the same scale, and because #20318 also carries reports of the offset changing with the display scaling and of the problem appearing only on a secondary monitor, which the client area fix alone does not explain. Happy to split it out if you would rather keep this PR to the part I can demonstrate.

## Repro

#20318 is still labelled `Needs-Repro`. The missing ingredient is the window state: only a maximized window is affected, which is easy to miss.

1. Start Windows Terminal with default settings and **maximize** it. A restored window is not affected, and neither is fullscreen.
2. Switch to a CJK IME. I verified this with the Microsoft IME for Japanese and with Google Japanese Input.
3. Type a few characters so the candidate window shows up, for example `あああああ`.
4. The candidate window overlaps the bottom of the row being composed. The caret can be anywhere on screen, it does not have to be near the bottom edge.
5. Un-maximize the window and repeat: no overlap.

The offset is `GetSystemMetricsForDpi(SM_CXPADDEDBORDER, dpi) + GetSystemMetricsForDpi(SM_CYSIZEFRAME, dpi)`, so it grows with the display scaling. It was 11px against a 26px cell on the 150% display I tested on.

It can also be seen without an IME: `ClientToScreen(hwnd, {0, 0}).y - GetWindowRect(hwnd).top` is 0 for a restored window and the resize handle height for a maximized one, and only the former was assumed here.

## Validation Steps Performed

Deployed a Dev package on Windows 11 26200, single display at 150%, and typed Japanese in a maximized window with both the Microsoft IME and Google Japanese Input.

* Build of `main` without this change: the candidate window covered the bottom of the composition, at any caret row, in a plain shell as well as under tmux and with Claude Code running.
* Same build with this change: the candidate window no longer overlaps the composition in any of those cases.
* Both builds behave the same in a restored (not maximized) window, which is what the measurements above predict.

## PR Checklist
- [x] Closes #20318
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Schema updated (if necessary)

No test is added. `GetCursorPosition()` needs a live `HWND` and a XAML visual tree (`TransformToVisual`, `SwapChainPanel`), which `UnitTests_Control` cannot construct, and the defect is not in the arithmetic but in which origin and scale are fed into it, so a unit test over an extracted helper would pass just as happily with the old inputs. Catching this needs the reported rectangle compared against the caret in a real maximized window.
