### PR TITLE
sui: fix the Spacebar on things inside settings cards

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/SettingsCard.cpp
+++ b/src/cascadia/TerminalSettingsEditor/SettingsCard.cpp
@@ -372,34 +372,40 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 strongThis->_GoToCommonState(NormalState, true);
             }
         });
-        _previewKeyDownRevoker = PreviewKeyDown(winrt::auto_revoke, [weakThis = get_weak()](auto&&, const Windows::UI::Xaml::Input::KeyRoutedEventArgs& e) {
-            const auto strongThis = weakThis.get();
-            if (!strongThis)
+    }
+
+    void SettingsCard::OnKeyDown(const Windows::UI::Xaml::Input::KeyRoutedEventArgs& e)
+    {
+        if (!_interactionEnabled)
+        {
+            return;
+        }
+
+        const auto key = e.Key();
+        if (key == Windows::System::VirtualKey::Enter || key == Windows::System::VirtualKey::Space || key == Windows::System::VirtualKey::GamepadA)
+        {
+            const auto focused{ _GetFocusedElement() };
+            if (focused && focused.try_as<Editor::SettingsCard>() == get_strong().as<Editor::SettingsCard>())
             {
-                return;
+                _GoToCommonState(PressedState, true);
             }
-            const auto key = e.Key();
-            if (key == Windows::System::VirtualKey::Enter || key == Windows::System::VirtualKey::Space || key == Windows::System::VirtualKey::GamepadA)
-            {
-                const auto focused{ strongThis->_GetFocusedElement() };
-                if (focused && focused.try_as<Editor::SettingsCard>() == strongThis.as<Editor::SettingsCard>())
-                {
-                    strongThis->_GoToCommonState(PressedState, true);
-                }
-            }
-        });
-        _previewKeyUpRevoker = PreviewKeyUp(winrt::auto_revoke, [weakThis = get_weak()](auto&&, const Windows::UI::Xaml::Input::KeyRoutedEventArgs& e) {
-            const auto strongThis = weakThis.get();
-            if (!strongThis)
-            {
-                return;
-            }
-            const auto key = e.Key();
-            if (key == Windows::System::VirtualKey::Enter || key == Windows::System::VirtualKey::Space || key == Windows::System::VirtualKey::GamepadA)
-            {
-                strongThis->_GoToCommonState(NormalState, true);
-            }
-        });
+            base_type::OnKeyDown(e);
+        }
+    }
+
+    void SettingsCard::OnKeyUp(const Windows::UI::Xaml::Input::KeyRoutedEventArgs& e)
+    {
+        if (!_interactionEnabled)
+        {
+            return;
+        }
+
+        const auto key = e.Key();
+        if (key == Windows::System::VirtualKey::Enter || key == Windows::System::VirtualKey::Space || key == Windows::System::VirtualKey::GamepadA)
+        {
+            _GoToCommonState(NormalState, true);
+            base_type::OnKeyUp(e);
+        }
     }
 
     void SettingsCard::_DisableButtonInteraction()
@@ -410,8 +416,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _pointerExitedRevoker.revoke();
         _pointerCaptureLostRevoker.revoke();
         _pointerCanceledRevoker.revoke();
-        _previewKeyDownRevoker.revoke();
-        _previewKeyUpRevoker.revoke();
     }
 
     void SettingsCard::_GoToCommonState(const std::wstring_view& state, bool useTransitions)

--- a/src/cascadia/TerminalSettingsEditor/SettingsCard.h
+++ b/src/cascadia/TerminalSettingsEditor/SettingsCard.h
@@ -29,6 +29,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void OnApplyTemplate();
         void OnPointerPressed(const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e);
         void OnPointerReleased(const Windows::UI::Xaml::Input::PointerRoutedEventArgs& e);
+        void OnKeyDown(const Windows::UI::Xaml::Input::KeyRoutedEventArgs& e);
+        void OnKeyUp(const Windows::UI::Xaml::Input::KeyRoutedEventArgs& e);
 
         // Automation peer override.
         Windows::UI::Xaml::Automation::Peers::AutomationPeer OnCreateAutomationPeer();
@@ -74,8 +76,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         Windows::UI::Xaml::UIElement::PointerExited_revoker _pointerExitedRevoker;
         Windows::UI::Xaml::UIElement::PointerCaptureLost_revoker _pointerCaptureLostRevoker;
         Windows::UI::Xaml::UIElement::PointerCanceled_revoker _pointerCanceledRevoker;
-        Windows::UI::Xaml::UIElement::PreviewKeyDown_revoker _previewKeyDownRevoker;
-        Windows::UI::Xaml::UIElement::PreviewKeyUp_revoker _previewKeyUpRevoker;
         Windows::UI::Xaml::VisualStateGroup::CurrentStateChanged_revoker _contentAlignmentStatesChangedRevoker;
         int64_t _contentChangedToken{ 0 };
     };


### PR DESCRIPTION
Okay, so, every SettingsCard inherits from ButtonBase. ButtonBase has its own local KeyDown/KeyUp handler, which can prevent the event from being bubbled at all.

Moving our key handling to our local KeyDown/KeyUp handler allows us to decide when to involve ButtonBase's handler, rather than allowing it to delegate to us.

Incidentally, this is probably why the implementer had to use the PreviewKeyXxx events; it was the only other way to get a "say" before the button handled it itself.

Closes #20657 (superseded)