### PR TITLE
Fix spaces not being accepted in SettingsCard/Expander

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/SettingsCard.cpp
+++ b/src/cascadia/TerminalSettingsEditor/SettingsCard.cpp
@@ -173,6 +173,22 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
     }
 
+    void SettingsCard::OnKeyDown(const winrt::Windows::UI::Xaml::Input::KeyRoutedEventArgs& e)
+    {
+        if (!IsClickKeyFromContent(*this, e))
+        {
+            base_type::OnKeyDown(e);
+        }
+    }
+
+    void SettingsCard::OnKeyUp(const winrt::Windows::UI::Xaml::Input::KeyRoutedEventArgs& e)
+    {
+        if (!IsClickKeyFromContent(*this, e))
+        {
+            base_type::OnKeyUp(e);
+        }
+    }
+
     void SettingsCard::OnApplyTemplate()
     {
         // Match WCT's SettingsCard.OnApplyTemplate() which calls base first so the

--- a/src/cascadia/TerminalSettingsEditor/SettingsCard.h
+++ b/src/cascadia/TerminalSettingsEditor/SettingsCard.h
@@ -8,6 +8,9 @@ Module Name:
 Abstract:
 - A base control for building consistent settings experiences. Based
   on the Windows Community Toolkit's SettingsCard.
+- Deviation from the toolkit: OnKeyDown/OnKeyUp refuse to hand Space/Enter to
+  ButtonBase when the key came from hosted content, so a TextBox in a card can
+  still be typed into.
 
 Author(s):
 - Carlos Zamora - 2026 May
@@ -29,6 +32,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void OnApplyTemplate();
         void OnPointerPressed(const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e);
         void OnPointerReleased(const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e);
+        void OnKeyDown(const Windows::UI::Xaml::Input::KeyRoutedEventArgs& e);
+        void OnKeyUp(const Windows::UI::Xaml::Input::KeyRoutedEventArgs& e);
 
         // Automation peer override.
         Windows::UI::Xaml::Automation::Peers::AutomationPeer OnCreateAutomationPeer();

--- a/src/cascadia/TerminalSettingsEditor/SettingsControlsHelpers.cpp
+++ b/src/cascadia/TerminalSettingsEditor/SettingsControlsHelpers.cpp
@@ -8,6 +8,7 @@
 #include "BottomCornerRadiusFilterConverter.g.cpp"
 #include "StringDefaultTemplateSelector.g.cpp"
 #include "StyleExtensions.g.cpp"
+#include "SettingsExpanderHeaderToggleButton.g.cpp"
 
 #include <limits>
 
@@ -260,6 +261,26 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             resources.Insert(markerKey, box_value(true));
         }
         CATCH_LOG();
+    }
+
+#pragma endregion
+
+#pragma region SettingsExpanderHeaderToggleButton
+
+    void SettingsExpanderHeaderToggleButton::OnKeyDown(const Windows::UI::Xaml::Input::KeyRoutedEventArgs& e)
+    {
+        if (!IsClickKeyFromContent(*this, e))
+        {
+            base_type::OnKeyDown(e);
+        }
+    }
+
+    void SettingsExpanderHeaderToggleButton::OnKeyUp(const Windows::UI::Xaml::Input::KeyRoutedEventArgs& e)
+    {
+        if (!IsClickKeyFromContent(*this, e))
+        {
+            base_type::OnKeyUp(e);
+        }
     }
 
 #pragma endregion

--- a/src/cascadia/TerminalSettingsEditor/SettingsControlsHelpers.h
+++ b/src/cascadia/TerminalSettingsEditor/SettingsControlsHelpers.h
@@ -21,6 +21,7 @@ Author(s):
 #include "BottomCornerRadiusFilterConverter.g.h"
 #include "StringDefaultTemplateSelector.g.h"
 #include "StyleExtensions.g.h"
+#include "SettingsExpanderHeaderToggleButton.g.h"
 #include "Utils.h"
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
@@ -88,6 +89,14 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         static Windows::UI::Xaml::ResourceDictionary _sharedImplicitStylesDictionary;
     };
+
+    struct SettingsExpanderHeaderToggleButton : SettingsExpanderHeaderToggleButtonT<SettingsExpanderHeaderToggleButton>
+    {
+        SettingsExpanderHeaderToggleButton() = default;
+
+        void OnKeyDown(const Windows::UI::Xaml::Input::KeyRoutedEventArgs& e);
+        void OnKeyUp(const Windows::UI::Xaml::Input::KeyRoutedEventArgs& e);
+    };
 }
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::factory_implementation
@@ -97,4 +106,5 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::factory_implementation
     BASIC_FACTORY(BottomCornerRadiusFilterConverter);
     BASIC_FACTORY(StringDefaultTemplateSelector);
     BASIC_FACTORY(StyleExtensions);
+    BASIC_FACTORY(SettingsExpanderHeaderToggleButton);
 }

--- a/src/cascadia/TerminalSettingsEditor/SettingsControlsHelpers.idl
+++ b/src/cascadia/TerminalSettingsEditor/SettingsControlsHelpers.idl
@@ -62,4 +62,9 @@ namespace Microsoft.Terminal.Settings.Editor
     {
         static void EnsureImplicitStylesMergedInto(Windows.UI.Xaml.FrameworkElement target);
     }
+
+    [default_interface] runtimeclass SettingsExpanderHeaderToggleButton : Windows.UI.Xaml.Controls.Primitives.ToggleButton
+    {
+        SettingsExpanderHeaderToggleButton();
+    }
 }

--- a/src/cascadia/TerminalSettingsEditor/SettingsControlsStyle.xaml
+++ b/src/cascadia/TerminalSettingsEditor/SettingsControlsStyle.xaml
@@ -17,6 +17,9 @@
     - Child controls (ToggleSwitch/Slider/ComboBox/TextBox) get implicit styles via
     C++ rather than the toolkit's StyleExtensions.Resources Setter (see
     SettingsControlsImplicitStyles.xaml for why)
+    - The Expander header is a local:SettingsExpanderHeaderToggleButton, not a plain
+    ToggleButton, so that Space/Enter typed into header content reaches that content
+    instead of being class-handled by ButtonBase. SettingsCard applies the same guard.
 -->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -589,25 +592,25 @@
                                            Height="*" />
                         </Grid.RowDefinitions>
 
-                        <ToggleButton x:Name="ExpanderHeader"
-                                      MinHeight="{TemplateBinding MinHeight}"
-                                      Padding="{StaticResource ExpanderHeaderPadding}"
-                                      HorizontalAlignment="Stretch"
-                                      HorizontalContentAlignment="{StaticResource ExpanderHeaderHorizontalContentAlignment}"
-                                      VerticalContentAlignment="{StaticResource ExpanderHeaderVerticalContentAlignment}"
-                                      AutomationProperties.AutomationId="ExpanderToggleButton"
-                                      AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
-                                      BackgroundSizing="{TemplateBinding BackgroundSizing}"
-                                      BorderBrush="{ThemeResource ExpanderHeaderBorderBrush}"
-                                      BorderThickness="{ThemeResource ExpanderHeaderBorderThickness}"
-                                      Content="{TemplateBinding Header}"
-                                      ContentTemplate="{TemplateBinding HeaderTemplate}"
-                                      ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
-                                      CornerRadius="{TemplateBinding CornerRadius}"
-                                      IsChecked="{Binding Path=IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                                      IsEnabled="{TemplateBinding IsEnabled}"
-                                      IsTabStop="True"
-                                      Style="{StaticResource SettingsExpanderHeaderDownStyle}" />
+                        <local:SettingsExpanderHeaderToggleButton x:Name="ExpanderHeader"
+                                                                  MinHeight="{TemplateBinding MinHeight}"
+                                                                  Padding="{StaticResource ExpanderHeaderPadding}"
+                                                                  HorizontalAlignment="Stretch"
+                                                                  HorizontalContentAlignment="{StaticResource ExpanderHeaderHorizontalContentAlignment}"
+                                                                  VerticalContentAlignment="{StaticResource ExpanderHeaderVerticalContentAlignment}"
+                                                                  AutomationProperties.AutomationId="ExpanderToggleButton"
+                                                                  AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
+                                                                  BackgroundSizing="{TemplateBinding BackgroundSizing}"
+                                                                  BorderBrush="{ThemeResource ExpanderHeaderBorderBrush}"
+                                                                  BorderThickness="{ThemeResource ExpanderHeaderBorderThickness}"
+                                                                  Content="{TemplateBinding Header}"
+                                                                  ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                                                  ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
+                                                                  CornerRadius="{TemplateBinding CornerRadius}"
+                                                                  IsChecked="{Binding Path=IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                                                                  IsEnabled="{TemplateBinding IsEnabled}"
+                                                                  IsTabStop="True"
+                                                                  Style="{StaticResource SettingsExpanderHeaderDownStyle}" />
 
                         <!--  The clip is a composition clip applied in code (by muxc:Expander).  -->
                         <Border x:Name="ExpanderContentClip"
@@ -769,13 +772,13 @@
         AnimatedIcon morph; see comment on ExpandCollapseChevron below.)
     -->
     <Style x:Key="SettingsExpanderHeaderDownStyle"
-           TargetType="ToggleButton">
+           TargetType="local:SettingsExpanderHeaderToggleButton">
         <Setter Property="Padding" Value="0" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="BackgroundSizing" Value="InnerBorderEdge" />
         <Setter Property="Template">
             <Setter.Value>
-                <ControlTemplate TargetType="ToggleButton">
+                <ControlTemplate TargetType="local:SettingsExpanderHeaderToggleButton">
                     <Grid x:Name="ToggleButtonGrid"
                           Width="{TemplateBinding Width}"
                           MinWidth="{TemplateBinding MinWidth}"

--- a/src/cascadia/TerminalSettingsEditor/Utils.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Utils.cpp
@@ -221,4 +221,19 @@ namespace winrt::Microsoft::Terminal::Settings
         }
         return nullptr;
     }
+
+    // BODGY: ButtonBase handles Space/Enter as a Click and marks them handled,
+    // eating the character before a TextBox in the Content can type it. Callers
+    // specifically refuse to call the base method when the key came from their Content,
+    // so a TextBox can still type Space/Enter.
+    // Important for SettingsCard/SettingsExpander.
+    bool IsClickKeyFromContent(const DependencyObject& self, const Input::KeyRoutedEventArgs& e)
+    {
+        const auto key = e.Key();
+        if (key != VirtualKey::Enter && key != VirtualKey::Space && key != VirtualKey::GamepadA)
+        {
+            return false;
+        }
+        return e.OriginalSource() != self;
+    }
 }

--- a/src/cascadia/TerminalSettingsEditor/Utils.h
+++ b/src/cascadia/TerminalSettingsEditor/Utils.h
@@ -83,6 +83,7 @@ namespace winrt::Microsoft::Terminal::Settings
     safe_void_coroutine ExpandAncestorsAndBringIntoView(winrt::Windows::UI::Xaml::FrameworkElement root, winrt::Windows::UI::Xaml::Controls::Control control);
     Editor::KeyChordListener FindKeyChordListener(const winrt::Windows::UI::Xaml::DependencyObject& root);
     winrt::Windows::UI::Xaml::Controls::Control FindFirstFocusable(const winrt::Windows::UI::Xaml::DependencyObject& root);
+    bool IsClickKeyFromContent(const winrt::Windows::UI::Xaml::DependencyObject& self, const winrt::Windows::UI::Xaml::Input::KeyRoutedEventArgs& e);
 }
 
 // BODGY!


### PR DESCRIPTION
## Summary of the Pull Request
Fixes a bug in the settings UI where spaces would not be accepted in the text box controls. This was caused by both of the WCT ports using a button:
- the SettingsExpander template uses a `ToggleButton`
- SettingsCard inherits from `ButtonBase` (see the IDL)

The button handles Space as a Click event, thus never reaching the content area and preventing a space from being added.

This PR adds a KeyUp/KeyDown handler to specifically handle Enter, Space, and GamepadA. The shared code is added to Utils.cpp for deduplication.

## References and Relevant Issues
Introduced by #20232

## Validation Steps Performed
✅ Profiles > Command Prompt > Name (SettingsCard w/ TextBox) accepts space
- Profiles > Command Prompt > Appearance > Background Image (SettingsExpander w/ TextBox) ...
   - ✅ accepts space
   - ✅ expander can be opened/closed using space when focused