### PR TITLE
Add profile icons to settings breadcrumbs

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -513,7 +513,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 {
                     _breadcrumbs.Clear();
                     _AppendProfilesRootCrumb();
-                    _breadcrumbs.Append(winrt::make<Breadcrumb>(breadcrumbTag, breadcrumbText, BreadcrumbSubPage::None));
+                    const auto profileIcon{ profile.IsBaseLayer() || profile.UsingNoIcon() ? Controls::IconElement{ nullptr } : profile.IconPreview() };
+                    _breadcrumbs.Append(winrt::make<Breadcrumb>(breadcrumbTag, breadcrumbText, BreadcrumbSubPage::None, profileIcon));
                 }
                 _NavigateToProfileSubPage(profile, currentPage, breadcrumbTag, {});
             }
@@ -666,7 +667,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             if (profile.Orphaned())
             {
                 contentFrame().Navigate(xaml_typename<Editor::Profiles_Base_Orphaned>(), winrt::make<NavigateToPageArgs>(profile, *this, elementToFocus));
-                _breadcrumbs.Append(winrt::make<Breadcrumb>(vm, profile.Name(), BreadcrumbSubPage::None));
+                const auto profileIcon{ profile.UsingNoIcon() ? Controls::IconElement{ nullptr } : profile.IconPreview() };
+                _breadcrumbs.Append(winrt::make<Breadcrumb>(vm, profile.Name(), BreadcrumbSubPage::None, profileIcon));
                 profile.CurrentPage(ProfileSubPage::Base);
                 _SetupProfileEventHandling(profile);
             }
@@ -677,7 +679,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 profile.CurrentPage(profileSubPage);
 
                 // Navigate directly to the correct sub-page
-                _breadcrumbs.Append(winrt::make<Breadcrumb>(vm, profile.Name(), BreadcrumbSubPage::None));
+                const auto profileIcon{ profile.UsingNoIcon() ? Controls::IconElement{ nullptr } : profile.IconPreview() };
+                _breadcrumbs.Append(winrt::make<Breadcrumb>(vm, profile.Name(), BreadcrumbSubPage::None, profileIcon));
                 _NavigateToProfileSubPage(profile, profileSubPage, vm, elementToFocus);
 
                 // Register handler for future user-driven sub-page changes

--- a/src/cascadia/TerminalSettingsEditor/MainPage.h
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.h
@@ -13,16 +13,19 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
     struct Breadcrumb : BreadcrumbT<Breadcrumb>
     {
-        Breadcrumb(IInspectable tag, winrt::hstring label, BreadcrumbSubPage subPage) :
+        Breadcrumb(IInspectable tag, winrt::hstring label, BreadcrumbSubPage subPage, const Windows::UI::Xaml::Controls::IconElement& icon = nullptr) :
             _Tag{ tag },
             _Label{ label },
-            _SubPage{ subPage } {}
+            _SubPage{ subPage },
+            _Icon{ icon } {}
 
         hstring ToString() { return _Label; }
+        bool HasIcon() const noexcept { return static_cast<bool>(_Icon); }
 
         WINRT_PROPERTY(IInspectable, Tag);
         WINRT_PROPERTY(winrt::hstring, Label);
         WINRT_PROPERTY(BreadcrumbSubPage, SubPage);
+        WINRT_PROPERTY(Windows::UI::Xaml::Controls::IconElement, Icon);
     };
 
     struct NavigateToPageArgs : NavigateToPageArgsT<NavigateToPageArgs>

--- a/src/cascadia/TerminalSettingsEditor/MainPage.idl
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.idl
@@ -41,6 +41,8 @@ namespace Microsoft.Terminal.Settings.Editor
         IInspectable Tag;
         String Label;
         BreadcrumbSubPage SubPage;
+        Windows.UI.Xaml.Controls.IconElement Icon { get; };
+        Boolean HasIcon { get; };
     }
 
     [default_interface] runtimeclass MainPage : Windows.UI.Xaml.Controls.Page, IHostedInWindow

--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -85,7 +85,15 @@
                                     ItemsSource="{x:Bind Breadcrumbs}">
                     <muxc:BreadcrumbBar.ItemTemplate>
                         <DataTemplate x:DataType="local:Breadcrumb">
-                            <TextBlock Text="{x:Bind Label}" />
+                            <StackPanel Orientation="Horizontal"
+                                        Spacing="6">
+                                <ContentControl Width="16"
+                                                Height="16"
+                                                Content="{x:Bind Icon, Mode=OneWay}"
+                                                IsTabStop="False"
+                                                Visibility="{x:Bind mtu:Converters.BooleanToVisibility(HasIcon), Mode=OneWay}" />
+                                <TextBlock Text="{x:Bind Label}" />
+                            </StackPanel>
                         </DataTemplate>
                     </muxc:BreadcrumbBar.ItemTemplate>
                     <muxc:BreadcrumbBar.Resources>

--- a/src/cascadia/UIHelpers/Converters.cpp
+++ b/src/cascadia/UIHelpers/Converters.cpp
@@ -16,6 +16,11 @@ namespace winrt::Microsoft::Terminal::UI::implementation
         return !value;
     }
 
+    winrt::Windows::UI::Xaml::Visibility Converters::BooleanToVisibility(bool value)
+    {
+        return value ? winrt::Windows::UI::Xaml::Visibility::Visible : winrt::Windows::UI::Xaml::Visibility::Collapsed;
+    }
+
     winrt::Windows::UI::Xaml::Visibility Converters::InvertedBooleanToVisibility(bool value)
     {
         return value ? winrt::Windows::UI::Xaml::Visibility::Collapsed : winrt::Windows::UI::Xaml::Visibility::Visible;

--- a/src/cascadia/UIHelpers/Converters.h
+++ b/src/cascadia/UIHelpers/Converters.h
@@ -11,6 +11,7 @@ namespace winrt::Microsoft::Terminal::UI::implementation
     {
         // Booleans
         static bool InvertBoolean(bool value);
+        static winrt::Windows::UI::Xaml::Visibility BooleanToVisibility(bool value);
         static winrt::Windows::UI::Xaml::Visibility InvertedBooleanToVisibility(bool value);
 
         // Numbers

--- a/src/cascadia/UIHelpers/Converters.idl
+++ b/src/cascadia/UIHelpers/Converters.idl
@@ -9,6 +9,7 @@ namespace Microsoft.Terminal.UI
     {
         // Booleans
         static Boolean InvertBoolean(Boolean value);
+        static Windows.UI.Xaml.Visibility BooleanToVisibility(Boolean value);
         static Windows.UI.Xaml.Visibility InvertedBooleanToVisibility(Boolean value);
 
         // Numbers


### PR DESCRIPTION
## Summary
- show each profile's configured icon in the Settings breadcrumb
- reserve no blank icon space when a profile icon is disabled or unset
- add a reusable Boolean-to-Visibility converter for the breadcrumb template

Fixes #9694

## Validation
- `dep\nuget\nuget.exe restore dep\nuget\packages.config`
- `clang-format --dry-run --Werror` on the changed C++ files
- parsed `MainPage.xaml` as XML
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`
- scanned the changed diff for common credential patterns

A full local application build could not be completed because this machine's Visual Studio installation is missing the v145 Windows Store build tools (`MSB8020`). The branch is otherwise ready for the repository CI build.