### PR TITLE
Use the I-beam pointer over the text area

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2017,12 +2017,23 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         args.Handled(true);
     }
 
+    void TermControl::_setPointerCursor(const bool showIBeam)
+    {
+        if (showIBeam == _ownsPointerCursor)
+        {
+            return;
+        }
+
+        CoreWindow::GetForCurrentThread().PointerCursor(CoreCursor{ showIBeam ? CoreCursorType::IBeam : CoreCursorType::Arrow, 0 });
+        _ownsPointerCursor = showIBeam;
+    }
+
     // Method Description:
     // - handle a mouse moved event. Specifically handling mouse drag to update selection process.
     // Arguments:
-    // - sender: not used
+    // - sender: the element the handler is attached to, i.e. the text area
     // - args: event data
-    void TermControl::_PointerMovedHandler(const Windows::Foundation::IInspectable& /*sender*/,
+    void TermControl::_PointerMovedHandler(const Windows::Foundation::IInspectable& sender,
                                            const Input::PointerRoutedEventArgs& args)
     {
         if (_IsClosing())
@@ -2046,6 +2057,11 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         if (type == Windows::Devices::Input::PointerDeviceType::Mouse ||
             type == Windows::Devices::Input::PointerDeviceType::Pen)
         {
+            const auto overTextArea = args.OriginalSource() == sender || args.OriginalSource() == SwapChainPanel();
+            const auto selectable = ControlKeyStates{ args.KeyModifiers() }.IsShiftPressed() ||
+                                    !winrt::get_self<ControlCore>(_core)->IsVtMouseModeEnabled();
+            _setPointerCursor(overTextArea && selectable);
+
             auto suppressFurtherHandling = _interactivity.PointerMoved(point.PointerId(),
                                                                        TermControl::GetPressedMouseButtons(point),
                                                                        TermControl::GetPointerUpdateKind(point),
@@ -3477,6 +3493,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                                             const Windows::UI::Xaml::Input::PointerRoutedEventArgs& /*e*/)
     {
         _core.ClearHoveredCell();
+        _setPointerCursor(false);
     }
 
     void TermControl::_hoveredHyperlinkChanged(const IInspectable& /*sender*/, const IInspectable& /*args*/)

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -308,6 +308,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         SafeDispatcherTimer _autoScrollTimer;
         std::optional<std::chrono::high_resolution_clock::time_point> _lastAutoScrollUpdateTime;
         bool _pointerPressedInBounds{ false };
+        bool _ownsPointerCursor{ false };
 
         winrt::Windows::UI::Composition::ScalarKeyFrameAnimation _bellLightAnimation{ nullptr };
         winrt::Windows::UI::Composition::ScalarKeyFrameAnimation _bellDarkAnimation{ nullptr };
@@ -367,6 +368,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void _KeyUpHandler(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Input::KeyRoutedEventArgs& e);
         void _CharacterHandler(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Input::CharacterReceivedRoutedEventArgs& e);
         void _PointerPressedHandler(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e);
+        void _setPointerCursor(const bool showIBeam);
         void _PointerMovedHandler(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e);
         void _PointerReleasedHandler(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e);
         void _PointerExitedHandler(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e);


### PR DESCRIPTION
Windows Terminal shows the arrow pointer over selectable text, which the Windows human interface guidelines treat as wrong and which no other mainstream terminal does. Closes #1441.

WinUI 2 has no per-element cursor - `UIElement.ProtectedCursor` is WinUI 3 only - so the shape is derived on every pointer move and set on the `CoreWindow`, the same cursor XAML itself applies. Setting it with Win32 `SetCursor` flickers instead, because it loses to the `WM_SETCURSOR` the XAML input site handles while the move is dispatched.

No setting turns this off. The global opt-out asked for in #5028 can follow in a separate change if it is still wanted.
