### PR TITLE
Convert NTM folder name expander to card

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/NewTabMenu.xaml
+++ b/src/cascadia/TerminalSettingsEditor/NewTabMenu.xaml
@@ -404,20 +404,11 @@
                                Margin="0,4,0,4"
                                Style="{StaticResource TextBlockSubHeaderStyle}" />
                     <!--  Name  -->
-                    <local:SettingsExpander x:Name="CurrentFolderName"
-                                            x:Uid="NewTabMenu_CurrentFolderName"
-                                            AutomationProperties.Name="{x:Bind ViewModel.CurrentFolderNameAccessibleName, Mode=OneWay}">
-                        <local:SettingsExpander.Content>
-                            <TextBlock Style="{StaticResource SettingContainerCurrentValueTextBlockStyle}"
-                                       Text="{x:Bind ViewModel.CurrentFolderName, Mode=OneWay}" />
-                        </local:SettingsExpander.Content>
-                        <local:SettingsExpander.ItemsHeader>
-                            <ContentPresenter Padding="16,12,16,16">
-                                <TextBox Style="{StaticResource TextBoxSettingStyle}"
-                                         Text="{x:Bind ViewModel.CurrentFolderName, Mode=TwoWay}" />
-                            </ContentPresenter>
-                        </local:SettingsExpander.ItemsHeader>
-                    </local:SettingsExpander>
+                    <local:SettingsCard x:Name="CurrentFolderName"
+                                        x:Uid="NewTabMenu_CurrentFolderName">
+                        <TextBox Style="{StaticResource TextBoxSettingStyle}"
+                                 Text="{x:Bind ViewModel.CurrentFolderName, Mode=TwoWay}" />
+                    </local:SettingsCard>
 
                     <!--  Icon  -->
                     <local:SettingsExpander x:Name="CurrentFolderIcon"

--- a/src/cascadia/TerminalSettingsEditor/NewTabMenuViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/NewTabMenuViewModel.cpp
@@ -150,10 +150,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 }
                 _NotifyChanges(L"IsFolderView", L"CurrentView");
             }
-            else if (viewModelProperty == L"CurrentFolderName")
-            {
-                _NotifyChanges(L"CurrentFolderNameAccessibleName");
-            }
         });
     }
 
@@ -178,11 +174,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             return {};
         }
         return _CurrentFolder.Name();
-    }
-
-    hstring NewTabMenuViewModel::CurrentFolderNameAccessibleName() const
-    {
-        return til::hstring_format(FMT_COMPILE(L"{}: {}"), RS_(L"NewTabMenu_CurrentFolderName/Header"), CurrentFolderName());
     }
 
     void NewTabMenuViewModel::CurrentFolderName(const hstring& value)

--- a/src/cascadia/TerminalSettingsEditor/NewTabMenuViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/NewTabMenuViewModel.h
@@ -41,7 +41,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         Editor::NewTabMenuEntryViewModel RequestAddRemainingProfilesEntry();
 
         hstring CurrentFolderName() const;
-        hstring CurrentFolderNameAccessibleName() const;
         void CurrentFolderName(const hstring& value);
         bool CurrentFolderInlining() const;
         void CurrentFolderInlining(bool value);

--- a/src/cascadia/TerminalSettingsEditor/NewTabMenuViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/NewTabMenuViewModel.idl
@@ -34,7 +34,6 @@ namespace Microsoft.Terminal.Settings.Editor
         Microsoft.Terminal.Settings.Model.Profile SelectedProfile;
 
         String CurrentFolderName;
-        String CurrentFolderNameAccessibleName { get; };
         Boolean CurrentFolderInlining;
         Boolean CurrentFolderAllowEmpty;
         String ProfileMatcherName;


### PR DESCRIPTION
Updates the "folder name" setting's control in the dropdown menu's page to be a SettingsCard instead of a SettingsExpander.