### PR TITLE
Return keyboard focus to terminal when pane context menu closes

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -5491,10 +5491,59 @@ namespace winrt::TerminalApp::implementation
             targetMenu.SecondaryCommands().Append(button);
         };
 
-        auto makeMenuItem = [](const winrt::hstring& label,
-                               const winrt::hstring& icon,
-                               const auto& subMenu,
-                               auto& targetMenu) {
+        // GH#20593: dismissing a nested flyout with Esc leaves keyboard focus on
+        // the button inside it that had it. That button is no longer on screen
+        // but still alive, so Enter invokes it. When a sub-flyout closes with
+        // focus still on one of its own buttons, hand it back to the button that
+        // opened it. (The top-level flyout does the same for the control itself
+        // in TermControl.)
+        auto handBackFocusOnClose = [weakControl = winrt::make_weak(control)](const MUX::Controls::CommandBarFlyout& subMenu, const AppBarButton& owner) {
+            subMenu.Closed([weakMenu = winrt::make_weak(subMenu), weakOwner = winrt::make_weak(owner), weakControl](auto&&, auto&&) {
+                const auto menu{ weakMenu.get() };
+                const auto owner{ weakOwner.get() };
+                if (!menu || !owner)
+                {
+                    return;
+                }
+                auto root{ owner.XamlRoot() };
+                if (!root)
+                {
+                    if (const auto control{ weakControl.get() })
+                    {
+                        root = control.XamlRoot();
+                    }
+                }
+                if (!root)
+                {
+                    return;
+                }
+                const auto focused{ WUX::Input::FocusManager::GetFocusedElement(root) };
+                if (const auto focusedDo = focused.try_as<WUX::DependencyObject>())
+                {
+                    if (IsElementInCommandBarFlyout(focusedDo, menu))
+                    {
+                        if (WUX::Media::VisualTreeHelper::GetParent(owner))
+                        {
+                            if (!owner.Focus(FocusState::Keyboard) && !owner.Focus(FocusState::Programmatic))
+                            {
+                                if (const auto control{ weakControl.get() })
+                                {
+                                    control.Focus(FocusState::Programmatic);
+                                }
+                            }
+                        }
+                        // If owner is detached (e.g. during light-dismiss of the entire flyout hierarchy),
+                        // do not force focus to the terminal here: the top-level menu's Closed handler in
+                        // TermControl will handle focus restoration and respect open UI states like the Find search box.
+                    }
+                }
+            });
+        };
+
+        auto makeMenuItem = [&handBackFocusOnClose](const winrt::hstring& label,
+                                                    const winrt::hstring& icon,
+                                                    const auto& subMenu,
+                                                    auto& targetMenu) {
             AppBarButton button{};
 
             if (!icon.empty())
@@ -5506,15 +5555,16 @@ namespace winrt::TerminalApp::implementation
 
             button.Label(label);
             button.Flyout(subMenu);
+            handBackFocusOnClose(subMenu, button);
             targetMenu.SecondaryCommands().Append(button);
         };
 
-        auto makeContextItem = [&makeCallback](const winrt::hstring& label,
-                                               const winrt::hstring& icon,
-                                               const winrt::hstring& tooltip,
-                                               const auto& action,
-                                               const auto& subMenu,
-                                               auto& targetMenu) {
+        auto makeContextItem = [&makeCallback, &handBackFocusOnClose](const winrt::hstring& label,
+                                                                     const winrt::hstring& icon,
+                                                                     const winrt::hstring& tooltip,
+                                                                     const auto& action,
+                                                                     const auto& subMenu,
+                                                                     auto& targetMenu) {
             AppBarButton button{};
 
             if (!icon.empty())
@@ -5528,6 +5578,7 @@ namespace winrt::TerminalApp::implementation
             button.Click(makeCallback(action));
             WUX::Controls::ToolTipService::SetToolTip(button, box_value(tooltip));
             button.ContextFlyout(subMenu);
+            handBackFocusOnClose(subMenu, button);
             targetMenu.SecondaryCommands().Append(button);
         };
 

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -3,6 +3,7 @@
 
 #include "pch.h"
 #include "TermControl.h"
+#include <Utils.h>
 
 #include <inputpaneinterop.h>
 
@@ -429,7 +430,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         ContextMenu().Closed([weakThis = get_weak()](auto&&, auto&&) {
             if (auto control{ weakThis.get() }; control && !control->_IsClosing())
             {
-                const auto& menu{ control->ContextMenu() };
+                const auto menu{ control->ContextMenu() };
+                control->_takeFocusBackFromContextMenu(menu);
                 menu.PrimaryCommands().Clear();
                 menu.SecondaryCommands().Clear();
                 for (const auto& e : control->_originalPrimaryElements)
@@ -445,7 +447,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         SelectionContextMenu().Closed([weakThis = get_weak()](auto&&, auto&&) {
             if (auto control{ weakThis.get() }; control && !control->_IsClosing())
             {
-                const auto& menu{ control->SelectionContextMenu() };
+                const auto menu{ control->SelectionContextMenu() };
+                control->_takeFocusBackFromContextMenu(menu);
                 menu.PrimaryCommands().Clear();
                 menu.SecondaryCommands().Clear();
                 for (const auto& e : control->_originalSelectedPrimaryElements)
@@ -3929,6 +3932,55 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             cursorPos.X * fontSize.Width + static_cast<float>(padding.Left),
             cursorPos.Y * fontSize.Height + static_cast<float>(padding.Top),
         };
+    }
+
+    // Method Description:
+    // - GH#20593: when the pane context menu is dismissed with Esc, XAML leaves
+    //   keyboard focus on the AppBarButton that had it, even though the flyout
+    //   is gone. The button is off screen but alive, so Enter would invoke it.
+    //   If the flyout closed with focus still on one of its own commands, nothing
+    //   else took focus, so hand it back to the control. We verify membership against
+    //   the closing menu specifically to avoid cross-pane focus stealing in
+    //   multi-pane layouts.
+    // Arguments:
+    // - menu: the CommandBarFlyout that was closed.
+    // Return Value:
+    // - <none>
+    void TermControl::_takeFocusBackFromContextMenu(const winrt::Microsoft::UI::Xaml::Controls::CommandBarFlyout& menu)
+    {
+        if (!menu)
+        {
+            return;
+        }
+
+        const auto root = XamlRoot();
+        if (!root)
+        {
+            return;
+        }
+
+        const auto focused = FocusManager::GetFocusedElement(root);
+        if (!focused)
+        {
+            return;
+        }
+
+        if (const auto focusedDo = focused.try_as<DependencyObject>())
+        {
+            if (IsElementInCommandBarFlyout(focusedDo, menu))
+            {
+                // GH#10112: if the search box is active/open, return focus to it;
+                // otherwise restore focus to the terminal control.
+                if (_searchBox && _searchBox->IsOpen())
+                {
+                    _searchBox->SetFocusOnTextbox();
+                }
+                else
+                {
+                    Focus(FocusState::Programmatic);
+                }
+            }
+        }
     }
 
     void TermControl::_contextMenuHandler(IInspectable /*sender*/,

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -433,6 +433,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void _pasteTextWithBroadcast(const winrt::hstring& text);
 
         void _contextMenuHandler(IInspectable sender, Control::ContextMenuRequestedEventArgs args);
+        void _takeFocusBackFromContextMenu(const winrt::Microsoft::UI::Xaml::Controls::CommandBarFlyout& menu);
         void _showContextMenuAt(const winrt::Windows::Foundation::Point& controlRelativePos);
 
         void _bubbleSearchMissingCommand(const IInspectable& sender, const Control::SearchMissingCommandEventArgs& args);

--- a/src/cascadia/WinRTUtils/inc/Utils.h
+++ b/src/cascadia/WinRTUtils/inc/Utils.h
@@ -117,4 +117,134 @@ winrt::Windows::Foundation::IInspectable ThemeLookup(const auto& res,
     // We didn't find it in the requested dict, fall back to the default dictionary.
     return res.Lookup(key);
 };
+
+#if __has_include(<winrt/Microsoft.UI.Xaml.Controls.h>)
+#include <winrt/Microsoft.UI.Xaml.Controls.h>
+
+// Function Description:
+// - GH#20593: Determines whether a focused dependency object (or any of its visual ancestors)
+//   belongs to the specified CommandBarFlyout or any of its nested child flyouts.
+//   Handles internal parts such as MoreButton (and its child elements) while strictly
+//   bounding upward traversal to CommandBar/Popup to avoid cross-pane focus stealing.
+// Arguments:
+// - focused: The currently focused DependencyObject.
+// - flyout: The CommandBarFlyout being checked.
+// Return value:
+// - true if the focused element is within the flyout hierarchy; false otherwise.
+inline bool IsElementInCommandBarFlyout(
+    const winrt::Windows::UI::Xaml::DependencyObject& focused,
+    const winrt::Microsoft::UI::Xaml::Controls::CommandBarFlyout& flyout)
+{
+    if (!focused || !flyout)
+    {
+        return false;
+    }
+
+    static constexpr std::wstring_view moreButtonPartName{ L"MoreButton" };
+
+    winrt::Windows::UI::Xaml::Controls::ICommandBarElement matchedCommand{ nullptr };
+    winrt::Windows::UI::Xaml::Controls::CommandBar focusedBar{ nullptr };
+    bool isInsideMoreButton = false;
+
+    for (auto cur = focused; cur; cur = winrt::Windows::UI::Xaml::Media::VisualTreeHelper::GetParent(cur))
+    {
+        if (auto cmd = cur.try_as<winrt::Windows::UI::Xaml::Controls::ICommandBarElement>())
+        {
+            matchedCommand = cmd;
+            break;
+        }
+        if (const auto fe = cur.try_as<winrt::Windows::UI::Xaml::FrameworkElement>(); fe && fe.Name() == moreButtonPartName)
+        {
+            isInsideMoreButton = true;
+        }
+        if (auto cb = cur.try_as<winrt::Windows::UI::Xaml::Controls::CommandBar>())
+        {
+            if (isInsideMoreButton)
+            {
+                focusedBar = cb;
+            }
+            break;
+        }
+        if (cur.try_as<winrt::Windows::UI::Xaml::Controls::Primitives::Popup>())
+        {
+            break;
+        }
+    }
+
+    if (!matchedCommand && !focusedBar)
+    {
+        return false;
+    }
+
+    struct MenuChecker
+    {
+        static bool Check(
+            const winrt::Microsoft::UI::Xaml::Controls::CommandBarFlyout& currentMenu,
+            const winrt::Windows::UI::Xaml::Controls::ICommandBarElement& targetCommand,
+            const winrt::Windows::UI::Xaml::Controls::CommandBar& targetBar,
+            const size_t depth)
+        {
+            if (depth > 8 || !currentMenu)
+            {
+                return false;
+            }
+
+            for (const auto& commands : { currentMenu.PrimaryCommands(), currentMenu.SecondaryCommands() })
+            {
+                if (commands)
+                {
+                    bool checkedBarForThisList = false;
+                    for (const auto& element : commands)
+                    {
+                        if (targetCommand && element == targetCommand)
+                        {
+                            return true;
+                        }
+                        if (targetBar && !checkedBarForThisList)
+                        {
+                            if (const auto cmdDo = element.try_as<winrt::Windows::UI::Xaml::DependencyObject>())
+                            {
+                                for (auto p = winrt::Windows::UI::Xaml::Media::VisualTreeHelper::GetParent(cmdDo); p; p = winrt::Windows::UI::Xaml::Media::VisualTreeHelper::GetParent(p))
+                                {
+                                    if (p == targetBar)
+                                    {
+                                        return true;
+                                    }
+                                    if (p.try_as<winrt::Windows::UI::Xaml::Controls::CommandBar>())
+                                    {
+                                        checkedBarForThisList = true;
+                                        break;
+                                    }
+                                    if (p.try_as<winrt::Windows::UI::Xaml::Controls::Primitives::Popup>())
+                                    {
+                                        checkedBarForThisList = true;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        if (const auto btn = element.try_as<winrt::Windows::UI::Xaml::Controls::AppBarButton>())
+                        {
+                            for (const auto& child : { btn.Flyout(), btn.ContextFlyout() })
+                            {
+                                if (const auto childFlyout = child.try_as<winrt::Microsoft::UI::Xaml::Controls::CommandBarFlyout>())
+                                {
+                                    if (Check(childFlyout, targetCommand, targetBar, depth + 1))
+                                    {
+                                        return true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+    };
+
+    return MenuChecker::Check(flyout, matchedCommand, focusedBar, 0);
+}
 #endif
+#endif
+


### PR DESCRIPTION
> _Note: English is not my native language; this PR description was written with the assistance of AI tools._

## Summary of the Pull Request

When the pane context menu (opened via Menu/Apps key, Shift+F10, or Right-Click when `rightClickContextMenu` is enabled) is dismissed with Esc, keyboard focus currently remains trapped on the now-hidden menu item (`AppBarButton` or overflow `MoreButton`). Pressing Enter afterwards invokes the hidden command (e.g. reopening a flyout or splitting a pane) instead of sending input to the active shell.

This PR ensures keyboard focus is properly restored to the terminal (or active Find search box) when the context menu is dismissed.

## References and Relevant Issues

- Closes #20593
- References #5750 (tab context menu focus return)

## Detailed Description of the Pull Request

### Root Cause
`CommandBarFlyout` moves focus to its menu buttons or overflow toggle (`MoreButton`). When dismissed via Esc, XAML closes the flyout but does not restore focus to the underlying control, leaving focus trapped on the invisible element.

### Proposed Changes
1. **Top-Level Menu Dismissal** (`TermControl.cpp`):
   - In `Closed`, checks if the currently focused element belongs to the closing menu (`PrimaryCommands`, `SecondaryCommands`, child flyouts, or internal `MoreButton`).
   - If Find (`_searchBox`) is open, restores focus to its textbox; otherwise restores focus to the terminal via `Focus(FocusState::Programmatic)`.
   - Traversal is bounded to the menu's `CommandBar` ancestor to prevent cross-pane focus stealing in multi-pane layouts.
2. **Submenu Dismissal** (`TerminalPage.cpp`):
   - In `handBackFocusOnClose`, hands focus back to the parent button that opened the submenu using `FocusState::Keyboard` (falling back to `FocusState::Programmatic`).
   - Handles light-dismiss safely: if the parent button is detached, focus restoration defers cleanly to `TermControl`.
3. **Shared Helper** (`Utils.h`):
   - Extracted `IsElementInCommandBarFlyout` into `WinRTUtils/inc/Utils.h` to eliminate logic duplication across `TermControl` and `TerminalPage`.

### Generative AI Disclosure

This pull request was developed with the assistance of Google Antigravity (Gemini Flash 3.8) for code exploration, edge-case analysis, and drafting this PR description. Problem investigation, focus contract definitions, manual testing, and final code verification were reviewed and directed by me.

## Validation Steps Performed

### Visual Demonstration

Both recordings capture the exact same top-level dismissal test (`test_esc_from_the_top_level_hands_focus_back_to_the_terminal`): navigating to `Split pane`, dismissing with Esc, then pressing Enter.

| Unpatched (focus trapped on hidden button; Enter reopens menu) | Patched (focus returned to terminal; Enter reaches shell) |
|:---:|:---:|
| ![Before: Esc leaves focus on hidden button](https://raw.githubusercontent.com/mangokingTW/terminal/evidence/before-unfixed.gif) | ![After: Esc returns focus to terminal](https://raw.githubusercontent.com/mangokingTW/terminal/evidence/after-fixed.gif) |
| **Clip: 39.4s – 48.0s** of `reproduction-20593-x64.mp4`<br>From [Run 34097704495](https://github.com/mangokingTW/terminal/actions/runs/34097704495) (`verification-recording-windows-latest`)<br>• **39.5s - 41.5s**: Menu opens, nav down to `Split pane`<br>• **41.5s - 42.5s**: `Split pane` entry highlighted<br>• **42.6s**: Esc pressed; menu disappears<br>• **46.5s**: Enter pressed<br>• **46.9s**: Submenu reopens in mid-air at (0, 0) | **Clip: 27.0s – 34.0s** of `reproduction-20593-x64.mp4`<br>From [Run 34170503162](https://github.com/mangokingTW/terminal/actions/runs/34170503162) (`verification-recording-windows-latest`)<br>• **27.0s - 29.2s**: Menu opens, nav down to `Split pane`<br>• **29.2s - 30.6s**: `Split pane` entry highlighted<br>• **30.7s**: Esc pressed; menu disappears, focus returned to terminal<br>• **32.0s**: Enter pressed<br>• **33.2s**: Enter sends newline to shell prompt |

### Automated UI Testing & Key Edge Cases

Verification was conducted with an automated UI test harness running under [wintegrate](https://github.com/mangokingTW/wintegrate) across Windows 11 x64 and ARM64 environments. [wintegrate](https://github.com/mangokingTW/wintegrate) provides native Windows UI Automation drivers, process discovery, keyboard/mouse input injection, and automated screen recordings during CI and VM test runs.

The complete test suite (19 edge-case tests) and continuous screen recordings are maintained in companion PR [#1 (fix/context-menu-focus-after-esc)](https://github.com/mangokingTW/terminal/pull/1):

- **CI Verification Run**: [Run 34170503162](https://github.com/mangokingTW/terminal/actions/runs/34170503162) (`windows-latest` x64 & `windows-11-arm` arm64)
- **Continuous Screen Recordings**:
  - [`verification-recording-windows-latest.zip`](https://github.com/mangokingTW/terminal/actions/runs/34170503162/artifacts/10035991925) (x64)
  - [`verification-recording-windows-11-arm.zip`](https://github.com/mangokingTW/terminal/actions/runs/34170503162/artifacts/10036009240) (arm64)
- **Baseline (Unpatched) Run**: [Run 34097704495](https://github.com/mangokingTW/terminal/actions/runs/34097704495) with recording artifact [`verification-recording-windows-latest.zip`](https://github.com/mangokingTW/terminal/actions/runs/34097704495/artifacts/10009282730)

| Key Test Scenario | Code Line | Unpatched Build (Observed Failure) | Patched Build | Result |
|---|---|---|---|---|
| **Top-Level Context Menu Esc**<br>• Apps / Menu key (default trigger)<br>• Shift+F10 (WCAG keybinding)<br>• Mouse Right-Click (with `rightClickContextMenu: true`) | [`L396`](https://github.com/mangokingTW/terminal/blob/0fef5aca8/src/cascadia/TerminalApp/ui-repro/test_issue_20593_focus_after_esc.py#L396)<br>[`L856`](https://github.com/mangokingTW/terminal/blob/0fef5aca8/src/cascadia/TerminalApp/ui-repro/test_issue_20593_focus_after_esc.py#L856)<br>[`L886`](https://github.com/mangokingTW/terminal/blob/0fef5aca8/src/cascadia/TerminalApp/ui-repro/test_issue_20593_focus_after_esc.py#L886) | ❌ **Failed (`FocusStaysTrappedOnMenu`)**<br>Focus remained trapped on invisible `AppBarButton`; pressing Enter re-opened the menu | ✅ **Passed**<br>Focus immediately returned to terminal; Enter sends newline to shell | Verified |
| **Nested Submenu 2-Stage Esc**<br>• Split pane submenu | [`L345`](https://github.com/mangokingTW/terminal/blob/0fef5aca8/src/cascadia/TerminalApp/ui-repro/test_issue_20593_focus_after_esc.py#L345) | ❌ **Failed (`AssertionError`)**<br>1st Esc closed submenu but focus failed to return to parent button; 2nd Esc failed to return to terminal | ✅ **Passed**<br>1st Esc returned focus to parent button; 2nd Esc returned focus to terminal | Verified |
| **Overflow `MoreButton` (`...`) Esc** | [`L665`](https://github.com/mangokingTW/terminal/blob/0fef5aca8/src/cascadia/TerminalApp/ui-repro/test_issue_20593_focus_after_esc.py#L665) | ❌ **Failed (`AssertionError`)**<br>Focus trapped on invisible `MoreButton`; terminal cannot receive input | ✅ **Passed**<br>Single-pass ancestor traversal matched CommandBar; focus restored to terminal | Verified |
| **Find Search Box Focus Return**<br>• Context menu Esc with Find open | [`L606`](https://github.com/mangokingTW/terminal/blob/0fef5aca8/src/cascadia/TerminalApp/ui-repro/test_issue_20593_focus_after_esc.py#L606) | ❌ **Failed (`AssertionError`)**<br>Focus remained trapped on invisible menu item instead of returning to search box TextBox | ✅ **Passed**<br>Detects active `_searchBox` and accurately restores focus to search box TextBox | Verified |
| **Multi-Pane Focus Isolation**<br>• Dismissing menu in split layout | [`L511`](https://github.com/mangokingTW/terminal/blob/0fef5aca8/src/cascadia/TerminalApp/ui-repro/test_issue_20593_focus_after_esc.py#L511)<br>[`L767`](https://github.com/mangokingTW/terminal/blob/0fef5aca8/src/cascadia/TerminalApp/ui-repro/test_issue_20593_focus_after_esc.py#L767) | ❌ **Failed (`FocusStolenCrossPane`)**<br>Dismissing Pane B menu left focus trapped on hidden item, terminal never received focus | ✅ **Passed**<br>Bounded tree search ensures each pane only handles its own menu without cross-pane interference | Verified |
| **Rapid Input & Concurrency**<br>• Rapid Esc + Enter<br>• Rapid typing after Esc | [`L950`](https://github.com/mangokingTW/terminal/blob/0fef5aca8/src/cascadia/TerminalApp/ui-repro/test_issue_20593_focus_after_esc.py#L950)<br>[`L971`](https://github.com/mangokingTW/terminal/blob/0fef5aca8/src/cascadia/TerminalApp/ui-repro/test_issue_20593_focus_after_esc.py#L971) | ❌ **Failed (`AssertionError`)**<br>Rapid keystrokes swallowed or triggered hidden actions; typed characters lost | ✅ **Passed**<br>Focus returned synchronously; subsequent keys and characters 100% delivered to shell | Verified |
| **Submenu Light-Dismiss Safety**<br>• Clicking outside open submenu | [`L726`](https://github.com/mangokingTW/terminal/blob/0fef5aca8/src/cascadia/TerminalApp/ui-repro/test_issue_20593_focus_after_esc.py#L726) | 🛡️ **Safety Invariant Test**<br>Verifies behavior when owner button is detached from Visual Tree during dismissal | ✅ **Passed (Safe Fallback)**<br>`handBackFocusOnClose` safely falls back without crash; focus returns cleanly | Verified |

## PR Checklist
- [x] Closes #20593
- [x] Tests added/passed
- [ ] Documentation updated
- [ ] Schema updated (if necessary)


