### PR TITLE
Dismiss the workspace menu when showing the delete confirmation

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -5796,11 +5796,22 @@ namespace winrt::TerminalApp::implementation
 
                     auto trashIcon = UI::IconPathConverter::IconWUX(L"\xE74D"); // Delete  glyph
 
-                    deleteItem.Click([weakThis{ get_weak() }, name](auto&&, auto&&) -> safe_void_coroutine {
+                    deleteItem.Click([weakThis{ get_weak() }, name, deleteFlyout](auto&&, auto&&) -> safe_void_coroutine {
                         auto page{ weakThis.get() };
                         if (!page)
                         {
                             co_return;
+                        }
+
+                        // The delete item lives in an attached context flyout, so
+                        // clicking it does not dismiss the parent workspace menu.
+                        // ContentDialog is a separate popup and will not light-
+                        // dismiss that menu either, which leaves it sitting over
+                        // the confirmation (GH#20636). Close both first.
+                        deleteFlyout.Hide();
+                        if (page->_workspaceFlyout)
+                        {
+                            page->_workspaceFlyout.Hide();
                         }
 
                         // Build and show a confirmation ContentDialog.


### PR DESCRIPTION
## Summary of the Pull Request

Right-clicking a saved workspace and choosing delete leaves the workspace dropdown open on top of the confirmation dialog. This closes the menu (and the little delete flyout) before we show that dialog.

## References and Relevant Issues

Closes #20636

## Detailed Description of the Pull Request / Additional comments

The workspace list is a `MenuFlyout` on the titlebar button. Delete is not a regular item in that menu — it is an *attached* context flyout on each saved workspace row (`FlyoutBase::SetAttachedFlyout` + `ShowAttachedFlyout` on `ContextRequested`).

Clicking an item in that attached flyout only dismisses the attached flyout. The parent workspace menu stays open. The confirmation is a `ContentDialog`, which is its own popup, so clicking around in it also does not light-dismiss the menu. That is the screenshot in #20636: the dropdown still sitting there while you try to confirm or cancel.

This is the same thing we already do before the close-window warning (`CloseWindow` hides the new-tab flyout and tab context menus first). Here we `Hide()` the attached delete flyout and `_workspaceFlyout` before `ShowDialog`. After that, cancel just leaves you back in the window, and confirm still removes the workspace from `ApplicationState` like before.

## Validation Steps Performed

I don't have a Windows build environment on this machine, so this is a code-path check rather than a deployed Dev package:

- `_PopulateWorkspaceFlyout` is the only place that builds the delete confirmation, so this is the only entry point for #20636.
- `MenuFlyout.Hide()` is already how we dismiss the new-tab flyout and tab context menus before other dialogs (`CloseWindow`, `TitlebarClicked`).
- After a confirmed delete we still call `_PopulateWorkspaceFlyout()`. That is a no-op visually once the flyout is closed; `Opening` rebuilds the list the next time the button is clicked.
- Cancel does not delete anything; we only `RemoveWorkspace` on `ContentDialogResult::Primary`, same as before.

## PR Checklist
- [x] Closes #20636
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Schema updated (if necessary)

No test added. This is a flyout vs. `ContentDialog` popup interaction in the XAML island, and `UnitTests_TerminalApp` does not host that tree. Catching it means opening the workspace button, right-clicking a saved workspace, choosing delete, and confirming the menu is gone before you hit the dialog.