### PR TITLE
Add a standalone (non-Terminal) console delegation target

### DIFF
--- a/doc/specs/Standalone Console Delegation.md
+++ b/doc/specs/Standalone Console Delegation.md
@@ -1,0 +1,190 @@
+---
+author: leecher1337 @leecher1337
+created on: 2026-09-05
+last updated: 2026-09-05
+issue id: n/a
+---
+
+# Standalone Console Delegation
+
+## Abstract
+
+This adds a way for a third-party `DelegationConsole` implementation
+(registered the same way Windows Terminal registers itself as the delegated
+console/terminal handler, per [`doc/specs/#492 - Default Terminal/spec.md`])
+to handle a handed-off console session as a genuine, native window - the same
+codepath a plain, non-delegated `OpenConsole.exe`/`conhost.exe` launch already
+uses - instead of being required to hand off again to a `DelegationTerminal`
+over ConPTY.
+
+Concretely: a new sentinel CLSID, `DelegationConfig::CLSID_Standalone`, can be
+used as the `DelegationTerminal` value (never `DelegationConsole`) in
+`HKCU\Console\%%Startup`. When `ConsoleEstablishHandoff` (`srvinit.cpp`) sees
+this as the resolved terminal, it stays a plain windowed host instead of
+`CoCreateInstance`-ing a Terminal.
+
+## Inspiration
+
+The existing delegation mechanism (`DelegationConsole`/`DelegationTerminal`,
+`CConsoleHandoff`, `ConsoleEstablishHandoff`) was designed for exactly one
+purpose: routing a console session to a Terminal UI over ConPTY. That's the
+right choice for the overwhelming majority of console applications, which
+only need a VT text stream.
+
+Some applications need more than that: direct, pixel-level control of their
+own console window (GDI/Direct2D/Direct3D), not just text over a pty. A
+ConPTY connection cannot carry that - there is no VT representation for raw
+pixel data. Today, any such application is locked out of delegation entirely;
+its only option is to be handed a legacy, non-delegated window, which means a
+third-party console host can never legitimately take over these sessions the
+way it can for ordinary text-mode ones.
+
+A concrete example driving this: a companion change resurrects
+`CONSOLE_GRAPHICS_BUFFER` support (see microsoft/terminal#246, "Bringing back
+the console graphics screen-buffers?"), which lets a client render a
+pixel-addressable buffer directly to its console window - historically used by
+NTVDM to display DOS graphics-mode output, but usable by any client
+(#246 itself notes Far Manager plugins wanting to show image thumbnails
+in-console as another example). Once graphics buffers exist at all, a
+third-party console host that implements them needs a way to actually be the
+one hosting a session where they're used, without an intervening ConPTY hop
+that would silently discard the pixel data. But the mechanism this spec adds
+is independent of that one use case: any application needing a real,
+natively-drawable console window - not just graphics buffers - can use it.
+
+## Solution Design
+
+- `DelegationConfig::CLSID_Standalone` (`propslib/DelegationConfig.hpp`): a
+  fixed, well-known sentinel CLSID, analogous to `CLSID_Default`/
+  `CLSID_Conhost`. It is never resolved via `CoCreateInstance` - the in-box
+  console host's own `attemptHandoff` (`server/IoDispatchers.cpp`) only ever
+  activates the `DelegationConsole` side, so a `DelegationTerminal` value
+  never needs to be a real, activatable class.
+- `ConsoleEstablishHandoff` (`host/srvinit.cpp`): once activated as
+  `DelegationConsole` and handed a session, checks whether the resolved
+  `DelegationTerminal` is `CLSID_Standalone`. If so, it skips the
+  `CoCreateInstance`/`EstablishPtyHandoff` sequence entirely and calls
+  `ConsoleCreateIoThread` directly, reusing the `Server`/`driverInputEvent`/
+  `connectMessage` the in-box host already established - identical to how a
+  normal, non-handoff launch reaches the same function
+  (`ConsoleCreateIoThreadLegacy`), just with those already provided instead of
+  freshly created.
+
+No changes are needed to `CConsoleHandoff`/the COM activation path itself -
+this only affects what happens once a session has already been handed off.
+
+### Registration
+
+Enabling this for a given console host build is two per-user registry writes
+(no elevation, no protected files):
+
+- `HKCU\Software\Classes\CLSID\{<the host's own CConsoleHandoff CLSID>}\LocalServer32`
+  → path to the host's `.exe`.
+- `HKCU\Console\%%Startup`:
+  - `DelegationConsole` = that CLSID
+  - `DelegationTerminal` = `{5C2A1F8E-8E3B-4A2B-9B4C-2F6A1D7E3C0A}` (`CLSID_Standalone`)
+
+An `AppID` association for the console's CLSID is also recommended (see
+Potential Issues below).
+
+**Important**: a build's `CConsoleHandoff` CLSID must not collide with an
+existing installed console/terminal's own CLSID. An installed Windows
+Terminal package can register COM servers for all four `WT_BRANDING_*`
+CLSIDs via registration-free MSIX COM, which takes precedence over a plain
+per-user `HKCU\Software\Classes` registration for the same CLSID - any
+third-party build sharing one of those four will silently resolve to
+Microsoft's own `OpenConsole.exe` instead. Third-party builds should use a
+CLSID of their own.
+
+## UI/UX Design
+
+None directly - this has no user-facing UI of its own. It's consumed the same
+way `DelegationConsole`/`DelegationTerminal` already are: a value in the
+registry, currently set by hand or by whatever installer a third-party
+console host provides. (Whether/how this should ever be exposed in Windows
+Terminal's own "Default Terminal Application" picker, alongside the existing
+"Let Windows decide"/"Windows Terminal"/"Windows Console Host" options, is an
+open question - see Future considerations.)
+
+## Capabilities
+
+### Accessibility
+
+No impact - the resulting window goes through the exact same
+`InitWindowsSubsystem`/`AccessibilityNotifier` path a normal, non-delegated
+launch already uses.
+
+### Security
+
+No new attack surface: this only changes what an *already-activated*
+`DelegationConsole` does with a session it has already been handed. The
+`CoCreateInstance`/`LocalServer32`/`AppID` security model that gates
+activation in the first place is completely unchanged.
+
+### Reliability
+
+One real gap was found and needs a documented workaround: `EndTask()`
+(`ConsoleControl(ConsoleEndTask, ...)`, called from `Ctrl+Close` handling in
+`input.cpp`'s `ProcessCtrlEvents`) relies on CSRSS recognizing the calling
+process as the legitimate console host for its target process. That
+recognition is never established for a handoff-received session - every
+existing handoff target is headless ConPTY, which never exercises this
+native-window `Ctrl+Close` path at all, so this gap was never hit before.
+`EndTask()` reports success but has no actual effect: the attached client is
+never signaled, and the window would never close on its own.
+
+Since this is undocumented CSRSS behavior with no public API to fix
+correctly, `ProcessCtrlEvents` falls back to terminating the attached
+process(es) directly via `TerminateProcess()` when handling
+`CTRL_CLOSE_EVENT` for a handoff-received session specifically
+(`ServiceLocator::LocateGlobals().handoffTarget`). This is scoped tightly
+enough that it cannot affect a normal, non-handoff launch, which continues to
+close via `EndTask()` exactly as before.
+
+### Compatibility
+
+Purely additive. `DelegationTerminal` values other than `CLSID_Standalone`
+behave identically to today; nothing changes for the existing
+"Let Windows decide"/`ConhostDelegationPair`/Terminal-delegation paths.
+
+### Performance, Power, and Efficiency
+
+No measurable impact - this is a one-time branch taken during session
+handoff, not a hot path.
+
+## Potential Issues
+
+- The `EndTask()`/CSRSS gap above is a real, if narrow, correctness gap in
+  the existing (unmodified) delegation machinery, only now visible because
+  this is the first scenario to combine a handoff-received session with a
+  real native window. The `TerminateProcess()` fallback means an attached
+  client never gets a chance to react to `CTRL_CLOSE_EVENT` gracefully in
+  this specific scenario (unlike a normal launch) - acceptable given the
+  alternative is a console window that can never be closed at all, but worth
+  a proper fix if CSRSS's ownership-recognition behavior for handoff-received
+  sessions is ever better understood or documented.
+- Per-user `LocalServer32` COM registrations without an explicit `AppID`
+  can see inconsistent/high-latency `CoCreateInstance(CLSCTX_LOCAL_SERVER)`
+  activation on some systems. Registering an `AppID` for the console's CLSID
+  and granting explicit Local Launch/Local Activation permission via
+  Component Services is recommended.
+
+## Future considerations
+
+- A well-known, standalone-capable third-party console host could
+  eventually be surfaced in Windows Terminal's own "Default Terminal
+  Application" settings UI, the same way installed Terminal-family packages
+  already are (`DelegationConfig::s_GetAvailablePackages`), rather than
+  requiring hand-written registry entries.
+- Any application needing genuine pixel/window-level console access - not
+  just the graphics-buffer use case that motivated this - can build on this
+  mechanism.
+
+## Resources
+
+- microsoft/terminal#246 - "Bringing back the console graphics
+  screen-buffers?" (the companion change this spec was motivated by)
+- `src/host/exe/CConsoleHandoff.cpp`/`.h`
+- `src/host/srvinit.cpp` (`ConsoleEstablishHandoff`)
+- `src/server/IoDispatchers.cpp` (`attemptHandoff`)
+- `src/propslib/DelegationConfig.hpp`/`.cpp`

--- a/src/host/input.cpp
+++ b/src/host/input.cpp
@@ -333,6 +333,18 @@ void ProcessCtrlEvents()
 
     const auto ctrl = ServiceLocator::LocateConsoleControl();
 
+    // EndTask() below relies on CSRSS recognizing this process as the
+    // legitimate console host for its target(s). A handoff-received session
+    // (see ConsoleEstablishHandoff in srvinit.cpp) never gets that
+    // recognition - every prior handoff target was headless ConPTY, which
+    // never exercises this native-window Ctrl+Close path at all - so
+    // EndTask() reports success without ever delivering CTRL_CLOSE_EVENT to
+    // the target, and the window would never close on its own. Fall back to
+    // terminating the process(es) directly in that case; a normal
+    // (non-handoff) launch already closes correctly via EndTask() and is
+    // unaffected.
+    const auto isHandoffCloseWorkaround = EventType == CTRL_CLOSE_EVENT && ServiceLocator::LocateGlobals().handoffTarget;
+
     for (const auto& r : termRecords)
     {
         // Older versions of Windows would do various things if the EndTask() call failed:
@@ -361,5 +373,10 @@ void ProcessCtrlEvents()
         // the process was already dead, or if the request actually failed for some reason.
         // Hopefully there aren't any regressions, but we can't know without trying.
         ctrl->EndTask(r.dwProcessID, EventType, CtrlFlags);
+
+        if (isHandoffCloseWorkaround && r.hProcess)
+        {
+            TerminateProcess(r.hProcess.get(), 0);
+        }
     }
 }

--- a/src/host/srvinit.cpp
+++ b/src/host/srvinit.cpp
@@ -416,6 +416,25 @@ try
     g.handoffTarget = true;
 
     g.delegationPair = DelegationConfig::s_GetDelegationPair();
+
+    // Configured (via DelegationTerminal == CLSID_Standalone) to stay a plain
+    // standalone window instead of handing off again to a Terminal over
+    // ConPTY. Reuse the session/handles the in-box conhost already
+    // established for us (Server/driverInputEvent/connectMessage) rather than
+    // creating a new one - otherwise this is identical to a normal,
+    // non-handoff launch (see ConsoleCreateIoThreadLegacy below).
+    if (g.delegationPair.terminal == DelegationConfig::CLSID_Standalone)
+    {
+        TraceLoggingWrite(g_hConhostV2EventTraceProvider,
+                          "SrvInit_ReceiveHandoff_Standalone",
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+
+        ConsoleArguments standaloneArgs;
+        RETURN_IF_FAILED(standaloneArgs.ParseCommandline());
+        return ConsoleCreateIoThread(Server, &standaloneArgs, driverInputEvent, connectMessage);
+    }
+
     // We've been handed off to (we're OpenConsole, not conhost).
     // If we get here and there's not a custom defterm set, then it must be because
     // conhost defaulted to us for DxD. Set up Terminal as the thing to handoff too.

--- a/src/propslib/DelegationConfig.hpp
+++ b/src/propslib/DelegationConfig.hpp
@@ -107,6 +107,15 @@ public:
     static constexpr CLSID CLSID_WindowsTerminalTerminal{ 0xe12cff52, 0xa866, 0x4c77, { 0x9a, 0x90, 0xf5, 0x70, 0xa7, 0xaa, 0x2c, 0x6b } };
     static constexpr CLSID CLSID_WindowsTerminalConsoleDev{ 0x1f9f2bf5, 0x5bc3, 0x4f17, { 0xb0, 0xe6, 0x91, 0x24, 0x13, 0xf1, 0xf4, 0x51 } };
     static constexpr CLSID CLSID_WindowsTerminalTerminalDev{ 0x051f34ee, 0xc1fd, 0x4b19, { 0xaf, 0x75, 0x9b, 0xa5, 0x46, 0x48, 0x43, 0x4c } };
+    // Sentinel DelegationTerminal value (never used as a DelegationConsole
+    // value, and never actually activated via COM): tells
+    // ConsoleEstablishHandoff (srvinit.cpp) that, once activated as the
+    // DelegationConsole, it should stay a normal standalone window instead of
+    // handing off again to a Terminal over ConPTY. Unmodified conhost.exe/
+    // Windows Terminal builds never resolve this CLSID themselves, since only
+    // the DelegationConsole side is ever activated by the in-box console
+    // host.
+    static constexpr CLSID CLSID_Standalone{ 0x5c2a1f8e, 0x8e3b, 0x4a2b, { 0x9b, 0x4c, 0x2f, 0x6a, 0x1d, 0x7e, 0x3c, 0x0a } };
     static constexpr DelegationPair DefaultDelegationPair{ DelegationPairKind::Default, CLSID_Default, CLSID_Default };
     static constexpr DelegationPair ConhostDelegationPair{ DelegationPairKind::Conhost, CLSID_Conhost, CLSID_Conhost };
     static constexpr DelegationPair TerminalDelegationPair{ DelegationPairKind::Custom, CLSID_WindowsTerminalConsole, CLSID_WindowsTerminalTerminal };


### PR DESCRIPTION
##  Summary of the Pull Request

  Adds a way for a third-party `DelegationConsole` implementation to handle a handed-off console session as a genuine, native window - the same codepath a plain, non-delegated `OpenConsole.exe`/`conhost.exe` launch already uses - instead of being required to hand off again to a `DelegationTerminal` over ConPTY.

##  References and Relevant Issues

  Related to #246 ("Bringing back the console graphics screen-buffers?") as motivation — a `CONSOLE_GRAPHICS_BUFFER`-capable console host needs a way to actually be the one hosting a session where graphics buffers are used, without an intervening ConPTY hop that would silently discard the pixel data. This PR is independent of that one though; not filed against #246 directly, since the mechanism here is useful to any client needing a real, natively-drawable console window, not just graphics buffers.

##  Detailed Description of the Pull Request / Additional comments

  Full design writeup is in `doc/specs/Standalone Console Delegation.md`. Summary:

  The existing delegation mechanism (`DelegationConsole`/`DelegationTerminal`, `CConsoleHandoff`, `ConsoleEstablishHandoff`) was designed for exactly one purpose: routing a console session to a Terminal UI over ConPTY. That's right for the overwhelming majority of console applications, which only need a VT text stream. Some applications need more than that — direct, pixel-level control of their own console window — and a ConPTY connection can't carry that. Today, any such application is locked out of delegation entirely.

  This adds `DelegationConfig::CLSID_Standalone`, a sentinel CLSID that can be used as the `DelegationTerminal` value (never `DelegationConsole`, never itself resolved via `CoCreateInstance`) in `HKCU\Console\%%Startup`. When `ConsoleEstablishHandoff` (`srvinit.cpp`) sees this as the resolved terminal, it skips the `CoCreateInstance`/`EstablishPtyHandoff` sequence entirely and calls `ConsoleCreateIoThread` directly, reusing the `Server/driverInputEvent/connectMessage` the in-box host already established - identical to how a normal, non-handoff launch reaches the same function, just with those already provided instead of freshly created. No changes are needed to `CConsoleHandoff`/the COM activation path itself.

  Also documents (and works around) a real, pre-existing gap this surfaced: `EndTask()` (`ConsoleControl(ConsoleEndTask, ...)`, called from `Ctrl+Close` handling) relies on CSRSS recognizing the calling process as the legitimate console host for its target process - recognition that's never established for a handoff-received session, since every existing handoff target is headless ConPTY and never exercises this native-window `Ctrl+Close` path. `EndTask()` reports success but has no actual effect, so the window would never close on its own. `ProcessCtrlEvents` (`input.cpp`) now falls back to `TerminateProcess() ` for `CTRL_CLOSE_EVENT` specifically when handling a handoff-received session, scoped tightly enough that a normal, non-handoff launch is unaffected and continues to close via `EndTask()` exactly as before.

##  Validation Steps Performed

Enabling this for a given console host build is two per-user registry writes
(no elevation, no protected files):

- `HKCU\Software\Classes\CLSID\{<the host's own CConsoleHandoff CLSID>}\LocalServer32`
  -> path to the host's `.exe`.
- `HKCU\Console\%%Startup`:
  - `DelegationConsole` = that CLSID
  - `DelegationTerminal` = `{5C2A1F8E-8E3B-4A2B-9B4C-2F6A1D7E3C0A}` (`CLSID_Standalone`)

Validated by launching an ordinary console app (e.g. `cmd.exe`) with those registry values set and confirming: it opens as a real, native `OpenConsole.exe` window (not routed through a Terminal/ConPTY) via the handoff path; closing that window via the title bar's X button (`Ctrl+Close`) actually terminates the session, exercising the `EndTask()`/`TerminateProcess()` fallback described above; and a normal, non-delegated launch is unaffected.

##  PR Checklist

  - [ ] Closes #xxx
  - [ ] Tests added/passed
  - [ ] Documentation updated
  - [ ] Schema updated (if necessary)

